### PR TITLE
Fix permission screen back behavior

### DIFF
--- a/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
+++ b/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.navigation.NavController
+import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -23,8 +24,8 @@ private fun NavController.navigateToAccountSetup() {
     navigate(NESTED_NAVIGATION_ROUTE_ACCOUNT_SETUP)
 }
 
-private fun NavController.navigateToPermissions() {
-    navigate(NESTED_NAVIGATION_ROUTE_PERMISSIONS)
+private fun NavController.navigateToPermissions(builder: NavOptionsBuilder.() -> Unit) {
+    navigate(NESTED_NAVIGATION_ROUTE_PERMISSIONS, builder)
 }
 
 @Composable
@@ -53,7 +54,11 @@ fun OnboardingNavHost(
                 onFinish = { createdAccountUuid: String ->
                     accountUuid = createdAccountUuid
                     if (hasRuntimePermissions()) {
-                        navController.navigateToPermissions()
+                        navController.navigateToPermissions {
+                            popUpTo(NESTED_NAVIGATION_ROUTE_WELCOME) {
+                                inclusive = true
+                            }
+                        }
                     } else {
                         onFinish(createdAccountUuid)
                     }

--- a/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsScreen.kt
+++ b/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsScreen.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.onboarding.permissions.ui
 
 import android.Manifest
 import android.os.Build
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
@@ -35,6 +36,10 @@ fun PermissionsScreen(
             Effect.RequestNotificationsPermission -> notificationsPermissionLauncher.requestNotificationsPermission()
             Effect.NavigateNext -> onNext()
         }
+    }
+
+    BackHandler {
+        // no back navigation
     }
 
     LaunchedEffect(key1 = Unit) {


### PR DESCRIPTION
Prevent back navigation on permission screen to not create accounts twice or get stuck on the account created screen.
