### PR TITLE
Revert "#7618 focus subject or content field on external intent"

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -372,8 +372,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             relatedMessageProcessed = savedInstanceState.getBoolean(STATE_KEY_SOURCE_MESSAGE_PROCED, false);
         }
 
-        boolean startedByExternalIntent = initFromIntent(intent);
-        if (startedByExternalIntent) {
+
+        if (initFromIntent(intent)) {
             action = Action.COMPOSE;
             changesMadeSinceLastSave = true;
         } else {
@@ -452,13 +452,6 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 action == Action.EDIT_DRAFT) {
             //change focus to message body.
             messageContentView.requestFocus();
-        } else if (startedByExternalIntent) {
-            // If started by external intent, focus "Subject" or content field (Issue #7618)
-            if (subjectView.getText().length() == 0) {
-                subjectView.requestFocus();
-            } else {
-                messageContentView.requestFocus();
-            }
         } else {
             // Explicitly set focus to "To:" input field (see issue 2998)
             recipientMvpView.requestFocusOnToField();


### PR DESCRIPTION
This unintentionally changed the behavior when handling share intents, see https://github.com/thunderbird/thunderbird-android/issues/7618#issuecomment-1944232016