### PR TITLE
Add `ClientCertificateException`

### DIFF
--- a/app-feature-preview/src/main/java/app/k9mail/feature/preview/auth/KeyChainKeyManager.java
+++ b/app-feature-preview/src/main/java/app/k9mail/feature/preview/auth/KeyChainKeyManager.java
@@ -15,15 +15,13 @@ import android.content.Context;
 import android.security.KeyChain;
 import android.security.KeyChainException;
 
-import com.fsck.k9.mail.CertificateValidationException;
+import com.fsck.k9.mail.ClientCertificateError;
+import com.fsck.k9.mail.ClientCertificateException;
 import com.fsck.k9.mail.MessagingException;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.security.auth.x500.X500Principal;
 import timber.log.Timber;
-
-import static com.fsck.k9.mail.CertificateValidationException.Reason;
-import static com.fsck.k9.mail.CertificateValidationException.Reason.RetrievalFailure;
 
 
 /**
@@ -48,11 +46,8 @@ class KeyChainKeyManager extends X509ExtendedKeyManager {
         try {
             mChain = fetchCertificateChain(context, alias);
             mPrivateKey = fetchPrivateKey(context, alias);
-        } catch (KeyChainException e) {
-            // The certificate was possibly deleted.  Notify user of error.
-            throw new CertificateValidationException(e.getMessage(), RetrievalFailure, alias);
-        } catch (InterruptedException e) {
-            throw new CertificateValidationException(e.getMessage(), RetrievalFailure, alias);
+        } catch (KeyChainException | InterruptedException e) {
+            throw new ClientCertificateException(ClientCertificateError.RetrievalFailure, e);
         }
     }
 
@@ -68,7 +63,7 @@ class KeyChainKeyManager extends X509ExtendedKeyManager {
                 certificate.checkValidity();
             }
         } catch (CertificateException e) {
-            throw new CertificateValidationException(e.getMessage(), Reason.Expired, alias);
+            throw new ClientCertificateException(ClientCertificateError.CertificateExpired, e);
         }
 
         return chain;

--- a/app/core/src/main/java/com/fsck/k9/helper/KeyChainKeyManager.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/KeyChainKeyManager.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import com.fsck.k9.mail.ClientCertificateError;
+import com.fsck.k9.mail.ClientCertificateException;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.security.auth.x500.X500Principal;
@@ -18,12 +20,9 @@ import android.content.Context;
 import android.security.KeyChain;
 import android.security.KeyChainException;
 
-import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.MessagingException;
 import timber.log.Timber;
 
-import static com.fsck.k9.mail.CertificateValidationException.Reason;
-import static com.fsck.k9.mail.CertificateValidationException.Reason.RetrievalFailure;
 
 /**
  * For client certificate authentication! Provide private keys and certificates
@@ -47,11 +46,8 @@ class KeyChainKeyManager extends X509ExtendedKeyManager {
         try {
             mChain = fetchCertificateChain(context, alias);
             mPrivateKey = fetchPrivateKey(context, alias);
-        } catch (KeyChainException e) {
-            // The certificate was possibly deleted.  Notify user of error.
-            throw new CertificateValidationException(e.getMessage(), RetrievalFailure, alias);
-        } catch (InterruptedException e) {
-            throw new CertificateValidationException(e.getMessage(), RetrievalFailure, alias);
+        } catch (KeyChainException | InterruptedException e) {
+            throw new ClientCertificateException(ClientCertificateError.RetrievalFailure, e);
         }
     }
 
@@ -67,7 +63,7 @@ class KeyChainKeyManager extends X509ExtendedKeyManager {
                 certificate.checkValidity();
             }
         } catch (CertificateException e) {
-            throw new CertificateValidationException(e.getMessage(), Reason.Expired, alias);
+            throw new ClientCertificateException(ClientCertificateError.CertificateExpired, e);
         }
 
         return chain;

--- a/mail/common/src/main/java/com/fsck/k9/mail/ClientCertificateException.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/ClientCertificateException.kt
@@ -1,0 +1,14 @@
+package com.fsck.k9.mail
+
+/**
+ * Thrown when there's a problem with the client certificate used with TLS.
+ */
+class ClientCertificateException(
+    val error: ClientCertificateError,
+    cause: Throwable,
+) : MessagingException("Problem with client certificate: $error", true, cause)
+
+enum class ClientCertificateError {
+    RetrievalFailure,
+    CertificateExpired,
+}


### PR DESCRIPTION
This is the last case where `CertificateValidationException` was used when it shouldn't have been.