### PR TITLE
Fix `RecipientLayoutCreator` to retain contact name colors

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientNamesView.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/RecipientNamesView.kt
@@ -125,7 +125,7 @@ class RecipientNamesView(context: Context, attrs: AttributeSet?) : ViewGroup(con
             availableWidth,
         )
 
-        recipientNameTextView.text = recipientLayoutData.recipientNames
+        recipientNameTextView.text = recipientLayoutData.recipientList
         val additionalRecipientsVisible = recipientLayoutData.additionalRecipients != null
         val remainingWidth: Int
         if (additionalRecipientsVisible) {

--- a/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/RecipientLayoutCreatorTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/RecipientLayoutCreatorTest.kt
@@ -1,10 +1,18 @@
 package com.fsck.k9.ui.messageview
 
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
 import app.k9mail.core.android.testing.RobolectricTest
+import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
 import org.junit.Test
+
+private const val COLOR = 0xFF0000
 
 class RecipientLayoutCreatorTest : RobolectricTest() {
     private val textMeasure = object : TextMeasure {
@@ -46,7 +54,19 @@ class RecipientLayoutCreatorTest : RobolectricTest() {
             availableWidth = 10,
         )
 
-        assertThat(result.recipientNames.toString()).isEqualTo("to me")
+        assertThat(result.recipientList).isEqualToSpanned("to me")
+        assertThat(result.additionalRecipients).isNull()
+    }
+
+    @Test
+    fun `single colored recipient name`() {
+        val result = recipientLayoutCreator.createRecipientLayout(
+            recipientNames = listOf(coloredString("Alice")),
+            totalNumberOfRecipients = 1,
+            availableWidth = 10,
+        )
+
+        assertThat(result.recipientList).isEqualToSpanned("to <color>Alice</color>")
         assertThat(result.additionalRecipients).isNull()
     }
 
@@ -58,55 +78,55 @@ class RecipientLayoutCreatorTest : RobolectricTest() {
             availableWidth = 1,
         )
 
-        assertThat(result.recipientNames.toString()).isEqualTo("to me")
+        assertThat(result.recipientList).isEqualToSpanned("to me")
         assertThat(result.additionalRecipients).isNull()
     }
 
     @Test
     fun `two recipient names where first one doesn't fit available width`() {
         val result = recipientLayoutCreator.createRecipientLayout(
-            recipientNames = listOf("Alice", "Bob"),
+            recipientNames = listOf(coloredString("Alice"), coloredString("Bob")),
             totalNumberOfRecipients = 2,
             availableWidth = 5,
         )
 
-        assertThat(result.recipientNames.toString()).isEqualTo("to Alice")
+        assertThat(result.recipientList).isEqualToSpanned("to <color>Alice</color>")
         assertThat(result.additionalRecipients).isEqualTo("+1")
     }
 
     @Test
     fun `two recipient names where both fit available width`() {
         val result = recipientLayoutCreator.createRecipientLayout(
-            recipientNames = listOf("Alice", "Bob"),
+            recipientNames = listOf("Alice", coloredString("Bob")),
             totalNumberOfRecipients = 2,
             availableWidth = 13,
         )
 
-        assertThat(result.recipientNames.toString()).isEqualTo("to Alice, Bob")
+        assertThat(result.recipientList).isEqualToSpanned("to Alice, <color>Bob</color>")
         assertThat(result.additionalRecipients).isNull()
     }
 
     @Test
     fun `three recipient names where only first one fits available width`() {
         val result = recipientLayoutCreator.createRecipientLayout(
-            recipientNames = listOf("Alice", "Bob", "Charly"),
+            recipientNames = listOf("Alice", coloredString("Bob"), "Charly"),
             totalNumberOfRecipients = 3,
             availableWidth = 13,
         )
 
-        assertThat(result.recipientNames.toString()).isEqualTo("to Alice")
+        assertThat(result.recipientList).isEqualToSpanned("to Alice")
         assertThat(result.additionalRecipients).isEqualTo("+2")
     }
 
     @Test
     fun `three recipient names where only first two fit available width`() {
         val result = recipientLayoutCreator.createRecipientLayout(
-            recipientNames = listOf("Alice", "Bob", "Charly"),
+            recipientNames = listOf("Alice", coloredString("Bob"), "Charly"),
             totalNumberOfRecipients = 3,
             availableWidth = 16,
         )
 
-        assertThat(result.recipientNames.toString()).isEqualTo("to Alice, Bob")
+        assertThat(result.recipientList).isEqualToSpanned("to Alice, <color>Bob</color>")
         assertThat(result.additionalRecipients).isEqualTo("+1")
     }
 
@@ -118,31 +138,60 @@ class RecipientLayoutCreatorTest : RobolectricTest() {
             availableWidth = 100,
         )
 
-        assertThat(result.recipientNames.toString()).isEqualTo("to Alice, Bob, Charly")
+        assertThat(result.recipientList).isEqualToSpanned("to Alice, Bob, Charly")
         assertThat(result.additionalRecipients).isNull()
     }
 
     @Test
     fun `five recipient names and additional recipients where only two fit available width`() {
         val result = recipientLayoutCreator.createRecipientLayout(
-            recipientNames = listOf("One", "Two", "Three", "Four", "Five"),
+            recipientNames = listOf(coloredString("One"), coloredString("Two"), "Three", "Four", "Five"),
             totalNumberOfRecipients = 10,
             availableWidth = 20,
         )
 
-        assertThat(result.recipientNames.toString()).isEqualTo("to One, Two")
+        assertThat(result.recipientList).isEqualToSpanned("to <color>One</color>, <color>Two</color>")
         assertThat(result.additionalRecipients).isEqualTo("+8")
     }
 
     @Test
     fun `five recipient names and additional recipients where all five fit available width`() {
         val result = recipientLayoutCreator.createRecipientLayout(
-            recipientNames = listOf("One", "Two", "Three", "Four", "Five"),
+            recipientNames = listOf("One", "Two", "Three", "Four", coloredString("Five")),
             totalNumberOfRecipients = 10,
             availableWidth = 100,
         )
 
-        assertThat(result.recipientNames.toString()).isEqualTo("to One, Two, Three, Four, Five")
+        assertThat(result.recipientList).isEqualToSpanned("to One, Two, Three, Four, <color>Five</color>")
         assertThat(result.additionalRecipients).isEqualTo("+5")
+    }
+
+    private fun coloredString(text: String): Spannable {
+        return SpannableString(text).apply {
+            setSpan(ForegroundColorSpan(COLOR), 0, text.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
+
+    private fun Assert<CharSequence>.isEqualToSpanned(expected: String) = given { charSequence ->
+        assertThat(charSequence).isInstanceOf<Spanned>()
+        val spanned = charSequence as Spanned
+
+        val spans = spanned.getSpans(0, spanned.length, Any::class.java)
+            .toList()
+            .sortedByDescending { spanned.getSpanStart(it) }
+
+        val tagString = buildString {
+            append(spanned)
+
+            for (span in spans) {
+                assertThat(span).isInstanceOf<ForegroundColorSpan>().given { colorSpan ->
+                    assertThat(colorSpan.foregroundColor).isEqualTo(COLOR)
+                    insert(spanned.getSpanEnd(colorSpan), "</color>")
+                    insert(spanned.getSpanStart(colorSpan), "<color>")
+                }
+            }
+        }
+
+        assertThat(tagString).isEqualTo(expected)
     }
 }


### PR DESCRIPTION
When *Settings → General settings → Colorize contacts* is enabled, recipient names passed to `RecipientLayoutCreator` might be instances of `Spanned`. We therefore can't use `String.format()`, because that would convert the arguments to `String` and lose the spans.

This fixes a regression introduced in #7205.