### PR TITLE
Add enabled state to `AccountOAuthView`

### DIFF
--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthContent.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthContent.kt
@@ -24,6 +24,7 @@ internal fun AccountOAuthContent(
     state: State,
     onEvent: (Event) -> Unit,
     modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
 ) {
     val resources = LocalContext.current.resources
 
@@ -47,6 +48,7 @@ internal fun AccountOAuthContent(
             SignInView(
                 onSignInClick = { onEvent(Event.SignInClicked) },
                 isGoogleSignIn = state.isGoogleSignIn,
+                isEnabled = isEnabled,
             )
         }
     }

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthView.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthView.kt
@@ -15,6 +15,7 @@ fun AccountOAuthView(
     onOAuthResult: (OAuthResult) -> Unit,
     viewModel: ViewModel,
     modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
 ) {
     val oAuthLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
@@ -34,5 +35,6 @@ fun AccountOAuthView(
         state = state.value,
         onEvent = { dispatch(it) },
         modifier = modifier,
+        isEnabled = isEnabled,
     )
 }

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInView.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInView.kt
@@ -18,6 +18,7 @@ internal fun SignInView(
     onSignInClick: () -> Unit,
     isGoogleSignIn: Boolean,
     modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -32,11 +33,13 @@ internal fun SignInView(
         if (isGoogleSignIn) {
             SignInWithGoogleButton(
                 onClick = onSignInClick,
+                enabled = isEnabled,
             )
         } else {
             Button(
                 text = stringResource(id = R.string.account_oauth_sign_in_button),
                 onClick = onSignInClick,
+                enabled = isEnabled,
             )
         }
     }

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
@@ -40,6 +40,7 @@ import app.k9mail.feature.account.oauth.R
 fun SignInWithGoogleButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     isLight: Boolean = MaterialTheme.colors.isLight,
 ) {
     OutlinedButton(
@@ -54,6 +55,7 @@ fun SignInWithGoogleButton(
             color = getBorderColor(isLight),
         ),
         contentPadding = PaddingValues(all = 0.dp),
+        enabled = enabled,
     ) {
         Row(
             modifier = Modifier

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -24,11 +23,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.k9mail.core.ui.compose.common.PreviewDevices
 import app.k9mail.core.ui.compose.theme.PreviewWithThemes
 import app.k9mail.feature.account.oauth.R
+import androidx.compose.material.Button as MaterialButton
 
 /**
  * A sign in with Google button, following the Google Branding Guidelines.
@@ -43,10 +43,10 @@ fun SignInWithGoogleButton(
     enabled: Boolean = true,
     isLight: Boolean = MaterialTheme.colors.isLight,
 ) {
-    OutlinedButton(
+    MaterialButton(
         onClick = onClick,
         modifier = modifier,
-        colors = ButtonDefaults.outlinedButtonColors(
+        colors = ButtonDefaults.buttonColors(
             contentColor = getTextColor(isLight),
             backgroundColor = getSurfaceColor(isLight),
         ),
@@ -90,7 +90,6 @@ fun SignInWithGoogleButton(
                     id = R.string.account_oauth_sign_in_with_google_button,
                 ),
                 style = TextStyle(
-                    color = getTextColor(isLight),
                     fontWeight = FontWeight.Medium,
                     fontSize = 14.sp,
                     letterSpacing = 1.25.sp,
@@ -127,12 +126,23 @@ private fun getTextColor(isLight: Boolean): Color {
     }
 }
 
-@PreviewDevices
+@Preview(showBackground = true)
 @Composable
 internal fun SignInWithGoogleButtonPreview() {
     PreviewWithThemes {
         SignInWithGoogleButton(
             onClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun SignInWithGoogleButtonDisabledPreview() {
+    PreviewWithThemes {
+        SignInWithGoogleButton(
+            onClick = {},
+            enabled = false,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/item/ContentItems.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/item/ContentItems.kt
@@ -49,9 +49,13 @@ internal fun LazyListScope.contentItems(
     } else if (state.configStep == ConfigStep.OAUTH) {
         item(key = "oauth") {
             ListItem {
+                val isAutoDiscoverySettingsTrusted = state.autoDiscoverySettings?.isTrusted ?: false
+                val isConfigurationApproved = state.configurationApproved.value ?: false
+
                 AccountOAuthView(
                     onOAuthResult = { result -> onEvent(Event.OnOAuthResult(result)) },
                     viewModel = oAuthViewModel,
+                    isEnabled = isAutoDiscoverySettingsTrusted || isConfigurationApproved,
                 )
             }
         }


### PR DESCRIPTION
This adds enabled state to `AccountOAuthView` used by AutoDisccovery to disable the sign in button in case configuration is not trusted.

This also adds visual disabled state to `SignInWithGoogleButton`:

Before:

![old_disabled_state](https://github.com/thunderbird/thunderbird-android/assets/2285235/3cb8532b-7b7e-40aa-a908-a57636976b09)

After:

![new_disabled_state](https://github.com/thunderbird/thunderbird-android/assets/2285235/0af127e5-14d0-4df4-8ddd-c53e8082c494)

