### PR TITLE
Update Proguard config to keep `XOAuth2Response`

### DIFF
--- a/app-k9mail/proguard-rules.pro
+++ b/app-k9mail/proguard-rules.pro
@@ -39,6 +39,8 @@
     public <init>(android.content.Context);
 }
 
+-keep class com.fsck.k9.mail.oauth.XOAuth2Response { *; }
+
 # okhttp rules
 # see: https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
 


### PR DESCRIPTION
~Proguard~ R8 stripped enough of this class to make [deserialization via Moshi](https://github.com/thunderbird/thunderbird-android/blob/93824f59d6d1d9021cf5e96c3a5d4ea6c252cafc/mail/common/src/main/java/com/fsck/k9/mail/oauth/XOAuth2ChallengeParser.java#L31-L32) fail.

See https://forum.k9mail.app/t/error-when-using-oauth2-cannot-serialize-abstract-class/8188