### PR TITLE
Fix `Context.registerReceiver()` calls to specify export behavior

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/push/AutoSyncManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/AutoSyncManager.kt
@@ -5,6 +5,7 @@ import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 import com.fsck.k9.K9
 import timber.log.Timber
 
@@ -38,7 +39,7 @@ internal class AutoSyncManager(private val context: Context) {
             Timber.v("Registering auto sync listener")
             isRegistered = true
             this.listener = listener
-            context.registerReceiver(receiver, intentFilter)
+            ContextCompat.registerReceiver(context, receiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/provider/AttachmentTempFileProvider.java
+++ b/app/core/src/main/java/com/fsck/k9/provider/AttachmentTempFileProvider.java
@@ -16,6 +16,7 @@ import android.os.AsyncTask;
 import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import timber.log.Timber;
 
@@ -188,7 +189,7 @@ public class AttachmentTempFileProvider extends FileProvider {
 
             IntentFilter intentFilter = new IntentFilter();
             intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
-            context.registerReceiver(cleanupReceiver, intentFilter);
+            ContextCompat.registerReceiver(context, cleanupReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED);
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/provider/DecryptedFileProvider.java
+++ b/app/core/src/main/java/com/fsck/k9/provider/DecryptedFileProvider.java
@@ -17,6 +17,7 @@ import android.os.ParcelFileDescriptor;
 import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import android.text.TextUtils;
 import timber.log.Timber;
@@ -194,7 +195,7 @@ public class DecryptedFileProvider extends FileProvider {
 
             IntentFilter intentFilter = new IntentFilter();
             intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
-            context.registerReceiver(cleanupReceiver, intentFilter);
+            ContextCompat.registerReceiver(context, cleanupReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED);
         }
     }
 


### PR DESCRIPTION
See https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported