### PR TITLE
Remove shape from `SignInWithGoogleButton`

### DIFF
--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInWithGoogleButton.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -71,7 +70,6 @@ fun SignInWithGoogleButton(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Surface(
-                shape = RoundedCornerShape(2.dp),
                 color = Color.White,
             ) {
                 Icon(


### PR DESCRIPTION
The shape is not necessary anymore as it is a regular Material2 Button that already used the default shape.