### PR TITLE
Notify user if permission to schedule exact alarms is missing

### DIFF
--- a/app/common/src/main/java/com/fsck/k9/backends/AndroidAlarmManager.kt
+++ b/app/common/src/main/java/com/fsck/k9/backends/AndroidAlarmManager.kt
@@ -60,10 +60,6 @@ class AndroidAlarmManager(
         )
     }
 
-    override fun canScheduleExactAlarms(): Boolean {
-        return alarmManager.canScheduleExactAlarms()
-    }
-
     override fun setAlarm(triggerTime: Long, callback: Callback) {
         this.callback.set(callback)
         alarmManager.scheduleAlarm(triggerTime, pendingIntent)

--- a/app/common/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
+++ b/app/common/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
@@ -44,9 +44,13 @@ class K9CoreResourceProvider(private val context: Context) : CoreResourceProvide
             PushNotificationState.LISTENING -> R.string.push_notification_state_listening
             PushNotificationState.WAIT_BACKGROUND_SYNC -> R.string.push_notification_state_wait_background_sync
             PushNotificationState.WAIT_NETWORK -> R.string.push_notification_state_wait_network
+            PushNotificationState.ALARM_PERMISSION_MISSING -> R.string.push_notification_state_alarm_permission_missing
         }
         return context.getString(resId)
     }
 
     override fun pushNotificationInfoText(): String = context.getString(R.string.push_notification_info)
+
+    override fun pushNotificationGrantAlarmPermissionText(): String =
+        context.getString(R.string.push_notification_grant_alarm_permission)
 }

--- a/app/core/src/main/java/com/fsck/k9/CoreResourceProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/CoreResourceProvider.kt
@@ -32,4 +32,5 @@ interface CoreResourceProvider {
     val iconPushNotification: Int
     fun pushNotificationText(notificationState: PushNotificationState): String
     fun pushNotificationInfoText(): String
+    fun pushNotificationGrantAlarmPermissionText(): String
 }

--- a/app/core/src/main/java/com/fsck/k9/controller/push/AlarmPermissionManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/AlarmPermissionManager.kt
@@ -1,0 +1,50 @@
+package com.fsck.k9.controller.push
+
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+import com.fsck.k9.helper.AlarmManagerCompat
+
+/**
+ * Checks whether the app can schedule exact alarms.
+ */
+internal interface AlarmPermissionManager {
+    /**
+     * Checks whether the app can schedule exact alarms.
+     *
+     * If this method returns `false`, the app has to request the permission to schedule exact alarms. See
+     * [Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM].
+     */
+    fun canScheduleExactAlarms(): Boolean
+
+    /**
+     * Register a listener to be notified when the app was granted the permission to schedule exact alarms.
+     */
+    fun registerListener(listener: AlarmPermissionListener)
+
+    /**
+     * Unregister the listener registered via [registerListener].
+     */
+    fun unregisterListener()
+}
+
+/**
+ * Factory method to create an Android API-specific instance of [AlarmPermissionManager].
+ */
+internal fun AlarmPermissionManager(context: Context, alarmManagerCompat: AlarmManagerCompat): AlarmPermissionManager {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        AlarmPermissionManagerApi31(context, alarmManagerCompat)
+    } else {
+        AlarmPermissionManagerApi21()
+    }
+}
+
+/**
+ * Listener that can be notified when the app was granted the permission to schedule exact alarms.
+ *
+ * Note: Currently Android stops (and potentially restarts) the app when the permission is revoked. So there's no
+ * callback mechanism for the permission revocation case.
+ */
+internal fun interface AlarmPermissionListener {
+    fun onAlarmPermissionGranted()
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/push/AlarmPermissionManagerApi21.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/AlarmPermissionManagerApi21.kt
@@ -1,0 +1,14 @@
+package com.fsck.k9.controller.push
+
+/**
+ * On Android versions prior to 12 there's no permission to limit an app's ability to schedule exact alarms.
+ */
+internal class AlarmPermissionManagerApi21 : AlarmPermissionManager {
+    override fun canScheduleExactAlarms(): Boolean {
+        return true
+    }
+
+    override fun registerListener(listener: AlarmPermissionListener) = Unit
+
+    override fun unregisterListener() = Unit
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/push/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/KoinModule.kt
@@ -22,9 +22,12 @@ internal val controllerPushModule = module {
             pushServiceManager = get(),
             bootCompleteManager = get(),
             autoSyncManager = get(),
+            alarmPermissionManager = get(),
             pushNotificationManager = get(),
             connectivityManager = get(),
             accountPushControllerFactory = get(),
         )
     }
+
+    single<AlarmPermissionManager> { AlarmPermissionManager(context = get(), alarmManagerCompat = get()) }
 }

--- a/app/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
+++ b/app/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
@@ -39,4 +39,5 @@ class TestCoreResourceProvider : CoreResourceProvider {
     }
 
     override fun pushNotificationInfoText(): String = throw UnsupportedOperationException("not implemented")
