### PR TITLE
Don't use AppAuth's `appAuthRedirectScheme` manifest placeholder

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -96,8 +96,6 @@ android {
                 "OAUTH_MICROSOFT_REDIRECT_URI",
                 "\"msauth://com.fsck.k9/Dx8yUsuhyU3dYYba1aA16Wxu5eM%3D\"",
             )
-
-            manifestPlaceholders["appAuthRedirectScheme"] = "com.fsck.k9"
         }
 
         debug {
@@ -128,8 +126,6 @@ android {
                 "OAUTH_MICROSOFT_REDIRECT_URI",
                 "\"msauth://com.fsck.k9.debug/VZF2DYuLYAu4TurFd6usQB2JPts%3D\"",
             )
-
-            manifestPlaceholders["appAuthRedirectScheme"] = "com.fsck.k9.debug"
         }
     }
 

--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.preferencex)
     implementation(libs.timber)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.appauth)
 
     implementation(libs.glide)
     annotationProcessor(libs.glide.compiler)

--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -41,13 +41,4 @@ dependencies {
 
 android {
     namespace = "com.fsck.k9.common"
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
 }

--- a/app/common/src/main/AndroidManifest.xml
+++ b/app/common/src/main/AndroidManifest.xml
@@ -336,15 +336,25 @@
 
         <activity
             android:name="net.openid.appauth.RedirectUriReceiverActivity"
-            android:exported="true"
-            tools:node="merge">
+            android:exported="true" >
+
+            <!-- The library's default intent filter with `appAuthRedirectScheme` replaced by `applicationId` -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <!-- Microsoft uses a special redirect URI format for Android apps -->
+                <data android:scheme="${applicationId}" />
+            </intent-filter>
+
+            <!-- Microsoft uses a special redirect URI format for Android apps -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
                 <data
                     android:scheme="msauth"
                     android:host="${applicationId}" />

--- a/app/ui/legacy/build.gradle.kts
+++ b/app/ui/legacy/build.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
     implementation(libs.fastadapter.extensions.utils)
     implementation(libs.circleImageView)
     implementation(libs.androidx.work.runtime)
-    api(libs.appauth)
 
     implementation(libs.commons.io)
     implementation(libs.androidx.core.ktx)
@@ -74,14 +73,5 @@ android {
 
     buildFeatures {
         buildConfig = true
-    }
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
     }
 }

--- a/app/ui/message-list-widget/build.gradle.kts
+++ b/app/ui/message-list-widget/build.gradle.kts
@@ -15,13 +15,4 @@ android {
     buildFeatures {
         buildConfig = true
     }
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
 }

--- a/feature/account/edit/build.gradle.kts
+++ b/feature/account/edit/build.gradle.kts
@@ -5,15 +5,6 @@ plugins {
 android {
     namespace = "app.k9mail.feature.account.edit"
     resourcePrefix = "account_edit_"
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
 }
 
 dependencies {

--- a/feature/account/oauth/build.gradle.kts
+++ b/feature/account/oauth/build.gradle.kts
@@ -5,15 +5,6 @@ plugins {
 android {
     namespace = "app.k9mail.feature.account.oauth"
     resourcePrefix = "account_oauth_"
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
 }
 
 dependencies {

--- a/feature/account/oauth/src/main/AndroidManifest.xml
+++ b/feature/account/oauth/src/main/AndroidManifest.xml
@@ -4,10 +4,6 @@
 
     <application>
 
-        <activity
-            android:name="app.k9mail.feature.settings.import.ui.OAuthFlowActivity"
-            android:label="@string/settings_import_oauth_sign_in" />
-
         <!-- We remove this activity entry to avoid all modules depending on this one having to define an override for
              the manifest placeholder 'appAuthRedirectScheme'. The entry is added back in :app:common -->
         <activity

--- a/feature/account/server/settings/build.gradle.kts
+++ b/feature/account/server/settings/build.gradle.kts
@@ -5,15 +5,6 @@ plugins {
 android {
     namespace = "app.k9mail.feature.account.server.settings"
     resourcePrefix = "account_server_settings_"
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
 }
 
 dependencies {

--- a/feature/account/server/validation/build.gradle.kts
+++ b/feature/account/server/validation/build.gradle.kts
@@ -5,15 +5,6 @@ plugins {
 android {
     namespace = "app.k9mail.feature.account.server.validation"
     resourcePrefix = "account_server_validation_"
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
 }
 
 dependencies {

--- a/feature/account/setup/build.gradle.kts
+++ b/feature/account/setup/build.gradle.kts
@@ -5,15 +5,6 @@ plugins {
 android {
     namespace = "app.k9mail.feature.account.setup"
     resourcePrefix = "account_setup_"
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
 }
 
 dependencies {

--- a/feature/launcher/build.gradle.kts
+++ b/feature/launcher/build.gradle.kts
@@ -5,15 +5,6 @@ plugins {
 android {
     namespace = "app.k9mail.feature.launcher"
     resourcePrefix = "launcher_"
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
 }
 
 dependencies {

--- a/feature/onboarding/main/build.gradle.kts
+++ b/feature/onboarding/main/build.gradle.kts
@@ -5,15 +5,6 @@ plugins {
 android {
     namespace = "app.k9mail.feature.onboarding.main"
     resourcePrefix = "onboarding_main_"
-
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
 }
 
 dependencies {

--- a/feature/settings/import/build.gradle.kts
+++ b/feature/settings/import/build.gradle.kts
@@ -8,15 +8,6 @@ android {
     namespace = "app.k9mail.feature.settings.importing"
     resourcePrefix = "settings_import_"
 
-    buildTypes {
-        debug {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-        release {
-            manifestPlaceholders["appAuthRedirectScheme"] = "FIXME: override this in your app project"
-        }
-    }
-
     lint {
         baseline = file("lint-baseline.xml")
     }


### PR DESCRIPTION
This change removes the `net.openid.appauth.RedirectUriReceiverActivity` entry from the manifest of modules depending on the AppAuth-Android library. That way modules depending on those modules don't have to provide a value for the `appAuthRedirectScheme` manifest placeholder.

The module `:app:common` is adding back the manifest entry for `net.openid.appauth.RedirectUriReceiverActivity` with `appAuthRedirectScheme` replaced by `applicationId`. That retains the current behavior without an app having to set the `appAuthRedirectScheme` manifest placeholder to the application ID.