### PR TITLE
Disable auto-correct for email address input

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/textfield/TextFieldOutlinedEmailAddress.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/textfield/TextFieldOutlinedEmailAddress.kt
@@ -29,6 +29,7 @@ fun TextFieldOutlinedEmailAddress(
         readOnly = isReadOnly,
         isError = hasError,
         keyboardOptions = KeyboardOptions(
+            autoCorrect = false,
             keyboardType = KeyboardType.Email,
         ),
         singleLine = true,


### PR DESCRIPTION
Test using an *Android 10.0 (Google APIs)* emulator.

Fixes #7665