### PR TITLE
Allow internal access to `AttachmentTempFileProvider`

### DIFF
--- a/app/common/src/main/AndroidManifest.xml
+++ b/app/common/src/main/AndroidManifest.xml
@@ -343,6 +343,10 @@
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/temp_file_provider_paths" />
+
+            <meta-data
+                android:name="de.cketti.safecontentresolver.ALLOW_INTERNAL_ACCESS"
+                android:value="true" />
         </provider>
 
         <activity


### PR DESCRIPTION
This allows an app that was selected to view an attachment to share the attachment back to K-9 Mail.

Fixes #7557