### PR TITLE
Display error details when checking server settings has failed

### DIFF
--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationStringMapper.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationStringMapper.kt
@@ -1,29 +1,60 @@
 package app.k9mail.feature.account.server.validation.ui
 
 import android.content.res.Resources
+import androidx.annotation.StringRes
 import app.k9mail.feature.account.server.validation.R
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Error
 
 internal fun Error.toResourceString(resources: Resources): String {
     return when (this) {
-        is Error.AuthenticationError -> resources.getString(
-            R.string.account_server_validation_error_authentication,
-        )
+        is Error.AuthenticationError -> {
+            resources.buildErrorString(
+                titleResId = R.string.account_server_validation_error_authentication,
+                detailsResId = R.string.account_server_validation_error_server_message,
+                detailsMessage = serverMessage,
+            )
+        }
 
         is Error.CertificateError -> resources.getString(
             R.string.account_server_validation_error_certificate,
         )
 
-        is Error.NetworkError -> resources.getString(
-            R.string.account_server_validation_error_network,
-        )
+        is Error.NetworkError -> {
+            resources.buildErrorString(
+                titleResId = R.string.account_server_validation_error_network,
+                detailsResId = R.string.account_server_validation_error_details,
+                detailsMessage = exception.message,
+            )
+        }
 
-        is Error.ServerError -> resources.getString(
-            R.string.account_server_validation_error_server,
-        )
+        is Error.ServerError -> {
+            resources.buildErrorString(
+                titleResId = R.string.account_server_validation_error_server,
+                detailsResId = R.string.account_server_validation_error_server_message,
+                detailsMessage = serverMessage,
+            )
+        }
 
-        is Error.UnknownError -> resources.getString(
-            R.string.account_server_validation_error_unknown,
-        )
+        is Error.UnknownError -> {
+            resources.buildErrorString(
+                titleResId = R.string.account_server_validation_error_unknown,
+                detailsResId = R.string.account_server_validation_error_details,
+                detailsMessage = message,
+            )
+        }
+    }
+}
+
+private fun Resources.buildErrorString(
+    @StringRes titleResId: Int,
+    @StringRes detailsResId: Int,
+    detailsMessage: String?,
+): String {
+    val title = getString(titleResId)
+    return if (detailsMessage != null) {
+        val details = getString(detailsResId, detailsMessage)
+        "$title\n\n$details"
+    } else {
+        title
     }
 }

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationStringMapper.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationStringMapper.kt
@@ -7,6 +7,8 @@ import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.
 
 internal fun Error.toResourceString(resources: Resources): String {
     return when (this) {
+        is Error.CertificateError -> error("Handle CertificateError using ServerCertificateErrorScreen")
+
         is Error.AuthenticationError -> {
             resources.buildErrorString(
                 titleResId = R.string.account_server_validation_error_authentication,
@@ -14,10 +16,6 @@ internal fun Error.toResourceString(resources: Resources): String {
                 detailsMessage = serverMessage,
             )
         }
-
-        is Error.CertificateError -> resources.getString(
-            R.string.account_server_validation_error_certificate,
-        )
 
         is Error.NetworkError -> {
             resources.buildErrorString(

--- a/feature/account/server/validation/src/main/res/values/strings.xml
+++ b/feature/account/server/validation/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="account_server_validation_error_network">Network error</string>
     <string name="account_server_validation_error_server">Server error</string>
     <string name="account_server_validation_error_unknown">Unknown error</string>
+    <string name="account_server_validation_error_server_message">The server returned the following message:\n%s</string>
+    <string name="account_server_validation_error_details">Details:\n%s</string>
     <string name="account_server_validation_incoming_loading_message">Checking incoming server settings…</string>
     <string name="account_server_validation_incoming_loading_error">Checking incoming server settings failed</string>
     <string name="account_server_validation_incoming_success">Incoming server settings are valid</string>

--- a/feature/account/server/validation/src/main/res/values/strings.xml
+++ b/feature/account/server/validation/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_server_validation_error_authentication">Authentication error</string>
-    <string name="account_server_validation_error_certificate">Certificate error</string>
     <string name="account_server_validation_error_network">Network error</string>
     <string name="account_server_validation_error_server">Server error</string>
     <string name="account_server_validation_error_unknown">Unknown error</string>


### PR DESCRIPTION
Add error details to the screen that is displayed when checking server settings has failed.

![image](https://github.com/thunderbird/thunderbird-android/assets/218061/9cfe55aa-8bfe-402a-bf42-bca8ae549dc4)
