### PR TITLE
Add support for one-time (initialization) events

### DIFF
--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/mvi/BaseViewModel.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/mvi/BaseViewModel.kt
@@ -35,6 +35,8 @@ abstract class BaseViewModel<STATE, EVENT, EFFECT>(
     private val _effect = MutableSharedFlow<EFFECT>()
     override val effect: SharedFlow<EFFECT> = _effect.asSharedFlow()
 
+    private val handledOneTimeEvents = mutableSetOf<EVENT>()
+
     /**
      * Updates the [STATE] of the ViewModel.
      *
@@ -52,6 +54,22 @@ abstract class BaseViewModel<STATE, EVENT, EFFECT>(
     protected fun emitEffect(effect: EFFECT) {
         viewModelScope.launch {
             _effect.emit(effect)
+        }
+    }
+
+    /**
+     * Ensures that one-time events are only handled once.
+     *
+     * When you can't ensure that an event is only sent once, but you want the event to only be handled once, call this
+     * method. It will ensure [block] is only executed the first time this function is called. Subsequent calls with an
+     * [event] argument equal to that of a previous invocation will not execute [block].
+     *
+     * Multiple one-time events are supported.
+     */
+    protected fun handleOneTimeEvent(event: EVENT, block: () -> Unit) {
+        if (event !in handledOneTimeEvents) {
+            handledOneTimeEvents.add(event)
+            block()
         }
     }
 }

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/save/BaseSaveServerSettingsViewModel.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/save/BaseSaveServerSettingsViewModel.kt
@@ -24,7 +24,7 @@ abstract class BaseSaveServerSettingsViewModel(
 
     override fun event(event: Event) {
         when (event) {
-            Event.SaveServerSettings -> onSaveServerSettings()
+            Event.SaveServerSettings -> handleOneTimeEvent(event, ::onSaveServerSettings)
             Event.OnNextClicked -> navigateNext()
             Event.OnBackClicked -> navigateBack()
         }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModel.kt
@@ -23,7 +23,7 @@ open class IncomingServerSettingsViewModel(
     @Suppress("CyclomaticComplexMethod")
     override fun event(event: Event) {
         when (event) {
-            Event.LoadAccountState -> loadAccountState()
+            Event.LoadAccountState -> handleOneTimeEvent(event, ::loadAccountState)
 
             is Event.ProtocolTypeChanged -> updateProtocolType(event.protocolType)
             is Event.ServerChanged -> updateState { it.copy(server = it.server.updateValue(event.server)) }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModel.kt
@@ -21,7 +21,7 @@ open class OutgoingServerSettingsViewModel(
 
     override fun event(event: Event) {
         when (event) {
-            Event.LoadAccountState -> loadAccountState()
+            Event.LoadAccountState -> handleOneTimeEvent(event, ::loadAccountState)
 
             is Event.ServerChanged -> updateState { it.copy(server = it.server.updateValue(event.server)) }
             is Event.SecurityChanged -> updateSecurity(event.security)

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/BaseServerValidationViewModel.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/BaseServerValidationViewModel.kt
@@ -37,7 +37,7 @@ abstract class BaseServerValidationViewModel(
 
     override fun event(event: Event) {
         when (event) {
-            Event.LoadAccountStateAndValidate -> loadAccountStateAndValidate()
+            Event.LoadAccountStateAndValidate -> handleOneTimeEvent(event, ::loadAccountStateAndValidate)
             is Event.OnOAuthResult -> onOAuthResult(event.result)
             Event.ValidateServerSettings -> onValidateConfig()
             Event.OnNextClicked -> navigateNext()

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsViewModel.kt
@@ -20,7 +20,7 @@ internal class AccountOptionsViewModel(
 
     override fun event(event: Event) {
         when (event) {
-            Event.LoadAccountState -> loadAccountState()
+            Event.LoadAccountState -> handleOneTimeEvent(event, ::loadAccountState)
 
             is Event.OnAccountNameChanged -> updateState { state ->
                 state.copy(


### PR DESCRIPTION
Add infrastructure to `BaseViewModel` to handle one-time events, i.e. events that should only trigger an action the first time the event is received; subsequent events are ignored.

Fixes #7291