### PR TITLE
Fix background color to match tone-based Surfaces in Material 3

### DIFF
--- a/app/core/src/main/res/values/k9_tonal_palette.xml
+++ b/app/core/src/main/res/values/k9_tonal_palette.xml
@@ -78,7 +78,6 @@
     <color name="k9_neutral_095">#FAEEEF</color>
     <color name="k9_neutral_096">#FDF1F2</color>
     <color name="k9_neutral_098">#FFF8F8</color>
-    <color name="k9_neutral_099">#FFFBFF</color>
     <color name="k9_neutral_100">#FFFFFF</color>
 
     <color name="k9_neutral_variant_000">#000000</color>

--- a/app/ui/legacy/src/main/res/values/themes.xml
+++ b/app/ui/legacy/src/main/res/values/themes.xml
@@ -36,7 +36,7 @@
         <item name="colorTertiaryFixedDim">@color/k9_tertiary_080</item>
         <item name="colorOnTertiaryFixed">@color/k9_tertiary_010</item>
         <item name="colorOnTertiaryFixedVariant">@color/k9_tertiary_030</item>
-        <item name="android:colorBackground">@color/k9_neutral_099</item>
+        <item name="android:colorBackground">@color/k9_neutral_098</item>
         <item name="colorOnBackground">@color/k9_neutral_010</item>
         <item name="colorSurface">@color/k9_neutral_098</item>
         <item name="colorOnSurface">@color/k9_neutral_010</item>


### PR DESCRIPTION
Fix light theme background color to match [Tone-based Surfaces in Material 3](https://material.io/blog/tone-based-surface-color-m3)

The default light theme surface role changed from tone 99 to tone 98
