### PR TITLE
Clean up special folders error view

### DIFF
--- a/feature/account/common/src/main/res/values/strings.xml
+++ b/feature/account/common/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_button_next">Next</string>
     <string name="account_common_button_back">Back</string>
+
+    <string name="account_common_error_server_message">The server returned the following message:\n%s</string>
 </resources>

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationStringMapper.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationStringMapper.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import androidx.annotation.StringRes
 import app.k9mail.feature.account.server.validation.R
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Error
+import app.k9mail.feature.account.common.R as CommonR
 
 internal fun Error.toResourceString(resources: Resources): String {
     return when (this) {
@@ -12,7 +13,7 @@ internal fun Error.toResourceString(resources: Resources): String {
         is Error.AuthenticationError -> {
             resources.buildErrorString(
                 titleResId = R.string.account_server_validation_error_authentication,
-                detailsResId = R.string.account_server_validation_error_server_message,
+                detailsResId = CommonR.string.account_common_error_server_message,
                 detailsMessage = serverMessage,
             )
         }
@@ -28,7 +29,7 @@ internal fun Error.toResourceString(resources: Resources): String {
         is Error.ServerError -> {
             resources.buildErrorString(
                 titleResId = R.string.account_server_validation_error_server,
-                detailsResId = R.string.account_server_validation_error_server_message,
+                detailsResId = CommonR.string.account_common_error_server_message,
                 detailsMessage = serverMessage,
             )
         }

--- a/feature/account/server/validation/src/main/res/values/strings.xml
+++ b/feature/account/server/validation/src/main/res/values/strings.xml
@@ -7,7 +7,6 @@
     <string name="account_server_validation_error_client_certificate_expired">The client certificate is no longer valid</string>
     <string name="account_server_validation_error_client_certificate_retrieval_failure">"The client certificate couldn't be accessed"</string>
     <string name="account_server_validation_error_missing_server_capability">Missing server capability</string>
-    <string name="account_server_validation_error_server_message">The server returned the following message:\n%s</string>
     <string name="account_server_validation_error_details">Details:\n%s</string>
     <string name="account_server_validation_error_missing_server_capability_details">The server is missing this capability:\n%s</string>
     <string name="account_server_validation_incoming_loading_message">Checking incoming server settings…</string>

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
@@ -29,6 +29,7 @@ import app.k9mail.feature.account.common.ui.loadingerror.rememberContentLoadingE
 import app.k9mail.feature.account.setup.R
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersContract.Event
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersContract.State
+import app.k9mail.feature.account.common.R as CommonR
 
 @Composable
 fun SpecialFoldersContent(
@@ -52,9 +53,8 @@ fun SpecialFoldersContent(
                 )
             },
             error = {
-                ErrorView(
-                    title = stringResource(id = R.string.account_setup_special_folders_error_message),
-                    message = state.error?.message,
+                SpecialFoldersErrorView(
+                    failure = state.error!!,
                     onRetry = { onEvent(Event.OnRetryClicked) },
                 )
             },
@@ -112,6 +112,26 @@ fun SuccessView(
             )
         }
     }
+}
+
+@Composable
+private fun SpecialFoldersErrorView(
+    failure: SpecialFoldersContract.Failure,
+    onRetry: () -> Unit,
+) {
+    val message = when (failure) {
+        is SpecialFoldersContract.Failure.LoadFoldersFailed -> {
+            failure.messageFromServer?.let { messageFromServer ->
+                stringResource(id = CommonR.string.account_common_error_server_message, messageFromServer)
+            }
+        }
+    }
+
+    ErrorView(
+        title = stringResource(id = R.string.account_setup_special_folders_error_message),
+        message = message,
+        onRetry = onRetry,
+    )
 }
 
 @Preview(showBackground = true)

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContract.kt
@@ -56,8 +56,6 @@ interface SpecialFoldersContract {
     }
 
     sealed interface Failure {
-        val message: String
-
-        data class LoadFoldersFailed(override val message: String) : Failure
+        data class LoadFoldersFailed(val messageFromServer: String?) : Failure
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersViewModel.kt
@@ -96,7 +96,7 @@ class SpecialFoldersViewModel(
                 state.copy(
                     isLoading = false,
                     isSuccess = false,
-                    error = SpecialFoldersContract.Failure.LoadFoldersFailed(exception.message ?: "unknown error"),
+                    error = SpecialFoldersContract.Failure.LoadFoldersFailed(exception.messageFromServer),
                 )
             }
             null

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersViewModelTest.kt
@@ -142,7 +142,7 @@ class SpecialFoldersViewModelTest {
         val testSubject = createTestSubject(
             formUiModel = FakeSpecialFoldersFormUiModel(),
             getSpecialFolderOptions = {
-                throw FolderFetcherException(IllegalStateException("Failed to load folders"))
+                throw FolderFetcherException(IllegalStateException(), messageFromServer = "Failed to load folders")
             },
             initialState = initialState,
         )


### PR DESCRIPTION
We try to avoid showing raw exception messages to the user whenever possible. Unless there's a message from the server, only show the error title.

|No message from server|Message from Server|
|-|-|
|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/f70f4018-8515-4474-b28c-977a73a7175e)|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/8f5cbf57-f6b1-43a4-8c0f-cf23ea9b36b5)|
