### PR TITLE
Focus subject or content field when composing email by external intent

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -370,8 +370,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             relatedMessageProcessed = savedInstanceState.getBoolean(STATE_KEY_SOURCE_MESSAGE_PROCED, false);
         }
 
-
-        if (initFromIntent(intent)) {
+        boolean startedByExternalIntent = initFromIntent(intent);
+        if (startedByExternalIntent) {
             action = Action.COMPOSE;
             changesMadeSinceLastSave = true;
         } else {
@@ -446,6 +446,13 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 action == Action.EDIT_DRAFT) {
             //change focus to message body.
             messageContentView.requestFocus();
+        } else if (startedByExternalIntent) {
+            // If started by external intent, focus "Subject" or content field (Issue #7618)
+            if(subjectView.getText().length() == 0) {
+                subjectView.requestFocus();
+            } else {
+                messageContentView.requestFocus();
+            }
         } else {
             // Explicitly set focus to "To:" input field (see issue 2998)
             recipientMvpView.requestFocusOnToField();

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -448,7 +448,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             messageContentView.requestFocus();
         } else if (startedByExternalIntent) {
             // If started by external intent, focus "Subject" or content field (Issue #7618)
-            if(subjectView.getText().length() == 0) {
+            if (subjectView.getText().length() == 0) {
                 subjectView.requestFocus();
             } else {
                 messageContentView.requestFocus();


### PR DESCRIPTION
When composing an email from an external intent, e.g. a mailto link: directly focus the subject field, or the content field if the intent contains a subject.
_Fixes #7618_
