### PR TITLE
Change lint rules

### DIFF
--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -2,6 +2,4 @@
 <lint>
     <issue id="MissingTranslation" severity="ignore" />
     <issue id="ExtraTranslation" severity="warning" />
-    <issue id="OldTargetApi" severity="ignore" />
-    <issue id="GoogleAppIndexingWarning" severity="ignore" />
 </lint>

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-    <issue id="MissingTranslation" severity="ignore" />
+    <issue id="MissingTranslation" severity="informational" />
     <issue id="ExtraTranslation" severity="warning" />
 </lint>

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -2,4 +2,5 @@
 <lint>
     <issue id="MissingTranslation" severity="informational" />
     <issue id="ExtraTranslation" severity="warning" />
+    <issue id="ImpliedQuantity" severity="warning" />
 </lint>


### PR DESCRIPTION
Remove unused lint rules, change `MissingTranslation` to `informational` and change `ImpliedQuantity` to `warning`.

The `ImpliedQuantity` is necessary as Weblate doesn't support latest Lint enforced rules for quantities in french language.