### PR TITLE
Replace Accompanist Systemuicontroller with edge-to-edge

### DIFF
--- a/app-k9mail/dependencies/releaseRuntimeClasspath.txt
+++ b/app-k9mail/dependencies/releaseRuntimeClasspath.txt
@@ -124,7 +124,6 @@ com.github.bumptech.glide:annotations:4.16.0
 com.github.bumptech.glide:disklrucache:4.16.0
 com.github.bumptech.glide:gifdecoder:4.16.0
 com.github.bumptech.glide:glide:4.16.0
-com.google.accompanist:accompanist-systemuicontroller:0.32.0
 com.google.android.flexbox:flexbox:3.0.0
 com.google.android.material:material:1.9.0
 com.google.errorprone:error_prone_annotations:2.15.0

--- a/core/ui/compose/theme/build.gradle.kts
+++ b/core/ui/compose/theme/build.gradle.kts
@@ -9,7 +9,8 @@ android {
 
 dependencies {
     api(projects.core.ui.compose.common)
-    implementation(libs.accompanist.systemuicontroller)
     implementation(libs.androidx.compose.material)
     implementation(libs.androidx.compose.material.icons.extended)
+
+    implementation(libs.androidx.activity)
 }

--- a/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/MainTheme.kt
+++ b/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/MainTheme.kt
@@ -31,7 +31,10 @@ fun MainTheme(
         lightImages
     }
 
-    SetSystemBarsColor(color = colors.toolbar)
+    SetSystemBarsColor(
+        darkTheme = darkTheme,
+        color = colors.toolbar,
+    )
 
     val shapes = MainTheme.shapes
 

--- a/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/color/SystemBarsColor.kt
+++ b/core/ui/compose/theme/src/main/java/app/k9mail/core/ui/compose/theme/color/SystemBarsColor.kt
@@ -1,19 +1,24 @@
 package app.k9mail.core.ui.compose.theme.color
 
+import android.app.Activity
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 @Composable
 fun SetSystemBarsColor(
-    color: Color,
+    darkTheme: Boolean,
+    color: Color = Color.Transparent,
 ) {
-    val systemUiController = rememberSystemUiController()
-
-    DisposableEffect(Unit) {
-        systemUiController.setSystemBarsColor(color = color)
-
-        onDispose { }
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = color.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+        }
     }
 }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.launcher
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.core.view.WindowCompat
+import androidx.activity.enableEdgeToEdge
 import app.k9mail.core.ui.compose.common.activity.setActivityContent
 import app.k9mail.core.ui.compose.common.navigation.toDeepLinkUri
 import app.k9mail.feature.account.edit.navigation.NAVIGATION_ROUTE_ACCOUNT_EDIT_SERVER_SETTINGS_INCOMING
@@ -19,7 +19,7 @@ class FeatureLauncherActivity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        enableEdgeToEdge()
 
         setActivityContent {
             FeatureLauncherApp()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@
 # 4. Run the app and check for any issues.
 
 [versions]
-accompanist = "0.32.0"
 androidDesugar = "2.0.4"
 androidMaterial = "1.9.0"
 # AGP and tools should be updated together
@@ -113,7 +112,6 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "kotlinKsp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }
 
 [libraries]
-accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 android-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "androidDesugar" }
 android-material = { module = "com.google.android.material:material", version.ref = "androidMaterial" }
 android-tools-common = { module = "com.android.tools:common", version.ref = "androidTools" }


### PR DESCRIPTION
This replaces the deprecated [Accompanist - System UI Controller](https://google.github.io/accompanist/systemuicontroller/) with the new [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) feature of the AndroidX Activity library.

Depends on #7660 