### PR TITLE
Use deep links in navigation

### DIFF
--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/navigation/NavigationExtensions.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/navigation/NavigationExtensions.kt
@@ -1,0 +1,30 @@
+package app.k9mail.core.ui.compose.common.navigation
+
+import android.net.Uri
+import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.runtime.Composable
+import androidx.core.net.toUri
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
+
+fun NavGraphBuilder.deepLinkComposable(
+    route: String,
+    arguments: List<NamedNavArgument> = emptyList(),
+    content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+) {
+    composable(
+        route = route,
+        arguments = arguments,
+        deepLinks = listOf(
+            navDeepLink { uriPattern = route.toDeepLink() },
+        ),
+        content = content,
+    )
+}
+
+fun String.toDeepLink(): String = "app://$this"
+
+fun String.toDeepLinkUri(): Uri = toDeepLink().toUri()

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavigation.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavigation.kt
@@ -4,9 +4,11 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import app.k9mail.feature.account.setup.ui.AccountSetupScreen
 
 const val NAVIGATION_ROUTE_ACCOUNT_SETUP = "/account/setup"
+const val DEEPLINK_ACCOUNT_SETUP = "app://$NAVIGATION_ROUTE_ACCOUNT_SETUP"
 
 fun NavController.navigateToAccountSetup(navOptions: NavOptions? = null) {
     navigate(NAVIGATION_ROUTE_ACCOUNT_SETUP, navOptions)
@@ -16,7 +18,12 @@ fun NavGraphBuilder.accountSetupRoute(
     onBack: () -> Unit,
     onFinish: (String) -> Unit,
 ) {
-    composable(route = NAVIGATION_ROUTE_ACCOUNT_SETUP) {
+    composable(
+        route = NAVIGATION_ROUTE_ACCOUNT_SETUP,
+        deepLinks = listOf(
+            navDeepLink { uriPattern = DEEPLINK_ACCOUNT_SETUP },
+        ),
+    ) {
         AccountSetupScreen(
             onBack = onBack,
             onFinish = onFinish,

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavigation.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavigation.kt
@@ -3,12 +3,10 @@ package app.k9mail.feature.account.setup.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.compose.composable
-import androidx.navigation.navDeepLink
+import app.k9mail.core.ui.compose.common.navigation.deepLinkComposable
 import app.k9mail.feature.account.setup.ui.AccountSetupScreen
 
 const val NAVIGATION_ROUTE_ACCOUNT_SETUP = "/account/setup"
-const val DEEPLINK_ACCOUNT_SETUP = "app://$NAVIGATION_ROUTE_ACCOUNT_SETUP"
 
 fun NavController.navigateToAccountSetup(navOptions: NavOptions? = null) {
     navigate(NAVIGATION_ROUTE_ACCOUNT_SETUP, navOptions)
@@ -18,12 +16,7 @@ fun NavGraphBuilder.accountSetupRoute(
     onBack: () -> Unit,
     onFinish: (String) -> Unit,
 ) {
-    composable(
-        route = NAVIGATION_ROUTE_ACCOUNT_SETUP,
-        deepLinks = listOf(
-            navDeepLink { uriPattern = DEEPLINK_ACCOUNT_SETUP },
-        ),
-    ) {
+    deepLinkComposable(route = NAVIGATION_ROUTE_ACCOUNT_SETUP) {
         AccountSetupScreen(
             onBack = onBack,
             onFinish = onFinish,

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
@@ -4,12 +4,12 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import app.k9mail.core.ui.compose.common.activity.setActivityContent
-import app.k9mail.feature.account.setup.navigation.DEEPLINK_ACCOUNT_SETUP
+import app.k9mail.core.ui.compose.common.navigation.toDeepLinkUri
+import app.k9mail.feature.account.setup.navigation.NAVIGATION_ROUTE_ACCOUNT_SETUP
 import app.k9mail.feature.launcher.ui.FeatureLauncherApp
-import app.k9mail.feature.onboarding.navigation.DEEPLINK_ONBOARDING
+import app.k9mail.feature.onboarding.navigation.NAVIGATION_ROUTE_ONBOARDING
 
 class FeatureLauncherActivity : ComponentActivity() {
 
@@ -27,7 +27,7 @@ class FeatureLauncherActivity : ComponentActivity() {
         @JvmStatic
         fun launchOnboarding(context: Activity) {
             val intent = Intent(context, FeatureLauncherActivity::class.java).apply {
-                data = DEEPLINK_ONBOARDING.toUri()
+                data = NAVIGATION_ROUTE_ONBOARDING.toDeepLinkUri()
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             }
             context.startActivity(intent)
@@ -36,7 +36,7 @@ class FeatureLauncherActivity : ComponentActivity() {
         @JvmStatic
         fun launchSetupAccount(context: Activity) {
             val intent = Intent(context, FeatureLauncherActivity::class.java).apply {
-                data = DEEPLINK_ACCOUNT_SETUP.toUri()
+                data = NAVIGATION_ROUTE_ACCOUNT_SETUP.toDeepLinkUri()
             }
             context.startActivity(intent)
         }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
@@ -4,11 +4,12 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import app.k9mail.core.ui.compose.common.activity.setActivityContent
-import app.k9mail.feature.account.setup.navigation.NAVIGATION_ROUTE_ACCOUNT_SETUP
+import app.k9mail.feature.account.setup.navigation.DEEPLINK_ACCOUNT_SETUP
 import app.k9mail.feature.launcher.ui.FeatureLauncherApp
-import app.k9mail.feature.onboarding.navigation.NAVIGATION_ROUTE_ONBOARDING
+import app.k9mail.feature.onboarding.navigation.DEEPLINK_ONBOARDING
 
 class FeatureLauncherActivity : ComponentActivity() {
 
@@ -17,22 +18,16 @@ class FeatureLauncherActivity : ComponentActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        val destination = intent.getStringExtra(EXTRA_DESTINATION)
-
         setActivityContent {
-            FeatureLauncherApp(startDestination = destination)
+            FeatureLauncherApp()
         }
     }
 
     companion object {
-        private const val EXTRA_DESTINATION = "destination"
-        private const val DESTINATION_ONBOARDING = NAVIGATION_ROUTE_ONBOARDING
-        private const val DESTINATION_SETUP_ACCOUNT = NAVIGATION_ROUTE_ACCOUNT_SETUP
-
         @JvmStatic
         fun launchOnboarding(context: Activity) {
             val intent = Intent(context, FeatureLauncherActivity::class.java).apply {
-                putExtra(EXTRA_DESTINATION, DESTINATION_ONBOARDING)
+                data = DEEPLINK_ONBOARDING.toUri()
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             }
             context.startActivity(intent)
@@ -41,7 +36,7 @@ class FeatureLauncherActivity : ComponentActivity() {
         @JvmStatic
         fun launchSetupAccount(context: Activity) {
             val intent = Intent(context, FeatureLauncherActivity::class.java).apply {
-                putExtra(EXTRA_DESTINATION, DESTINATION_SETUP_ACCOUNT)
+                data = DEEPLINK_ACCOUNT_SETUP.toUri()
             }
             context.startActivity(intent)
         }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
@@ -15,7 +15,6 @@ import org.koin.compose.koinInject
 @Composable
 fun FeatureLauncherNavHost(
     navController: NavHostController,
-    startDestination: String?,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
     importSettingsLauncher: ImportSettingsLauncher = koinInject(),
@@ -23,7 +22,7 @@ fun FeatureLauncherNavHost(
 ) {
     NavHost(
         navController = navController,
-        startDestination = startDestination ?: NAVIGATION_ROUTE_ONBOARDING,
+        startDestination = NAVIGATION_ROUTE_ONBOARDING,
         modifier = modifier,
     ) {
         onboardingRoute(

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/ui/FeatureLauncherApp.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/ui/FeatureLauncherApp.kt
@@ -12,7 +12,6 @@ import app.k9mail.feature.launcher.navigation.FeatureLauncherNavHost
 
 @Composable
 fun FeatureLauncherApp(
-    startDestination: String?,
     modifier: Modifier = Modifier,
 ) {
     val navController = rememberNavController()
@@ -28,7 +27,6 @@ fun FeatureLauncherApp(
 
             FeatureLauncherNavHost(
                 navController = navController,
-                startDestination = startDestination,
                 onBack = { activity.finish() },
             )
         }

--- a/feature/onboarding/src/main/kotlin/app/k9mail/feature/onboarding/navigation/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/kotlin/app/k9mail/feature/onboarding/navigation/OnboardingNavigation.kt
@@ -4,9 +4,11 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import app.k9mail.feature.onboarding.ui.OnboardingScreen
 
 const val NAVIGATION_ROUTE_ONBOARDING = "/onboarding"
+const val DEEPLINK_ONBOARDING = "app://$NAVIGATION_ROUTE_ONBOARDING"
 
 fun NavController.navigateToOnboarding(
     navOptions: NavOptions? = null,
@@ -18,7 +20,12 @@ fun NavGraphBuilder.onboardingRoute(
     onStart: () -> Unit,
     onImport: () -> Unit,
 ) {
-    composable(route = NAVIGATION_ROUTE_ONBOARDING) {
+    composable(
+        route = NAVIGATION_ROUTE_ONBOARDING,
+        deepLinks = listOf(
+            navDeepLink { uriPattern = DEEPLINK_ONBOARDING },
+        ),
+    ) {
         OnboardingScreen(
             onStartClick = onStart,
             onImportClick = onImport,

--- a/feature/onboarding/src/main/kotlin/app/k9mail/feature/onboarding/navigation/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/kotlin/app/k9mail/feature/onboarding/navigation/OnboardingNavigation.kt
@@ -3,12 +3,10 @@ package app.k9mail.feature.onboarding.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.compose.composable
-import androidx.navigation.navDeepLink
+import app.k9mail.core.ui.compose.common.navigation.deepLinkComposable
 import app.k9mail.feature.onboarding.ui.OnboardingScreen
 
 const val NAVIGATION_ROUTE_ONBOARDING = "/onboarding"
-const val DEEPLINK_ONBOARDING = "app://$NAVIGATION_ROUTE_ONBOARDING"
 
 fun NavController.navigateToOnboarding(
     navOptions: NavOptions? = null,
@@ -20,12 +18,7 @@ fun NavGraphBuilder.onboardingRoute(
     onStart: () -> Unit,
     onImport: () -> Unit,
 ) {
-    composable(
-        route = NAVIGATION_ROUTE_ONBOARDING,
-        deepLinks = listOf(
-            navDeepLink { uriPattern = DEEPLINK_ONBOARDING },
-        ),
-    ) {
+    deepLinkComposable(route = NAVIGATION_ROUTE_ONBOARDING) {
         OnboardingScreen(
             onStartClick = onStart,
             onImportClick = onImport,


### PR DESCRIPTION
Use deep links for navigation instead of dynamically setting the start destination.

This way the navigation library will handle extracting arguments from the Intent's `data` property instead of us having to fetch them manually, then pass the arguments along (see https://github.com/thundernest/k-9/pull/7182/commits/b24d284f51df18a6176e183b09a8a291e972e11c#diff-8e45623ed780e40d9a9cf52f612d43890b66fe3d4382b761732f0e2fa8de2bafR24-R30).