### PR TITLE
Remove deprecation warning of `K9` class

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -13,7 +13,7 @@ import kotlinx.datetime.Clock
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
-@Deprecated("Use GeneralSettingsManager and GeneralSettings instead")
+// TODO "Use GeneralSettingsManager and GeneralSettings instead"
 object K9 : EarlyInit {
     private val generalSettingsManager: RealGeneralSettingsManager by inject()
 


### PR DESCRIPTION
The message is not true anymore and it's spamming the build output and hides other important build warnings. It is replaced by TODO for now.

