### PR TITLE
Add more errors to `ServerSettingsValidationResult`

### DIFF
--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/BaseServerValidationViewModel.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/BaseServerValidationViewModel.kt
@@ -136,12 +136,24 @@ abstract class BaseServerValidationViewModel(
                     Error.CertificateError(result.certificateChain),
                 )
 
+                ServerSettingsValidationResult.ClientCertificateError.ClientCertificateExpired -> updateError(
+                    Error.ClientCertificateExpired,
+                )
+
+                ServerSettingsValidationResult.ClientCertificateError.ClientCertificateRetrievalFailure -> updateError(
+                    Error.ClientCertificateRetrievalFailure,
+                )
+
                 is ServerSettingsValidationResult.NetworkError -> updateError(
                     Error.NetworkError(result.exception),
                 )
 
                 is ServerSettingsValidationResult.ServerError -> updateError(
                     Error.ServerError(result.serverMessage),
+                )
+
+                is ServerSettingsValidationResult.MissingServerCapabilityError -> updateError(
+                    Error.MissingServerCapabilityError(result.capabilityName),
                 )
 
                 is ServerSettingsValidationResult.UnknownError -> updateError(

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationContract.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationContract.kt
@@ -46,8 +46,11 @@ interface ServerValidationContract {
     sealed interface Error {
         data class NetworkError(val exception: IOException) : Error
         data class CertificateError(val certificateChain: List<X509Certificate>) : Error
+        data object ClientCertificateRetrievalFailure : Error
+        data object ClientCertificateExpired : Error
         data class AuthenticationError(val serverMessage: String?) : Error
         data class ServerError(val serverMessage: String?) : Error
+        data class MissingServerCapabilityError(val capabilityName: String) : Error
         data class UnknownError(val message: String) : Error
     }
 }

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationStringMapper.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationStringMapper.kt
@@ -40,6 +40,22 @@ internal fun Error.toResourceString(resources: Resources): String {
                 detailsMessage = message,
             )
         }
+
+        Error.ClientCertificateExpired -> {
+            resources.getString(R.string.account_server_validation_error_client_certificate_expired)
+        }
+
+        Error.ClientCertificateRetrievalFailure -> {
+            resources.getString(R.string.account_server_validation_error_client_certificate_retrieval_failure)
+        }
+
+        is Error.MissingServerCapabilityError -> {
+            resources.buildErrorString(
+                titleResId = R.string.account_server_validation_error_missing_server_capability,
+                detailsResId = R.string.account_server_validation_error_missing_server_capability_details,
+                detailsMessage = capabilityName,
+            )
+        }
     }
 }
 

--- a/feature/account/server/validation/src/main/res/values/strings.xml
+++ b/feature/account/server/validation/src/main/res/values/strings.xml
@@ -4,8 +4,12 @@
     <string name="account_server_validation_error_network">Network error</string>
     <string name="account_server_validation_error_server">Server error</string>
     <string name="account_server_validation_error_unknown">Unknown error</string>
+    <string name="account_server_validation_error_client_certificate_expired">The client certificate is no longer valid</string>
+    <string name="account_server_validation_error_client_certificate_retrieval_failure">"The client certificate couldn't be accessed"</string>
+    <string name="account_server_validation_error_missing_server_capability">Missing server capability</string>
     <string name="account_server_validation_error_server_message">The server returned the following message:\n%s</string>
     <string name="account_server_validation_error_details">Details:\n%s</string>
+    <string name="account_server_validation_error_missing_server_capability_details">The server is missing this capability:\n%s</string>
     <string name="account_server_validation_incoming_loading_message">Checking incoming server settings…</string>
     <string name="account_server_validation_incoming_loading_error">Checking incoming server settings failed</string>
     <string name="account_server_validation_incoming_success">Incoming server settings are valid</string>

--- a/mail/common/src/main/java/com/fsck/k9/mail/server/ServerSettingsValidationResult.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/server/ServerSettingsValidationResult.kt
@@ -24,6 +24,21 @@ sealed interface ServerSettingsValidationResult {
     data class CertificateError(val certificateChain: List<X509Certificate>) : ServerSettingsValidationResult
 
     /**
+     * There's a problem with the client certificate.
+     */
+    sealed interface ClientCertificateError : ServerSettingsValidationResult {
+        /**
+         * The client certificate couldn't be retrieved.
+         */
+        data object ClientCertificateRetrievalFailure : ClientCertificateError
+
+        /**
+         * The client certificate (or another one in the chain) has expired.
+         */
+        data object ClientCertificateExpired : ClientCertificateError
+    }
+
+    /**
      * Authentication failed while checking the server settings.
      */
     data class AuthenticationError(val serverMessage: String?) : ServerSettingsValidationResult
@@ -32,6 +47,11 @@ sealed interface ServerSettingsValidationResult {
      * The server returned an error while checking the server settings.
      */
     data class ServerError(val serverMessage: String?) : ServerSettingsValidationResult
+
+    /**
+     * The server is missing a capability that is required by the current server settings.
+     */
+    data class MissingServerCapabilityError(val capabilityName: String) : ServerSettingsValidationResult
 
     /**
      * An unknown error occurred while checking the server settings.

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapServerSettingsValidator.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapServerSettingsValidator.kt
@@ -2,12 +2,17 @@ package com.fsck.k9.mail.store.imap
 
 import com.fsck.k9.mail.AuthenticationFailedException
 import com.fsck.k9.mail.CertificateValidationException
+import com.fsck.k9.mail.ClientCertificateError.CertificateExpired
+import com.fsck.k9.mail.ClientCertificateError.RetrievalFailure
+import com.fsck.k9.mail.ClientCertificateException
 import com.fsck.k9.mail.MessagingException
+import com.fsck.k9.mail.MissingCapabilityException
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.oauth.AuthStateStorage
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider
 import com.fsck.k9.mail.oauth.OAuth2TokenProviderFactory
 import com.fsck.k9.mail.server.ServerSettingsValidationResult
+import com.fsck.k9.mail.server.ServerSettingsValidationResult.ClientCertificateError
 import com.fsck.k9.mail.server.ServerSettingsValidator
 import com.fsck.k9.mail.ssl.TrustedSocketFactory
 import java.io.IOException
@@ -42,6 +47,13 @@ class ImapServerSettingsValidator(
             ServerSettingsValidationResult.CertificateError(e.certificateChain)
         } catch (e: NegativeImapResponseException) {
             ServerSettingsValidationResult.ServerError(e.responseText)
+        } catch (e: MissingCapabilityException) {
+            ServerSettingsValidationResult.MissingServerCapabilityError(e.capabilityName)
+        } catch (e: ClientCertificateException) {
+            when (e.error) {
+                RetrievalFailure -> ClientCertificateError.ClientCertificateRetrievalFailure
+                CertificateExpired -> ClientCertificateError.ClientCertificateExpired
+            }
         } catch (e: MessagingException) {
             val cause = e.cause
             if (cause is IOException) {


### PR DESCRIPTION
Display custom error messages for error cases that the protocol code already supported, but that have been treated as "unknown error" in the UI so far.