### PR TITLE
Don't display password field when autoconfig fails

### DIFF
--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContract.kt
@@ -16,6 +16,7 @@ interface AccountAutoDiscoveryContract {
         EMAIL_ADDRESS,
         OAUTH,
         PASSWORD,
+        MANUAL_SETUP,
     }
 
     interface ViewModel : UnidirectionalViewModel<State, Event, Effect> {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryViewModel.kt
@@ -92,6 +92,7 @@ internal class AccountAutoDiscoveryViewModel(
 
             ConfigStep.PASSWORD -> submitPassword()
             ConfigStep.OAUTH -> Unit
+            ConfigStep.MANUAL_SETUP -> navigateNext(isAutomaticConfig = false)
         }
     }
 
@@ -142,7 +143,7 @@ internal class AccountAutoDiscoveryViewModel(
             it.copy(
                 isLoading = false,
                 autoDiscoverySettings = null,
-                configStep = ConfigStep.PASSWORD,
+                configStep = ConfigStep.MANUAL_SETUP,
             )
         }
     }
@@ -223,6 +224,7 @@ internal class AccountAutoDiscoveryViewModel(
 
             ConfigStep.OAUTH,
             ConfigStep.PASSWORD,
+            ConfigStep.MANUAL_SETUP,
             -> updateState {
                 it.copy(
                     configStep = ConfigStep.EMAIL_ADDRESS,


### PR DESCRIPTION
|Before|After|
|-|-|
|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/353fa46c-ce27-4be9-81d0-44f37402feb2)|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/32c458d1-c637-40df-9b0b-473abe7ff722)|

