### PR TITLE
Change lint config to lower ExtraTranslation to warning level

### DIFF
--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
     <issue id="MissingTranslation" severity="ignore" />
+    <issue id="ExtraTranslation" severity="warning" />
     <issue id="OldTargetApi" severity="ignore" />
     <issue id="GoogleAppIndexingWarning" severity="ignore" />
 </lint>


### PR DESCRIPTION
The feature app's build is having errors due to translated resource strings whose source has been removed. These are being flagged by lint. To address this, I've adjusted the configuration to downgrade these errors to warnings.
