### PR TITLE
Extract decision whether to immediately delete a message to `LocalDeleteOperationDecider`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -24,13 +24,17 @@ val controllerModule = module {
             get<MessageStoreManager>(),
             get<SaveMessageDataCreator>(),
             get<SpecialLocalFoldersCreator>(),
+            get<LocalDeleteOperationDecider>(),
             get(named("controllerExtensions")),
         )
     }
+
     single<MessageCountsProvider> {
         DefaultMessageCountsProvider(
             accountManager = get(),
             messageStoreManager = get(),
         )
     }
+
+    single { LocalDeleteOperationDecider() }
 }

--- a/app/core/src/main/java/com/fsck/k9/controller/LocalDeleteOperationDecider.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/LocalDeleteOperationDecider.kt
@@ -1,0 +1,26 @@
+package com.fsck.k9.controller
+
+import com.fsck.k9.Account
+
+/**
+ * Decides whether deleting a message in the app moves it to the trash folder or deletes it immediately.
+ *
+ * Note: This only applies to local messages. What remote operation is performed when deleting a message is controlled
+ * by [Account.deletePolicy].
+ */
+internal class LocalDeleteOperationDecider {
+    fun isDeleteImmediately(account: Account, folderId: Long): Boolean {
+        // If there's no trash folder configured, all messages are deleted immediately.
+        if (!account.hasTrashFolder()) {
+            return true
+        }
+
+        // Deleting messages from the trash folder will delete them immediately.
+        val isTrashFolder = folderId == account.trashFolderId
+
+        // Messages deleted from the spam folder are deleted immediately.
+        val isSpamFolder = folderId == account.spamFolderId
+
+        return isTrashFolder || isSpamFolder
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -117,6 +117,7 @@ public class MessagingController {
     private final MessageStoreManager messageStoreManager;
     private final SaveMessageDataCreator saveMessageDataCreator;
     private final SpecialLocalFoldersCreator specialLocalFoldersCreator;
+    private final LocalDeleteOperationDecider localDeleteOperationDecider;
 
     private final Thread controllerThread;
 
@@ -140,7 +141,7 @@ public class MessagingController {
             NotificationStrategy notificationStrategy, LocalStoreProvider localStoreProvider,
             BackendManager backendManager, Preferences preferences, MessageStoreManager messageStoreManager,
             SaveMessageDataCreator saveMessageDataCreator, SpecialLocalFoldersCreator specialLocalFoldersCreator,
-            List<ControllerExtension> controllerExtensions) {
+            LocalDeleteOperationDecider localDeleteOperationDecider, List<ControllerExtension> controllerExtensions) {
         this.context = context;
         this.notificationController = notificationController;
         this.notificationStrategy = notificationStrategy;
@@ -150,6 +151,7 @@ public class MessagingController {
         this.messageStoreManager = messageStoreManager;
         this.saveMessageDataCreator = saveMessageDataCreator;
         this.specialLocalFoldersCreator = specialLocalFoldersCreator;
+        this.localDeleteOperationDecider = localDeleteOperationDecider;
 
         controllerThread = new Thread(new Runnable() {
             @Override
@@ -1978,10 +1980,8 @@ public class MessagingController {
 
             Map<String, String> uidMap = null;
             Long trashFolderId = account.getTrashFolderId();
-            boolean isSpamFolder = account.hasSpamFolder() && account.getSpamFolderId() == folderId;
             boolean doNotMoveToTrashFolder = skipTrashFolder ||
-                !account.hasTrashFolder() || folderId == trashFolderId ||
-                isSpamFolder;
+                localDeleteOperationDecider.isDeleteImmediately(account, folderId);
 
             LocalFolder localTrashFolder = null;
             if (doNotMoveToTrashFolder) {

--- a/app/core/src/test/java/com/fsck/k9/controller/LocalDeleteOperationDeciderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/controller/LocalDeleteOperationDeciderTest.kt
@@ -1,0 +1,52 @@
+package com.fsck.k9.controller
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import com.fsck.k9.Account
+import java.util.UUID
+import kotlin.test.Test
+
+class LocalDeleteOperationDeciderTest {
+    private val localDeleteOperationDecider = LocalDeleteOperationDecider()
+    private val account = Account(UUID.randomUUID().toString()).apply {
+        spamFolderId = SPAM_FOLDER_ID
+        trashFolderId = TRASH_FOLDER_ID
+    }
+
+    @Test
+    fun `delete message from trash folder`() {
+        val result = localDeleteOperationDecider.isDeleteImmediately(account, TRASH_FOLDER_ID)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `delete message from spam folder`() {
+        val result = localDeleteOperationDecider.isDeleteImmediately(account, SPAM_FOLDER_ID)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `delete message from regular folder`() {
+        val result = localDeleteOperationDecider.isDeleteImmediately(account, REGULAR_FOLDER_ID)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `delete message from regular folder without trash folder configured`() {
+        account.trashFolderId = null
+
+        val result = localDeleteOperationDecider.isDeleteImmediately(account, REGULAR_FOLDER_ID)
+
+        assertThat(result).isTrue()
+    }
+
+    companion object {
+        private const val REGULAR_FOLDER_ID = 1L
+        private const val SPAM_FOLDER_ID = 2L
+        private const val TRASH_FOLDER_ID = 3L
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -122,7 +122,8 @@ public class MessagingControllerTest extends K9RobolectricTest {
 
         controller = new MessagingController(appContext, notificationController, notificationStrategy,
                 localStoreProvider, backendManager, preferences, messageStoreManager,
-                saveMessageDataCreator, specialLocalFoldersCreator, Collections.<ControllerExtension>emptyList());
+                saveMessageDataCreator, specialLocalFoldersCreator, new LocalDeleteOperationDecider(),
+                Collections.<ControllerExtension>emptyList());
 
         configureAccount();
         configureBackendManager();


### PR DESCRIPTION
Extracted from #7731. `DeleteOperationDecider` has been renamed to `LocalDeleteOperationDecider` as suggested.