### PR TITLE
Add missing permission to AndroidManifest

### DIFF
--- a/app/core/src/main/AndroidManifest.xml
+++ b/app/core/src/main/AndroidManifest.xml
@@ -3,5 +3,6 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 </manifest>


### PR DESCRIPTION
This removes a warning about the missing `android.permission.POST_NOTIFICATIONS`
