### PR TITLE
Remove search configuration

### DIFF
--- a/app/common/src/main/AndroidManifest.xml
+++ b/app/common/src/main/AndroidManifest.xml
@@ -39,10 +39,6 @@
         tools:replace="android:theme"
         tools:ignore="UnusedAttribute">
 
-        <meta-data
-            android:name="android.app.default_searchable"
-            android:value="com.fsck.k9.activity.Search" />
-
         <!-- TODO: Remove once minSdkVersion has been changed to 24+ -->
         <meta-data
             android:name="com.lge.support.SPLIT_WINDOW"
@@ -170,21 +166,10 @@
             </intent-filter>
         </activity>
 
-        <!-- Search Activity - searchable -->
         <activity
             android:name="com.fsck.k9.activity.Search"
-            android:configChanges="locale"
             android:label="@string/search_action"
-            android:uiOptions="splitActionBarWhenNarrow"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.SEARCH" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-            <meta-data
-                android:name="android.app.searchable"
-                android:resource="@xml/searchable" />
-        </activity>
+            android:exported="false" />
 
         <!--
         This component is disabled by default. It will be enabled programmatically after an account has been set up.

--- a/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -9,7 +9,6 @@ val mailStoreModule = module {
     single { FolderRepository(messageStoreManager = get(), accountManager = get()) }
     single { MessageViewInfoExtractorFactory(get(), get(), get()) }
     single { StorageManager.getInstance(get()) }
-    single { SearchStatusManager() }
     single { SpecialFolderSelectionStrategy() }
     single {
         K9BackendStorageFactory(

--- a/app/core/src/main/java/com/fsck/k9/mailstore/SearchStatusManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/SearchStatusManager.kt
@@ -1,5 +1,0 @@
-package com.fsck.k9.mailstore
-
-class SearchStatusManager {
-    var isActive = false
-}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -940,6 +940,10 @@ open class MessageList :
         }
     }
 
+    private fun expandSearchView() {
+        searchView?.isIconified = false
+    }
+
     fun setActionBarTitle(title: String, subtitle: String? = null) {
         actionBar.title = title
         actionBar.subtitle = subtitle
@@ -1047,6 +1051,15 @@ open class MessageList :
         if (isDrawerEnabled) {
             lockDrawer()
         }
+    }
+
+    override fun onSearchRequested(): Boolean {
+        if (displayMode == DisplayMode.MESSAGE_VIEW || searchView == null) {
+            return false
+        }
+
+        expandSearchView()
+        return true
     }
 
     override fun startSearch(query: String, account: Account?, folderId: Long?): Boolean {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -911,8 +911,6 @@ open class MessageList :
         val searchView = searchItem.actionView as SearchView
         searchView.maxWidth = Int.MAX_VALUE
         searchView.queryHint = resources.getString(R.string.search_action)
-        val searchManager = getSystemService(SEARCH_SERVICE) as SearchManager
-        searchView.setSearchableInfo(searchManager.getSearchableInfo(componentName))
         searchView.setOnQueryTextListener(
             object : SearchView.OnQueryTextListener {
                 override fun onQueryTextSubmit(query: String): Boolean {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -40,7 +40,6 @@ import com.fsck.k9.activity.compose.MessageActions
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.helper.ParcelableUtil
-import com.fsck.k9.mailstore.SearchStatusManager
 import com.fsck.k9.preferences.AccountManager
 import com.fsck.k9.preferences.GeneralSettingsManager
 import com.fsck.k9.search.LocalSearch
@@ -82,7 +81,6 @@ open class MessageList :
     FragmentManager.OnBackStackChangedListener,
     OnSwitchCompleteListener {
 
-    protected val searchStatusManager: SearchStatusManager by inject()
     private val preferences: Preferences by inject()
     private val accountManager: AccountManager by inject()
     private val defaultFolderProvider: DefaultFolderProvider by inject()
@@ -506,12 +504,6 @@ open class MessageList :
 
         if (displayMode != DisplayMode.MESSAGE_VIEW) {
             onMessageListDisplayed()
-        }
-
-        if (this !is Search) {
-            // necessary b/c no guarantee Search.onStop will be called before MessageList.onResume
-            // when returning from search results
-            searchStatusManager.isActive = false
         }
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/Search.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/Search.java
@@ -3,18 +3,6 @@ package com.fsck.k9.activity;
 
 public class Search extends MessageList {
     @Override
-    public void onStart() {
-        getSearchStatusManager().setActive(true);
-        super.onStart();
-    }
-
-    @Override
-    public void onStop() {
-        getSearchStatusManager().setActive(false);
-        super.onStop();
-    }
-
-    @Override
     protected boolean isDrawerEnabled() {
         return false;
     }

--- a/app/ui/legacy/src/main/res/xml/searchable.xml
+++ b/app/ui/legacy/src/main/res/xml/searchable.xml
@@ -1,7 +1,0 @@
- <searchable xmlns:android="http://schemas.android.com/apk/res/android"
-     android:label="@string/search_action"
-     android:hint="@string/search_action" 
-     android:voiceSearchMode="showVoiceSearchButton|launchRecognizer" 
-     android:voiceLanguageModel="free-form"
-     >
- </searchable>


### PR DESCRIPTION
Fixes an ANR reported via Google Play.

```
This Binder call may be taking too long, causing the main thread to wait, and triggering the ANR
      at android.os.BinderProxy.transact (BinderProxy.java:584)
      at android.app.ISearchManager$Stub$Proxy.getSearchableInfo (ISearchManager.java:201)
      at android.app.SearchManager.getSearchableInfo (SearchManager.java:864)
      at com.fsck.k9.activity.MessageList.initializeSearchMenuItem (MessageList.kt:923)
Your app's code results in the Binder call above. Code that triggers Binder calls should be moved out of the main thread.
      at com.fsck.k9.activity.MessageList.onCreateOptionsMenu (MessageList.kt:907)
```

The search key now no longer opens the `Search` activity from anywhere in the app. Pressing the search key while the message list is displayed, will expand and focus the search view in the toolbar (can be triggered using `adb shell input keyevent 84`).