### PR TITLE
Remove app name from `AccountTopAppBar`

### DIFF
--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBar.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBar.kt
@@ -3,12 +3,10 @@ package app.k9mail.feature.account.common.ui
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.organism.TopAppBar
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.PreviewWithThemes
-import app.k9mail.feature.account.common.R
 
 /**
  * Top app bar for the account screens.
@@ -21,7 +19,6 @@ fun AccountTopAppBar(
     TopAppBar(
         title = title,
         modifier = modifier,
-        subtitle = stringResource(id = R.string.account_common_title),
         titleContentPadding = PaddingValues(
             start = MainTheme.spacings.double,
         ),


### PR DESCRIPTION
|Before|After|
|-|-|
|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/37f6f795-a310-4562-ac68-211d03ccdc60)|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/2e856df0-b6d8-4594-af82-fcd3746350af)|
