### PR TITLE
Use toolbar in `ServerValidationScreen` when editing server settings

### DIFF
--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
@@ -1,6 +1,7 @@
 package app.k9mail.feature.account.edit.ui.server.settings
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -8,6 +9,7 @@ import androidx.navigation.compose.rememberNavController
 import app.k9mail.feature.account.edit.ui.server.settings.modify.ModifyIncomingServerSettingsViewModel
 import app.k9mail.feature.account.edit.ui.server.settings.save.SaveIncomingServerSettingsViewModel
 import app.k9mail.feature.account.edit.ui.server.settings.save.SaveServerSettingsScreen
+import app.k9mail.feature.account.server.settings.R
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsScreen
 import app.k9mail.feature.account.server.validation.ui.IncomingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.ServerValidationScreen
@@ -49,6 +51,7 @@ fun EditIncomingServerSettingsNavHost(
         }
         composable(route = NESTED_NAVIGATION_ROUTE_VALIDATE) {
             ServerValidationScreen(
+                title = stringResource(id = R.string.account_server_settings_incoming_top_bar_title),
                 onBack = { navController.popBackStack() },
                 onNext = { navController.navigateToSave() },
                 viewModel = koinViewModel<IncomingServerValidationViewModel> {

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
@@ -1,6 +1,7 @@
 package app.k9mail.feature.account.edit.ui.server.settings
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -8,6 +9,7 @@ import androidx.navigation.compose.rememberNavController
 import app.k9mail.feature.account.edit.ui.server.settings.modify.ModifyOutgoingServerSettingsViewModel
 import app.k9mail.feature.account.edit.ui.server.settings.save.SaveOutgoingServerSettingsViewModel
 import app.k9mail.feature.account.edit.ui.server.settings.save.SaveServerSettingsScreen
+import app.k9mail.feature.account.server.settings.R
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsScreen
 import app.k9mail.feature.account.server.validation.ui.OutgoingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.ServerValidationScreen
@@ -49,6 +51,7 @@ fun EditOutgoingServerSettingsNavHost(
         }
         composable(route = NESTED_NAVIGATION_ROUTE_VALIDATE) {
             ServerValidationScreen(
+                title = stringResource(id = R.string.account_server_settings_outgoing_top_bar_title),
                 onBack = { navController.popBackStack() },
                 onNext = { navController.navigateToSave() },
                 viewModel = koinViewModel<OutgoingServerValidationViewModel> {

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
@@ -17,6 +17,7 @@ fun ServerValidationScreen(
     onBack: () -> Unit,
     viewModel: ViewModel,
     modifier: Modifier = Modifier,
+    title: String? = null,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
         when (effect) {
@@ -40,9 +41,17 @@ fun ServerValidationScreen(
             modifier = modifier,
         )
     } else {
-        ServerValidationMainScreen(
-            viewModel = viewModel,
-            modifier = modifier,
-        )
+        if (title != null) {
+            ServerValidationToolbarScreen(
+                title = title,
+                viewModel = viewModel,
+                modifier = modifier,
+            )
+        } else {
+            ServerValidationMainScreen(
+                viewModel = viewModel,
+                modifier = modifier,
+            )
+        }
     }
 }

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationToolbarScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationToolbarScreen.kt
@@ -1,0 +1,64 @@
+package app.k9mail.feature.account.server.validation.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
+import app.k9mail.core.ui.compose.common.mvi.observeWithoutEffect
+import app.k9mail.core.ui.compose.designsystem.template.Scaffold
+import app.k9mail.core.ui.compose.theme.K9Theme
+import app.k9mail.feature.account.common.ui.AccountTopAppBarWithBackButton
+import app.k9mail.feature.account.common.ui.WizardNavigationBar
+import app.k9mail.feature.account.common.ui.WizardNavigationBarState
+import app.k9mail.feature.account.oauth.ui.preview.PreviewAccountOAuthViewModel
+import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Event
+import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.ViewModel
+import app.k9mail.feature.account.server.validation.ui.fake.FakeIncomingServerValidationViewModel
+
+@Composable
+internal fun ServerValidationToolbarScreen(
+    title: String,
+    viewModel: ViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val (state, dispatch) = viewModel.observeWithoutEffect()
+
+    Scaffold(
+        topBar = {
+            AccountTopAppBarWithBackButton(
+                title = title,
+                onBackClicked = { dispatch(Event.OnBackClicked) },
+            )
+        },
+        bottomBar = {
+            WizardNavigationBar(
+                onNextClick = {},
+                onBackClick = { dispatch(Event.OnBackClicked) },
+                state = WizardNavigationBarState(
+                    showNext = false,
+                ),
+            )
+        },
+        modifier = modifier,
+    ) { innerPadding ->
+        ServerValidationContent(
+            onEvent = { dispatch(it) },
+            state = state.value,
+            isIncomingValidation = viewModel.isIncomingValidation,
+            oAuthViewModel = viewModel.oAuthViewModel,
+            contentPadding = innerPadding,
+        )
+    }
+}
+
+@Composable
+@PreviewDevices
+internal fun IncomingServerValidationToolbarScreenK9Preview() {
+    K9Theme {
+        ServerValidationToolbarScreen(
+            title = "Incoming server settings",
+            viewModel = FakeIncomingServerValidationViewModel(
+                oAuthViewModel = PreviewAccountOAuthViewModel(),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
When editing server settings of an existing account, the app is currently switching from a screen with a toolbar to a screen with `AppTitleTopHeader` to a screen with a toolbar. With this change, a toolbar is used in all screens displayed when editing server settings.

 The setup flow is still using the `AppTitleTopHeader` variant.

|Before|After|
|-|-|
|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/8d6d6c83-82d5-4231-80ea-c4f5fdd5cee6)|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/0d989736-59aa-4bf3-809d-6b15e58b8173)|
