### PR TITLE
Fix button bar paddings in permission screen

### DIFF
--- a/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
+++ b/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
@@ -151,10 +151,10 @@ private fun BottomBar(
             Row(
                 modifier = Modifier
                     .padding(
-                        start = MainTheme.spacings.double,
-                        end = MainTheme.spacings.double,
-                        top = MainTheme.spacings.half,
-                        bottom = MainTheme.spacings.half,
+                        start = MainTheme.spacings.quadruple,
+                        end = MainTheme.spacings.quadruple,
+                        top = MainTheme.spacings.default,
+                        bottom = MainTheme.spacings.double,
                     )
                     .fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,


### PR DESCRIPTION
Match the padding used in `WizardNavigationBar`.

Fixes #7559
