### PR TITLE
Add header folding to `MimeHeaderEncoder`

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeHeaderEncoder.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeHeaderEncoder.kt
@@ -1,23 +1,29 @@
 package com.fsck.k9.mail.internet
 
+import org.apache.james.mime4j.util.MimeUtil
+
 object MimeHeaderEncoder {
     @JvmStatic
     fun encode(name: String, value: String): String {
         // TODO: Fold long text that provides enough opportunities for folding and doesn't contain any characters that
         //  need to be encoded.
-        return if (hasToBeEncoded(name, value)) {
-            EncoderUtil.encodeEncodedWord(value)
+
+        // Number of characters already used up on the first line (header field name + colon + space)
+        val usedCharacters = name.length + COLON_PLUS_SPACE_LENGTH
+
+        return if (hasToBeEncoded(value, usedCharacters)) {
+            MimeUtil.fold(EncoderUtil.encodeEncodedWord(value), usedCharacters)
         } else {
             value
         }
     }
 
-    private fun hasToBeEncoded(name: String, value: String): Boolean {
-        return exceedsRecommendedLineLength(name, value) || charactersNeedEncoding(value)
+    private fun hasToBeEncoded(value: String, usedCharacters: Int): Boolean {
+        return exceedsRecommendedLineLength(value, usedCharacters) || charactersNeedEncoding(value)
     }
 
-    private fun exceedsRecommendedLineLength(name: String, value: String): Boolean {
-        return name.length + COLON_PLUS_SPACE_LENGTH + value.length > RECOMMENDED_MAX_LINE_LENGTH
+    private fun exceedsRecommendedLineLength(value: String, usedCharacters: Int): Boolean {
+        return usedCharacters + value.length > RECOMMENDED_MAX_LINE_LENGTH
     }
 
     private fun charactersNeedEncoding(text: String): Boolean {

--- a/mail/common/src/test/java/com/fsck/k9/mail/internet/MimeHeaderEncoderTest.kt
+++ b/mail/common/src/test/java/com/fsck/k9/mail/internet/MimeHeaderEncoderTest.kt
@@ -1,0 +1,75 @@
+package com.fsck.k9.mail.internet
+
+import assertk.Assert
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.each
+import assertk.assertions.isEqualTo
+import assertk.assertions.isLessThanOrEqualTo
+import assertk.assertions.length
+import assertk.fail
+import kotlin.test.Test
+
+class MimeHeaderEncoderTest {
+    @Test
+    fun `short subject containing only ASCII characters should not be encoded`() {
+        val result = MimeHeaderEncoder.encode(name = "Subject", value = "Hello World!")
+
+        assertThat(result).isEqualTo("Hello World!")
+    }
+
+    @Test
+    fun `short subject containing non-ASCII characters should be encoded`() {
+        val result = MimeHeaderEncoder.encode(name = "Subject", value = "Gänseblümchen")
+
+        assertThat(result).isEqualTo("=?UTF-8?Q?G=C3=A4nsebl=C3=BCmchen?=")
+    }
+
+    @Test
+    fun `subject with recommended line length should not be folded`() {
+        val subject = "a".repeat(RECOMMENDED_MAX_LINE_LENGTH - "Subject: ".length)
+
+        val result = MimeHeaderEncoder.encode(name = "Subject", value = subject)
+
+        assertThat(result).isEqualTo(subject)
+    }
+
+    @Test
+    fun `subject exceeding recommended line length should be folded`() {
+        val subject = "a".repeat(34) + " " + "a".repeat(35)
+
+        val result = MimeHeaderEncoder.encode(name = "Subject", value = subject)
+
+        assertThat(result).all {
+            transform { it.lines() }.each {
+                it.length().isLessThanOrEqualTo(RECOMMENDED_MAX_LINE_LENGTH)
+            }
+            isValidHeader(name = "Subject")
+            decodesTo(subject)
+        }
+    }
+
+    @Test
+    fun `subject exceeding maximum line length should be encoded`() {
+        val subject = "a".repeat(999)
+
+        val result = MimeHeaderEncoder.encode(name = "Subject", value = subject)
+
+        assertThat(result).all {
+            isValidHeader(name = "Subject")
+            decodesTo(subject)
+        }
+    }
+
+    private fun Assert<String>.isValidHeader(name: String) = given { value ->
+        try {
+            MimeHeaderChecker.checkHeader(name, value)
+        } catch (e: MimeHeaderParserException) {
+            fail(AssertionError("Not a valid RFC5322 header", e))
+        }
+    }
+
+    private fun Assert<String>.decodesTo(expected: String) = given { value ->
+        assertThat(MimeUtility.unfoldAndDecode(value)).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
This fixes a crash reported via Google Play (for K-9 Mail 6.800).

```text
Exception java.lang.RuntimeException: An error occurred while executing doInBackground()
  at android.os.AsyncTask$4.done (AsyncTask.java:415)
  at java.util.concurrent.FutureTask.finishCompletion (FutureTask.java:381)
  at java.util.concurrent.FutureTask.setException (FutureTask.java:250)
  at java.util.concurrent.FutureTask.run (FutureTask.java:269)
  at android.os.AsyncTask$SerialExecutor$1.run (AsyncTask.java:305)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1145)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:644)
  at java.lang.Thread.run (Thread.java:1012)
Caused by java.lang.AssertionError: Invalid header
  at com.fsck.k9.mail.internet.MimeHeader.checkHeader (MimeHeader.kt:109)
  at com.fsck.k9.mail.internet.MimeHeader.requireValidHeader (MimeHeader.kt:90)
  at com.fsck.k9.mail.internet.MimeHeader.addHeader (MimeHeader.kt:31)
  at com.fsck.k9.mail.internet.MimeHeader.setHeader (MimeHeader.kt:44)
  at com.fsck.k9.mail.internet.MimeMessage.setHeader (MimeMessage.java:433)
  at com.fsck.k9.mail.internet.MimeMessage.setSubject (MimeMessage.java:281)
  at com.fsck.k9.message.MessageBuilder.buildHeader (MessageBuilder.java:106)
  at com.fsck.k9.message.MessageBuilder.build (MessageBuilder.java:92)
  at com.fsck.k9.message.SimpleMessageBuilder.buildMessageInternal (SimpleMessageBuilder.java:33)
  at com.fsck.k9.message.MessageBuilder$1.doInBackground (MessageBuilder.java:532)
  at com.fsck.k9.message.MessageBuilder$1.doInBackground (MessageBuilder.java:529)
  at android.os.AsyncTask$3.call (AsyncTask.java:394)
  at java.util.concurrent.FutureTask.run (FutureTask.java:264)
Caused by com.fsck.k9.mail.internet.MimeHeaderParserException:
  at com.fsck.k9.mail.internet.UnstructuredHeaderChecker.checkHeaderValue (MimeHeaderChecker.kt:65)
  at com.fsck.k9.mail.internet.MimeHeaderChecker.checkHeader (MimeHeaderChecker.kt:25)
  at com.fsck.k9.mail.internet.MimeHeader.checkHeader (MimeHeader.kt:106)
```

The problem was that long lines were encoded using the encoded word encoding, but the result was not [folded](https://datatracker.ietf.org/doc/html/rfc5322#section-2.2.3). So the maximum line length (998 characters) could be exceeded.

To avoid sending invalid messages that e.g. exceed the maximum line length we use `MimeHeaderChecker` to catch those errors and crash the app.