### PR TITLE
Fix autodiscovery ssl for lets encrypt

### DIFF
--- a/app-k9mail/dependencies/releaseRuntimeClasspath.txt
+++ b/app-k9mail/dependencies/releaseRuntimeClasspath.txt
@@ -139,6 +139,7 @@ com.mikepenz:fastadapter:5.7.0
 com.mikepenz:materialdrawer:8.4.5
 com.splitwise:tokenautocomplete:4.0.0-beta01
 com.squareup.moshi:moshi:1.15.1
+com.squareup.okhttp3:okhttp-tls:4.12.0
 com.squareup.okhttp3:okhttp:4.12.0
 com.squareup.okio:okio-jvm:3.7.0
 com.squareup.okio:okio:3.7.0

--- a/app/common/src/main/java/com/fsck/k9/CommonKoinModule.kt
+++ b/app/common/src/main/java/com/fsck/k9/CommonKoinModule.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9
 
+import app.k9mail.core.common.net.ssl.TrustedCertificateProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.featureflag.FeatureFlagProvider
 import app.k9mail.core.featureflag.InMemoryFeatureFlagProvider
@@ -11,6 +12,7 @@ import com.fsck.k9.crypto.EncryptionExtractor
 import com.fsck.k9.crypto.openpgp.OpenPgpEncryptionExtractor
 import com.fsck.k9.feature.featureModule
 import com.fsck.k9.featureflag.InMemoryFeatureFlagFactory
+import com.fsck.k9.net.ssl.DefaultTrustedCertificateProvider
 import com.fsck.k9.notification.notificationModule
 import com.fsck.k9.preferences.K9StoragePersister
 import com.fsck.k9.preferences.StoragePersister
@@ -39,6 +41,7 @@ val commonAppModule = module {
             featureFlagFactory = get(),
         )
     }
+    single<TrustedCertificateProvider> { DefaultTrustedCertificateProvider() }
 }
 
 val commonAppModules = listOf(

--- a/app/common/src/main/java/com/fsck/k9/net/ssl/DefaultTrustedCertificateProvider.kt
+++ b/app/common/src/main/java/com/fsck/k9/net/ssl/DefaultTrustedCertificateProvider.kt
@@ -1,0 +1,19 @@
+package com.fsck.k9.net.ssl
+
+import android.os.Build
+import app.k9mail.core.common.net.ssl.TrustedCertificateProvider
+import app.k9mail.core.common.net.ssl.decodeCertificatePem
+import java.security.cert.X509Certificate
+
+class DefaultTrustedCertificateProvider : TrustedCertificateProvider {
+    override fun getCertificates(): List<X509Certificate> {
+        return if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N) {
+            listOf(
+                TrustedCertificates.certificateIsrgRootX1.decodeCertificatePem(),
+                TrustedCertificates.certificateIsrgRootX2.decodeCertificatePem(),
+            )
+        } else {
+            emptyList()
+        }
+    }
+}

