### PR TITLE
Add finish to make sure activity closes after launching

### DIFF
--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
@@ -27,7 +27,10 @@ fun FeatureLauncherNavHost(
         modifier = modifier,
     ) {
         onboardingRoute(
-            onFinish = { accountUuid -> accountSetupFinishedLauncher.launch(accountUuid) },
+            onFinish = { accountUuid ->
+                accountSetupFinishedLauncher.launch(accountUuid)
+                activity.finish()
+            },
         )
         accountSetupRoute(
             onBack = onBack,


### PR DESCRIPTION
Fixes #7585

I'm not a fan of having to call `activity.finish()` additionally. But as stated in [start before finish](https://commonsware.com/blog/2020/02/01/start-before-finish.html) a `startActivityAndFinish()` is not available.