### PR TITLE
Update Detekt

### DIFF
--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/atom/CatalogAtomContent.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/ui/atom/CatalogAtomContent.kt
@@ -2,7 +2,7 @@ package app.k9mail.ui.catalog.ui.atom
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
 import app.k9mail.ui.catalog.ui.atom.CatalogAtomPage.BUTTON
@@ -46,7 +46,7 @@ fun CatalogContent(
     }
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun CatalogContentK9ThemePreview() {
     K9Theme {
@@ -57,7 +57,7 @@ internal fun CatalogContentK9ThemePreview() {
     }
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun CatalogContentThunderbirdThemePreview() {
     ThunderbirdTheme {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -664,8 +664,6 @@ style:
     active: true
   OptionalUnit:
     active: true
-  OptionalWhenBraces:
-    active: false
   PreferToOverPairSyntax:
     active: true
   ProtectedMemberInFinalClass:
@@ -811,7 +809,7 @@ Compose:
     active: true
   ComposableParamOrder:
     active: true
-  PreviewNaming:
+  PreviewAnnotationNaming:
     active: true
   PreviewPublic:
     active: true

--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/PreviewDevices.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/PreviewDevices.kt
@@ -13,4 +13,4 @@ import androidx.compose.ui.tooling.preview.Preview
 @Preview(name = "Foldable", device = Devices.FOLDABLE)
 @Preview(name = "Tablet", device = Devices.TABLET)
 @Preview(name = "Desktop", device = Devices.DESKTOP)
-annotation class DevicePreviews
+annotation class PreviewDevices

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContent.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContent.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.common.window.WindowSizeClass
 import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
@@ -114,7 +114,7 @@ private fun ExpandedContent(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun ResponsiveContentPreview() {
     K9Theme {
         Surface {

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContentWithBrackground.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContentWithBrackground.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.Background
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme.K9Theme
@@ -31,7 +31,7 @@ fun ResponsiveContentWithBackground(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun ResponsiveContentWithBackgroundPreview() {
     K9Theme {
         ResponsiveContentWithBackground {

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveWidthContainer.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveWidthContainer.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.common.window.WindowSizeClass
 import app.k9mail.core.ui.compose.common.window.WindowSizeClass.Compact
 import app.k9mail.core.ui.compose.common.window.WindowSizeClass.Expanded
@@ -69,7 +69,7 @@ fun ResponsiveWidthContainer(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun ResponsiveWidthContainerK9Preview() {
     K9Theme {
         Background {
@@ -86,7 +86,7 @@ internal fun ResponsiveWidthContainerK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun ResponsiveWidthContainerThunderbirdPreview() {
     K9Theme {
         Background {

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/Scaffold.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/Scaffold.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -88,7 +88,7 @@ private fun ScaffoldFabPosition.toMaterialFabPosition(): MaterialFabPosition {
 private const val DRAWER_TOGGLE_DELAY = 250L
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun ScaffoldPreview() {
     K9Theme {
         Scaffold(

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBar.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBar.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.organism.TopAppBar
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.PreviewWithThemes
@@ -28,7 +28,7 @@ fun AccountTopAppBar(
     )
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun AccountTopAppBarPreview() {
     PreviewWithThemes {

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBarWithBackButton.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBarWithBackButton.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonIcon
 import app.k9mail.core.ui.compose.designsystem.organism.TopAppBar
 import app.k9mail.core.ui.compose.theme.Icons
@@ -37,7 +37,7 @@ fun AccountTopAppBarWithBackButton(
     )
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun AccountTopAppBarWithBackButtonPreview() {
     PreviewWithThemes {

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/WizardNavigationBar.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/WizardNavigationBar.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.button.Button
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonOutlined
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
@@ -69,7 +69,7 @@ private fun getHorizontalArrangement(state: WizardNavigationBarState): Arrangeme
     }
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun WizardNavigationBarK9Preview() {
     K9Theme {
@@ -80,7 +80,7 @@ internal fun WizardNavigationBarK9Preview() {
     }
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun WizardNavigationBarPreview() {
     PreviewWithThemes {
@@ -91,7 +91,7 @@ internal fun WizardNavigationBarPreview() {
     }
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun WizardNavigationBarDisabledPreview() {
     PreviewWithThemes {
@@ -106,7 +106,7 @@ internal fun WizardNavigationBarDisabledPreview() {
     }
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun WizardNavigationBarHideNextPreview() {
     PreviewWithThemes {
@@ -120,7 +120,7 @@ internal fun WizardNavigationBarHideNextPreview() {
     }
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun WizardNavigationBarHideBackPreview() {
     PreviewWithThemes {

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthContent.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthContent.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.molecule.ErrorView
 import app.k9mail.core.ui.compose.designsystem.molecule.LoadingView
 import app.k9mail.core.ui.compose.theme.K9Theme
@@ -53,7 +53,7 @@ internal fun AccountOAuthContent(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountOAuthContentK9Preview() {
     K9Theme {
         AccountOAuthContent(
@@ -64,7 +64,7 @@ internal fun AccountOAuthContentK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountOAuthContentThunderbirdPreview() {
     ThunderbirdTheme {
         AccountOAuthContent(

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInView.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInView.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.button.Button
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextCaption
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -42,7 +42,7 @@ internal fun SignInView(
     }
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun SignInViewPreview() {
     SignInView(
@@ -51,7 +51,7 @@ internal fun SignInViewPreview() {
     )
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun SignInViewWithGooglePreview() {
     SignInView(

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.theme.PreviewWithThemes
 import app.k9mail.feature.account.oauth.R
 
@@ -66,7 +66,6 @@ fun SignInWithGoogleButton(
                 .padding(
                     end = 8.dp,
                 ),
-
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Surface(
@@ -126,7 +125,7 @@ private fun getTextColor(isLight: Boolean): Color {
     }
 }
 
-@DevicePreviews
+@PreviewDevices
 @Composable
 internal fun SignInWithGoogleButtonPreview() {
     PreviewWithThemes {

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreen.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.common.baseline.withBaseline
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.atom.Icon
@@ -127,7 +127,7 @@ fun ServerCertificateErrorScreen(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun ServerCertificateErrorScreenK9Preview() {
     val inputStream = """
         -----BEGIN CERTIFICATE-----

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -57,7 +57,7 @@ internal fun IncomingServerSettingsContent(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun IncomingServerSettingsContentK9Preview() {
     K9Theme {
         IncomingServerSettingsContent(
@@ -70,7 +70,7 @@ internal fun IncomingServerSettingsContentK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun IncomingServerSettingsContentThunderbirdPreview() {
     ThunderbirdTheme {
         IncomingServerSettingsContent(

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.core.ui.compose.theme.K9Theme
@@ -73,7 +73,7 @@ fun IncomingServerSettingsScreen(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun IncomingServerSettingsScreenK9Preview() {
     K9Theme {
         IncomingServerSettingsScreen(
@@ -89,7 +89,7 @@ internal fun IncomingServerSettingsScreenK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun IncomingServerSettingsScreenThunderbirdPreview() {
     ThunderbirdTheme {
         IncomingServerSettingsScreen(

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -54,7 +54,7 @@ internal fun OutgoingServerSettingsContent(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun OutgoingServerSettingsContentK9Preview() {
     K9Theme {
         OutgoingServerSettingsContent(
@@ -66,7 +66,7 @@ internal fun OutgoingServerSettingsContentK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun OutgoingServerSettingsContentThunderbirdPreview() {
     ThunderbirdTheme {
         OutgoingServerSettingsContent(

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreen.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.core.ui.compose.theme.K9Theme
@@ -72,7 +72,7 @@ fun OutgoingServerSettingsScreen(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun OutgoingServerSettingsScreenK9Preview() {
     K9Theme {
         OutgoingServerSettingsScreen(
@@ -88,7 +88,7 @@ internal fun OutgoingServerSettingsScreenK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun OutgoingServerSettingsScreenThunderbirdPreview() {
     ThunderbirdTheme {
         OutgoingServerSettingsScreen(

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationContent.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationContent.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextSubtitle1
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme.MainTheme
@@ -123,7 +123,7 @@ internal fun ServerValidationContent(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun IncomingServerValidationContentPreview() {
     PreviewWithThemes {
         ServerValidationContent(
@@ -137,7 +137,7 @@ internal fun IncomingServerValidationContentPreview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun OutgoingServerValidationContentPreview() {
     PreviewWithThemes {
         ServerValidationContent(

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationContent.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationContent.kt
@@ -31,7 +31,7 @@ import app.k9mail.feature.account.server.validation.R
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Event
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.State
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "ViewModelForwarding")
 @Composable
 internal fun ServerValidationContent(
     state: State,

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreen.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.account.server.validation.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.common.mvi.observeWithoutEffect
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.core.ui.compose.theme.K9Theme
@@ -49,7 +49,7 @@ internal fun ServerValidationMainScreen(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun IncomingServerValidationScreenK9Preview() {
     K9Theme {
         ServerValidationMainScreen(
@@ -61,7 +61,7 @@ internal fun IncomingServerValidationScreenK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun IncomingServerValidationScreenThunderbirdPreview() {
     ThunderbirdTheme {
         ServerValidationMainScreen(
@@ -73,7 +73,7 @@ internal fun IncomingServerValidationScreenThunderbirdPreview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountOutgoingValidationScreenK9Preview() {
     K9Theme {
         ServerValidationMainScreen(
@@ -85,7 +85,7 @@ internal fun AccountOutgoingValidationScreenK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountOutgoingValidationScreenThunderbirdPreview() {
     ThunderbirdTheme {
         ServerValidationMainScreen(

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
@@ -10,6 +10,7 @@ import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Event
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.ViewModel
 
+@Suppress("ViewModelForwarding")
 @Composable
 fun ServerValidationScreen(
     onNext: () -> Unit,

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/AccountSetupScreen.kt
@@ -25,7 +25,7 @@ import app.k9mail.feature.account.setup.ui.options.AccountOptionsScreen
 import app.k9mail.feature.account.setup.ui.options.AccountOptionsViewModel
 import org.koin.androidx.compose.koinViewModel
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "ViewModelForwarding")
 @Composable
 fun AccountSetupScreen(
     onFinish: (String) -> Unit,

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.molecule.ContentLoadingErrorView
 import app.k9mail.core.ui.compose.designsystem.molecule.ErrorView
 import app.k9mail.core.ui.compose.designsystem.molecule.LoadingView
@@ -80,7 +80,7 @@ internal fun AccountAutoDiscoveryContent(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountAutoDiscoveryContentK9Preview() {
     K9Theme {
         AccountAutoDiscoveryContent(
@@ -93,7 +93,7 @@ internal fun AccountAutoDiscoveryContentK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountAutoDiscoveryContentThunderbirdPreview() {
     ThunderbirdTheme {
         AccountAutoDiscoveryContent(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import app.k9mail.autodiscovery.api.AutoDiscoveryResult
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.core.ui.compose.theme.K9Theme
@@ -63,7 +63,7 @@ internal fun AccountAutoDiscoveryScreen(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountAutoDiscoveryScreenK9Preview() {
     K9Theme {
         AccountAutoDiscoveryScreen(
@@ -80,7 +80,7 @@ internal fun AccountAutoDiscoveryScreenK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountAutoDiscoveryScreenThunderbirdPreview() {
     ThunderbirdTheme {
         AccountAutoDiscoveryScreen(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsContent.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextOverline
 import app.k9mail.core.ui.compose.designsystem.molecule.input.SelectInput
 import app.k9mail.core.ui.compose.designsystem.molecule.input.SwitchInput
@@ -148,7 +148,7 @@ internal fun AccountOptionsContent(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountOptionsContentK9Preview() {
     K9Theme {
         AccountOptionsContent(
@@ -160,7 +160,7 @@ internal fun AccountOptionsContentK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountOptionsContentThunderbirdPreview() {
     ThunderbirdTheme {
         AccountOptionsContent(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/AccountOptionsScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.core.ui.compose.theme.K9Theme
@@ -64,7 +64,7 @@ internal fun AccountOptionsScreen(
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountOptionsScreenK9Preview() {
     K9Theme {
         AccountOptionsScreen(
@@ -79,7 +79,7 @@ internal fun AccountOptionsScreenK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun AccountOptionsScreenThunderbirdPreview() {
     ThunderbirdTheme {
         AccountOptionsScreen(

--- a/feature/onboarding/src/main/kotlin/app/k9mail/feature/onboarding/ui/OnboardingContent.kt
+++ b/feature/onboarding/src/main/kotlin/app/k9mail/feature/onboarding/ui/OnboardingContent.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.DevicePreviews
+import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.Background
 import app.k9mail.core.ui.compose.designsystem.atom.button.Button
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
@@ -143,7 +143,7 @@ private fun Modifier.defaultItemModifier() = composed {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun OnboardingContentK9Preview() {
     K9Theme {
         OnboardingContent(
@@ -154,7 +154,7 @@ internal fun OnboardingContentK9Preview() {
 }
 
 @Composable
-@DevicePreviews
+@PreviewDevices
 internal fun OnboardingContentThunderbirdPreview() {
     ThunderbirdTheme {
         OnboardingContent(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 spotless = "com.diffplug.spotless:6.22.0"
-detekt = "io.gitlab.arturbosch.detekt:1.23.0"
+detekt = "io.gitlab.arturbosch.detekt:1.23.2"
 dependency-check = "com.github.ben-manes.versions:0.48.0"
 
 [libraries]
@@ -155,7 +155,7 @@ assertk = "com.willowtreeapps.assertk:assertk-jvm:0.27.0"
 
 leakcanary-android = "com.squareup.leakcanary:leakcanary-android:2.9.1"
 
-detekt-plugin-compose = "io.nlopez.compose.rules:detekt:0.1.11"
+detekt-plugin-compose = "io.nlopez.compose.rules:detekt:0.3.2"
 
 [bundles]
 shared-jvm-main = [


### PR DESCRIPTION
This updates Detekt 1.23.0 -> 1.23.3 and Detekt Compose Rules 0.1.11 -> 0.3.2.

`DevicePreviews` have been renamed to `PreviewDevices` to follow Google's naming convention for `@Preview` annotations.
