### PR TITLE
Include all supported server settings in `AutoconfigParserResult`

### DIFF
--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigParserResult.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigParserResult.kt
@@ -11,9 +11,14 @@ internal sealed interface AutoconfigParserResult {
      * Server settings extracted from the Autoconfig XML.
      */
     data class Settings(
-        val incomingServerSettings: IncomingServerSettings,
-        val outgoingServerSettings: OutgoingServerSettings,
-    ) : AutoconfigParserResult
+        val incomingServerSettings: List<IncomingServerSettings>,
+        val outgoingServerSettings: List<OutgoingServerSettings>,
+    ) : AutoconfigParserResult {
+        init {
+            require(incomingServerSettings.isNotEmpty())
+            require(outgoingServerSettings.isNotEmpty())
+        }
+    }
 
     /**
      * Server settings couldn't be extracted.

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/RealAutoconfigFetcher.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/RealAutoconfigFetcher.kt
@@ -38,8 +38,8 @@ internal class RealAutoconfigFetcher(
                 return when (val parserResult = parser.parseSettings(inputStream, email)) {
                     is Settings -> {
                         AutoDiscoveryResult.Settings(
-                            incomingServerSettings = parserResult.incomingServerSettings,
-                            outgoingServerSettings = parserResult.outgoingServerSettings,
+                            incomingServerSettings = parserResult.incomingServerSettings.first(),
+                            outgoingServerSettings = parserResult.outgoingServerSettings.first(),
                             isTrusted = fetchResult.isTrusted,
                             source = autoconfigUrl.toString(),
                         )


### PR DESCRIPTION
This only changes the parser, but not the output of `RealAutoconfigFetcher`. So it shouldn't change the account setup behavior.

It's in preparation for a change that will allow us to skip unsupported OAuth settings (see <https://bugzilla.mozilla.org/show_bug.cgi?id=1869122>).