### PR TITLE
Update notification preferences when fragment is created

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -208,17 +208,14 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             findPreference<NotificationSoundPreference>(PREFERENCE_NOTIFICATION_SOUND)?.let { preference ->
                 notificationSoundPreference = preference
-                preference.isEnabled = false
             }
 
             findPreference<ListPreference>(PREFERENCE_NOTIFICATION_LIGHT)?.let { preference ->
                 notificationLightPreference = preference
-                preference.isEnabled = false
             }
 
             findPreference<VibrationPreference>(PREFERENCE_NOTIFICATION_VIBRATION)?.let { preference ->
                 notificationVibrationPreference = preference
-                preference.isEnabled = false
             }
 
             findPreference<NotificationsPreference>(PREFERENCE_NOTIFICATION_SETTINGS_MESSAGES)?.let {
@@ -232,6 +229,8 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
                     notificationChannelManager.getChannelIdFor(account, ChannelType.MISCELLANEOUS)
                 }
             }
+
+            updateNotificationPreferences(account)
         } else {
             findPreference<PreferenceCategory>(PREFERENCE_NOTIFICATION_CHANNELS).remove()
         }
@@ -251,15 +250,9 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         notificationSettingsUpdater.updateNotificationSettings(account)
         val notificationSettings = account.notificationSettings
 
-        notificationSoundPreference?.let { preference ->
-            preference.setNotificationSound(notificationSettings.ringtone?.toUri())
-            preference.isEnabled = true
-        }
+        notificationSoundPreference?.setNotificationSound(notificationSettings.ringtone?.toUri())
 
-        notificationLightPreference?.let { preference ->
-            preference.value = notificationSettings.light.name
-            preference.isEnabled = true
-        }
+        notificationLightPreference?.value = notificationSettings.light.name
 
         notificationVibrationPreference?.let { preference ->
             val notificationVibration = notificationSettings.vibration
@@ -268,7 +261,6 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
                 vibratePattern = notificationVibration.pattern,
                 vibrationTimes = notificationVibration.repeatCount,
             )
-            preference.isEnabled = true
         }
     }
 


### PR DESCRIPTION
Update notification preferences right away instead of waiting for it to happen in `onResume()`.

The notification preferences were initially disabled and only enabled after the current state has been read from the `NotificationChannel`.

https://github.com/thunderbird/thunderbird-android/blob/cba9ca31aa6bdb8911a2787afc145c27cf366bec/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt#L250-L273

However, calling `updateNotificationPreferences()` is skipped when the user returns from setting the notification sound.

https://github.com/thunderbird/thunderbird-android/blob/cba9ca31aa6bdb8911a2787afc145c27cf366bec/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt#L102-L111

This could lead to the notification preferences never being enabled when the activity was recreated while returning from the system screen to set a notification sound (see #7468).

Fixes #7468