### PR TITLE
Enable emailaddress parameter for autoconfig

### DIFF
--- a/feature/autodiscovery/service/src/main/kotlin/app/k9mail/autodiscovery/service/RealAutoDiscoveryRegistry.kt
+++ b/feature/autodiscovery/service/src/main/kotlin/app/k9mail/autodiscovery/service/RealAutoDiscoveryRegistry.kt
@@ -17,7 +17,7 @@ class RealAutoDiscoveryRegistry(
     companion object {
         val defaultAutoconfigUrlConfig = AutoconfigUrlConfig(
             httpsOnly = false,
-            includeEmailAddress = false,
+            includeEmailAddress = true,
         )
 
         fun createDefault(


### PR DESCRIPTION
This matches the behaviour of Thunderbird on desktop.

Also, some ISPs rely on the parameter for returning the correct username.
