### PR TITLE
Add "After marking a message as unread" navigation setting

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -185,6 +185,9 @@ object K9 : EarlyInit {
 
     var messageViewPostRemoveNavigation: PostRemoveNavigation = PostRemoveNavigation.ReturnToMessageList
 
+    var messageViewPostMarkAsUnreadNavigation: PostMarkAsUnreadNavigation =
+        PostMarkAsUnreadNavigation.ReturnToMessageList
+
     @JvmStatic
     var isUseVolumeKeysForNavigation = false
 
@@ -329,6 +332,8 @@ object K9 : EarlyInit {
         isUseMessageViewFixedWidthFont = storage.getBoolean("messageViewFixedWidthFont", false)
         messageViewPostRemoveNavigation =
             storage.getEnum("messageViewPostDeleteAction", PostRemoveNavigation.ReturnToMessageList)
+        messageViewPostMarkAsUnreadNavigation =
+            storage.getEnum("messageViewPostMarkAsUnreadAction", PostMarkAsUnreadNavigation.ReturnToMessageList)
         isHideUserAgent = storage.getBoolean("hideUserAgent", false)
         isHideTimeZone = storage.getBoolean("hideTimeZone", false)
 
@@ -402,6 +407,7 @@ object K9 : EarlyInit {
         editor.putInt("registeredNameColor", contactNameColor)
         editor.putBoolean("messageViewFixedWidthFont", isUseMessageViewFixedWidthFont)
         editor.putEnum("messageViewPostDeleteAction", messageViewPostRemoveNavigation)
+        editor.putEnum("messageViewPostMarkAsUnreadAction", messageViewPostMarkAsUnreadNavigation)
         editor.putBoolean("hideUserAgent", isHideUserAgent)
         editor.putBoolean("hideTimeZone", isHideTimeZone)
 
@@ -539,5 +545,14 @@ object K9 : EarlyInit {
         ReturnToMessageList,
         ShowPreviousMessage,
         ShowNextMessage,
+    }
+
+    /**
+     * The navigation actions that can be to performed after the user has marked a message as unread from the message
+     * view screen.
+     */
+    enum class PostMarkAsUnreadNavigation {
+        StayOnCurrentMessage,
+        ReturnToMessageList,
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -17,6 +17,7 @@ import com.fsck.k9.FontSizes;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.BACKGROUND_OPS;
 import com.fsck.k9.K9.NotificationQuickDelete;
+import com.fsck.k9.K9.PostMarkAsUnreadNavigation;
 import com.fsck.k9.K9.PostRemoveNavigation;
 import com.fsck.k9.K9.SplitViewMode;
 import com.fsck.k9.SwipeAction;
@@ -291,6 +292,10 @@ public class GeneralSettingsDescriptions {
         ));
         s.put("messageViewPostDeleteAction", Settings.versions(
             new V(89, new EnumSetting<>(PostRemoveNavigation.class, PostRemoveNavigation.ReturnToMessageList))
+        ));
+        s.put("messageViewPostMarkAsUnreadAction", Settings.versions(
+            new V(90,
+                new EnumSetting<>(PostMarkAsUnreadNavigation.class, PostMarkAsUnreadNavigation.ReturnToMessageList))
         ));
 
         SETTINGS = Collections.unmodifiableMap(s);

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 89;
+    public static final int VERSION = 90;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/core/src/main/res/values/arrays_general_settings_values.xml
+++ b/app/core/src/main/res/values/arrays_general_settings_values.xml
@@ -227,4 +227,9 @@
         <item>ShowNextMessage</item>
     </string-array>
 
+    <string-array name="post_mark_as_unread_navigation_values" translatable="false">
+        <item>StayOnCurrentMessage</item>
+        <item>ReturnToMessageList</item>
+    </string-array>
+
 </resources>

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -31,6 +31,7 @@ import app.k9mail.core.android.common.contact.ContactRepository
 import app.k9mail.feature.launcher.FeatureLauncherActivity
 import com.fsck.k9.Account
 import com.fsck.k9.K9
+import com.fsck.k9.K9.PostMarkAsUnreadNavigation
 import com.fsck.k9.K9.PostRemoveNavigation
 import com.fsck.k9.K9.SplitViewMode
 import com.fsck.k9.Preferences
@@ -1134,6 +1135,13 @@ open class MessageList :
             PostRemoveNavigation.ReturnToMessageList -> returnToMessageList()
             PostRemoveNavigation.ShowPreviousMessage -> showPreviousMessageOrReturn()
             PostRemoveNavigation.ShowNextMessage -> showNextMessageOrReturn()
+        }
+    }
+
+    override fun performNavigationAfterMarkAsUnread() {
+        when (K9.messageViewPostMarkAsUnreadNavigation) {
+            PostMarkAsUnreadNavigation.StayOnCurrentMessage -> Unit
+            PostMarkAsUnreadNavigation.ReturnToMessageList -> returnToMessageList()
         }
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -642,7 +642,14 @@ class MessageViewFragment :
     }
 
     fun onToggleRead() {
+        val message = checkNotNull(this.message)
+        val isMarkAsUnreadAction = message.isSet(Flag.SEEN)
+
         toggleFlag(Flag.SEEN)
+
+        if (isMarkAsUnreadAction) {
+            fragmentListener.performNavigationAfterMarkAsUnread()
+        }
     }
 
     fun onToggleFlagged() {
@@ -864,6 +871,7 @@ class MessageViewFragment :
         fun onReply(messageReference: MessageReference, decryptionResultForReply: Parcelable?)
         fun setProgress(enable: Boolean)
         fun performNavigationAfterMessageRemoval()
+        fun performNavigationAfterMarkAsUnread()
     }
 
     private val messageLoaderCallbacks: MessageLoaderCallbacks = object : MessageLoaderCallbacks {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -2,6 +2,7 @@ package com.fsck.k9.ui.settings.general
 
 import androidx.preference.PreferenceDataStore
 import com.fsck.k9.K9
+import com.fsck.k9.K9.PostMarkAsUnreadNavigation
 import com.fsck.k9.K9.PostRemoveNavigation
 import com.fsck.k9.SwipeAction
 import com.fsck.k9.UiDensity
@@ -124,6 +125,7 @@ class GeneralSettingsDataStore(
             "swipe_action_left" -> swipeActionToString(K9.swipeLeftAction)
             "message_list_density" -> K9.messageListDensity.toString()
             "post_remove_navigation" -> K9.messageViewPostRemoveNavigation.name
+            "post_mark_as_unread_navigation" -> K9.messageViewPostMarkAsUnreadNavigation.name
             else -> defValue
         }
     }
@@ -161,6 +163,9 @@ class GeneralSettingsDataStore(
             "swipe_action_left" -> K9.swipeLeftAction = stringToSwipeAction(value)
             "message_list_density" -> K9.messageListDensity = UiDensity.valueOf(value)
             "post_remove_navigation" -> K9.messageViewPostRemoveNavigation = PostRemoveNavigation.valueOf(value)
+            "post_mark_as_unread_navigation" -> {
+                K9.messageViewPostMarkAsUnreadNavigation = PostMarkAsUnreadNavigation.valueOf(value)
+            }
             else -> return
         }
 

--- a/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
+++ b/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
@@ -180,4 +180,9 @@
         <item>@string/general_settings_post_remove_action_show_next_message</item>
     </string-array>
 
+    <string-array name="post_mark_as_unread_navigation_entries">
+        <item>@string/general_settings_post_mark_as_unread_action_stay</item>
+        <item>@string/general_settings_post_mark_as_unread_action_return_to_list</item>
+    </string-array>
+
 </resources>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -272,6 +272,11 @@
     <string name="general_settings_post_remove_action_show_previous_message">Show previous message</string>
     <string name="general_settings_post_remove_action_show_next_message">Show next message</string>
 
+    <!-- Name of the setting to configure the navigation action to perform after the user has marked a message as unread from the message view screen -->
+    <string name="general_settings_post_mark_as_unread_action_title">After marking a message as unread</string>
+    <string name="general_settings_post_mark_as_unread_action_stay">Stay on current message</string>
+    <string name="general_settings_post_mark_as_unread_action_return_to_list">Return to message list</string>
+
     <string name="global_settings_confirm_actions_title">Confirm actions</string>
     <string name="global_settings_confirm_actions_summary">Show a dialog whenever you perform selected actions</string>
     <string name="global_settings_confirm_action_delete">Delete</string>

--- a/app/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/general_settings.xml
@@ -322,6 +322,14 @@
             android:title="@string/general_settings_post_remove_action_title"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            android:dialogTitle="@string/general_settings_post_mark_as_unread_action_title"
+            android:entries="@array/post_mark_as_unread_navigation_entries"
+            android:entryValues="@array/post_mark_as_unread_navigation_values"
+            android:key="post_mark_as_unread_navigation"
+            android:title="@string/general_settings_post_mark_as_unread_action_title"
+            app:useSimpleSummaryProvider="true" />
+
         <MultiSelectListPreference
             android:dialogTitle="@string/global_settings_confirm_actions_title"
             android:entries="@array/confirm_action_entries"

--- a/config/detekt/detekt-baseline-app-core.xml
+++ b/config/detekt/detekt-baseline-app-core.xml
@@ -14,6 +14,7 @@
     <ID>LongMethod:AccountPreferenceSerializer.kt$AccountPreferenceSerializer$@Synchronized fun loadAccount(account: Account, storage: Storage)</ID>
     <ID>LongMethod:AccountPreferenceSerializer.kt$AccountPreferenceSerializer$@Synchronized fun save(editor: StorageEditor, storage: Storage, account: Account)</ID>
     <ID>LongMethod:AccountPreferenceSerializer.kt$AccountPreferenceSerializer$fun loadDefaults(account: Account)</ID>
+    <ID>LongMethod:K9.kt$K9$@JvmStatic fun loadPrefs(storage: Storage)</ID>
     <ID>LongMethod:MessageListRepositoryTest.kt$MessageListRepositoryTest$@Test fun `getThread() should use flag values from the cache`()</ID>
     <ID>LongMethod:NotificationDataStore.kt$NotificationDataStore$@Synchronized fun removeNotifications( account: Account, selector: (List&lt;MessageReference&gt;) -&gt; List&lt;MessageReference&gt;, ): RemoveNotificationsResult?</ID>
     <ID>LongMethod:SettingsExporter.kt$SettingsExporter$private fun writeAccount(serializer: XmlSerializer, account: Account, prefs: Map&lt;String, Any&gt;)</ID>


### PR DESCRIPTION
Adds a setting to configure the navigation action to perform after marking a message as unread from the message view screen.

Available options are:
- Stay on current message
- Return to message list

Previously the behavior was to do nothing. With this change applied, *Return to message list* is the new default behavior.

Closes #7081