### PR TITLE
Add `MissingCapabilityException`

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/MissingCapabilityException.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/MissingCapabilityException.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.mail
+
+class MissingCapabilityException(
+    val capabilityName: String,
+) : MessagingException("Missing capability: $capabilityName", true)

--- a/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
+++ b/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
@@ -26,16 +26,26 @@ import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.MissingCapabilityException;
 import com.fsck.k9.mail.filter.Base64;
 import com.fsck.k9.mail.filter.Hex;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
 import javax.net.ssl.SSLException;
 
-import static com.fsck.k9.mail.CertificateValidationException.Reason.MissingCapability;
 import static com.fsck.k9.mail.K9MailLib.DEBUG_PROTOCOL_POP3;
 import static com.fsck.k9.mail.NetworkTimeouts.SOCKET_CONNECT_TIMEOUT;
 import static com.fsck.k9.mail.NetworkTimeouts.SOCKET_READ_TIMEOUT;
-import static com.fsck.k9.mail.store.pop3.Pop3Commands.*;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.AUTH_CRAM_MD5_CAPABILITY;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.AUTH_EXTERNAL_CAPABILITY;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.AUTH_PLAIN_CAPABILITY;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.CAPA_COMMAND;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.PASS_COMMAND;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.SASL_CAPABILITY;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.STLS_CAPABILITY;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.STLS_COMMAND;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.TOP_CAPABILITY;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.UIDL_CAPABILITY;
+import static com.fsck.k9.mail.store.pop3.Pop3Commands.USER_COMMAND;
 
 
 class Pop3Connection {
@@ -159,8 +169,7 @@ class Pop3Connection {
             }
             capabilities = getCapabilities();
         } else {
-            throw new CertificateValidationException(
-                    "STARTTLS connection security not available");
+            throw new MissingCapabilityException(STLS_CAPABILITY);
         }
 
     }
@@ -188,8 +197,7 @@ class Pop3Connection {
                 if (capabilities.external) {
                     authExternal();
                 } else {
-                    // Provide notification to user of a problem authenticating using client certificates
-                    throw new CertificateValidationException(MissingCapability);
+                    throw new MissingCapabilityException(SASL_CAPABILITY + " " + AUTH_EXTERNAL_CAPABILITY);
                 }
                 break;
 

--- a/mail/protocols/pop3/src/test/java/com/fsck/k9/mail/store/pop3/Pop3ConnectionTest.kt
+++ b/mail/protocols/pop3/src/test/java/com/fsck/k9/mail/store/pop3/Pop3ConnectionTest.kt
@@ -17,6 +17,7 @@ import com.fsck.k9.mail.ConnectionSecurity.NONE
 import com.fsck.k9.mail.ConnectionSecurity.SSL_TLS_REQUIRED
 import com.fsck.k9.mail.ConnectionSecurity.STARTTLS_REQUIRED
 import com.fsck.k9.mail.MessagingException
+import com.fsck.k9.mail.MissingCapabilityException
 import com.fsck.k9.mail.helpers.TestTrustedSocketFactory
 import com.fsck.k9.mail.ssl.TrustedSocketFactory
 import java.io.IOException
@@ -78,14 +79,17 @@ class Pop3ConnectionTest {
         createAndOpenPop3Connection(settings, mockSocketFactory)
     }
 
-    @Test(expected = CertificateValidationException::class)
-    fun `open() with STLS capability unavailable should throw CertificateValidationException`() {
+    @Test
+    fun `open() with STLS capability unavailable should throw`() {
         val server = startServer {
             setupServerWithAuthenticationMethods("PLAIN")
         }
         val settings = server.createSettings(connectionSecurity = STARTTLS_REQUIRED)
 
-        createAndOpenPop3Connection(settings)
+        assertFailure {
+            createAndOpenPop3Connection(settings)
+        }.isInstanceOf<MissingCapabilityException>()
+            .prop(MissingCapabilityException::capabilityName).isEqualTo("STLS")
     }
 
     @Test(expected = Pop3ErrorResponse::class)
@@ -300,9 +304,8 @@ class Pop3ConnectionTest {
 
         assertFailure {
             createAndOpenPop3Connection(settings)
-        }.isInstanceOf<CertificateValidationException>()
-            .prop(CertificateValidationException::getReason)
-            .isEqualTo(CertificateValidationException.Reason.MissingCapability)
+        }.isInstanceOf<MissingCapabilityException>()
+            .prop(MissingCapabilityException::capabilityName).isEqualTo("SASL EXTERNAL")
 
         server.verifyConnectionStillOpen()
         server.verifyInteractionCompleted()


### PR DESCRIPTION
Throw `MissingCapabilityException` when the server is missing a capability that is required in general or required by the currently configured server settings.