### PR TITLE
Fix order of discovery methods

### DIFF
--- a/feature/autodiscovery/service/src/main/kotlin/app/k9mail/autodiscovery/service/RealAutoDiscoveryRegistry.kt
+++ b/feature/autodiscovery/service/src/main/kotlin/app/k9mail/autodiscovery/service/RealAutoDiscoveryRegistry.kt
@@ -29,10 +29,10 @@ class RealAutoDiscoveryRegistry(
                     okHttpClient = okHttpClient,
                     config = autoconfigUrlConfig,
                 ),
-                createMxLookupAutoconfigDiscovery(
+                createIspDbAutoconfigDiscovery(
                     okHttpClient = okHttpClient,
                 ),
-                createIspDbAutoconfigDiscovery(
+                createMxLookupAutoconfigDiscovery(
                     okHttpClient = okHttpClient,
                 ),
             ),


### PR DESCRIPTION
Isp lookup should have higher priority than the MX lookup
