### PR TITLE
Explicitly specify MIME type when exporting debug log

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
@@ -24,7 +24,7 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
     private var currentUiState: GeneralSettingsUiState? = null
     private var snackbar: Snackbar? = null
 
-    private val exportLogsResultContract = registerForActivityResult(CreateDocument()) { contentUri ->
+    private val exportLogsResultContract = registerForActivityResult(CreateDocument("text/plain")) { contentUri ->
         if (contentUri != null) {
             viewModel.exportLogs(contentUri)
         }


### PR DESCRIPTION
This might fix the problem of not being able to export a debug log mentioned in #7640. 
Regardless of that, it fixes a deprecation warning.