### PR TITLE
Add `PermanentDeleteChecker` to check if messages will be deleted permanently

### DIFF
--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     // Required for DependencyInjectionTest to be able to resolve OpenPgpApiManager
     testImplementation(projects.plugins.openpgpApiLib.openpgpApi)
 
+    testImplementation(projects.app.testing)
+
     testImplementation(libs.robolectric)
 }
 

--- a/app/common/src/test/java/com/fsck/k9/account/AccountServerSettingsUpdaterTest.kt
+++ b/app/common/src/test/java/com/fsck/k9/account/AccountServerSettingsUpdaterTest.kt
@@ -21,7 +21,7 @@ class AccountServerSettingsUpdaterTest {
 
     @Test
     fun `updateServerSettings() SHOULD return account not found exception WHEN none present with uuid`() = runTest {
-        val accountManager = FakeAccountManager(accounts = mutableMapOf())
+        val accountManager = FakeAccountManager()
         val testSubject = AccountServerSettingsUpdater(accountManager)
 
         val result = testSubject.updateServerSettings(
@@ -36,7 +36,7 @@ class AccountServerSettingsUpdaterTest {
 
     @Test
     fun `updateServerSettings() SHOULD return success with updated incoming settings WHEN is incoming`() = runTest {
-        val accountManager = FakeAccountManager(accounts = mutableMapOf(ACCOUNT_UUID to createAccount(ACCOUNT_UUID)))
+        val accountManager = FakeAccountManager(accounts = listOf(createAccount(ACCOUNT_UUID)))
         val updatedIncomingServerSettings = INCOMING_SERVER_SETTINGS.copy(port = 123)
         val updatedAuthorizationState = AuthorizationState("new")
         val testSubject = AccountServerSettingsUpdater(accountManager)
@@ -60,7 +60,7 @@ class AccountServerSettingsUpdaterTest {
 
     @Test
     fun `updateServerSettings() SHOULD return success with updated outgoing settings WHEN is not incoming`() = runTest {
-        val accountManager = FakeAccountManager(accounts = mutableMapOf(ACCOUNT_UUID to createAccount(ACCOUNT_UUID)))
+        val accountManager = FakeAccountManager(accounts = listOf(createAccount(ACCOUNT_UUID)))
         val updatedOutgoingServerSettings = OUTGOING_SERVER_SETTINGS.copy(port = 123)
         val updatedAuthorizationState = AuthorizationState("new")
         val testSubject = AccountServerSettingsUpdater(accountManager)
@@ -85,7 +85,7 @@ class AccountServerSettingsUpdaterTest {
     @Test
     fun `updateServerSettings() SHOULD return unknown error when exception thrown`() = runTest {
         val accountManager = FakeAccountManager(
-            accounts = mutableMapOf(ACCOUNT_UUID to createAccount(ACCOUNT_UUID)),
+            accounts = listOf(createAccount(ACCOUNT_UUID)),
             isFailureOnSave = true,
         )
         val testSubject = AccountServerSettingsUpdater(accountManager)

--- a/app/common/src/test/java/com/fsck/k9/account/AccountServerSettingsUpdaterTest.kt
+++ b/app/common/src/test/java/com/fsck/k9/account/AccountServerSettingsUpdaterTest.kt
@@ -12,6 +12,7 @@ import assertk.assertions.prop
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.preferences.FakeAccountManager
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import com.fsck.k9.Account as K9Account

--- a/app/common/src/test/java/com/fsck/k9/account/AccountStateLoaderTest.kt
+++ b/app/common/src/test/java/com/fsck/k9/account/AccountStateLoaderTest.kt
@@ -28,8 +28,8 @@ class AccountStateLoaderTest {
 
     @Test
     fun `loadAccountState() SHOULD return account when present in accountManager`() = runTest {
-        val accounts = mutableMapOf(
-            "accountUuid" to Account(uuid = "accountUuid").apply {
+        val accounts = listOf(
+            Account(uuid = "accountUuid").apply {
                 identities = mutableListOf(Identity())
                 email = "emailAddress"
                 incomingServerSettings = INCOMING_SERVER_SETTINGS

--- a/app/common/src/test/java/com/fsck/k9/account/AccountStateLoaderTest.kt
+++ b/app/common/src/test/java/com/fsck/k9/account/AccountStateLoaderTest.kt
@@ -10,6 +10,7 @@ import com.fsck.k9.Identity
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.preferences.FakeAccountManager
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 

--- a/app/core/src/main/java/com/fsck/k9/controller/DeleteOperationDecider.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/DeleteOperationDecider.kt
@@ -1,0 +1,26 @@
+package com.fsck.k9.controller
+
+import com.fsck.k9.Account
+
+/**
+ * Decides whether deleting a message in the app moves it to the trash folder or deletes it immediately.
+ *
+ * Note: This only applies to local messages. What remote operation is performed when deleting a message is controlled
+ * by [Account.deletePolicy].
+ */
+internal class DeleteOperationDecider {
+    fun isDeleteImmediately(account: Account, folderId: Long): Boolean {
+        // If there's no trash folder configured, all messages are deleted immediately.
+        if (!account.hasTrashFolder()) {
+            return true
+        }
+
+        // Deleting messages from the trash folder will delete them immediately.
+        val isTrashFolder = folderId == account.trashFolderId
+
+        // Messages deleted from the spam folder are deleted immediately.
+        val isSpamFolder = folderId == account.spamFolderId
+
+        return isTrashFolder || isSpamFolder
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -24,13 +24,17 @@ val controllerModule = module {
             get<MessageStoreManager>(),
             get<SaveMessageDataCreator>(),
             get<SpecialLocalFoldersCreator>(),
+            get<DeleteOperationDecider>(),
             get(named("controllerExtensions")),
         )
     }
+
     single<MessageCountsProvider> {
         DefaultMessageCountsProvider(
             accountManager = get(),
             messageStoreManager = get(),
         )
     }
+
+    single { DeleteOperationDecider() }
 }

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -37,4 +37,14 @@ val controllerModule = module {
     }
 
     single { DeleteOperationDecider() }
+
+    single<LocalFolderChecker> { DefaultLocalFolderChecker(folderRepository = get()) }
+
+    single {
+        PermanentDeleteChecker(
+            accountManager = get(),
+            localFolderChecker = get(),
+            deleteOperationDecider = get(),
+        )
+    }
 }

--- a/app/core/src/main/java/com/fsck/k9/controller/LocalFolderChecker.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/LocalFolderChecker.kt
@@ -1,0 +1,17 @@
+package com.fsck.k9.controller
+
+import com.fsck.k9.Account
+import com.fsck.k9.mailstore.FolderRepository
+
+/**
+ * Checks whether a folder is only available locally.
+ */
+internal fun interface LocalFolderChecker {
+    fun isLocalFolder(account: Account, folderId: Long): Boolean
+}
+
+internal class DefaultLocalFolderChecker(private val folderRepository: FolderRepository) : LocalFolderChecker {
+    override fun isLocalFolder(account: Account, folderId: Long): Boolean {
+        return folderRepository.isLocalFolder(account, folderId)
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -117,6 +117,7 @@ public class MessagingController {
     private final MessageStoreManager messageStoreManager;
     private final SaveMessageDataCreator saveMessageDataCreator;
     private final SpecialLocalFoldersCreator specialLocalFoldersCreator;
+    private final DeleteOperationDecider deleteOperationDecider;
 
     private final Thread controllerThread;
 
@@ -140,7 +141,7 @@ public class MessagingController {
             NotificationStrategy notificationStrategy, LocalStoreProvider localStoreProvider,
             BackendManager backendManager, Preferences preferences, MessageStoreManager messageStoreManager,
             SaveMessageDataCreator saveMessageDataCreator, SpecialLocalFoldersCreator specialLocalFoldersCreator,
-            List<ControllerExtension> controllerExtensions) {
+            DeleteOperationDecider deleteOperationDecider, List<ControllerExtension> controllerExtensions) {
         this.context = context;
         this.notificationController = notificationController;
         this.notificationStrategy = notificationStrategy;
@@ -150,6 +151,7 @@ public class MessagingController {
         this.messageStoreManager = messageStoreManager;
         this.saveMessageDataCreator = saveMessageDataCreator;
         this.specialLocalFoldersCreator = specialLocalFoldersCreator;
+        this.deleteOperationDecider = deleteOperationDecider;
 
         controllerThread = new Thread(new Runnable() {
             @Override
@@ -1978,10 +1980,8 @@ public class MessagingController {
 
             Map<String, String> uidMap = null;
             Long trashFolderId = account.getTrashFolderId();
-            boolean isSpamFolder = account.hasSpamFolder() && account.getSpamFolderId() == folderId;
             boolean doNotMoveToTrashFolder = skipTrashFolder ||
-                !account.hasTrashFolder() || folderId == trashFolderId ||
-                isSpamFolder;
+                deleteOperationDecider.isDeleteImmediately(account, folderId);
 
             LocalFolder localTrashFolder = null;
             if (doNotMoveToTrashFolder) {

--- a/app/core/src/main/java/com/fsck/k9/controller/PermanentDeleteChecker.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/PermanentDeleteChecker.kt
@@ -1,0 +1,83 @@
+package com.fsck.k9.controller
+
+import androidx.annotation.WorkerThread
+import com.fsck.k9.Account
+import com.fsck.k9.Account.DeletePolicy
+import com.fsck.k9.preferences.AccountManager
+
+/**
+ * Checks whether deleting a list of messages in the app will permanently delete none, some, or all of them.
+ *
+ * Deleting a message permanently means both the local copy and the server copy will be deleted.
+ */
+class PermanentDeleteChecker internal constructor(
+    private val accountManager: AccountManager,
+    private val localFolderChecker: LocalFolderChecker,
+    private val deleteOperationDecider: DeleteOperationDecider,
+) {
+    /**
+     * Check whether deleting messages will delete some of them permanently.
+     *
+     * Note: This method can perform disk I/O. Don't call it from the main thread!
+     */
+    @WorkerThread
+    fun checkPermanentDelete(messageReferences: List<MessageReference>): PermanentDeleteResult {
+        val permanentDeleteCount = messageReferences
+            .groupBy { it.accountUuid }
+            .mapKeysNotNull { accountUuid ->
+                accountManager.getAccount(accountUuid)
+            }
+            .map { (account, messageReferences) ->
+                getPermanentDeleteCount(account, messageReferences)
+            }
+            .sum()
+
+        return when (permanentDeleteCount) {
+            0 -> PermanentDeleteResult.None
+            messageReferences.size -> PermanentDeleteResult.All
+            else -> PermanentDeleteResult.Some(permanentDeleteCount)
+        }
+    }
+
+    private fun getPermanentDeleteCount(account: Account, messageReferences: List<MessageReference>): Int {
+        return messageReferences
+            .groupBy { it.folderId }
+            .map { (folderId, messageReferences) ->
+                if (isPermanentDelete(account, folderId)) {
+                    messageReferences.size
+                } else {
+                    0
+                }
+            }
+            .sum()
+    }
+
+    private fun isPermanentDelete(account: Account, folderId: Long): Boolean {
+        return deleteOperationDecider.isDeleteImmediately(account, folderId) && !isRemoteCopyKept(account, folderId)
+    }
+
+    private fun isRemoteCopyKept(account: Account, folderId: Long): Boolean {
+        val isRemoteFolder = !localFolderChecker.isLocalFolder(account, folderId)
+
+        // Only DeletePolicy.ON_DELETE will actually remove messages from the server.
+        val keepRemoteCopy = account.deletePolicy != DeletePolicy.ON_DELETE
+
+        return isRemoteFolder && keepRemoteCopy
+    }
+}
+
+private fun <K, V, R : Any> Map<K, V>.mapKeysNotNull(transform: (K) -> R?): Map<R, V> {
+    return buildMap {
+        this@mapKeysNotNull.forEach { (key, value) ->
+            transform(key)?.let { newKey ->
+                put(newKey, value)
+            }
+        }
+    }
+}
+
+sealed interface PermanentDeleteResult {
+    data object None : PermanentDeleteResult
+    data class Some(val permanentDeleteCount: Int) : PermanentDeleteResult
+    data object All : PermanentDeleteResult
+}

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
@@ -223,6 +223,11 @@ class FolderRepository(
         return messageStore.getFolder(folderId) { true } ?: false
     }
 
+    fun isLocalFolder(account: Account, folderId: Long): Boolean {
+        val messageStore = messageStoreManager.getMessageStore(account)
+        return messageStore.getFolder(folderId) { it.isLocalOnly } ?: false
+    }
+
     fun updateFolderDetails(account: Account, folderDetails: FolderDetails) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.updateFolderSettings(folderDetails)

--- a/app/core/src/test/java/com/fsck/k9/controller/DeleteOperationDeciderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/controller/DeleteOperationDeciderTest.kt
@@ -1,0 +1,52 @@
+package com.fsck.k9.controller
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import com.fsck.k9.Account
+import java.util.UUID
+import kotlin.test.Test
+
+class DeleteOperationDeciderTest {
+    private val deleteOperationDecider = DeleteOperationDecider()
+    private val account = Account(UUID.randomUUID().toString()).apply {
+        spamFolderId = SPAM_FOLDER_ID
+        trashFolderId = TRASH_FOLDER_ID
+    }
+
+    @Test
+    fun `delete message from trash folder`() {
+        val result = deleteOperationDecider.isDeleteImmediately(account, TRASH_FOLDER_ID)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `delete message from spam folder`() {
+        val result = deleteOperationDecider.isDeleteImmediately(account, SPAM_FOLDER_ID)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `delete message from regular folder`() {
+        val result = deleteOperationDecider.isDeleteImmediately(account, REGULAR_FOLDER_ID)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `delete message from regular folder without trash folder configured`() {
+        account.trashFolderId = null
+
+        val result = deleteOperationDecider.isDeleteImmediately(account, REGULAR_FOLDER_ID)
+
+        assertThat(result).isTrue()
+    }
+
+    companion object {
+        private const val REGULAR_FOLDER_ID = 1L
+        private const val SPAM_FOLDER_ID = 2L
+        private const val TRASH_FOLDER_ID = 3L
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -122,7 +122,8 @@ public class MessagingControllerTest extends K9RobolectricTest {
 
         controller = new MessagingController(appContext, notificationController, notificationStrategy,
                 localStoreProvider, backendManager, preferences, messageStoreManager,
-                saveMessageDataCreator, specialLocalFoldersCreator, Collections.<ControllerExtension>emptyList());
+                saveMessageDataCreator, specialLocalFoldersCreator, new DeleteOperationDecider(),
+                Collections.<ControllerExtension>emptyList());
 
         configureAccount();
         configureBackendManager();

--- a/app/core/src/test/java/com/fsck/k9/controller/PermanentDeleteCheckerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/controller/PermanentDeleteCheckerTest.kt
@@ -1,0 +1,191 @@
+package com.fsck.k9.controller
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.fsck.k9.Account
+import com.fsck.k9.Account.DeletePolicy
+import com.fsck.k9.preferences.FakeAccountManager
+import java.util.UUID
+import kotlin.test.Test
+
+class PermanentDeleteCheckerTest {
+    private val accountDefault = createAccount {
+        spamFolderId = SPAM_FOLDER_ID
+        trashFolderId = TRASH_FOLDER_ID
+        deletePolicy = DeletePolicy.ON_DELETE
+    }
+    private val accountNoDelete = createAccount {
+        spamFolderId = SPAM_FOLDER_ID
+        trashFolderId = TRASH_FOLDER_ID
+        deletePolicy = DeletePolicy.NEVER
+    }
+    private val accountAlwaysDelete = createAccount {
+        spamFolderId = null
+        trashFolderId = null
+        deletePolicy = DeletePolicy.ON_DELETE
+    }
+    private val accountLocalTrash = createAccount {
+        spamFolderId = null
+        trashFolderId = LOCAL_FOLDER_ID
+        deletePolicy = DeletePolicy.NEVER
+    }
+    private val accountManager = FakeAccountManager(
+        accounts = listOf(accountDefault, accountNoDelete, accountAlwaysDelete, accountLocalTrash),
+    )
+    private val localFolderChecker = LocalFolderChecker { _, folderId ->
+        folderId == LOCAL_FOLDER_ID
+    }
+    private val deleteOperationDecider = DeleteOperationDecider()
+    private val permanentDeleteChecker = PermanentDeleteChecker(
+        accountManager,
+        localFolderChecker,
+        deleteOperationDecider,
+    )
+
+    @Test
+    fun `delete message from local folder with delete policy set to not delete`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountLocalTrash.uuid, folderId = LOCAL_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.All)
+    }
+
+    @Test
+    fun `delete message from trash folder with delete policy set to delete`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountDefault.uuid, folderId = TRASH_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.All)
+    }
+
+    @Test
+    fun `delete message from trash folder with delete policy set to not delete`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountNoDelete.uuid, folderId = TRASH_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.None)
+    }
+
+    @Test
+    fun `delete message from spam folder with delete policy set to delete`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountDefault.uuid, folderId = SPAM_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.All)
+    }
+
+    @Test
+    fun `delete message from spam folder with delete policy set to not delete`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountNoDelete.uuid, folderId = SPAM_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.None)
+    }
+
+    @Test
+    fun `delete message from regular folder with delete policy set to delete`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountDefault.uuid, folderId = REGULAR_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.None)
+    }
+
+    @Test
+    fun `delete message from regular folder with delete policy set to not delete`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountNoDelete.uuid, folderId = REGULAR_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.None)
+    }
+
+    @Test
+    fun `delete messages from multiple accounts, none permanently`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountDefault.uuid, folderId = REGULAR_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountNoDelete.uuid, folderId = REGULAR_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountNoDelete.uuid, folderId = SPAM_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountNoDelete.uuid, folderId = TRASH_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.None)
+    }
+
+    @Test
+    fun `delete messages from multiple accounts, some permanently`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountDefault.uuid, folderId = REGULAR_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountDefault.uuid, folderId = SPAM_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountDefault.uuid, folderId = TRASH_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountNoDelete.uuid, folderId = REGULAR_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountNoDelete.uuid, folderId = SPAM_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountNoDelete.uuid, folderId = TRASH_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountLocalTrash.uuid, folderId = LOCAL_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.Some(permanentDeleteCount = 3))
+    }
+
+    @Test
+    fun `delete messages from multiple accounts, all permanently`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountDefault.uuid, folderId = SPAM_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountDefault.uuid, folderId = TRASH_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountAlwaysDelete.uuid, folderId = REGULAR_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountAlwaysDelete.uuid, folderId = SPAM_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountAlwaysDelete.uuid, folderId = TRASH_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = accountLocalTrash.uuid, folderId = LOCAL_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.All)
+    }
+
+    @Test
+    fun `skip unknown account`() {
+        val messageReferences = listOf(
+            MessageReference(accountUuid = accountDefault.uuid, folderId = REGULAR_FOLDER_ID, uid = "irrelevant"),
+            MessageReference(accountUuid = "invalid", folderId = TRASH_FOLDER_ID, uid = "irrelevant"),
+        )
+
+        val result = permanentDeleteChecker.checkPermanentDelete(messageReferences)
+
+        assertThat(result).isEqualTo(PermanentDeleteResult.None)
+    }
+
+    private fun createAccount(block: Account.() -> Unit): Account {
+        return Account(uuid = UUID.randomUUID().toString()).apply(block)
+    }
+
+    companion object {
+        private const val REGULAR_FOLDER_ID = 1L
+        private const val SPAM_FOLDER_ID = 2L
+        private const val TRASH_FOLDER_ID = 3L
+        private const val LOCAL_FOLDER_ID = 4L
+    }
+}

--- a/app/testing/src/main/java/com/fsck/k9/preferences/FakeAccountManager.kt
+++ b/app/testing/src/main/java/com/fsck/k9/preferences/FakeAccountManager.kt
@@ -6,9 +6,10 @@ import com.fsck.k9.AccountsChangeListener
 import kotlinx.coroutines.flow.Flow
 
 class FakeAccountManager(
-    private val accounts: MutableMap<String, Account> = mutableMapOf(),
+    accounts: List<Account> = listOf(),
     private val isFailureOnSave: Boolean = false,
 ) : AccountManager {
+    private val accounts = accounts.associateBy { it.uuid }.toMutableMap()
 
     override fun getAccounts(): List<Account> = accounts.values.toList()
 

--- a/app/testing/src/main/java/com/fsck/k9/preferences/FakeAccountManager.kt
+++ b/app/testing/src/main/java/com/fsck/k9/preferences/FakeAccountManager.kt
@@ -1,9 +1,8 @@
-package com.fsck.k9.account
+package com.fsck.k9.preferences
 
 import com.fsck.k9.Account
 import com.fsck.k9.AccountRemovedListener
 import com.fsck.k9.AccountsChangeListener
-import com.fsck.k9.preferences.AccountManager
 import kotlinx.coroutines.flow.Flow
 
 class FakeAccountManager(


### PR DESCRIPTION
It's surprisingly complex to find out whether deleting a message in the app will permanently delete this message, i.e. delete the local copy and the server copy (if available).

This is required functionality for #7707.