### PR TITLE
Remove unnecessary test server operation

### DIFF
--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapServerSettingsValidatorTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapServerSettingsValidatorTest.kt
@@ -254,7 +254,6 @@ class ImapServerSettingsValidatorTest {
             output("1 OK CAPABILITY Completed")
             expect("2 STARTTLS")
             output("2 OK Begin TLS negotiation now")
-            startTls()
         }
         val serverSettings = ServerSettings(
             type = "imap",


### PR DESCRIPTION
In the flaky test the client code throws before actually attempting to upgrade the connection to TLS. So there's no need for `MockImapServer` to attempt a TLS handshake. Because the TLS handshake blocks the server thread, this could lead to the client disconnect only being registered after `verifyConnectionClosed()` has already timed out and failed.

Fixes #7562