### PR TITLE
Use `AuthenticationFailedException` when appropriate

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
@@ -521,14 +521,7 @@ internal class RealImapConnection(
             val command = Commands.AUTHENTICATE_EXTERNAL + " " + Base64.encode(settings.username)
             executeSimpleCommand(command, false)
         } catch (e: NegativeImapResponseException) {
-            /*
-             * Provide notification to the user of a problem authenticating
-             * using client certificates. We don't use an
-             * AuthenticationFailedException because that would trigger a
-             * "Username or password incorrect" notification in
-             * AccountSetupCheckSettings.
-             */
-            throw CertificateValidationException(e.message)
+            throw handleAuthenticationFailure(e)
         }
     }
 

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
@@ -520,11 +520,11 @@ class RealImapConnectionTest {
         }
         val imapConnection = startServerAndCreateImapConnection(server, authType = AuthType.EXTERNAL)
 
-        // FIXME: improve exception message
         assertFailure {
             imapConnection.open()
-        }.isInstanceOf<CertificateValidationException>()
-            .message().isNotNull().contains("Bad certificate")
+        }.isInstanceOf<AuthenticationFailedException>()
+            .prop(AuthenticationFailedException::messageFromServer)
+            .isEqualTo("Bad certificate")
 
         server.verifyConnectionClosed()
         server.verifyInteractionCompleted()

--- a/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
+++ b/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
@@ -312,15 +312,7 @@ class Pop3Connection {
                     String.format("AUTH EXTERNAL %s",
                             Base64.encode(settings.getUsername())), false);
         } catch (Pop3ErrorResponse e) {
-            /*
-             * Provide notification to the user of a problem authenticating
-             * using client certificates. We don't use an
-             * AuthenticationFailedException because that would trigger a
-             * "Username or password incorrect" notification in
-             * AccountSetupCheckSettings.
-             */
-            throw new CertificateValidationException(
-                    "POP3 client certificate authentication failed: " + e.getMessage(), e);
+            throw new AuthenticationFailedException("AUTH EXTERNAL failed", e, e.getResponseText());
         }
     }
 

--- a/mail/protocols/pop3/src/test/java/com/fsck/k9/mail/store/pop3/Pop3ConnectionTest.kt
+++ b/mail/protocols/pop3/src/test/java/com/fsck/k9/mail/store/pop3/Pop3ConnectionTest.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.mail.store.pop3
 
 import assertk.assertFailure
-import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
@@ -319,8 +318,7 @@ class Pop3ConnectionTest {
 
         assertFailure {
             createAndOpenPop3Connection(settings)
-        }.isInstanceOf<CertificateValidationException>()
-            .hasMessage("POP3 client certificate authentication failed: -ERR Invalid certificate")
+        }.isInstanceOf<AuthenticationFailedException>()
 
         server.verifyInteractionCompleted()
     }


### PR DESCRIPTION
`CertificateValidationException` should have never been used for this.