### PR TITLE
Center text in `LoadingView`, `SuccessView`, and `ErrorView`

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/ErrorView.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/ErrorView.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.R
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
@@ -54,6 +55,7 @@ fun ErrorView(
                 )
                 TextSubtitle1(
                     text = title,
+                    textAlign = TextAlign.Center,
                 )
             }
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/LoadingView.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/LoadingView.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.atom.CircularProgressIndicator
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextSubtitle1
@@ -36,7 +37,10 @@ fun LoadingView(
             verticalArrangement = Arrangement.Center,
         ) {
             if (message != null) {
-                TextSubtitle1(text = message)
+                TextSubtitle1(
+                    text = message,
+                    textAlign = TextAlign.Center,
+                )
             }
             Row(
                 modifier = Modifier.height(MainTheme.sizes.larger),

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/view/SuccessView.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/view/SuccessView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.atom.Icon
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextSubtitle1
@@ -28,7 +29,10 @@ fun SuccessView(
             .then(modifier),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        TextSubtitle1(text = message)
+        TextSubtitle1(
+            text = message,
+            textAlign = TextAlign.Center,
+        )
         Row(
             modifier = Modifier.height(MainTheme.sizes.larger),
             verticalAlignment = Alignment.CenterVertically,
@@ -47,7 +51,7 @@ fun SuccessView(
 internal fun SuccessViewPreview() {
     PreviewWithThemes {
         SuccessView(
-            message = "Success",
+            message = "The app tried really hard and managed to successfully complete the operation.",
         )
     }
 }


### PR DESCRIPTION
The special folders success message is fairly long and takes up two lines on my test device.

Without this change, the text is left-aligned and looks off.

|Before|After|
|-|-|
|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/4e08c998-4e33-461a-a933-c208bdc68ae4)|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/4bacd699-f2e8-4acb-b1fa-ad833449e490)|
