### PR TITLE
Add check to prevent the use of IP addresses as SNI hostnames

### DIFF
--- a/app-feature-preview/src/main/java/app/k9mail/feature/preview/auth/DefaultTrustedSocketFactory.java
+++ b/app-feature-preview/src/main/java/app/k9mail/feature/preview/auth/DefaultTrustedSocketFactory.java
@@ -14,6 +14,7 @@ import android.net.SSLCertificateSocketFactory;
 import android.os.Build;
 import android.text.TextUtils;
 
+import app.k9mail.core.common.net.HostNameUtils;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.ssl.TrustManagerFactory;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
@@ -129,7 +130,10 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
 
         hardenSocket(sslSocket);
 
-        setSniHost(socketFactory, sslSocket, host);
+        // RFC 6066 does not permit the use of literal IPv4 or IPv6 addresses as SNI hostnames.
+        if (HostNameUtils.INSTANCE.isLegalIPAddress(host) == null) {
+            setSniHost(socketFactory, sslSocket, host);
+        }
 
         return trustedSocket;
     }

--- a/app/core/src/main/java/com/fsck/k9/helper/DefaultTrustedSocketFactory.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/DefaultTrustedSocketFactory.java
@@ -14,6 +14,7 @@ import android.net.SSLCertificateSocketFactory;
 import android.os.Build;
 import android.text.TextUtils;
 
+import app.k9mail.core.common.net.HostNameUtils;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.ssl.TrustManagerFactory;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
@@ -129,7 +130,10 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
 
         hardenSocket(sslSocket);
 
-        setSniHost(socketFactory, sslSocket, host);
+        // RFC 6066 does not permit the use of literal IPv4 or IPv6 addresses as SNI hostnames.
+        if (HostNameUtils.INSTANCE.isLegalIPAddress(host) == null) {
+            setSniHost(socketFactory, sslSocket, host);
+        }
 
         return trustedSocket;
     }


### PR DESCRIPTION
Fixes #3676 (kind of).

When I attempt to add my mail server using a literal IPv6 address, I get the following error:
<details>
  <summary>Screenshot</summary>
<img src="https://github.com/thunderbird/thunderbird-android/assets/8599643/9094639a-9ea3-48af-be01-524a318a0c45" width="200px" />
</details>

The error occurs because the constructor of `javax.net.ssl.SNIHostName` fails to parse the hostname. This behavior is consistent with [RFC 6066](https://datatracker.ietf.org/doc/html/rfc6066), which explicitly prohibits using literal IPv4 or IPv6 addresses as SNI hostnames.

This PR fixes the problem by adding the corresponding check before setting the SNI hostname for the SSL/TLS connection.
The other problems mentioned in the original issue are no longer relevant, since the server settings validator was recently updated to accept literal IPv6 addresses.