--- a/app/common/src/main/java/com/fsck/k9/net/ssl/TrustedCertificates.kt
+++ b/app/common/src/main/java/com/fsck/k9/net/ssl/TrustedCertificates.kt
@@ -1,16 +1,15 @@
 package com.fsck.k9.net.ssl
 
 /**
- * The PEM-encoded certificates for trusted Certificate Authorities (CAs).
+ * List of PEM-encoded certificates for trusted Certificate Authorities (CAs).
  *
- * These certificates are used to establish a list of trusted certificates for the TLS (Transport Layer Security)
- * implementation and to supplement the list of certificates that are not included in the system's trust store.
- * This is essential to maintain the ability to establish TLS connections on older versions of Android.
+ * These aim to fill the gap of missing certificates in earlier versions of Android.
  */
 object TrustedCertificates {
 
     // Let's Encrypt Certificates - https://letsencrypt.org/certificates/
     // ISRG Root X1 self-signed: https://letsencrypt.org/certs/isrgrootx1.pem
+    // Not present in Android 7 and earlier
     internal val certificateIsrgRootX1 = """
         -----BEGIN CERTIFICATE-----
         MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
@@ -47,6 +46,7 @@ object TrustedCertificates {
 
     // Let's Encrypt Certificates - https://letsencrypt.org/certificates/
     // ISRG Root X2 self-signed: https://letsencrypt.org/certs/isrg-root-x2.pem
+    // Not present in Android 13 and earlier
     internal val certificateIsrgRootX2 = """
         -----BEGIN CERTIFICATE-----
         MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw

--- a/app/common/src/main/java/com/fsck/k9/net/ssl/TrustedCertificates.kt
+++ b/app/common/src/main/java/com/fsck/k9/net/ssl/TrustedCertificates.kt
@@ -1,0 +1,66 @@
+package com.fsck.k9.net.ssl
+
+/**
+ * The PEM-encoded certificates for trusted Certificate Authorities (CAs).
+ *
+ * These certificates are used to establish a list of trusted certificates for the TLS (Transport Layer Security)
+ * implementation and to supplement the list of certificates that are not included in the system's trust store.
+ * This is essential to maintain the ability to establish TLS connections on older versions of Android.
+ */
+object TrustedCertificates {
+
+    // Let's Encrypt Certificates - https://letsencrypt.org/certificates/
+    // ISRG Root X1 self-signed: https://letsencrypt.org/certs/isrgrootx1.pem
+    internal val certificateIsrgRootX1 = """
+        -----BEGIN CERTIFICATE-----
+        MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+        TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+        cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+        WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+        ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+        MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+        h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+        0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+        A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+        T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+        B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+        B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+        KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+        OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+        jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+        qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+        rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+        HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+        hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+        ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+        3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+        NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+        ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+        TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+        jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+        oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+        4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+        mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+        emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+        -----END CERTIFICATE-----
+    """.trimIndent()
+
+    // Let's Encrypt Certificates - https://letsencrypt.org/certificates/
+    // ISRG Root X2 self-signed: https://letsencrypt.org/certs/isrg-root-x2.pem
+    internal val certificateIsrgRootX2 = """
+        -----BEGIN CERTIFICATE-----
+        MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw
+        CQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2gg
+        R3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMjAeFw0yMDA5MDQwMDAwMDBaFw00
+        MDA5MTcxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5ldCBT
+        ZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgyMHYw
+        EAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0HttwW
+        +1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7AlF9
+        ItgKbppbd9/w+kHsOdx1ymgHDB/qo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0T
+        AQH/BAUwAwEB/zAdBgNVHQ4EFgQUfEKWrt5LSDv6kviejM9ti6lyN5UwCgYIKoZI
+        zj0EAwMDaAAwZQIwe3lORlCEwkSHRhtFcP9Ymd70/aTSVaYgLXTWNLxBo1BfASdW
+        tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1
+        /q4AaOeMSQ+2b1tbFfLn
+        -----END CERTIFICATE-----
+    """.trimIndent()
+}

--- a/app/common/src/test/java/com/fsck/k9/net/ssl/DefaultTrustedCertificateProviderTest.kt
+++ b/app/common/src/test/java/com/fsck/k9/net/ssl/DefaultTrustedCertificateProviderTest.kt
@@ -1,0 +1,39 @@
+package com.fsck.k9.net.ssl
+
+import android.os.Build.VERSION_CODES
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class DefaultTrustedCertificateProviderTest {
+
+    @Test
+    @Config(sdk = [VERSION_CODES.N, VERSION_CODES.M, VERSION_CODES.LOLLIPOP_MR1, VERSION_CODES.LOLLIPOP])
+    fun `should return certificates on pre-N devices`() {
+        // Given
+        val provider = DefaultTrustedCertificateProvider()
+
+        // When
+        val result = provider.getCertificates()
+
+        // Then
+        assertThat(result.size).isEqualTo(2)
+    }
+
+    @Test
+    @Config(sdk = [VERSION_CODES.N_MR1, VERSION_CODES.O])
+    fun `should return empty list on N_MR1 and later devices`() {
+        // Given
+        val provider = DefaultTrustedCertificateProvider()
+
+        // When
+        val result = provider.getCertificates()
+
+        // Then
+        assertThat(result).isEqualTo(emptyList())
+    }
+}

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -4,5 +4,7 @@ plugins {
 }
 
 dependencies {
+    implementation(libs.okio)
+
     testImplementation(projects.core.testing)
 }

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 
 dependencies {
     implementation(libs.okio)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.tls)
 
     testImplementation(projects.core.testing)
 }

