### PR TITLE
Fix range for `messageListPreviewLines` in `GeneralSettingsDescriptions`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -132,7 +132,7 @@ public class GeneralSettingsDescriptions {
                 new V(1, new LanguageSetting())
         ));
         s.put("messageListPreviewLines", Settings.versions(
-                new V(1, new IntegerRangeSetting(1, 100, 2))
+                new V(1, new IntegerRangeSetting(0, 6, 2))
         ));
         s.put("messageListStars", Settings.versions(
                 new V(1, new BooleanSetting(true))


### PR DESCRIPTION
Change `messageListPreviewLines` entry in `GeneralSettingsDescriptions` to (only) allow the values that can be selected in the settings UI.

Fixes #7493