### PR TITLE
IMAP: Use MOVE command if available

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
@@ -18,4 +18,5 @@ class Capabilities {
     public static final String SPECIAL_USE = "SPECIAL-USE";
     public static final String UID_PLUS = "UIDPLUS";
     public static final String LIST_EXTENDED = "LIST-EXTENDED";
+    public static final String MOVE = "MOVE";
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
@@ -19,5 +19,6 @@ class Commands {
     public static final String UID_STORE = "UID STORE";
     public static final String UID_FETCH = "UID FETCH";
     public static final String UID_COPY = "UID COPY";
+    public static final String UID_MOVE = "UID MOVE";
     public static final String UID_EXPUNGE = "UID EXPUNGE";
 }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
@@ -300,6 +300,24 @@ class RealImapFolderTest {
     }
 
     @Test
+    fun `moveMessages() with MOVE extension`() {
+        val sourceFolder = createFolder("Folder")
+        prepareImapFolderForOpen(OpenMode.READ_WRITE)
+        imapConnection.stub {
+            on { hasCapability(Capabilities.MOVE) } doReturn true
+        }
+        val destinationFolder = createFolder("Destination")
+        val messages = listOf(createImapMessage("1"))
+        setupMoveResponse("x OK [COPYUID 23 1 101] Success")
+        sourceFolder.open(OpenMode.READ_WRITE)
+
+        val uidMapping = sourceFolder.moveMessages(messages, destinationFolder)
+
+        assertCommandWithIdsIssued("UID MOVE 1 \"Destination\"")
+        assertThat(uidMapping).isNotNull().containsOnly("1" to "101")
+    }
+
+    @Test
     fun moveMessages_shouldCopyMessages() {
         val sourceFolder = createFolder("Folder")
         prepareImapFolderForOpen(OpenMode.READ_WRITE)
@@ -1201,6 +1219,13 @@ class RealImapFolderTest {
     private fun setupCopyResponse(response: String) {
         val imapResponses = listOf(createImapResponse(response))
         whenever(imapConnection.executeCommandWithIdSet(eq(Commands.UID_COPY), anyString(), anySet()))
+            .thenReturn(imapResponses)
+    }
+
+    @Suppress("SameParameterValue")
+    private fun setupMoveResponse(response: String) {
+        val imapResponses = listOf(createImapResponse(response))
+        whenever(imapConnection.executeCommandWithIdSet(eq(Commands.UID_MOVE), anyString(), anySet()))
             .thenReturn(imapResponses)
     }
 


### PR DESCRIPTION
Use the `UID MOVE` command if available. See  [RFC 6851](https://datatracker.ietf.org/doc/html/rfc6851) for the MOVE extension.