### PR TITLE
IMAP: Add support for the \NonExistent LIST response attribute

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapStore.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapStore.kt
@@ -143,8 +143,13 @@ internal open class RealImapStore(
             }
 
             if (RealImapFolder.INBOX.equals(serverId, ignoreCase = true)) {
+                // We always add our own inbox entry to the returned list.
                 continue
             } else if (listResponse.hasAttribute("\\NoSelect")) {
+                // RFC 3501, section 7.2.2: It is not possible to use this name as a selectable mailbox.
+                continue
+            } else if (listResponse.hasAttribute("\\NonExistent")) {
+                // RFC 5258, section 3: The "\NonExistent" attribute implies "\NoSelect".
                 continue
             }
 


### PR DESCRIPTION
Gmail changed the LIST response attribute for the `[Gmail]` folder from `\NoSelect` to `\NonExistent`. This means K-9 Mail currently displays this entry in the folder list.