### PR TITLE
Copy action added to Recipient select view

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
@@ -19,6 +19,7 @@ import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.appcompat.widget.TooltipCompat;
 import com.fsck.k9.activity.compose.RecipientAdapter;
 import com.fsck.k9.ui.ContactBadge;
 import com.fsck.k9.ui.R;
@@ -164,6 +165,8 @@ public class AlternateRecipientAdapter extends BaseAdapter {
             }
         });
 
+        holder.copyEmailAddress.setOnClickListener(v -> listener.onRecipientAddressCopy(currentRecipient));
+
         configureCryptoStatusView(holder, recipient);
     }
 
@@ -237,6 +240,7 @@ public class AlternateRecipientAdapter extends BaseAdapter {
         public final TextView headerAddressLabel;
         public final ContactBadge headerPhoto;
         public final View headerRemove;
+        public final View copyEmailAddress;
         public final TextView itemAddress;
         public final TextView itemAddressLabel;
         public final View itemCryptoStatus;
@@ -253,6 +257,8 @@ public class AlternateRecipientAdapter extends BaseAdapter {
             headerPhoto = view.findViewById(R.id.alternate_contact_photo);
             headerRemove = view.findViewById(R.id.alternate_remove);
 
+            copyEmailAddress = view.findViewById(R.id.button_copy_email_address);
+            TooltipCompat.setTooltipText(copyEmailAddress, copyEmailAddress.getContext().getString(R.string.copy_action));
             itemAddress = view.findViewById(R.id.alternate_address);
             itemAddressLabel = view.findViewById(R.id.alternate_address_label);
             itemCryptoStatus = view.findViewById(R.id.alternate_crypto_status);
@@ -270,5 +276,6 @@ public class AlternateRecipientAdapter extends BaseAdapter {
     public interface AlternateRecipientListener {
         void onRecipientRemove(Recipient currentRecipient);
         void onRecipientChange(Recipient currentRecipient, Recipient alternateRecipient);
+        void onRecipientAddressCopy(Recipient currentRecipient);
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -36,6 +36,7 @@ import android.widget.TextView;
 import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.ui.R;
+import com.fsck.k9.helper.ClipboardManager;
 import com.fsck.k9.activity.AlternateRecipientAdapter;
 import com.fsck.k9.activity.AlternateRecipientAdapter.AlternateRecipientListener;
 import com.fsck.k9.activity.compose.RecipientAdapter;
@@ -484,6 +485,14 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
 
         invalidate();
         invalidateCursorPositionHack();
+    }
+
+    @Override
+    public void onRecipientAddressCopy(Recipient currentRecipient) {
+        ClipboardManager clipboardManager = DI.get(ClipboardManager.class);
+        String label = getContext().getResources().getString(R.string.clipboard_label_name_and_email_address);
+        String nameAndEmailAddress = currentRecipient.address.toString();
+        clipboardManager.setText(label, nameAndEmailAddress);
     }
 
     /**

--- a/app/ui/legacy/src/main/res/layout/recipient_alternate_item.xml
+++ b/app/ui/legacy/src/main/res/layout/recipient_alternate_item.xml
@@ -143,6 +143,15 @@
             tools:visibility="visible"
             />
 
+        <ImageView
+            android:id="@+id/button_copy_email_address"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:scaleType="center"
+            android:background="?attr/controlBackground"
+            android:contentDescription="@string/copy_action"
+            app:srcCompat="@drawable/ic_content_copy" />
+
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
According to the issue #4371 ,  we have some problems with copying address in recipients inputs.
I added a "copy" button to RecipientSelectView to easily copying email address of selected recipient in the Message compose activity. You can see the UI and its action in this video:

https://github.com/thunderbird/thunderbird-android/assets/8654398/da5c24d3-c62d-4cac-b612-fc404cc5d933

There are many other ways to resolve the issue but I'v proposed this solution because of the TokenAutoComplete library limitations. I think it has better UX than copy long clicked item and it has less issues with the copied text.