### PR TITLE
Fix Koin setup

### DIFF
--- a/app-feature-preview/src/main/java/app/k9mail/feature/preview/FeatureApplication.kt
+++ b/app-feature-preview/src/main/java/app/k9mail/feature/preview/FeatureApplication.kt
@@ -10,6 +10,7 @@ class FeatureApplication : Application() {
         super.onCreate()
 
         startKoin {
+            allowOverride(false)
             androidContext(this@FeatureApplication)
             modules(featureModule)
         }

--- a/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/CatalogApplication.kt
+++ b/app-ui-catalog/src/main/java/app/k9mail/ui/catalog/CatalogApplication.kt
@@ -11,6 +11,7 @@ class CatalogApplication : Application() {
         super.onCreate()
 
         startKoin {
+            allowOverride(false)
             androidContext(this@CatalogApplication)
             modules(catalogUiModule)
         }

--- a/app/core/src/main/java/com/fsck/k9/DI.kt
+++ b/app/core/src/main/java/com/fsck/k9/DI.kt
@@ -15,8 +15,10 @@ object DI {
     private const val DEBUG = false
 
     @JvmStatic
-    fun start(application: Application, modules: List<Module>) {
+    fun start(application: Application, modules: List<Module>, allowOverride: Boolean = false) {
         startKoin {
+            allowOverride(allowOverride)
+
             if (BuildConfig.DEBUG && DEBUG) {
                 androidLogger()
             }

--- a/app/core/src/main/java/com/fsck/k9/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/KoinModule.kt
@@ -10,7 +10,6 @@ import com.fsck.k9.mail.ssl.TrustedSocketFactory
 import com.fsck.k9.mailstore.LocalStoreProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
-import kotlinx.datetime.Clock
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -32,7 +31,6 @@ val mainModule = module {
     single { TrustManagerFactory.createInstance(get()) }
     single { LocalKeyStoreManager(get()) }
     single<TrustedSocketFactory> { DefaultTrustedSocketFactory(get(), get()) }
-    single<Clock> { Clock.System }
     factory { EmailAddressValidator() }
     factory { ServerSettingsSerializer() }
 }

--- a/app/core/src/test/java/com/fsck/k9/TestApp.kt
+++ b/app/core/src/test/java/com/fsck/k9/TestApp.kt
@@ -20,7 +20,11 @@ class TestApp : Application() {
         Core.earlyInit()
 
         super.onCreate()
-        DI.start(this, coreModules + storageModule + testModule)
+        DI.start(
+            application = this,
+            modules = coreModules + storageModule + testModule,
+            allowOverride = true,
+        )
 
         K9.init(this)
         Core.init(this)

--- a/app/ui/legacy/src/test/java/com/fsck/k9/TestApp.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/TestApp.kt
@@ -11,7 +11,11 @@ class TestApp : Application() {
         Core.earlyInit()
 
         super.onCreate()
-        DI.start(this, coreModules + storageModule + testModule)
+        DI.start(
+            application = this,
+            modules = coreModules + storageModule + testModule,
+            allowOverride = true,
+        )
 
         K9.init(this)
         Core.init(this)


### PR DESCRIPTION
Disable Koin override behaviour and fix dublicated `Clock.System` inject.

According to [Overriding definition or module ](https://insert-koin.io/docs/reference/koin-core/modules/#overriding-definition-or-module-310) the default changed to allow overrides by default. When there are 2 or more definitions in different modules, that have the same mapping, the last applied will override all other definitions.
