### PR TITLE
Don't allow username or password to contain line break

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/ServerSettings.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/ServerSettings.kt
@@ -22,6 +22,8 @@ data class ServerSettings @JvmOverloads constructor(
 
     init {
         require(type == type.lowercase()) { "type must be all lower case" }
+        require(username.contains(LINE_BREAK).not()) { "username must not contain line break" }
+        require(password?.contains(LINE_BREAK) != true) { "password must not contain line break" }
     }
 
     fun newPassword(newPassword: String?): ServerSettings {
@@ -30,5 +32,9 @@ data class ServerSettings @JvmOverloads constructor(
 
     fun newAuthenticationType(authType: AuthType): ServerSettings {
         return this.copy(authenticationType = authType)
+    }
+
+    companion object {
+        private val LINE_BREAK = "[\\r\\n]".toRegex()
     }
 }

--- a/mail/common/src/test/java/com/fsck/k9/mail/ServerSettingsTest.kt
+++ b/mail/common/src/test/java/com/fsck/k9/mail/ServerSettingsTest.kt
@@ -1,0 +1,107 @@
+package com.fsck.k9.mail
+
+import assertk.assertFailure
+import assertk.assertions.hasMessage
+import assertk.assertions.isInstanceOf
+import kotlin.test.Test
+
+class ServerSettingsTest {
+    @Test
+    fun `creating typical ServerSettings should not throw`() {
+        ServerSettings(
+            type = "imap",
+            host = "imap.domain.example",
+            port = 993,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "user",
+            password = "123456",
+            clientCertificateAlias = null,
+        )
+    }
+
+    @Test
+    fun `type that is not all lower case should throw`() {
+        assertFailure {
+            ServerSettings(
+                type = "IMAP",
+                host = "imap.domain.example",
+                port = 993,
+                connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+                authenticationType = AuthType.PLAIN,
+                username = "user",
+                password = "123456",
+                clientCertificateAlias = null,
+            )
+        }.isInstanceOf<IllegalArgumentException>()
+            .hasMessage("type must be all lower case")
+    }
+
+    @Test
+    fun `username containing LF should throw`() {
+        assertFailure {
+            ServerSettings(
+                type = "imap",
+                host = "imap.domain.example",
+                port = 993,
+                connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+                authenticationType = AuthType.PLAIN,
+                username = "user\nname",
+                password = "123456",
+                clientCertificateAlias = null,
+            )
+        }.isInstanceOf<IllegalArgumentException>()
+            .hasMessage("username must not contain line break")
+    }
+
+    @Test
+    fun `username containing CR should throw`() {
+        assertFailure {
+            ServerSettings(
+                type = "imap",
+                host = "imap.domain.example",
+                port = 993,
+                connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+                authenticationType = AuthType.PLAIN,
+                username = "user\rname",
+                password = "123456",
+                clientCertificateAlias = null,
+            )
+        }.isInstanceOf<IllegalArgumentException>()
+            .hasMessage("username must not contain line break")
+    }
+
+    @Test
+    fun `password containing LF should throw`() {
+        assertFailure {
+            ServerSettings(
+                type = "imap",
+                host = "imap.domain.example",
+                port = 993,
+                connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+                authenticationType = AuthType.PLAIN,
+                username = "user",
+                password = "123456\n",
+                clientCertificateAlias = null,
+            )
+        }.isInstanceOf<IllegalArgumentException>()
+            .hasMessage("password must not contain line break")
+    }
+
+    @Test
+    fun `password containing CR should throw`() {
+        assertFailure {
+            ServerSettings(
+                type = "imap",
+                host = "imap.domain.example",
+                port = 993,
+                connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+                authenticationType = AuthType.PLAIN,
+                username = "user",
+                password = "123456\r",
+                clientCertificateAlias = null,
+            )
+        }.isInstanceOf<IllegalArgumentException>()
+            .hasMessage("password must not contain line break")
+    }
+}


### PR DESCRIPTION
Much of our protocol code isn't prepared to deal with line breaks in the username or password. Since IMAP, POP3, and SMTP are line-based protocols, this could lead to command injection. We avoid this by not allowing the username and password in `ServerSettings` to contain line breaks.

We still need to make sure we don't allow the user to enter such values (see #7670).