### PR TITLE
Add account setup folder sync on create

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/backend/BackendManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/backend/BackendManager.kt
@@ -2,73 +2,13 @@ package com.fsck.k9.backend
 
 import com.fsck.k9.Account
 import com.fsck.k9.backend.api.Backend
-import com.fsck.k9.mail.ServerSettings
-import java.util.concurrent.CopyOnWriteArraySet
 
-class BackendManager(private val backendFactories: Map<String, BackendFactory>) {
-    private val backendCache = mutableMapOf<String, BackendContainer>()
-    private val listeners = CopyOnWriteArraySet<BackendChangedListener>()
-
-    fun getBackend(account: Account): Backend {
-        val newBackend = synchronized(backendCache) {
-            val container = backendCache[account.uuid]
-            if (container != null && isBackendStillValid(container, account)) {
-                return container.backend
-            }
-
-            createBackend(account).also { backend ->
-                backendCache[account.uuid] = BackendContainer(
-                    backend,
-                    account.incomingServerSettings,
-                    account.outgoingServerSettings,
-                )
-            }
-        }
-
-        notifyListeners(account)
-
-        return newBackend
-    }
-
-    private fun isBackendStillValid(container: BackendContainer, account: Account): Boolean {
-        return container.incomingServerSettings == account.incomingServerSettings &&
-            container.outgoingServerSettings == account.outgoingServerSettings
-    }
-
-    fun removeBackend(account: Account) {
-        synchronized(backendCache) {
-            backendCache.remove(account.uuid)
-        }
-
-        notifyListeners(account)
-    }
-
-    private fun createBackend(account: Account): Backend {
-        val serverType = account.incomingServerSettings.type
-        val backendFactory = backendFactories[serverType] ?: error("Unsupported account type")
-        return backendFactory.createBackend(account)
-    }
-
-    fun addListener(listener: BackendChangedListener) {
-        listeners.add(listener)
-    }
-
-    fun removeListener(listener: BackendChangedListener) {
-        listeners.remove(listener)
-    }
-
-    private fun notifyListeners(account: Account) {
-        for (listener in listeners) {
-            listener.onBackendChanged(account)
-        }
-    }
+interface BackendManager {
+    fun getBackend(account: Account): Backend
+    fun removeBackend(account: Account)
+    fun addListener(listener: BackendChangedListener)
+    fun removeListener(listener: BackendChangedListener)
 }
-
-private data class BackendContainer(
-    val backend: Backend,
-    val incomingServerSettings: ServerSettings,
-    val outgoingServerSettings: ServerSettings,
-)
 
 fun interface BackendChangedListener {
     fun onBackendChanged(account: Account)

--- a/app/core/src/main/java/com/fsck/k9/backend/ConcreteBackendManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/backend/ConcreteBackendManager.kt
@@ -1,0 +1,71 @@
+package com.fsck.k9.backend
+
+import com.fsck.k9.Account
+import com.fsck.k9.backend.api.Backend
+import com.fsck.k9.mail.ServerSettings
+import java.util.concurrent.CopyOnWriteArraySet
+
+class ConcreteBackendManager(private val backendFactories: Map<String, BackendFactory>) : BackendManager {
+    private val backendCache = mutableMapOf<String, BackendContainer>()
+    private val listeners = CopyOnWriteArraySet<BackendChangedListener>()
+
+    override fun getBackend(account: Account): Backend {
+        val newBackend = synchronized(backendCache) {
+            val container = backendCache[account.uuid]
+            if (container != null && isBackendStillValid(container, account)) {
+                return container.backend
+            }
+
+            createBackend(account).also { backend ->
+                backendCache[account.uuid] = BackendContainer(
+                    backend,
+                    account.incomingServerSettings,
+                    account.outgoingServerSettings,
+                )
+            }
+        }
+
+        notifyListeners(account)
+
+        return newBackend
+    }
+
+    private fun isBackendStillValid(container: BackendContainer, account: Account): Boolean {
+        return container.incomingServerSettings == account.incomingServerSettings &&
+            container.outgoingServerSettings == account.outgoingServerSettings
+    }
+
+    override fun removeBackend(account: Account) {
+        synchronized(backendCache) {
+            backendCache.remove(account.uuid)
+        }
+
+        notifyListeners(account)
+    }
+
+    private fun createBackend(account: Account): Backend {
+        val serverType = account.incomingServerSettings.type
+        val backendFactory = backendFactories[serverType] ?: error("Unsupported account type")
+        return backendFactory.createBackend(account)
+    }
+
+    override fun addListener(listener: BackendChangedListener) {
+        listeners.add(listener)
+    }
+
+    override fun removeListener(listener: BackendChangedListener) {
+        listeners.remove(listener)
+    }
+
+    private fun notifyListeners(account: Account) {
+        for (listener in listeners) {
+            listener.onBackendChanged(account)
+        }
+    }
+}
+
+private data class BackendContainer(
+    val backend: Backend,
+    val incomingServerSettings: ServerSettings,
+    val outgoingServerSettings: ServerSettings,
+)

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -25,6 +25,7 @@ val controllerModule = module {
             get<SaveMessageDataCreator>(),
             get<SpecialLocalFoldersCreator>(),
             get(named("controllerExtensions")),
+            get(),
         )
     }
     single<MessageCountsProvider> {

--- a/app/core/src/main/java/com/fsck/k9/controller/command/AccountCommandFactory.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/command/AccountCommandFactory.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.controller.command
+
+interface AccountCommandFactory {
+    fun createUpdateFolderListCommand(accountUuid: String): Command
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/command/Command.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/command/Command.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.controller.command
+
+interface Command {
+    operator fun invoke()
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/command/ConcreteAccountCommandFactory.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/command/ConcreteAccountCommandFactory.kt
@@ -1,0 +1,20 @@
+package com.fsck.k9.controller.command
+
+import com.fsck.k9.backend.BackendManager
+import com.fsck.k9.preferences.AccountManager
+import kotlinx.datetime.Clock
+
+class ConcreteAccountCommandFactory(
+    private val accountManager: AccountManager,
+    private val backendManager: BackendManager,
+    private val clock: Clock,
+) : AccountCommandFactory {
+    override fun createUpdateFolderListCommand(accountUuid: String): Command {
+        return UpdateFolderListCommand(
+            argument = UpdateFolderListArgument(accountUuid),
+            accountManager = accountManager,
+            backendManager = backendManager,
+            clock = clock,
+        )
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/command/UpdateFolderListCommand.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/command/UpdateFolderListCommand.kt
@@ -1,0 +1,58 @@
+package com.fsck.k9.controller.command
+
+import com.fsck.k9.Account
+import com.fsck.k9.backend.BackendManager
+import com.fsck.k9.preferences.AccountManager
+import kotlinx.datetime.Clock
+import timber.log.Timber
+
+data class UpdateFolderListArgument(
+    val accountUuid: String,
+)
+
+class UpdateFolderListCommand(
+    private val argument: UpdateFolderListArgument,
+    private val accountManager: AccountManager,
+    private val backendManager: BackendManager,
+    private val clock: Clock,
+) : Command {
+
+    override fun invoke() {
+        val account = accountManager.getAccount(argument.accountUuid)
+
+        if (account == null) {
+            Timber.e("Account not found: ${argument.accountUuid}")
+            error("Account not found: ${argument.accountUuid}")
+        } else {
+            if (isStale(account)) {
+                Timber.d("Folder list is stale, updating now for account ${argument.accountUuid}")
+                refreshFolderList(account)
+            } else {
+                Timber.d("Folder list not stale, no update necessary for account ${argument.accountUuid}")
+            }
+        }
+    }
+
+    private fun isStale(account: Account): Boolean {
+        val lastRefreshTime = account.lastFolderListRefreshTime
+        val now = clock.now()
+
+        return now.toEpochMilliseconds() - lastRefreshTime > FOLDER_LIST_STALENESS_THRESHOLD
+    }
+
+    private fun refreshFolderList(account: Account) {
+        val backend = backendManager.getBackend(account)
+        backend.refreshFolderList()
+
+        val now = clock.now()
+        Timber.d("Folder list successfully updated @ %tc", now)
+
+        account.lastFolderListRefreshTime = now.toEpochMilliseconds()
+
+        accountManager.saveAccount(account)
+    }
+
+    companion object {
+        private const val FOLDER_LIST_STALENESS_THRESHOLD = 24 * 60 * 60 * 1000L
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/command/UpdateFolderListCommand.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/command/UpdateFolderListCommand.kt
@@ -45,7 +45,7 @@ class UpdateFolderListCommand(
         backend.refreshFolderList()
 
         val now = clock.now()
-        Timber.d("Folder list successfully updated @ %tc", now)
+        Timber.d("Folder list successfully updated @ %s", now)
 
         account.lastFolderListRefreshTime = now.toEpochMilliseconds()
 

--- a/app/core/src/test/java/com/fsck/k9/TestApp.kt
+++ b/app/core/src/test/java/com/fsck/k9/TestApp.kt
@@ -36,7 +36,7 @@ val testModule = module {
     single { mock<CoreResourceProvider>() }
     single { mock<EncryptionExtractor>() }
     single<StoragePersister> { InMemoryStoragePersister() }
-    single { mock<BackendManager>() }
+    single<BackendManager> { mock<BackendManager>() }
     single { mock<NotificationResourceProvider>() }
     single { mock<NotificationActionCreator>() }
     single { mock<NotificationStrategy>() }

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -8,6 +8,8 @@ import java.util.Set;
 
 import android.content.Context;
 
+import app.k9mail.core.common.mail.Protocols;
+import app.k9mail.core.testing.TestClock;
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9RobolectricTest;
@@ -34,7 +36,6 @@ import com.fsck.k9.mailstore.SendState;
 import com.fsck.k9.mailstore.SpecialLocalFoldersCreator;
 import com.fsck.k9.notification.NotificationController;
 import com.fsck.k9.notification.NotificationStrategy;
-import app.k9mail.core.common.mail.Protocols;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,8 +50,8 @@ import org.robolectric.shadows.ShadowLog;
 
 import static java.util.Collections.emptyList;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -111,6 +112,8 @@ public class MessagingControllerTest extends K9RobolectricTest {
     private Preferences preferences;
     private String accountUuid;
 
+    private TestClock testClock = new TestClock();
+
 
     @Before
     public void setUp() throws MessagingException {
@@ -121,8 +124,9 @@ public class MessagingControllerTest extends K9RobolectricTest {
         preferences = Preferences.getPreferences();
 
         controller = new MessagingController(appContext, notificationController, notificationStrategy,
-                localStoreProvider, backendManager, preferences, messageStoreManager,
-                saveMessageDataCreator, specialLocalFoldersCreator, Collections.<ControllerExtension>emptyList());
+            localStoreProvider, backendManager, preferences, messageStoreManager,
+            saveMessageDataCreator, specialLocalFoldersCreator, Collections.<ControllerExtension>emptyList(),
+            testClock);
 
         configureAccount();
         configureBackendManager();

--- a/app/core/src/test/java/com/fsck/k9/controller/command/ConcreteAccountCommandFactoryTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/controller/command/ConcreteAccountCommandFactoryTest.kt
@@ -1,0 +1,27 @@
+package com.fsck.k9.controller.command
+
+import app.k9mail.core.testing.TestClock
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import com.fsck.k9.backend.BackendManager
+import com.fsck.k9.preferences.AccountManager
+import kotlin.test.Test
+import org.mockito.Mockito.mock
+
+class ConcreteAccountCommandFactoryTest {
+
+    @Test
+    fun `createUpdateFolderListCommand should return UpdateFolderListCommand`() {
+        // Given
+        val accountManager = mock<AccountManager>()
+        val backendManager = mock<BackendManager>()
+        val clock = TestClock()
+        val factory = ConcreteAccountCommandFactory(accountManager, backendManager, clock)
+
+        // When
+        val command = factory.createUpdateFolderListCommand("accountUuid")
+
+        // Then
+        assertThat(command).isInstanceOf(UpdateFolderListCommand::class.java)
+    }
+}

--- a/app/k9mail/build.gradle.kts
+++ b/app/k9mail/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.preferencex)
     implementation(libs.timber)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.datetime)
 
     implementation(libs.glide)
     annotationProcessor(libs.glide.compiler)

--- a/app/k9mail/src/main/java/com/fsck/k9/account/AccountCreator.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/account/AccountCreator.kt
@@ -8,6 +8,7 @@ import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCrea
 import com.fsck.k9.Account.FolderMode
 import com.fsck.k9.Core
 import com.fsck.k9.Preferences
+import com.fsck.k9.controller.command.AccountCommandFactory
 import com.fsck.k9.logging.Timber
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.autoDetectNamespace
@@ -25,6 +26,7 @@ import com.fsck.k9.Account as K9Account
 class AccountCreator(
     private val accountColorPicker: AccountColorPicker,
     private val localFoldersCreator: SpecialLocalFoldersCreator,
+    private val accountCommandFactory: AccountCommandFactory,
     private val preferences: Preferences,
     private val context: Context,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -70,6 +72,8 @@ class AccountCreator(
         newAccount.markSetupFinished()
 
         preferences.saveAccount(newAccount)
+
+        accountCommandFactory.createUpdateFolderListCommand(newAccount.uuid).invoke()
 
         Core.setServicesEnabled(context)
 

--- a/app/k9mail/src/main/java/com/fsck/k9/account/AccountModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/account/AccountModule.kt
@@ -3,6 +3,8 @@ package com.fsck.k9.account
 import app.k9mail.feature.account.common.AccountCommonExternalContract
 import app.k9mail.feature.account.edit.AccountEditExternalContract
 import app.k9mail.feature.account.setup.AccountSetupExternalContract
+import com.fsck.k9.controller.command.AccountCommandFactory
+import com.fsck.k9.controller.command.ConcreteAccountCommandFactory
 import org.koin.android.ext.koin.androidApplication
 import org.koin.dsl.module
 
@@ -20,10 +22,19 @@ val newAccountModule = module {
         )
     }
 
+    single<AccountCommandFactory> {
+        ConcreteAccountCommandFactory(
+            accountManager = get(),
+            backendManager = get(),
+            clock = get(),
+        )
+    }
+
     factory<AccountSetupExternalContract.AccountCreator> {
         AccountCreator(
             accountColorPicker = get(),
             localFoldersCreator = get(),
+            accountCommandFactory = get(),
             preferences = get(),
             context = androidApplication(),
         )

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/KoinModule.kt
@@ -4,6 +4,7 @@ import app.k9mail.dev.developmentBackends
 import app.k9mail.dev.developmentModuleAdditions
 import com.fsck.k9.BuildConfig
 import com.fsck.k9.backend.BackendManager
+import com.fsck.k9.backend.ConcreteBackendManager
 import com.fsck.k9.backend.imap.BackendIdleRefreshManager
 import com.fsck.k9.backend.imap.SystemAlarmManager
 import com.fsck.k9.mail.oauth.OAuth2TokenProviderFactory
@@ -12,8 +13,8 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val backendsModule = module {
-    single {
-        BackendManager(
+    single<BackendManager> {
+        ConcreteBackendManager(
             mapOf(
                 "imap" to get<ImapBackendFactory>(),
                 "pop3" to get<Pop3BackendFactory>(),


### PR DESCRIPTION
This is a draft version of the account setup folder sync. It lacks tests as I had to remove them because of issues with the used testing library. 

It uses a command pattern with a command factory to have testable code and to start discussion about how to refactor the `MessageController` class.
