### PR TITLE
Fix `NullPointerException` by avoiding race condition

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/AttachmentDownloadDialogFragment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/AttachmentDownloadDialogFragment.java
@@ -18,7 +18,6 @@ public class AttachmentDownloadDialogFragment extends DialogFragment {
     private static final String ARG_MESSAGE = "message";
 
 
-    private ProgressDialog dialog;
     private MessagingListener messagingListener;
     private MessagingController messagingController;
 
@@ -42,6 +41,14 @@ public class AttachmentDownloadDialogFragment extends DialogFragment {
 
         final SizeUnit sizeUnit = SizeUnit.getAppropriateFor(size);
 
+        ProgressDialog dialog = new ProgressDialog(getActivity());
+        dialog.setMessage(message);
+        dialog.setMax(sizeUnit.valueInSizeUnit(size));
+        dialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+        dialog.setProgress(0);
+        dialog.setProgressNumberFormat("%1d/%2d " + sizeUnit.shortName);
+        dialog.show();
+
         messagingListener = new SimpleMessagingListener() {
             @Override
             public void updateProgress(int progress) {
@@ -51,14 +58,6 @@ public class AttachmentDownloadDialogFragment extends DialogFragment {
 
         messagingController = MessagingController.getInstance(getActivity());
         messagingController.addListener(messagingListener);
-
-        dialog = new ProgressDialog(getActivity());
-        dialog.setMessage(message);
-        dialog.setMax(sizeUnit.valueInSizeUnit(size));
-        dialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
-        dialog.setProgress(0);
-        dialog.setProgressNumberFormat("%1d/%2d " + sizeUnit.shortName);
-        dialog.show();
 
         return dialog;
     }


### PR DESCRIPTION
Fixes a crash reported via Google Play (K-9 Mail 6.800).

```text
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'void android.app.ProgressDialog.setProgress(int)' on a null object reference
  at com.fsck.k9.fragment.AttachmentDownloadDialogFragment$1.updateProgress (AttachmentDownloadDialogFragment.java:48)
  at com.fsck.k9.controller.MessagingController$4$1.updateProgress (MessagingController.java:1352)
  at com.fsck.k9.controller.ProgressBodyFactory$1.run (ProgressBodyFactory.java:29)
  at java.util.TimerThread.mainLoop (Timer.java:563)
  at java.util.TimerThread.run (Timer.java:513)
```