### PR TITLE
Update issue templates to use updated labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Let us know about crashes or existing functionality not working like it should.
-labels: [ "bug", "unconfirmed" ]
+labels: [ "type: bug", "unconfirmed" ]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an idea for K-9 Mail
-labels: [ "enhancement", "unconfirmed" ]
+labels: [ "type: enhancement", "unconfirmed" ]
 body:
   - type: checkboxes
     id: checklist


### PR DESCRIPTION
The labels `bug` and `enhancement` have been renamed to `type: bug` and `type: enhancement`, this applies this changes to the templates as well.
