### PR TITLE
Add Maestro flow to record screenshots for the user manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build.xml
 proguard-project.txt
 .idea/
 *.iml
+user-manual

--- a/ui-flows/screenshots/user_manual_account_setup.yml
+++ b/ui-flows/screenshots/user_manual_account_setup.yml
@@ -1,0 +1,158 @@
+appId: com.fsck.k9.debug
+---
+- launchApp:
+    clearState: true
+
+- assertVisible:
+    id: "com.fsck.k9.debug:id/welcome_message"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/welcome_screen"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step1_empty"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/account_email"
+- inputText: "dummy@outlook.com"
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step1_sign_in"
+
+- pressKey: "back"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/account_email"
+- eraseText
+- inputText: "user@domain.example"
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+- tapOn:
+    id: "com.fsck.k9.debug:id/account_password"
+- inputText: "password"
+- pressKey: "back"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step1_filled_in"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step2_account_type_selection"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/imap"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step3_imap_incoming_server_1"
+
+- scroll
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step3_imap_incoming_server_2"
+
+- scrollUntilVisible:
+    element:
+      id: "com.fsck.k9.debug:id/account_server"
+    direction: UP
+- tapOn:
+    id: "com.fsck.k9.debug:id/account_server"
+- eraseText
+- inputText: "wrong.host.badssl.com"
+- tapOn:
+    id: "com.fsck.k9.debug:id/account_port"
+- eraseText
+- inputText: "443"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+
+- assertVisible:
+    id: "android:id/alertTitle"
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step3.6_invalid_certificate"
+
+- tapOn:
+    id: "android:id/button2"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/account_server"
+- eraseText
+- inputText: "127.0.0.1"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+
+- assertVisible:
+    id: "android:id/alertTitle"
+- pressKey: "back"
+
+- assertVisible:
+    id: "com.fsck.k9.debug:id/progress"
+- takeScreenshot: "user-manual/screenshots/account_setup_step3.5_imap_checking_incoming_server_settings"
+
+- pressKey: "back"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+- tapOn:
+    id: "android:id/button2"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step4_smtp_outgoing_server"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/account_server"
+- eraseText
+- inputText: "127.0.0.1"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+
+- assertVisible:
+    id: "android:id/alertTitle"
+- pressKey: "back"
+
+- assertVisible:
+    id: "com.fsck.k9.debug:id/progress"
+- takeScreenshot: "user-manual/screenshots/account_setup_step4.5_smtp_checking_outgoing_server_settings"
+
+- pressKey: "back"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+- tapOn:
+    id: "android:id/button2"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step5_account_options"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/next"
+- tapOn:
+    id: "com.fsck.k9.debug:id/account_description"
+- inputText: "My first account"
+- tapOn:
+    id: "com.fsck.k9.debug:id/account_name"
+- inputText: "Demo User"
+- pressKey: "back"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step6_account_name"
+
+- pressKey: "back"
+- pressKey: "back"
+- pressKey: "back"
+- pressKey: "back"
+
+- tapOn:
+    id: "com.fsck.k9.debug:id/pop"
+
+- waitForAnimationToEnd
+- takeScreenshot: "user-manual/screenshots/account_setup_step3_pop3_incoming_server"


### PR DESCRIPTION
The [user manual](https://docs.k9mail.app/) contains quite a few screenshots. Manually redoing all of them when the UI changes is very annoying. Fortunately, we don't have to. This PR adds a Maestro flow to record screenshots for the account setup pages.

The screenshots still have to be manually committed to the [k9mail/k9mail-docs](https://github.com/k9mail/k9mail-docs) repository.