### PR TITLE
Fix NPE on devices that don't support widgets

### DIFF
--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListWidgetManager.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListWidgetManager.kt
@@ -23,6 +23,9 @@ class MessageListWidgetManager(
 
     fun init() {
         appWidgetManager = AppWidgetManager.getInstance(context)
+        if (appWidgetManager == null) {
+            Timber.v("Message list widget is not supported on this device.")
+        }
 
         if (isAtLeastOneMessageListWidgetAdded()) {
             resetMessageListWidget()

--- a/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListWidgetManager.kt
+++ b/app/ui/message-list-widget/src/main/java/app/k9mail/ui/widget/list/MessageListWidgetManager.kt
@@ -14,7 +14,7 @@ class MessageListWidgetManager(
     private val messageListRepository: MessageListRepository,
     private val config: MessageListWidgetConfig,
 ) {
-    private lateinit var appWidgetManager: AppWidgetManager
+    private var appWidgetManager: AppWidgetManager? = null
 
     private var listenerAdded = false
     private val listener = MessageListChangedListener {
@@ -83,7 +83,7 @@ class MessageListWidgetManager(
     private fun triggerMessageListWidgetUpdate() {
         val appWidgetIds = getAppWidgetIds()
         if (appWidgetIds.isNotEmpty()) {
-            appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetIds, R.id.listView)
+            appWidgetManager?.notifyAppWidgetViewDataChanged(appWidgetIds, R.id.listView)
         }
     }
 
@@ -101,6 +101,6 @@ class MessageListWidgetManager(
 
     private fun getAppWidgetIds(): IntArray {
         val componentName = ComponentName(context, config.providerClass)
-        return appWidgetManager.getAppWidgetIds(componentName)
+        return appWidgetManager?.getAppWidgetIds(componentName) ?: intArrayOf()
     }
 }


### PR DESCRIPTION
Turns out, `AppWidgetManager.getInstance(context)` can return null:

* https://github.com/chromium/chromium/blob/08033c4b62f48e46e66f97be3a39c99ab9163402/chrome/android/java/src/org/chromium/chrome/browser/quickactionsearchwidget/QuickActionSearchWidgetProvider.java#L289
* https://github.com/tasks/tasks/blob/d25f859385e8301ae274835297f151125f7cefb7/app/src/main/java/org/tasks/widget/AppWidgetManager.kt#L18

I've tested that this change fixes K-9 crash on the device.