### PR TITLE
Improve certificate error screen (part 2)

### DIFF
--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/resources/StringResources.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/resources/StringResources.kt
@@ -1,0 +1,31 @@
+package app.k9mail.core.ui.compose.common.resources
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+
+private const val PLACE_HOLDER = "{placeHolder}"
+
+/**
+ * Loads a string resource with a single string parameter that will be replaced with the given [AnnotatedString].
+ */
+@Composable
+@ReadOnlyComposable
+fun annotatedStringResource(@StringRes id: Int, argument: AnnotatedString): AnnotatedString {
+    val stringWithPlaceHolder = stringResource(id, PLACE_HOLDER)
+    return buildAnnotatedString {
+        val placeHolderStartIndex = stringWithPlaceHolder.indexOf(PLACE_HOLDER)
+        require(placeHolderStartIndex != -1)
+
+        append(text = stringWithPlaceHolder, start = 0, end = placeHolderStartIndex)
+        append(argument)
+        append(
+            text = stringWithPlaceHolder,
+            start = placeHolderStartIndex + PLACE_HOLDER.length,
+            end = stringWithPlaceHolder.length,
+        )
+    }
+}

--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/text/AnnotatedStrings.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/text/AnnotatedStrings.kt
@@ -1,0 +1,18 @@
+package app.k9mail.core.ui.compose.common.text
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+
+/**
+ * Converts a [String] into an [AnnotatedString] with all of the text being bold.
+ */
+fun String.bold(): AnnotatedString {
+    return buildAnnotatedString {
+        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+            append(this@bold)
+        }
+    }
+}

--- a/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/resources/StringResourcesTest.kt
+++ b/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/resources/StringResourcesTest.kt
@@ -1,0 +1,28 @@
+package app.k9mail.core.ui.compose.common.resources
+
+import androidx.compose.ui.text.buildAnnotatedString
+import app.k9mail.core.ui.compose.common.text.bold
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Test
+import app.k9mail.core.ui.compose.common.test.R
+
+class StringResourcesTest : ComposeTest() {
+    @Test
+    fun `annotatedStringResource() with bold text`() = runComposeTest {
+        val argument = "text".bold()
+
+        setContent {
+            val result = annotatedStringResource(id = R.string.StringResourcesTest, argument)
+
+            assertThat(result).isEqualTo(
+                buildAnnotatedString {
+                    append("prefix ")
+                    append(argument)
+                    append(" suffix")
+                }
+            )
+        }
+    }
+}

--- a/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/text/AnnotatedStringsTest.kt
+++ b/core/ui/compose/common/src/test/kotlin/app/k9mail/core/ui/compose/common/text/AnnotatedStringsTest.kt
@@ -1,0 +1,27 @@
+package app.k9mail.core.ui.compose.common.text
+
+import androidx.compose.ui.text.AnnotatedString.Range
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class AnnotatedStringsTest {
+    @Test
+    fun bold() {
+        val input = "text"
+
+        val result = input.bold()
+
+        assertThat(result.toString()).isEqualTo(input)
+        assertThat(result.spanStyles).containsExactly(
+            Range(
+                item = SpanStyle(fontWeight = FontWeight.Bold),
+                start = 0,
+                end = input.length,
+            ),
+        )
+    }
+}

--- a/core/ui/compose/common/src/test/res/values/test_strings.xml
+++ b/core/ui/compose/common/src/test/res/values/test_strings.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources>
+    <string name="StringResourcesTest">prefix %s suffix</string>
+</resources>

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ServerCertificateModule.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ServerCertificateModule.kt
@@ -4,7 +4,9 @@ import app.k9mail.feature.account.server.certificate.data.InMemoryServerCertific
 import app.k9mail.feature.account.server.certificate.domain.ServerCertificateDomainContract
 import app.k9mail.feature.account.server.certificate.domain.usecase.AddServerCertificateException
 import app.k9mail.feature.account.server.certificate.domain.usecase.FormatServerCertificateError
