### PR TITLE
Run all tests tasks except for `testReleaseUnitTest` on CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,10 +76,12 @@ allprojects {
 }
 
 tasks.register("testsOnCi") {
+    val skipTests = setOf("testReleaseUnitTest")
+
     dependsOn(
         subprojects.map { project -> project.tasks.withType(Test::class.java) }
             .flatten()
-            .filterNot { task -> task.name in arrayOf("testDebugUnitTest", "test") },
+            .filterNot { task -> task.name in skipTests },
     )
 }
 


### PR DESCRIPTION
It looks like the conversion to Kotlin Script changed the logic. This restores to the original behavior.

I noticed this because #7372 broke some tests, but all checks passed on GitHub :see_no_evil: 