--- a/core/common/src/main/kotlin/app/k9mail/core/common/net/ssl/OkHttpTrustedCertificatesInstaller.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/net/ssl/OkHttpTrustedCertificatesInstaller.kt
@@ -1,0 +1,18 @@
+package app.k9mail.core.common.net.ssl
+
+import okhttp3.OkHttpClient
+import okhttp3.tls.HandshakeCertificates
+
+fun OkHttpClient.Builder.installTrustedCertificates(
+    trustedCertificateProvider: TrustedCertificateProvider,
+): OkHttpClient.Builder {
+    val handshakeCertificates = HandshakeCertificates.Builder().apply {
+        trustedCertificateProvider.getCertificates().forEach { addTrustedCertificate(it) }
+
+        addPlatformTrustedCertificates()
+    }.build()
+
+    sslSocketFactory(handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager)
+
+    return this
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/net/ssl/TrustedCertificateProvider.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/net/ssl/TrustedCertificateProvider.kt
@@ -1,0 +1,7 @@
+package app.k9mail.core.common.net.ssl
+
+import java.security.cert.X509Certificate
+
+interface TrustedCertificateProvider {
+    fun getCertificates(): List<X509Certificate>
+}

--- a/core/common/src/main/kotlin/app/k9mail/core/common/net/ssl/X509CertificateHelper.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/net/ssl/X509CertificateHelper.kt
@@ -1,0 +1,30 @@
+package app.k9mail.core.common.net.ssl
+
+import java.security.GeneralSecurityException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import okio.Buffer
+
+/**
+ * Decode a PEM encoded certificate [RFC-7468](https://tools.ietf.org/html/rfc7468)
+ * into a [X509Certificate].
+ *
+ * Taken from okhttp3.tls.Certificates
+ *
+ * @throws IllegalArgumentException if the certificate could not be decoded.
+ */
+@Suppress("ThrowsCount")
+fun String.decodeCertificatePem(): X509Certificate {
+    try {
+        val certificateFactory = CertificateFactory.getInstance("X.509")
+        val certificates = certificateFactory.generateCertificates(Buffer().writeUtf8(this).inputStream())
+
+        return certificates.single() as X509Certificate
+    } catch (exception: NoSuchElementException) {
+        throw IllegalArgumentException("failed to decode certificate", exception)
+    } catch (exception: IllegalArgumentException) {
+        throw IllegalArgumentException("failed to decode certificate", exception)
+    } catch (exception: GeneralSecurityException) {
+        throw IllegalArgumentException("failed to decode certificate", exception)
+    }
+}

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreen.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import app.k9mail.core.common.net.ssl.decodeCertificatePem
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.common.koin.koinPreview
 import app.k9mail.core.ui.compose.common.mvi.observe
@@ -32,8 +33,6 @@ import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorCo
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract.Event
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract.State
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract.ViewModel
-import java.security.cert.CertificateFactory
-import java.security.cert.X509Certificate
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -128,7 +127,7 @@ private fun ButtonBar(
 @Composable
 @PreviewDevices
 internal fun ServerCertificateErrorScreenK9Preview() {
-    val inputStream = """
+    val certificate = """
         -----BEGIN CERTIFICATE-----
         MIIE8jCCA9qgAwIBAgISA3bsPKY1eoe/RiBO2t8fUvh1MA0GCSqGSIb3DQEBCwUA
         MDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD
@@ -158,10 +157,7 @@ internal fun ServerCertificateErrorScreenK9Preview() {
         o7IlPgdD9rzZCsbYe+VNBQWY3358u7ifOJG8r2jXzyHKgUC+OBXgz3kjrClzJfl1
         pjcJhNU1UQtIVERwmxI9F5oQqUyxvA==
         -----END CERTIFICATE-----
-    """.trimIndent().byteInputStream()
-
-    val certificateFactory = CertificateFactory.getInstance("X.509")
-    val certificate = certificateFactory.generateCertificate(inputStream) as X509Certificate
+    """.trimIndent().decodeCertificatePem()
 
     val serverCertificateError = ServerCertificateError(
         hostname = "mail.domain.example",

--- a/feature/account/server/certificate/src/test/kotlin/app/k9mail/feature/account/server/certificate/domain/usecase/FormatServerCertificateErrorTest.kt
+++ b/feature/account/server/certificate/src/test/kotlin/app/k9mail/feature/account/server/certificate/domain/usecase/FormatServerCertificateErrorTest.kt
@@ -1,12 +1,11 @@
 package app.k9mail.feature.account.server.certificate.domain.usecase
 
+import app.k9mail.core.common.net.ssl.decodeCertificatePem
 import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateError
 import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateProperties
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import java.security.cert.CertificateFactory
-import java.security.cert.X509Certificate
 import java.text.DateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -28,7 +27,7 @@ class FormatServerCertificateErrorTest {
         val serverCertificateError = ServerCertificateError(
             hostname = "expired.badssl.com",
             port = 443,
-            certificateChain = listOf(readCertificate(EXPIRED_CERTIFICATE)),
+            certificateChain = listOf(EXPIRED_CERTIFICATE),
         )
 
         val result = formatCertificateError(serverCertificateError)
@@ -60,19 +59,12 @@ class FormatServerCertificateErrorTest {
         val serverCertificateError = ServerCertificateError(
             hostname = "10.0.0.1",
             port = 993,
-            certificateChain = listOf(readCertificate(CERTIFICATE_WITHOUT_SAN)),
+            certificateChain = listOf(CERTIFICATE_WITHOUT_SAN),
         )
 
         val result = formatCertificateError(serverCertificateError)
 
         assertThat(result.serverCertificateProperties.subjectAlternativeNames).isEmpty()
-    }
-
-    private fun readCertificate(asciiArmoredCertificate: String): X509Certificate {
-        val inputStream = asciiArmoredCertificate.byteInputStream()
-
-        val certificateFactory = CertificateFactory.getInstance("X.509")
-        return certificateFactory.generateCertificate(inputStream) as X509Certificate
     }
 
     companion object {
@@ -108,7 +100,7 @@ class FormatServerCertificateErrorTest {
             8TRwz311SotoKQwe6Zaoz7ASH1wq7mcvf71z81oBIgxw+s1F73hczg36TuHvzmWf
             RwxPuzZEaFZcVlmtqoq8
             -----END CERTIFICATE-----
-        """.trimIndent()
+        """.trimIndent().decodeCertificatePem()
 
         val CERTIFICATE_WITHOUT_SAN = """
             -----BEGIN CERTIFICATE-----
@@ -132,6 +124,6 @@ class FormatServerCertificateErrorTest {
             kTCTsMtIFWhH3hoyYAamOOuITpPZHD7yP0lfbuncGDEqAQu2YWbYxRixfq2VSxgv
             gWbFcmkgBLYpE8iDWT3Kdluo1+6PHaDaLg2SacOY6Go=
             -----END CERTIFICATE-----
-        """.trimIndent()
+        """.trimIndent().decodeCertificatePem()
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/AccountSetupModule.kt
@@ -4,6 +4,7 @@ import app.k9mail.autodiscovery.api.AutoDiscoveryRegistry
 import app.k9mail.autodiscovery.api.AutoDiscoveryService
 import app.k9mail.autodiscovery.service.RealAutoDiscoveryRegistry
 import app.k9mail.autodiscovery.service.RealAutoDiscoveryService
+import app.k9mail.core.common.net.ssl.installTrustedCertificates
 import app.k9mail.feature.account.common.featureAccountCommonModule
 import app.k9mail.feature.account.oauth.featureAccountOAuthModule
 import app.k9mail.feature.account.server.settings.featureAccountServerSettingsModule
@@ -41,7 +42,9 @@ val featureAccountSetupModule: Module = module {
     )
 
     single<OkHttpClient> {
-        OkHttpClient()
+        OkHttpClient.Builder()
+            .installTrustedCertificates(trustedCertificateProvider = get())
+            .build()
     }
 
     single<AutoDiscoveryRegistry> {

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
@@ -1,6 +1,7 @@
 package app.k9mail.feature.account.setup
 
 import android.content.Context
+import app.k9mail.core.common.net.ssl.TrustedCertificateProvider
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.feature.account.common.AccountCommonExternalContract
 import app.k9mail.feature.account.common.domain.entity.AccountState
@@ -61,6 +62,7 @@ class AccountSetupModuleKtTest : KoinTest {
         single<LocalKeyStore> { mock() }
         single<AccountCommonExternalContract.AccountStateLoader> { mock() }
         factory<AccountSetupExternalContract.AccountOwnerNameProvider> { mock() }
+        single<TrustedCertificateProvider> { mock() }
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -210,6 +210,7 @@ mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 preferencex = { module = "com.takisoft.preferencex:preferencex", version.ref = "preferencesFix" }

--- a/mail/testing/src/main/java/com/fsck/k9/mail/helpers/VeryTrustingTrustManager.java
+++ b/mail/testing/src/main/java/com/fsck/k9/mail/helpers/VeryTrustingTrustManager.java
@@ -7,6 +7,7 @@ import java.security.cert.X509Certificate;
 import javax.net.ssl.X509TrustManager;
 
 
+@SuppressWarnings("CustomX509TrustManager")
 class VeryTrustingTrustManager implements X509TrustManager {
     private final X509Certificate serverCertificate;
 


### PR DESCRIPTION
This update fixes the problem preventing Android 7.0 and earlier versions from connecting to Let's Encrypt signed domains due to their new root certificate, as discussed in issue #7646.

This leaves out changes to the SSL connections using `TrustedSocketFactory` and need to be addressed in a different fix.