+    override fun pushNotificationGrantAlarmPermissionText() = throw UnsupportedOperationException("not implemented")
 }

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -1098,7 +1098,9 @@ You can keep this message and use it as a backup for your secret key. If you wan
     <string name="push_notification_state_listening">Waiting for new emails</string>
     <string name="push_notification_state_wait_background_sync">Sleeping until background sync is allowed</string>
     <string name="push_notification_state_wait_network">Sleeping until network is available</string>
+    <string name="push_notification_state_alarm_permission_missing">Missing permission to schedule alarms</string>
     <string name="push_notification_info">Tap to learn more.</string>
+    <string name="push_notification_grant_alarm_permission">Tap to grant permission.</string>
 
     <string name="push_info_title">Push Info</string>
     <string name="push_info_notification_explanation_text">When using Push, K-9 Mail maintains a connection to the mail server. Android requires displaying an ongoing notification while the app is active in the background. %s</string>

--- a/app/ui/legacy/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
@@ -39,4 +39,5 @@ class TestCoreResourceProvider : CoreResourceProvider {
     }
 
     override fun pushNotificationInfoText(): String = throw UnsupportedOperationException("not implemented")
+    override fun pushNotificationGrantAlarmPermissionText() = throw UnsupportedOperationException("not implemented")
 }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/BackendIdleRefreshManager.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/BackendIdleRefreshManager.kt
@@ -19,10 +19,6 @@ class BackendIdleRefreshManager(private val alarmManager: SystemAlarmManager) : 
     private var minTimeout = Long.MAX_VALUE
     private var minTimeoutTimestamp = 0L
 
-    override fun canScheduleTimers(): Boolean {
-        return alarmManager.canScheduleExactAlarms()
-    }
-
     @Synchronized
     override fun startTimer(timeout: Long, callback: Callback): IdleRefreshTimer {
         require(timeout > MIN_TIMER_DELTA) { "Timeout needs to be greater than $MIN_TIMER_DELTA ms" }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
@@ -50,11 +50,6 @@ internal class ImapBackendPusher(
     private var currentIdleRefreshMs = 15 * 60 * 1000L
 
     override fun start() {
-        if (!idleRefreshManager.canScheduleTimers()) {
-            Timber.v("Not starting ImapBackendPusher for %s because the app can't schedule timers", accountName)
-            return
-        }
-
         coroutineScope.launch {
             pushConfigProvider.maxPushFoldersFlow.collect { maxPushFolders ->
                 currentMaxPushFolders = maxPushFolders

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/SystemAlarmManager.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/SystemAlarmManager.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.backend.imap
 
 interface SystemAlarmManager {
-    fun canScheduleExactAlarms(): Boolean
     fun setAlarm(triggerTime: Long, callback: () -> Unit)
     fun cancelAlarm()
     fun now(): Long

--- a/backend/imap/src/test/java/com/fsck/k9/backend/imap/BackendIdleRefreshManagerTest.kt
+++ b/backend/imap/src/test/java/com/fsck/k9/backend/imap/BackendIdleRefreshManagerTest.kt
@@ -156,10 +156,6 @@ class MockSystemAlarmManager(startTime: Long) : SystemAlarmManager {
     var callback: Callback? = null
     val alarmTimes = mutableListOf<Long>()
 
-    override fun canScheduleExactAlarms(): Boolean {
-        throw UnsupportedOperationException("not implemented")
-    }
-
     override fun setAlarm(triggerTime: Long, callback: () -> Unit) {
         this.triggerTime = triggerTime
         this.callback = callback

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/IdleRefreshManager.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/IdleRefreshManager.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.mail.store.imap
 
 interface IdleRefreshManager {
-    fun canScheduleTimers(): Boolean
     fun startTimer(timeout: Long, callback: () -> Unit): IdleRefreshTimer
     fun resetTimers()
 }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestIdleRefreshManager.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestIdleRefreshManager.kt
@@ -1,13 +1,7 @@
 package com.fsck.k9.mail.store.imap
 
-class TestIdleRefreshManager(
-    private val areTimersSupported: Boolean = true,
-) : IdleRefreshManager {
+class TestIdleRefreshManager : IdleRefreshManager {
     private val timers = mutableListOf<TestIdleRefreshTimer>()
-
-    override fun canScheduleTimers(): Boolean {
-        return areTimersSupported
-    }
 
     @Synchronized
     override fun startTimer(timeout: Long, callback: () -> Unit): TestIdleRefreshTimer {


### PR DESCRIPTION
Use ongoing notification for `PushService` to notify the user when the permission to schedule exact alarms is missing.

![image](https://github.com/thunderbird/thunderbird-android/assets/218061/3dab90d6-87fa-4cc7-92d1-5d04640de162)

Tapping the notification will open the system screen to grant the permission.

![image](https://github.com/thunderbird/thunderbird-android/assets/218061/acfd1d65-34fe-4a1c-81bb-a50a6d059799)
