### PR TITLE
Remove app name from `AccountTopAppBarWithBackButton`

### DIFF
--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBarWithBackButton.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AccountTopAppBarWithBackButton.kt
@@ -3,14 +3,12 @@ package app.k9mail.feature.account.common.ui
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonIcon
 import app.k9mail.core.ui.compose.designsystem.organism.TopAppBar
 import app.k9mail.core.ui.compose.theme.Icons
 import app.k9mail.core.ui.compose.theme.MainTheme
 import app.k9mail.core.ui.compose.theme.PreviewWithThemes
-import app.k9mail.feature.account.common.R
 
 /**
  * Top app bar for the account screens with a back button.
@@ -24,7 +22,6 @@ fun AccountTopAppBarWithBackButton(
     TopAppBar(
         title = title,
         modifier = modifier,
-        subtitle = stringResource(id = R.string.account_common_title),
         titleContentPadding = PaddingValues(
             start = MainTheme.spacings.default,
         ),


### PR DESCRIPTION
I missed this when working on #7543.