### PR TITLE
Save special folder mapping and fetch folder list after creating account

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.kt
+++ b/app/core/src/main/java/com/fsck/k9/Account.kt
@@ -151,23 +151,18 @@ class Account(override val uuid: String) : BaseAccount {
 
     @get:Synchronized
     var draftsFolderSelection = SpecialFolderSelection.AUTOMATIC
-        private set
 
     @get:Synchronized
     var sentFolderSelection = SpecialFolderSelection.AUTOMATIC
-        private set
 
     @get:Synchronized
     var trashFolderSelection = SpecialFolderSelection.AUTOMATIC
-        private set
 
     @get:Synchronized
     var archiveFolderSelection = SpecialFolderSelection.AUTOMATIC
-        private set
 
     @get:Synchronized
     var spamFolderSelection = SpecialFolderSelection.AUTOMATIC
-        private set
 
     @get:Synchronized
     @set:Synchronized

--- a/app/k9mail/src/main/java/com/fsck/k9/account/AccountCreator.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/account/AccountCreator.kt
@@ -8,6 +8,7 @@ import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCrea
 import com.fsck.k9.Account.FolderMode
 import com.fsck.k9.Core
 import com.fsck.k9.Preferences
+import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.logging.Timber
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.autoDetectNamespace
@@ -27,6 +28,7 @@ class AccountCreator(
     private val localFoldersCreator: SpecialLocalFoldersCreator,
     private val preferences: Preferences,
     private val context: Context,
+    private val messagingController: MessagingController,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AccountSetupExternalContract.AccountCreator {
 
@@ -72,6 +74,8 @@ class AccountCreator(
         preferences.saveAccount(newAccount)
 
         Core.setServicesEnabled(context)
+
+        messagingController.refreshFolderListBlocking(newAccount)
 
         return newAccount.uuid
     }

--- a/app/k9mail/src/main/java/com/fsck/k9/account/AccountModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/account/AccountModule.kt
@@ -26,6 +26,7 @@ val newAccountModule = module {
             localFoldersCreator = get(),
             preferences = get(),
             context = androidApplication(),
+            messagingController = get(),
         )
     }
 


### PR DESCRIPTION
To save special folders we use the same mechanism that is used when importing server settings. The server IDs of the special folders are saved in `Account.imported*Folder`. Then the first time the folder list is synced, `SpecialFolderUpdater` will map those server IDs to the database IDs for the folder and call `Account.set*FolderId()`.

Closes #7329
Closes #5826