### PR TITLE
Set button corners to material default values

### DIFF
--- a/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/Shapes.kt
+++ b/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/Shapes.kt
@@ -9,7 +9,7 @@ import androidx.compose.material.Shapes as MaterialShapes
 
 @Immutable
 data class Shapes(
-    val small: CornerBasedShape = RoundedCornerShape(8.dp),
+    val small: CornerBasedShape = RoundedCornerShape(4.dp),
     val medium: CornerBasedShape = RoundedCornerShape(4.dp),
     val large: CornerBasedShape = RoundedCornerShape(0.dp),
 )


### PR DESCRIPTION
Set button corners to material default values

Reference: https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material/material/src/commonMain/kotlin/androidx/compose/material/Shapes.kt;l=44-58;drc=696caaf1f75d83dc5fbe4ec30434021db31668e8
