### PR TITLE
Add cut icon on Recipient alternate

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
@@ -167,6 +167,11 @@ public class AlternateRecipientAdapter extends BaseAdapter {
 
         holder.copyEmailAddress.setOnClickListener(v -> listener.onRecipientAddressCopy(currentRecipient));
 
+        holder.cutEmailAddress.setOnClickListener(v -> {
+            listener.onRecipientAddressCopy(currentRecipient);
+            listener.onRecipientRemove(currentRecipient);
+        });
+
         configureCryptoStatusView(holder, recipient);
     }
 
@@ -241,6 +246,7 @@ public class AlternateRecipientAdapter extends BaseAdapter {
         public final ContactBadge headerPhoto;
         public final View headerRemove;
         public final View copyEmailAddress;
+        public final View cutEmailAddress;
         public final TextView itemAddress;
         public final TextView itemAddressLabel;
         public final View itemCryptoStatus;
@@ -258,6 +264,7 @@ public class AlternateRecipientAdapter extends BaseAdapter {
             headerRemove = view.findViewById(R.id.alternate_remove);
 
             copyEmailAddress = view.findViewById(R.id.button_copy_email_address);
+            cutEmailAddress = view.findViewById(R.id.button_cut_email_address);
             TooltipCompat.setTooltipText(copyEmailAddress, copyEmailAddress.getContext().getString(R.string.copy_action));
             itemAddress = view.findViewById(R.id.alternate_address);
             itemAddressLabel = view.findViewById(R.id.alternate_address_label);

--- a/app/ui/legacy/src/main/res/drawable/ic_cut.xml
+++ b/app/ui/legacy/src/main/res/drawable/ic_cut.xml
@@ -1,0 +1,11 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp">
+
+    <path android:fillColor="@android:color/white" android:pathData="M9.64,7.64c0.23,-0.5 0.36,-1.05 0.36,-1.64 0,-2.21 -1.79,-4 -4,-4S2,3.79 2,6s1.79,4 4,4c0.59,0 1.14,-0.13 1.64,-0.36L10,12l-2.36,2.36C7.14,14.13 6.59,14 6,14c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4c0,-0.59 -0.13,-1.14 -0.36,-1.64L12,14l7,7h3v-1L9.64,7.64zM6,8c-1.1,0 -2,-0.89 -2,-2s0.9,-2 2,-2 2,0.89 2,2 -0.9,2 -2,2zM6,20c-1.1,0 -2,-0.89 -2,-2s0.9,-2 2,-2 2,0.89 2,2 -0.9,2 -2,2zM12,12.5c-0.28,0 -0.5,-0.22 -0.5,-0.5s0.22,-0.5 0.5,-0.5 0.5,0.22 0.5,0.5 -0.22,0.5 -0.5,0.5zM19,3l-6,6 2,2 7,-7L22,3z"/>
+
+</vector>

--- a/app/ui/legacy/src/main/res/layout/recipient_alternate_item.xml
+++ b/app/ui/legacy/src/main/res/layout/recipient_alternate_item.xml
@@ -144,13 +144,23 @@
             />
 
         <ImageView
+            android:id="@+id/button_cut_email_address"
+            android:layout_width="40dp"
+            android:layout_height="48dp"
+            android:scaleType="center"
+            android:background="?attr/controlBackground"
+            android:contentDescription="@string/cut_action"
+            app:srcCompat="@drawable/ic_cut" />
+
+        <ImageView
             android:id="@+id/button_copy_email_address"
-            android:layout_width="48dp"
+            android:layout_width="40dp"
             android:layout_height="48dp"
             android:scaleType="center"
             android:background="?attr/controlBackground"
             android:contentDescription="@string/copy_action"
-            app:srcCompat="@drawable/ic_content_copy" />
+            app:srcCompat="@drawable/ic_content_copy"
+            android:layout_marginEnd="8dp"/>
 
     </LinearLayout>
 

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="flag_action">Add star</string>
     <string name="unflag_action">Remove star</string>
     <string name="copy_action">Copy</string>
+    <string name="cut_action">Cut</string>
     <string name="unsubscribe_action">Unsubscribe</string>
     <string name="show_headers_action">Show headers</string>
     <plurals name="copy_address_to_clipboard">


### PR DESCRIPTION
see #7448 

* Adds a cut icon on the Recipient alternate view;
* Added a new string under the id - `cut_action`.

For an explanation of why this was the approach followed, please look at [this comment](https://github.com/thunderbird/thunderbird-android/issues/7448#issuecomment-1866347877).

### Visuals
<img src="https://github.com/thunderbird/thunderbird-android/assets/40279132/01b473c2-47ae-4c6f-b031-960c61060833" width="40%" height="40%"/> <img src="https://github.com/thunderbird/thunderbird-android/assets/40279132/c4ae6667-0733-4a98-b0b9-ec2733c2d3c2" width="40%" height="40%"/>

### Behaviour
https://github.com/thunderbird/thunderbird-android/assets/40279132/8e786f66-5ab4-4661-8725-ba8ec6ce842e