### PR TITLE
Allow placeholders in Autoconfig `domain` elements

### DIFF
--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/RealAutoconfigParser.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/RealAutoconfigParser.kt
@@ -112,7 +112,7 @@ private class ClientConfigParser(
             if (eventType == XmlPullParser.START_TAG) {
                 when (pullParser.name) {
                     "domain" -> {
-                        val domain = readText()
+                        val domain = readText().replaceVariables()
                         if (domain.isValidHostname()) {
                             domainFound = true
                         }

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/RealAutoconfigParserTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/RealAutoconfigParserTest.kt
@@ -112,6 +112,7 @@ class RealAutoconfigParserTest {
     @Test
     fun `replace variables`() {
         val inputStream = minimalConfig.withModifications {
+            element("domain").text("%EMAILDOMAIN%")
             element("incomingServer > hostname").text("%EMAILLOCALPART%.domain.example")
             element("outgoingServer > hostname").text("%EMAILLOCALPART%.outgoing.domain.example")
             element("outgoingServer > username").text("%EMAILDOMAIN%")


### PR DESCRIPTION
We implemented the domain check so K-9 Mail wouldn't allow a config that Thunderbird rejected. It turns out Thunderbird is fine with placeholders in the domain element and K-9 Mail is not.

Config that causes the issue:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<clientConfig version="1.1">
  <emailProvider id="irrelevant">
    <domain>%EMAILDOMAIN%</domain>
    <!-- … -->
  </emailProvider>
</clientConfig>
```

This bug was reported in the support forum: https://forum.k9mail.app/t/autodiscover-autoconfig/7118/7