+import app.k9mail.feature.account.server.certificate.ui.DefaultServerNameFormatter
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorViewModel
+import app.k9mail.feature.account.server.certificate.ui.ServerNameFormatter
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -24,6 +26,8 @@ val featureAccountServerCertificateModule: Module = module {
     factory<ServerCertificateDomainContract.UseCase.FormatServerCertificateError> {
         FormatServerCertificateError()
     }
+
+    factory<ServerNameFormatter> { DefaultServerNameFormatter() }
 
     viewModel {
         ServerCertificateErrorViewModel(

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContent.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContent.kt
@@ -29,18 +29,20 @@ import app.k9mail.feature.account.server.certificate.R
 import app.k9mail.feature.account.server.certificate.domain.entity.FormattedServerCertificateError
 import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateProperties
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract.State
+import org.koin.compose.koinInject
 
 @Composable
 internal fun ServerCertificateErrorContent(
     innerPadding: PaddingValues,
     state: State,
     scrollState: ScrollState,
+    serverNameFormatter: ServerNameFormatter = koinInject(),
 ) {
     ResponsiveWidthContainer(modifier = Modifier.padding(innerPadding)) {
         Column(
             modifier = Modifier.verticalScroll(scrollState),
         ) {
-            CertificateErrorOverview(state)
+            CertificateErrorOverview(state, serverNameFormatter)
 
             AnimatedContent(
                 targetState = state.isShowServerCertificate,
@@ -49,6 +51,7 @@ internal fun ServerCertificateErrorContent(
                 if (isShowServerCertificate) {
                     ServerCertificateView(
                         serverCertificateProperties = state.certificateError!!.serverCertificateProperties,
+                        serverNameFormatter = serverNameFormatter,
                     )
                 }
             }
@@ -57,7 +60,7 @@ internal fun ServerCertificateErrorContent(
 }
 
 @Composable
-private fun CertificateErrorOverview(state: State) {
+private fun CertificateErrorOverview(state: State, serverNameFormatter: ServerNameFormatter) {
     Column(
         modifier = Modifier.padding(all = MainTheme.spacings.double),
     ) {
@@ -67,7 +70,7 @@ private fun CertificateErrorOverview(state: State) {
         Spacer(modifier = Modifier.height(MainTheme.spacings.quadruple))
 
         state.certificateError?.let { certificateError ->
-            CertificateErrorDescription(certificateError)
+            CertificateErrorDescription(certificateError, serverNameFormatter)
         }
     }
 }
@@ -97,11 +100,14 @@ private fun WarningTitle() {
 }
 
 @Composable
-private fun CertificateErrorDescription(certificateError: FormattedServerCertificateError) {
+private fun CertificateErrorDescription(
+    certificateError: FormattedServerCertificateError,
+    serverNameFormatter: ServerNameFormatter,
+) {
     TextBody1(
         text = stringResource(
             id = R.string.account_server_certificate_unknown_error_description_format,
-            certificateError.hostname,
+            serverNameFormatter.format(certificateError.hostname),
         ),
     )
 }
@@ -132,6 +138,7 @@ internal fun ServerCertificateErrorContentPreview() {
             innerPadding = PaddingValues(all = 0.dp),
             state = state,
             scrollState = rememberScrollState(),
+            serverNameFormatter = DefaultServerNameFormatter(),
         )
     }
 }

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContent.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContent.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.common.baseline.withBaseline
+import app.k9mail.core.ui.compose.common.resources.annotatedStringResource
+import app.k9mail.core.ui.compose.common.text.bold
 import app.k9mail.core.ui.compose.designsystem.atom.Icon
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBody1
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextHeadline4
@@ -105,9 +107,9 @@ private fun CertificateErrorDescription(
     serverNameFormatter: ServerNameFormatter,
 ) {
     TextBody1(
-        text = stringResource(
+        text = annotatedStringResource(
             id = R.string.account_server_certificate_unknown_error_description_format,
-            serverNameFormatter.format(certificateError.hostname),
+            serverNameFormatter.format(certificateError.hostname).bold(),
         ),
     )
 }

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateView.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateView.kt
@@ -19,8 +19,9 @@ import app.k9mail.feature.account.server.certificate.R
 import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateProperties
 
 @Composable
-fun ServerCertificateView(
+internal fun ServerCertificateView(
     serverCertificateProperties: ServerCertificateProperties,
+    serverNameFormatter: ServerNameFormatter,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -35,7 +36,7 @@ fun ServerCertificateView(
 
         TextSubtitle2(stringResource(R.string.account_server_certificate_subject_alternative_names))
         for (subjectAlternativeName in serverCertificateProperties.subjectAlternativeNames) {
-            BulletedListItem(subjectAlternativeName)
+            BulletedListItem(serverNameFormatter.format(subjectAlternativeName))
         }
 
         Spacer(modifier = Modifier.height(MainTheme.spacings.double))
@@ -92,7 +93,11 @@ private fun BulletedListItem(text: String) {
 @Preview(showBackground = true)
 internal fun ServerCertificateViewPreview() {
     val serverCertificateProperties = ServerCertificateProperties(
-        subjectAlternativeNames = listOf("*.domain.example", "domain.example"),
+        subjectAlternativeNames = listOf(
+            "*.domain.example",
+            "domain.example",
+            "quite.the.long.domain.name.that.hopefully.exceeds.the.available.width.example",
+        ),
         notValidBefore = "January 1, 2023, 12:00 AM",
         notValidAfter = "December 31, 2023, 11:59 PM",
         subject = "CN=*.domain.example",
@@ -106,6 +111,7 @@ internal fun ServerCertificateViewPreview() {
     K9Theme {
         ServerCertificateView(
             serverCertificateProperties = serverCertificateProperties,
+            serverNameFormatter = DefaultServerNameFormatter(),
         )
     }
 }

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerNameFormatter.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerNameFormatter.kt
@@ -1,0 +1,32 @@
+package app.k9mail.feature.account.server.certificate.ui
+
+import app.k9mail.core.common.net.HostNameUtils
+
+/**
+ * Format a hostname or IP address for display.
+ *
+ * Inserts zero width space (U+200B) after components separators to decrease the chance of long lines being displayed
+ * with a line break in the middle of a component (DNS label or number component of an IP address).
+ */
+internal fun interface ServerNameFormatter {
+    fun format(hostname: String): String
+}
+
+internal class DefaultServerNameFormatter : ServerNameFormatter {
+    override fun format(hostname: String): String {
+        val address = HostNameUtils.isLegalIPv6Address(hostname)
+        return if (address != null) {
+            formatIPv6Address(address)
+        } else {
+            formatDotName(hostname)
+        }
+    }
+
+    private fun formatIPv6Address(address: String): String {
+        return address.replace(":", ":\u200B")
+    }
+
+    private fun formatDotName(hostname: String): String {
+        return hostname.replace(".", ".\u200B")
+    }
+}

--- a/feature/account/server/certificate/src/test/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerNameFormatterTest.kt
+++ b/feature/account/server/certificate/src/test/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerNameFormatterTest.kt
@@ -1,0 +1,25 @@
+package app.k9mail.feature.account.server.certificate.ui
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class ServerNameFormatterTest {
+    private val formatter = DefaultServerNameFormatter()
+
+    @Test
+    fun hostname() {
+        assertThat(formatter.format("domain.example")).isEqualTo("domain.\u200Bexample")
+    }
+
+    @Test
+    fun `IPv4 address`() {
+        assertThat(formatter.format("127.0.0.1")).isEqualTo("127.\u200B0.\u200B0.\u200B1")
+    }
+
+    @Test
+    fun `IPv6 address`() {
+        assertThat(formatter.format("2001:db8::1"))
+            .isEqualTo("2001:\u200B0db8:\u200B0000:\u200B0000:\u200B0000:\u200B0000:\u200B0000:\u200B0001")
+    }
+}


### PR DESCRIPTION
- Insert [zero width spaces](https://en.wikipedia.org/wiki/Zero-width_space) to host names so the text renderer can break them in convenient places if necessary
- Display the server name in bold in the error message

![image](https://github.com/thunderbird/thunderbird-android/assets/218061/2fc87e18-8824-4153-a66e-892c2f295ee5)
