### PR TITLE
Add "Push folders" settings screen that prompts for alarm permission

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/push/AlarmPermissionManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/AlarmPermissionManager.kt
@@ -8,7 +8,7 @@ import com.fsck.k9.helper.AlarmManagerCompat
 /**
  * Checks whether the app can schedule exact alarms.
  */
-internal interface AlarmPermissionManager {
+interface AlarmPermissionManager {
     /**
      * Checks whether the app can schedule exact alarms.
      *
@@ -45,6 +45,6 @@ internal fun AlarmPermissionManager(context: Context, alarmManagerCompat: AlarmM
  * Note: Currently Android stops (and potentially restarts) the app when the permission is revoked. So there's no
  * callback mechanism for the permission revocation case.
  */
-internal fun interface AlarmPermissionListener {
+fun interface AlarmPermissionListener {
     fun onAlarmPermissionGranted()
 }

--- a/app/core/src/main/res/values/arrays_account_settings_values.xml
+++ b/app/core/src/main/res/values/arrays_account_settings_values.xml
@@ -116,14 +116,6 @@
         <item>NONE</item>
     </string-array>
 
-    <string-array name="folder_push_mode_values" translatable="false">
-        <item>ALL</item>
-        <item>FIRST_CLASS</item>
-        <item>FIRST_AND_SECOND_CLASS</item>
-        <item>NOT_SECOND_CLASS</item>
-        <item>NONE</item>
-    </string-array>
-
     <string-array name="push_limit_values" translatable="false">
         <item>5</item>
         <item>10</item>

--- a/app/ui/legacy/build.gradle.kts
+++ b/app/ui/legacy/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     // TODO: Remove AccountOauth dependency
     implementation(projects.feature.account.oauth)
     implementation(projects.feature.settings.import)
+    implementation(projects.feature.settings.push)
 
     compileOnly(projects.mail.protocols.imap)
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/UiKoinModules.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/UiKoinModules.kt
@@ -2,6 +2,7 @@ package com.fsck.k9
 
 import app.k9mail.feature.account.oauth.featureAccountOAuthModule
 import app.k9mail.feature.launcher.di.featureLauncherModule
+import app.k9mail.feature.settings.push.featureSettingsPushModule
 import com.fsck.k9.account.accountModule
 import com.fsck.k9.activity.activityModule
 import com.fsck.k9.contacts.contactsModule
@@ -42,4 +43,5 @@ val uiModules = listOf(
     messageViewUiModule,
     identityUiModule,
     featureLauncherModule,
+    featureSettingsPushModule,
 )

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -14,6 +14,8 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreference
 import app.k9mail.feature.launcher.FeatureLauncherActivity
+import app.k9mail.feature.settings.push.ui.PushFoldersActivity
+import app.k9mail.feature.settings.push.ui.PushFoldersPreference
 import com.fsck.k9.Account
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.activity.ManageIdentities
@@ -58,6 +60,11 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     private var notificationSoundPreference: NotificationSoundPreference? = null
     private var notificationLightPreference: ListPreference? = null
     private var notificationVibrationPreference: VibrationPreference? = null
+
+    private var pushFoldersPreference: PushFoldersPreference? = null
+    private val pushFoldersScreenLauncher = registerForActivityResult(PushFoldersActivity.ResultContract()) { result ->
+        pushFoldersPreference?.onValueSelected(result)
+    }
 
     private val accountUuid: String by lazy {
         checkNotNull(arguments?.getString(ARG_ACCOUNT_UUID)) { "$ARG_ACCOUNT_UUID == null" }
@@ -198,6 +205,13 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         if (!messagingController.isPushCapable(account)) {
             findPreference<Preference>(PREFERENCE_PUSH_MODE)?.remove()
             findPreference<Preference>(PREFERENCE_ADVANCED_PUSH_SETTINGS)?.remove()
+        } else {
+            pushFoldersPreference = findPreference<PushFoldersPreference>(PREFERENCE_PUSH_MODE)?.apply {
+                setOnPreferenceClickListener {
+                    pushFoldersScreenLauncher.launch(accountUuid)
+                    true
+                }
+            }
         }
     }
 

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -89,12 +89,8 @@
             app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_folder_sync_mode_label" />
 
-        <ListPreference
-            android:dialogTitle="@string/account_settings_folder_push_mode_label"
-            android:entries="@array/folder_push_mode_entries"
-            android:entryValues="@array/folder_push_mode_values"
+        <app.k9mail.feature.settings.push.ui.PushFoldersPreference
             android:key="folder_push_mode"
-            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_folder_push_mode_label" />
 
         <CheckBoxPreference

--- a/feature/settings/push/build.gradle.kts
+++ b/feature/settings/push/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "app.k9mail.feature.settings.push"
+    resourcePrefix = "settings_push_"
+}
+
+dependencies {
+    implementation(projects.app.core)
+    implementation(projects.app.ui.base)
+    implementation(projects.core.ui.compose.designsystem)
+
+    // We include this to be able to use radio buttons which aren't in the design library yet. Since we're in the
+    // process of switching from Material 2 to Material 3 and we want to get rid of the "Push folders" setting
+    // (see <https://github.com/thunderbird/thunderbird-android/issues/7761>), it's easier to temporarily add radio
+    // buttons to this module instead of modifying the design library that is currently being worked on.
+    // TODO: Remove the "Push folders" setting and with it the need to directly include this dependency.
+    implementation(libs.androidx.compose.material)
+
+    implementation(libs.androidx.preference)
+    implementation(libs.timber)
+}

--- a/feature/settings/push/src/debug/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersContentPreview.kt
+++ b/feature/settings/push/src/debug/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersContentPreview.kt
@@ -1,0 +1,40 @@
+package app.k9mail.feature.settings.push.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.theme.K9Theme
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.State
+import com.fsck.k9.Account.FolderMode
+
+@Composable
+@Preview(showBackground = true)
+fun PushFoldersContentWithPermissionPromptPreview() {
+    K9Theme {
+        PushFoldersContent(
+            state = State(
+                isLoading = false,
+                showPermissionPrompt = true,
+                selectedOption = FolderMode.NONE,
+            ),
+            onEvent = {},
+            innerPadding = PaddingValues(),
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun PushFoldersContentWithoutPermissionPromptPreview() {
+    K9Theme {
+        PushFoldersContent(
+            state = State(
+                isLoading = false,
+                showPermissionPrompt = false,
+                selectedOption = FolderMode.ALL,
+            ),
+            onEvent = {},
+            innerPadding = PaddingValues(),
+        )
+    }
+}

--- a/feature/settings/push/src/debug/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersScreenPreview.kt
+++ b/feature/settings/push/src/debug/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersScreenPreview.kt
@@ -1,0 +1,36 @@
+package app.k9mail.feature.settings.push.ui
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
+import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.core.ui.compose.theme.K9Theme
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.Effect
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.Event
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.State
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.ViewModel
+import com.fsck.k9.Account.FolderMode
+
+@Composable
+@PreviewDevices
+fun PushFoldersScreenPreview() {
+    K9Theme {
+        PushFoldersScreen(
+            accountUuid = "accountUuid",
+            onOptionSelected = {},
+            onBack = {},
+            viewModel = FakePushFolderViewModel(
+                initialState = State(
+                    isLoading = false,
+                    showPermissionPrompt = true,
+                    selectedOption = FolderMode.FIRST_CLASS,
+                ),
+            ),
+        )
+    }
+}
+
+private class FakePushFolderViewModel(
+    initialState: State = State(),
+) : BaseViewModel<State, Event, Effect>(initialState), ViewModel {
+    override fun event(event: Event) = Unit
+}

--- a/feature/settings/push/src/main/AndroidManifest.xml
+++ b/feature/settings/push/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+
+        <activity
+            android:name="app.k9mail.feature.settings.push.ui.PushFoldersActivity"
+            android:exported="false" />
+
+    </application>
+</manifest>

--- a/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/PushFoldersModule.kt
+++ b/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/PushFoldersModule.kt
@@ -1,0 +1,16 @@
+package app.k9mail.feature.settings.push
+
+import app.k9mail.feature.settings.push.ui.PushFoldersViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val featureSettingsPushModule: Module = module {
+    viewModel { (accountUuid: String) ->
+        PushFoldersViewModel(
+            accountUuid = accountUuid,
+            accountManager = get(),
+            alarmPermissionManager = get(),
+        )
+    }
+}

--- a/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFolderOptionStringMapper.kt
+++ b/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFolderOptionStringMapper.kt
@@ -1,0 +1,17 @@
+package app.k9mail.feature.settings.push.ui
+
+import android.content.res.Resources
+import app.k9mail.feature.settings.push.R
+import com.fsck.k9.Account.FolderMode
+
+internal fun FolderMode.toResourceString(resources: Resources): String {
+    val resourceId = when (this) {
+        FolderMode.NONE -> R.string.settings_push_option_none
+        FolderMode.ALL -> R.string.settings_push_option_all
+        FolderMode.FIRST_CLASS -> R.string.settings_push_option_first_class
+        FolderMode.FIRST_AND_SECOND_CLASS -> R.string.settings_push_option_first_and_second_class
+        FolderMode.NOT_SECOND_CLASS -> R.string.settings_push_option_all_except_second_class
+    }
+
+    return resources.getString(resourceId)
+}

--- a/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersActivity.kt
+++ b/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersActivity.kt
@@ -1,0 +1,62 @@
+package app.k9mail.feature.settings.push.ui
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContract
+import app.k9mail.core.ui.compose.theme.K9Theme
+import com.fsck.k9.Account.FolderMode
+import com.fsck.k9.ui.base.K9Activity
+
+/**
+ * Screen to change the "Push folders" setting of an account.
+ */
+class PushFoldersActivity : K9Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val accountUuid = intent.getStringExtra(EXTRA_ACCOUNT_UUID) ?: error("Missing extra '$EXTRA_ACCOUNT_UUID'")
+
+        setContent {
+            K9Theme {
+                PushFoldersScreen(
+                    accountUuid = accountUuid,
+                    onOptionSelected = ::onPushFoldersChanged,
+                    onBack = { finish() },
+                )
+            }
+        }
+    }
+
+    private fun onPushFoldersChanged(result: FolderMode) {
+        val resultIntent = Intent().apply {
+            putExtra(EXTRA_RESULT, result.name)
+        }
+
+        setResult(Activity.RESULT_OK, resultIntent)
+        finish()
+    }
+
+    class ResultContract : ActivityResultContract<String, FolderMode?>() {
+        override fun createIntent(context: Context, input: String): Intent {
+            return Intent(context, PushFoldersActivity::class.java).apply {
+                putExtra(EXTRA_ACCOUNT_UUID, input)
+            }
+        }
+
+        override fun parseResult(resultCode: Int, intent: Intent?): FolderMode? {
+            return if (resultCode == Activity.RESULT_OK && intent != null) {
+                intent.getStringExtra(EXTRA_RESULT)?.let { FolderMode.valueOf(it) }
+            } else {
+                null
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_ACCOUNT_UUID = "accountUuid"
+        private const val EXTRA_RESULT = "result"
+    }
+}

--- a/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersContent.kt
+++ b/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersContent.kt
@@ -1,0 +1,168 @@
+package app.k9mail.feature.settings.push.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.RadioButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.k9mail.core.ui.compose.designsystem.atom.button.Button
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBody1
+import app.k9mail.core.ui.compose.designsystem.molecule.LoadingView
+import app.k9mail.core.ui.compose.designsystem.template.ResponsiveContent
+import app.k9mail.core.ui.compose.theme.MainTheme
+import app.k9mail.feature.settings.push.R
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.Event
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.State
+import com.fsck.k9.Account.FolderMode
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+
+private val listItemMinHeight = 56.dp
+private val listItemContentStart = 72.dp
+
+@Composable
+internal fun PushFoldersContent(
+    state: State,
+    onEvent: (Event) -> Unit,
+    innerPadding: PaddingValues,
+) {
+    ResponsiveContent(
+        modifier = Modifier.padding(innerPadding),
+    ) {
+        if (state.isLoading) {
+            LoadingIndicator()
+        } else {
+            ContentView(
+                state = state,
+                onEvent = onEvent,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingIndicator() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        LoadingView()
+    }
+}
+
+@Composable
+private fun ContentView(
+    state: State,
+    onEvent: (Event) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxHeight()
+            .verticalScroll(state = rememberScrollState()),
+    ) {
+        if (state.showPermissionPrompt) {
+            PermissionPrompt(onEvent)
+        }
+
+        PushFolderOptionRadioGroup(
+            selectedOption = state.selectedOption,
+            options = persistentListOf(
+                FolderMode.ALL,
+                FolderMode.FIRST_CLASS,
+                FolderMode.FIRST_AND_SECOND_CLASS,
+                FolderMode.NOT_SECOND_CLASS,
+                FolderMode.NONE,
+            ),
+            onSelected = { onEvent(Event.OptionSelected(it)) },
+            enabled = !state.showPermissionPrompt,
+            modifier = Modifier.padding(vertical = MainTheme.spacings.double),
+        )
+    }
+}
+
+@Composable
+private fun PermissionPrompt(onEvent: (Event) -> Unit) {
+    Column(modifier = Modifier.padding(all = MainTheme.spacings.double)) {
+        TextBody1(text = stringResource(R.string.settings_push_permission_info_text))
+
+        Spacer(modifier = Modifier.height(MainTheme.spacings.double))
+
+        Button(
+            text = stringResource(R.string.settings_push_grant_permission_button),
+            onClick = { onEvent(Event.GrantAlarmPermissionClicked) },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+    }
+}
+
+@Composable
+private fun PushFolderOptionRadioGroup(
+    selectedOption: FolderMode,
+    options: PersistentList<FolderMode>,
+    onSelected: (FolderMode) -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val resources = LocalContext.current.resources
+
+    Column(modifier = modifier) {
+        for (option in options) {
+            val isSelected = option == selectedOption
+            val isEnabled = enabled || option == FolderMode.NONE
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = listItemMinHeight)
+                    .selectable(
+                        selected = isSelected,
+                        enabled = isEnabled,
+                        onClick = { onSelected(option) },
+                    ),
+            ) {
+                RadioButton(
+                    selected = isSelected,
+                    onClick = { onSelected(option) },
+                    enabled = isEnabled,
+                    modifier = Modifier.width(listItemContentStart),
+                )
+                TextBody1(
+                    text = option.toResourceString(resources),
+                    modifier = Modifier
+                        .padding(end = MainTheme.spacings.double)
+                        .disabledText(!isEnabled, ContentAlpha.disabled),
+                )
+            }
+        }
+    }
+}
+
+@Stable
+private fun Modifier.disabledText(disabled: Boolean, disabledAlpha: Float): Modifier {
+    return if (disabled) {
+        alpha(disabledAlpha)
+    } else {
+        this
+    }
+}

--- a/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersContract.kt
+++ b/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersContract.kt
@@ -1,0 +1,27 @@
+package app.k9mail.feature.settings.push.ui
+
+import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
+import com.fsck.k9.Account.FolderMode
+
+internal interface PushFoldersContract {
+    interface ViewModel : UnidirectionalViewModel<State, Event, Effect>
+
+    data class State(
+        val isLoading: Boolean = true,
+        val showPermissionPrompt: Boolean = false,
+        val selectedOption: FolderMode = FolderMode.NONE,
+    )
+
+    sealed interface Event {
+        data object BackClicked : Event
+        data object GrantAlarmPermissionClicked : Event
+        data object AlarmPermissionResult : Event
+        data class OptionSelected(val option: FolderMode) : Event
+    }
+
+    sealed interface Effect {
+        data object RequestAlarmPermission : Effect
+        data object NavigateBack : Effect
+        data class OptionSelected(val option: FolderMode) : Effect
+    }
+}

--- a/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersPreference.kt
+++ b/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersPreference.kt
@@ -1,0 +1,55 @@
+package app.k9mail.feature.settings.push.ui
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import androidx.core.content.res.TypedArrayUtils
+import androidx.preference.Preference
+import app.k9mail.feature.settings.push.R
+import com.fsck.k9.Account.FolderMode
+import com.fsck.k9.controller.push.AlarmPermissionManager
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+@SuppressLint("RestrictedApi")
+class PushFoldersPreference
+@JvmOverloads
+constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = TypedArrayUtils.getAttr(
+        context,
+        androidx.preference.R.attr.preferenceStyle,
+        android.R.attr.preferenceStyle,
+    ),
+    defStyleRes: Int = 0,
+) : Preference(context, attrs, defStyleAttr, defStyleRes), KoinComponent {
+    private val alarmPermissionManager: AlarmPermissionManager by inject()
+
+    private var folderPushMode: FolderMode = FolderMode.NONE
+
+    override fun onSetInitialValue(defaultValue: Any?) {
+        folderPushMode = getPersistedString(defaultValue as? String)?.let { FolderMode.valueOf(it) } ?: folderPushMode
+        updateSummary()
+    }
+
+    fun onValueSelected(folderPushMode: FolderMode?) {
+        if (folderPushMode != null) {
+            this.folderPushMode = folderPushMode
+            persistString(folderPushMode.name)
+        }
+
+        updateSummary()
+    }
+
+    private fun updateSummary() {
+        val needAlarmPermission = !alarmPermissionManager.canScheduleExactAlarms()
+        val displayName = folderPushMode.toResourceString(context.resources)
+
+        summary = if (needAlarmPermission && folderPushMode != FolderMode.NONE) {
+            context.getString(R.string.settings_push_alarm_permission_required, displayName)
+        } else {
+            displayName
+        }
+    }
+}

--- a/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersScreen.kt
+++ b/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersScreen.kt
@@ -1,0 +1,60 @@
+package app.k9mail.feature.settings.push.ui
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.common.mvi.observe
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonIcon
+import app.k9mail.core.ui.compose.designsystem.organism.TopAppBar
+import app.k9mail.core.ui.compose.designsystem.template.Scaffold
+import app.k9mail.core.ui.compose.theme.Icons
+import app.k9mail.feature.settings.push.R
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.Effect
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.Event
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.ViewModel
+import com.fsck.k9.Account.FolderMode
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+@Composable
+internal fun PushFoldersScreen(
+    accountUuid: String,
+    onOptionSelected: (FolderMode) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ViewModel = koinViewModel<PushFoldersViewModel> { parametersOf(accountUuid) },
+) {
+    val contactsPermissionLauncher = rememberLauncherForActivityResult(RequestAlarmPermission()) {
+        viewModel.event(Event.AlarmPermissionResult)
+    }
+
+    val (state, dispatch) = viewModel.observe { effect ->
+        when (effect) {
+            Effect.NavigateBack -> onBack()
+            is Effect.OptionSelected -> onOptionSelected(effect.option)
+            Effect.RequestAlarmPermission -> contactsPermissionLauncher.launch(Unit)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = stringResource(R.string.settings_push_title),
+                navigationIcon = {
+                    ButtonIcon(
+                        onClick = onBack,
+                        imageVector = Icons.Outlined.arrowBack,
+                    )
+                },
+            )
+        },
+        modifier = modifier,
+    ) { innerPadding ->
+        PushFoldersContent(
+            state = state.value,
+            onEvent = dispatch,
+            innerPadding = innerPadding,
+        )
+    }
+}

--- a/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersViewModel.kt
+++ b/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/PushFoldersViewModel.kt
@@ -1,0 +1,78 @@
+package app.k9mail.feature.settings.push.ui
+
+import androidx.lifecycle.viewModelScope
+import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.Effect
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.Event
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.State
+import app.k9mail.feature.settings.push.ui.PushFoldersContract.ViewModel
+import com.fsck.k9.controller.push.AlarmPermissionManager
+import com.fsck.k9.preferences.AccountManager
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+internal class PushFoldersViewModel(
+    private val accountUuid: String,
+    private val accountManager: AccountManager,
+    private val alarmPermissionManager: AlarmPermissionManager,
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : BaseViewModel<State, Event, Effect>(initialState = State(isLoading = true)), ViewModel {
+    init {
+        initializeShowPermissionPromptValue()
+        loadAccount()
+    }
+
+    private fun initializeShowPermissionPromptValue() {
+        updateState { state ->
+            state.copy(showPermissionPrompt = !alarmPermissionManager.canScheduleExactAlarms())
+        }
+    }
+
+    private fun loadAccount() {
+        viewModelScope.launch {
+            val account = withContext(backgroundDispatcher) {
+                accountManager.getAccount(accountUuid)
+            }
+
+            if (account == null) {
+                Timber.w("Account not found: %s", accountUuid)
+                emitEffect(Effect.NavigateBack)
+            } else {
+                updateState { state ->
+                    state.copy(
+                        isLoading = false,
+                        selectedOption = account.folderPushMode,
+                    )
+                }
+            }
+        }
+    }
+
+    override fun event(event: Event) {
+        when (event) {
+            Event.BackClicked -> emitEffect(Effect.NavigateBack)
+            Event.GrantAlarmPermissionClicked -> emitEffect(Effect.RequestAlarmPermission)
+            is Event.AlarmPermissionResult -> updateShowPermissionPromptValue()
+            is Event.OptionSelected -> handleOptionSelected(event)
+        }
+    }
+
+    private fun updateShowPermissionPromptValue() {
+        updateState { state ->
+            state.copy(showPermissionPrompt = !alarmPermissionManager.canScheduleExactAlarms())
+        }
+    }
+
+    private fun handleOptionSelected(event: Event.OptionSelected) {
+        val selectedOption = event.option
+
+        updateState { state ->
+            state.copy(selectedOption = selectedOption)
+        }
+
+        emitEffect(Effect.OptionSelected(selectedOption))
+    }
+}

--- a/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/RequestAlarmPermission.kt
+++ b/feature/settings/push/src/main/kotlin/app/k9mail/feature/settings/push/ui/RequestAlarmPermission.kt
@@ -1,0 +1,31 @@
+package app.k9mail.feature.settings.push.ui
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.RequiresApi
+
+/**
+ * Start the system activity to request the permission to schedule exact alarms.
+ *
+ * Note: [Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM] is documented to return [Activity.RESULT_OK] when the
+ * permission was granted, [Activity.RESULT_CANCELED] otherwise. But at least on Android 14 `RESULT_CANCELED` is always
+ * returned.
+ * So the result mechanism should only be used as a trigger to check the permission again.
+ */
+internal class RequestAlarmPermission : ActivityResultContract<Unit, Unit>() {
+    @RequiresApi(Build.VERSION_CODES.S)
+    override fun createIntent(context: Context, input: Unit): Intent {
+        return Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+            data = Uri.parse("package:${context.packageName}")
+        }
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?) {
+        // We can't rely on the system activity returning a useful result.
+    }
+}

--- a/feature/settings/push/src/main/res/values/strings.xml
+++ b/feature/settings/push/src/main/res/values/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="settings_push_title">Push folders</string>
+    <string name="settings_push_option_all">All</string>
+    <string name="settings_push_option_first_class">Only 1st Class folders</string>
+    <string name="settings_push_option_first_and_second_class">1st and 2nd Class folders</string>
+    <string name="settings_push_option_all_except_second_class">All except 2nd Class folders</string>
+    <string name="settings_push_option_none">None</string>
+    <string name="settings_push_alarm_permission_required">Permission required (<xliff:g id="currentValue" example="None">%s</xliff:g>)</string>
+    <string name="settings_push_permission_info_text">K-9 Mail needs to regularly wake up to keep Push connections alive. In order for this to work you need to grant the permission to schedule alarms.</string>
+    <string name="settings_push_grant_permission_button">Grant permission</string>
+</resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,7 @@ include(
 
 include(
     ":feature:settings:import",
+    ":feature:settings:push",
 )
 
 include(


### PR DESCRIPTION
Change the UI for the "Push folders" setting to ask for the permission to schedule exact alarms before allowing the user to enable Push.

It's possible to end up in a state where Push is enabled but the permission is missing. That's why we always allow the user to select the `None` option to disable Push, even when the permission hasn't been granted.

![image](https://github.com/thunderbird/thunderbird-android/assets/218061/78da84df-c346-469c-aeb8-96d31c87a1ee)

The plan is to change the way Push is enabled for folders (#7761). So almost all of this code is going to be removed in the near future.

### Test instructions
- Use an Android 14 device.
- Set up an IMAP account.
- Go to *Settings → [Account] → Fetching mail → Push folders*.
  - On a fresh install the permission to schedule alarms won't have been granted. So the permission text + button should be visible.
  - Once the permission has been granted, only the radio buttons should be visible. All of them should be enabled and selectable.
  - To test the case where Push is enabled (the setting has a value other than *None*) but the permission wasn't granted, first grant the permission, then enable Push, then navigate to the *Alarms & reminders* screen from the system's *App info* screen and revoke the permission. Then go to *Settings → [Account] → Fetching mail → Push folders* again.

Closes #7363