### PR TITLE
Set proper toolbar title when saving server settings

### DIFF
--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
@@ -61,6 +61,7 @@ fun EditIncomingServerSettingsNavHost(
         }
         composable(route = NESTED_NAVIGATION_ROUTE_SAVE) {
             SaveServerSettingsScreen(
+                title = stringResource(id = R.string.account_server_settings_incoming_top_bar_title),
                 onNext = onFinish,
                 onBack = { navController.popBackStack(route = NESTED_NAVIGATION_ROUTE_MODIFY, inclusive = false) },
                 viewModel = koinViewModel<SaveIncomingServerSettingsViewModel> {

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
@@ -61,6 +61,7 @@ fun EditOutgoingServerSettingsNavHost(
         }
         composable(route = NESTED_NAVIGATION_ROUTE_SAVE) {
             SaveServerSettingsScreen(
+                title = stringResource(id = R.string.account_server_settings_outgoing_top_bar_title),
                 onNext = onFinish,
                 onBack = { navController.popBackStack(route = NESTED_NAVIGATION_ROUTE_MODIFY, inclusive = false) },
                 viewModel = koinViewModel<SaveOutgoingServerSettingsViewModel> {

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/save/SaveServerSettingsScreen.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/save/SaveServerSettingsScreen.kt
@@ -19,6 +19,7 @@ import app.k9mail.feature.account.edit.ui.server.settings.save.fake.FakeSaveServ
 
 @Composable
 fun SaveServerSettingsScreen(
+    title: String,
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
@@ -42,7 +43,7 @@ fun SaveServerSettingsScreen(
     Scaffold(
         topBar = {
             AccountTopAppBarWithBackButton(
-                title = "Edit Server Settings",
+                title = title,
                 onBackClicked = {
                     dispatch(Event.OnBackClicked)
                 },
@@ -76,6 +77,7 @@ fun SaveServerSettingsScreen(
 internal fun SaveServerSettingsScreenK9Preview() {
     K9Theme {
         SaveServerSettingsScreen(
+            title = "Incoming server settings",
             onNext = {},
             onBack = {},
             viewModel = FakeSaveServerSettingsViewModel(
@@ -90,6 +92,7 @@ internal fun SaveServerSettingsScreenK9Preview() {
 internal fun SaveServerSettingsScreenThunderbirdPreview() {
     ThunderbirdTheme {
         SaveServerSettingsScreen(
+            title = "Incoming server settings",
             onNext = {},
             onBack = {},
             viewModel = FakeSaveServerSettingsViewModel(

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/save/SaveServerSettingsScreenKtTest.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/save/SaveServerSettingsScreenKtTest.kt
@@ -27,6 +27,7 @@ class SaveServerSettingsScreenKtTest : ComposeTest() {
 
         setContent {
             SaveServerSettingsScreen(
+                title = "irrelevant",
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,


### PR DESCRIPTION
Replace the hardcoded "Edit Server Settings" with `@string/account_server_settings_incoming_top_bar_title` or `@string/account_server_settings_outgoing_top_bar_title`.