### PR TITLE
Change features to theme 2 - part 2

### DIFF
--- a/feature/account/common/src/debug/kotlin/app/k9mail/feature/account/common/ui/fake/FakeAccountStateRepository.kt
+++ b/feature/account/common/src/debug/kotlin/app/k9mail/feature/account/common/ui/fake/FakeAccountStateRepository.kt
@@ -1,0 +1,57 @@
+package app.k9mail.feature.account.common.ui.fake
+
+import app.k9mail.feature.account.common.domain.AccountDomainContract
+import app.k9mail.feature.account.common.domain.entity.AccountDisplayOptions
+import app.k9mail.feature.account.common.domain.entity.AccountState
+import app.k9mail.feature.account.common.domain.entity.AccountSyncOptions
+import app.k9mail.feature.account.common.domain.entity.AuthorizationState
+import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
+import app.k9mail.feature.account.common.domain.entity.SpecialFolderSettings
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ServerSettings
+
+@Suppress("TooManyFunctions")
+class FakeAccountStateRepository : AccountDomainContract.AccountStateRepository {
+
+    override fun getState(): AccountState = AccountState(
+        emailAddress = "test@example.com",
+        incomingServerSettings = ServerSettings(
+            type = "imap",
+            host = "imap.example.com",
+            port = 993,
+            connectionSecurity = MailConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "test",
+            password = "password",
+            clientCertificateAlias = null,
+        ),
+        outgoingServerSettings = ServerSettings(
+            type = "smtp",
+            host = "smtp.example.com",
+            port = 465,
+            connectionSecurity = MailConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "test",
+            password = "password",
+            clientCertificateAlias = null,
+        ),
+    )
+
+    override fun setState(accountState: AccountState) = Unit
+
+    override fun setEmailAddress(emailAddress: String) = Unit
+
+    override fun setIncomingServerSettings(serverSettings: ServerSettings) = Unit
+
+    override fun setOutgoingServerSettings(serverSettings: ServerSettings) = Unit
+
+    override fun setAuthorizationState(authorizationState: AuthorizationState) = Unit
+
+    override fun setSpecialFolderSettings(specialFolderSettings: SpecialFolderSettings) = Unit
+
+    override fun setDisplayOptions(displayOptions: AccountDisplayOptions) = Unit
+
+    override fun setSyncOptions(syncOptions: AccountSyncOptions) = Unit
+
+    override fun clear() = Unit
+}

--- a/feature/account/server/certificate/src/debug/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContentPreview.kt
+++ b/feature/account/server/certificate/src/debug/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContentPreview.kt
@@ -1,0 +1,49 @@
+package app.k9mail.feature.account.server.certificate.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import app.k9mail.core.ui.compose.common.koin.koinPreview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.server.certificate.domain.entity.FormattedServerCertificateError
+import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateProperties
+import okio.ByteString.Companion.decodeHex
+
+@Composable
+@Preview(showBackground = true)
+internal fun ServerCertificateErrorContentPreview() {
+    val state = ServerCertificateErrorContract.State(
+        isShowServerCertificate = true,
+        certificateError = FormattedServerCertificateError(
+            hostname = "mail.domain.example",
+            serverCertificateProperties = ServerCertificateProperties(
+                subjectAlternativeNames = listOf("*.domain.example", "domain.example"),
+                notValidBefore = "January 1, 2023, 12:00 AM",
+                notValidAfter = "December 31, 2023, 11:59 PM",
+                subject = "CN=*.domain.example",
+                issuer = "CN=test, O=MZLA",
+                fingerprintSha1 = "33ab5639bfd8e7b95eb1d8d0b87781d4ffea4d5d".decodeHex(),
+                fingerprintSha256 = "1894a19c85ba153acbf743ac4e43fc004c891604b26f8c69e1e83ea2afc7c48f".decodeHex(),
+                fingerprintSha512 = (
+                    "81381f1dacd4824a6c503fd07057763099c12b8309d0abcec4000c9060cbbfa6" +
+                        "7988b2ada669ab4837fcd3d4ea6e2b8db2b9da9197d5112fb369fd006da545de"
+                    ).decodeHex(),
+            ),
+        ),
+    )
+
+    koinPreview {
+        factory<ServerNameFormatter> { DefaultServerNameFormatter() }
+        factory<FingerprintFormatter> { DefaultFingerprintFormatter() }
+    } WithContent {
+        PreviewWithTheme {
+            ServerCertificateErrorContent(
+                innerPadding = PaddingValues(all = 0.dp),
+                state = state,
+                scrollState = rememberScrollState(),
+            )
+        }
+    }
+}

--- a/feature/account/server/certificate/src/debug/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreenPreview.kt
+++ b/feature/account/server/certificate/src/debug/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreenPreview.kt
@@ -1,0 +1,74 @@
+package app.k9mail.feature.account.server.certificate.ui
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
+import app.k9mail.core.ui.compose.common.koin.koinPreview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.server.certificate.data.InMemoryServerCertificateErrorRepository
+import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateError
+import app.k9mail.feature.account.server.certificate.domain.usecase.FormatServerCertificateError
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+
+@Composable
+@PreviewDevices
+internal fun ServerCertificateErrorScreenPreview() {
+    val inputStream = """
+        -----BEGIN CERTIFICATE-----
+        MIIE8jCCA9qgAwIBAgISA3bsPKY1eoe/RiBO2t8fUvh1MA0GCSqGSIb3DQEBCwUA
+        MDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD
+        EwJSMzAeFw0yMzA3MjEyMDU1MTJaFw0yMzEwMTkyMDU1MTFaMBcxFTATBgNVBAMM
+        DCouYmFkc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJgw
+        o/dYmPaujmm7sqIuZCe5/kyMwDYKo/pWeeXSvQxRXhxiVvd2Xu9PG0ZXW2R0xOSr
+        BpaRWm6MXxEnNqNr+n22j9US6M62zJpcuU4tQ0J8xRyIGL6rM53z59rEnCdkF9HQ
+        +7y7PBlVXCm0jrw51h3Bg5qryvTFyimIbqGw0UJhM7m/NaVJWZyBRwHp7emXxRJC
+        kC7pdX462c+m/7rQ06iohqUt6mf0DkUH1QjpaVbZm8CBs/GSiLB3LdMHj1uvrXgH
+        z8dp0nQ3eVRCjuD1xVcZnFoeEa/W3a9ZdcBj1phr9XOwaqYMeAv64g2w40G6fXMH
+        9DpHuFarRtleQusiPAMCAwEAAaOCAhswggIXMA4GA1UdDwEB/wQEAwIFoDAdBgNV
+        HSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4E
+        FgQU1M4J2vX/9DWJnsAtofmT+94js/YwHwYDVR0jBBgwFoAUFC6zF7dYVsuuUAlA
+        5h+vnYsUwsYwVQYIKwYBBQUHAQEESTBHMCEGCCsGAQUFBzABhhVodHRwOi8vcjMu
+        by5sZW5jci5vcmcwIgYIKwYBBQUHMAKGFmh0dHA6Ly9yMy5pLmxlbmNyLm9yZy8w
+        IwYDVR0RBBwwGoIMKi5iYWRzc2wuY29tggpiYWRzc2wuY29tMBMGA1UdIAQMMAow
+        CAYGZ4EMAQIBMIIBBQYKKwYBBAHWeQIEAgSB9gSB8wDxAHYAtz77JN+cTbp18jnF
+        ulj0bF38Qs96nzXEnh0JgSXttJkAAAGJenMebAAABAMARzBFAiAH7A3OWC1AKOcO
+        jsOP39nzkyoIdrwYFHOOW1qKkLrk9gIhAJD0xFn5FwJvag3K6mTXAlW1EvIy9joA
+        okiPniKVBIztAHcAejKMVNi3LbYg6jjgUh7phBZwMhOFTTvSK8E6V6NS61IAAAGJ
+        enMehwAABAMASDBGAiEAvRyLnINSJQ0WyfcU8L0PY5z7//Gq8P9i2HJvZJvnfBkC
+        IQCHslQMJaOg+rn9+2WW4KKgYW/yDrvBbiVABW5CcYWR0DANBgkqhkiG9w0BAQsF
+        AAOCAQEAB/JpXHqRnGmCFz3f0hx7mJYY/auSNWnOgpdRpc3JXzcOHHUd+569UGtu
+        TSMAFEGNXYTbXrG52iGBCrdfe1kkRokg7/KtUvFRelkoNt4FN/4/zVjBxINXVIMb
+        /7toq4OxBF/sz4SU+eXanmwJyOMmNQzM94zqDwrEmMNuNLYshdWn7XyJCXIM4X+6
+        8M/anh/pi2AviLHH9pszkeuH3AjGJR68cPf+QKC4XcFloR08fhx0jKl8LBa4A6Nm
+        o7IlPgdD9rzZCsbYe+VNBQWY3358u7ifOJG8r2jXzyHKgUC+OBXgz3kjrClzJfl1
+        pjcJhNU1UQtIVERwmxI9F5oQqUyxvA==
+        -----END CERTIFICATE-----
+    """.trimIndent().byteInputStream()
+
+    val certificateFactory = CertificateFactory.getInstance("X.509")
+    val certificate = certificateFactory.generateCertificate(inputStream) as X509Certificate
+
+    val serverCertificateError = ServerCertificateError(
+        hostname = "mail.domain.example",
+        port = 143,
+        certificateChain = listOf(certificate),
+    )
+
+    koinPreview {
+        factory<ServerNameFormatter> { DefaultServerNameFormatter() }
+        factory<FingerprintFormatter> { DefaultFingerprintFormatter() }
+    } WithContent {
+        PreviewWithTheme {
+            ServerCertificateErrorScreen(
+                onCertificateAccepted = {},
+                onBack = {},
+                viewModel = ServerCertificateErrorViewModel(
+                    addServerCertificateException = { _, _, _ -> },
+                    certificateErrorRepository = InMemoryServerCertificateErrorRepository(serverCertificateError),
+                    formatServerCertificateError = FormatServerCertificateError(),
+                    initialState = ServerCertificateErrorContract.State(isShowServerCertificate = false),
+                ),
+            )
+        }
+    }
+}

--- a/feature/account/server/certificate/src/debug/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateViewPreview.kt
+++ b/feature/account/server/certificate/src/debug/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateViewPreview.kt
@@ -1,0 +1,41 @@
+package app.k9mail.feature.account.server.certificate.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.common.koin.koinPreview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateProperties
+import okio.ByteString.Companion.decodeHex
+
+@Composable
+@Preview(showBackground = true)
+internal fun ServerCertificateViewPreview() {
+    val serverCertificateProperties = ServerCertificateProperties(
+        subjectAlternativeNames = listOf(
+            "*.domain.example",
+            "domain.example",
+            "quite.the.long.domain.name.that.hopefully.exceeds.the.available.width.example",
+        ),
+        notValidBefore = "January 1, 2023, 12:00 AM",
+        notValidAfter = "December 31, 2023, 11:59 PM",
+        subject = "CN=*.domain.example",
+        issuer = "CN=test, O=MZLA",
+        fingerprintSha1 = "33ab5639bfd8e7b95eb1d8d0b87781d4ffea4d5d".decodeHex(),
+        fingerprintSha256 = "1894a19c85ba153acbf743ac4e43fc004c891604b26f8c69e1e83ea2afc7c48f".decodeHex(),
+        fingerprintSha512 = (
+            "81381f1dacd4824a6c503fd07057763099c12b8309d0abcec4000c9060cbbfa6" +
+                "7988b2ada669ab4837fcd3d4ea6e2b8db2b9da9197d5112fb369fd006da545de"
+            ).decodeHex(),
+    )
+
+    koinPreview {
+        factory<ServerNameFormatter> { DefaultServerNameFormatter() }
+        factory<FingerprintFormatter> { DefaultFingerprintFormatter() }
+    } WithContent {
+        PreviewWithTheme {
+            ServerCertificateView(
+                serverCertificateProperties = serverCertificateProperties,
+            )
+        }
+    }
+}

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContent.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContent.kt
@@ -9,15 +9,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.common.baseline.withBaseline
-import app.k9mail.core.ui.compose.common.koin.koinPreview
 import app.k9mail.core.ui.compose.common.resources.annotatedStringResource
 import app.k9mail.core.ui.compose.common.text.bold
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
@@ -26,13 +22,10 @@ import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextHeadlineMedium
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
-import app.k9mail.core.ui.compose.theme.K9Theme
-import app.k9mail.core.ui.compose.theme.MainTheme
+import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.account.server.certificate.R
 import app.k9mail.feature.account.server.certificate.domain.entity.FormattedServerCertificateError
-import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateProperties
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract.State
-import okio.ByteString.Companion.decodeHex
 import org.koin.compose.koinInject
 
 @Composable
@@ -112,41 +105,4 @@ private fun CertificateErrorDescription(
             serverNameFormatter.format(certificateError.hostname).bold(),
         ),
     )
-}
-
-@Composable
-@Preview(showBackground = true)
-internal fun ServerCertificateErrorContentPreview() {
-    val state = State(
-        isShowServerCertificate = true,
-        certificateError = FormattedServerCertificateError(
-            hostname = "mail.domain.example",
-            serverCertificateProperties = ServerCertificateProperties(
-                subjectAlternativeNames = listOf("*.domain.example", "domain.example"),
-                notValidBefore = "January 1, 2023, 12:00 AM",
-                notValidAfter = "December 31, 2023, 11:59 PM",
-                subject = "CN=*.domain.example",
-                issuer = "CN=test, O=MZLA",
-                fingerprintSha1 = "33ab5639bfd8e7b95eb1d8d0b87781d4ffea4d5d".decodeHex(),
-                fingerprintSha256 = "1894a19c85ba153acbf743ac4e43fc004c891604b26f8c69e1e83ea2afc7c48f".decodeHex(),
-                fingerprintSha512 = (
-                    "81381f1dacd4824a6c503fd07057763099c12b8309d0abcec4000c9060cbbfa6" +
-                        "7988b2ada669ab4837fcd3d4ea6e2b8db2b9da9197d5112fb369fd006da545de"
-                    ).decodeHex(),
-            ),
-        ),
-    )
-
-    koinPreview {
-        factory<ServerNameFormatter> { DefaultServerNameFormatter() }
-        factory<FingerprintFormatter> { DefaultFingerprintFormatter() }
-    } WithContent {
-        K9Theme {
-            ServerCertificateErrorContent(
-                innerPadding = PaddingValues(all = 0.dp),
-                state = state,
-                scrollState = rememberScrollState(),
-            )
-        }
-    }
 }

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreen.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreen.kt
@@ -14,26 +14,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
-import app.k9mail.core.ui.compose.common.koin.koinPreview
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonFilled
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonOutlined
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
-import app.k9mail.core.ui.compose.theme.K9Theme
-import app.k9mail.core.ui.compose.theme.MainTheme
+import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.account.server.certificate.R
-import app.k9mail.feature.account.server.certificate.data.InMemoryServerCertificateErrorRepository
-import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateError
-import app.k9mail.feature.account.server.certificate.domain.usecase.FormatServerCertificateError
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract.Effect
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract.Event
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract.State
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract.ViewModel
-import java.security.cert.CertificateFactory
-import java.security.cert.X509Certificate
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -123,69 +115,6 @@ private fun ButtonBar(
                     }
                 }
             }
-        }
-    }
-}
-
-@Composable
-@PreviewDevices
-internal fun ServerCertificateErrorScreenK9Preview() {
-    val inputStream = """
-        -----BEGIN CERTIFICATE-----
-        MIIE8jCCA9qgAwIBAgISA3bsPKY1eoe/RiBO2t8fUvh1MA0GCSqGSIb3DQEBCwUA
-        MDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD
-        EwJSMzAeFw0yMzA3MjEyMDU1MTJaFw0yMzEwMTkyMDU1MTFaMBcxFTATBgNVBAMM
-        DCouYmFkc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJgw
-        o/dYmPaujmm7sqIuZCe5/kyMwDYKo/pWeeXSvQxRXhxiVvd2Xu9PG0ZXW2R0xOSr
-        BpaRWm6MXxEnNqNr+n22j9US6M62zJpcuU4tQ0J8xRyIGL6rM53z59rEnCdkF9HQ
-        +7y7PBlVXCm0jrw51h3Bg5qryvTFyimIbqGw0UJhM7m/NaVJWZyBRwHp7emXxRJC
-        kC7pdX462c+m/7rQ06iohqUt6mf0DkUH1QjpaVbZm8CBs/GSiLB3LdMHj1uvrXgH
-        z8dp0nQ3eVRCjuD1xVcZnFoeEa/W3a9ZdcBj1phr9XOwaqYMeAv64g2w40G6fXMH
-        9DpHuFarRtleQusiPAMCAwEAAaOCAhswggIXMA4GA1UdDwEB/wQEAwIFoDAdBgNV
-        HSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4E
-        FgQU1M4J2vX/9DWJnsAtofmT+94js/YwHwYDVR0jBBgwFoAUFC6zF7dYVsuuUAlA
-        5h+vnYsUwsYwVQYIKwYBBQUHAQEESTBHMCEGCCsGAQUFBzABhhVodHRwOi8vcjMu
-        by5sZW5jci5vcmcwIgYIKwYBBQUHMAKGFmh0dHA6Ly9yMy5pLmxlbmNyLm9yZy8w
-        IwYDVR0RBBwwGoIMKi5iYWRzc2wuY29tggpiYWRzc2wuY29tMBMGA1UdIAQMMAow
-        CAYGZ4EMAQIBMIIBBQYKKwYBBAHWeQIEAgSB9gSB8wDxAHYAtz77JN+cTbp18jnF
-        ulj0bF38Qs96nzXEnh0JgSXttJkAAAGJenMebAAABAMARzBFAiAH7A3OWC1AKOcO
-        jsOP39nzkyoIdrwYFHOOW1qKkLrk9gIhAJD0xFn5FwJvag3K6mTXAlW1EvIy9joA
-        okiPniKVBIztAHcAejKMVNi3LbYg6jjgUh7phBZwMhOFTTvSK8E6V6NS61IAAAGJ
-        enMehwAABAMASDBGAiEAvRyLnINSJQ0WyfcU8L0PY5z7//Gq8P9i2HJvZJvnfBkC
-        IQCHslQMJaOg+rn9+2WW4KKgYW/yDrvBbiVABW5CcYWR0DANBgkqhkiG9w0BAQsF
-        AAOCAQEAB/JpXHqRnGmCFz3f0hx7mJYY/auSNWnOgpdRpc3JXzcOHHUd+569UGtu
-        TSMAFEGNXYTbXrG52iGBCrdfe1kkRokg7/KtUvFRelkoNt4FN/4/zVjBxINXVIMb
-        /7toq4OxBF/sz4SU+eXanmwJyOMmNQzM94zqDwrEmMNuNLYshdWn7XyJCXIM4X+6
-        8M/anh/pi2AviLHH9pszkeuH3AjGJR68cPf+QKC4XcFloR08fhx0jKl8LBa4A6Nm
-        o7IlPgdD9rzZCsbYe+VNBQWY3358u7ifOJG8r2jXzyHKgUC+OBXgz3kjrClzJfl1
-        pjcJhNU1UQtIVERwmxI9F5oQqUyxvA==
-        -----END CERTIFICATE-----
-    """.trimIndent().byteInputStream()
-
-    val certificateFactory = CertificateFactory.getInstance("X.509")
-    val certificate = certificateFactory.generateCertificate(inputStream) as X509Certificate
-
-    val serverCertificateError = ServerCertificateError(
-        hostname = "mail.domain.example",
-        port = 143,
-        certificateChain = listOf(certificate),
-    )
-
-    koinPreview {
-        factory<ServerNameFormatter> { DefaultServerNameFormatter() }
-        factory<FingerprintFormatter> { DefaultFingerprintFormatter() }
-    } WithContent {
-        K9Theme {
-            ServerCertificateErrorScreen(
-                onCertificateAccepted = {},
-                onBack = {},
-                viewModel = ServerCertificateErrorViewModel(
-                    addServerCertificateException = { _, _, _ -> },
-                    certificateErrorRepository = InMemoryServerCertificateErrorRepository(serverCertificateError),
-                    formatServerCertificateError = FormatServerCertificateError(),
-                    initialState = State(isShowServerCertificate = false),
-                ),
-            )
         }
     }
 }

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateView.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateView.kt
@@ -8,18 +8,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import app.k9mail.core.ui.compose.common.koin.koinPreview
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextLabelSmall
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleSmall
-import app.k9mail.core.ui.compose.theme.K9Theme
-import app.k9mail.core.ui.compose.theme.MainTheme
+import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.account.server.certificate.R
 import app.k9mail.feature.account.server.certificate.domain.entity.ServerCertificateProperties
 import okio.ByteString
-import okio.ByteString.Companion.decodeHex
 import org.koin.compose.koinInject
 
 @Composable
@@ -85,7 +81,7 @@ private fun Fingerprint(
 ) {
     val formattedFingerprint = fingerprintFormatter.format(
         fingerprint,
-        separatorColor = MainTheme.colors.onBackgroundSecondary,
+        separatorColor = MainTheme.colors.onSurfaceVariant,
     )
 
     Column {
@@ -103,38 +99,5 @@ private fun BulletedListItem(text: String) {
             modifier = Modifier.padding(horizontal = MainTheme.spacings.half),
         )
         TextBodyLarge(text = text)
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-internal fun ServerCertificateViewPreview() {
-    val serverCertificateProperties = ServerCertificateProperties(
-        subjectAlternativeNames = listOf(
-            "*.domain.example",
-            "domain.example",
-            "quite.the.long.domain.name.that.hopefully.exceeds.the.available.width.example",
-        ),
-        notValidBefore = "January 1, 2023, 12:00 AM",
-        notValidAfter = "December 31, 2023, 11:59 PM",
-        subject = "CN=*.domain.example",
-        issuer = "CN=test, O=MZLA",
-        fingerprintSha1 = "33ab5639bfd8e7b95eb1d8d0b87781d4ffea4d5d".decodeHex(),
-        fingerprintSha256 = "1894a19c85ba153acbf743ac4e43fc004c891604b26f8c69e1e83ea2afc7c48f".decodeHex(),
-        fingerprintSha512 = (
-            "81381f1dacd4824a6c503fd07057763099c12b8309d0abcec4000c9060cbbfa6" +
-                "7988b2ada669ab4837fcd3d4ea6e2b8db2b9da9197d5112fb369fd006da545de"
-            ).decodeHex(),
-    )
-
-    koinPreview {
-        factory<ServerNameFormatter> { DefaultServerNameFormatter() }
-        factory<FingerprintFormatter> { DefaultFingerprintFormatter() }
-    } WithContent {
-        K9Theme {
-            ServerCertificateView(
-                serverCertificateProperties = serverCertificateProperties,
-            )
-        }
     }
 }

--- a/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/common/ServerSettingsPasswordInputPreview.kt
+++ b/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/common/ServerSettingsPasswordInputPreview.kt
@@ -1,0 +1,28 @@
+package app.k9mail.feature.account.server.settings.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.theme.PreviewWithThemes
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
+
+@Composable
+@Preview(showBackground = true)
+internal fun ServerSettingsPasswordInputCreatePreview() {
+    PreviewWithThemes {
+        ServerSettingsPasswordInput(
+            mode = InteractionMode.Create,
+            onPasswordChange = {},
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun ServerSettingsPasswordInputEditPreview() {
+    PreviewWithThemes {
+        ServerSettingsPasswordInput(
+            mode = InteractionMode.Edit,
+            onPasswordChange = {},
+        )
+    }
+}

--- a/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContentPreview.kt
+++ b/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContentPreview.kt
@@ -1,0 +1,20 @@
+package app.k9mail.feature.account.server.settings.ui.incoming
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
+
+@Composable
+@PreviewDevices
+internal fun IncomingServerSettingsContentPreview() {
+    PreviewWithTheme {
+        IncomingServerSettingsContent(
+            mode = InteractionMode.Create,
+            onEvent = { },
+            state = IncomingServerSettingsContract.State(),
+            contentPadding = PaddingValues(),
+        )
+    }
+}

--- a/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreenPreview.kt
+++ b/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreenPreview.kt
@@ -1,0 +1,23 @@
+package app.k9mail.feature.account.server.settings.ui.incoming
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
+import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
+
+@Composable
+@PreviewDevices
+internal fun IncomingServerSettingsScreenPreview() {
+    PreviewWithTheme {
+        IncomingServerSettingsScreen(
+            onNext = {},
+            onBack = {},
+            viewModel = IncomingServerSettingsViewModel(
+                mode = InteractionMode.Create,
+                validator = IncomingServerSettingsValidator(),
+                accountStateRepository = FakeAccountStateRepository(),
+            ),
+        )
+    }
+}

--- a/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/IncomingServerSettingsScreenPreview.kt
+++ b/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/IncomingServerSettingsScreenPreview.kt
@@ -1,0 +1,23 @@
+package app.k9mail.feature.account.server.settings.ui.outgoing
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
+import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
+
+@Composable
+@PreviewDevices
+internal fun OutgoingServerSettingsScreenPreview() {
+    PreviewWithTheme {
+        OutgoingServerSettingsScreen(
+            onNext = {},
+            onBack = {},
+            viewModel = OutgoingServerSettingsViewModel(
+                mode = InteractionMode.Create,
+                validator = OutgoingServerSettingsValidator(),
+                accountStateRepository = FakeAccountStateRepository(),
+            ),
+        )
+    }
+}

--- a/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContentPreview.kt
+++ b/feature/account/server/settings/src/debug/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContentPreview.kt
@@ -1,0 +1,20 @@
+package app.k9mail.feature.account.server.settings.ui.outgoing
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.domain.entity.InteractionMode
+
+@Composable
+@PreviewDevices
+internal fun OutgoingServerSettingsContentPreview() {
+    PreviewWithTheme {
+        OutgoingServerSettingsContent(
+            mode = InteractionMode.Create,
+            state = OutgoingServerSettingsContract.State(),
+            onEvent = { },
+            contentPadding = PaddingValues(),
+        )
+    }
+}

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/common/ServerSettingsPasswordInput.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/common/ServerSettingsPasswordInput.kt
@@ -3,10 +3,8 @@ package app.k9mail.feature.account.server.settings.ui.common
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.molecule.input.PasswordInput
 import app.k9mail.core.ui.compose.designsystem.molecule.input.inputContentPadding
-import app.k9mail.core.ui.compose.theme.PreviewWithThemes
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
 
 @Composable
@@ -36,28 +34,6 @@ fun ServerSettingsPasswordInput(
             isRequired = isRequired,
             errorMessage = errorMessage,
             contentPadding = contentPadding,
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-internal fun ServerSettingsPasswordInputCreatePreview() {
-    PreviewWithThemes {
-        ServerSettingsPasswordInput(
-            mode = InteractionMode.Create,
-            onPasswordChange = {},
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-internal fun ServerSettingsPasswordInputEditPreview() {
-    PreviewWithThemes {
-        ServerSettingsPasswordInput(
-            mode = InteractionMode.Edit,
-            onPasswordChange = {},
         )
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
@@ -12,12 +12,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.molecule.ContentLoadingErrorView
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
-import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.MainTheme
-import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.ui.loadingerror.rememberContentLoadingErrorViewState
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
@@ -61,31 +58,5 @@ internal fun IncomingServerSettingsContent(
                 )
             }
         }
-    }
-}
-
-@Composable
-@PreviewDevices
-internal fun IncomingServerSettingsContentK9Preview() {
-    K9Theme {
-        IncomingServerSettingsContent(
-            mode = InteractionMode.Create,
-            onEvent = { },
-            state = State(),
-            contentPadding = PaddingValues(),
-        )
-    }
-}
-
-@Composable
-@PreviewDevices
-internal fun IncomingServerSettingsContentThunderbirdPreview() {
-    ThunderbirdTheme {
-        IncomingServerSettingsContent(
-            mode = InteractionMode.Create,
-            onEvent = { },
-            state = State(),
-            contentPadding = PaddingValues(),
-        )
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreen.kt
@@ -5,16 +5,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.organism.TopAppBarWithBackButton
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
-import app.k9mail.core.ui.compose.theme.K9Theme
-import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.ui.AccountTopAppBar
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
-import app.k9mail.feature.account.common.ui.preview.PreviewAccountStateRepository
 import app.k9mail.feature.account.server.settings.R
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
@@ -68,38 +64,6 @@ fun IncomingServerSettingsScreen(
             onEvent = { dispatch(it) },
             state = state.value,
             contentPadding = innerPadding,
-        )
-    }
-}
-
-@Composable
-@PreviewDevices
-internal fun IncomingServerSettingsScreenK9Preview() {
-    K9Theme {
-        IncomingServerSettingsScreen(
-            onNext = {},
-            onBack = {},
-            viewModel = IncomingServerSettingsViewModel(
-                mode = InteractionMode.Create,
-                validator = IncomingServerSettingsValidator(),
-                accountStateRepository = PreviewAccountStateRepository(),
-            ),
-        )
-    }
-}
-
-@Composable
-@PreviewDevices
-internal fun IncomingServerSettingsScreenThunderbirdPreview() {
-    ThunderbirdTheme {
-        IncomingServerSettingsScreen(
-            onNext = {},
-            onBack = {},
-            viewModel = IncomingServerSettingsViewModel(
-                mode = InteractionMode.Create,
-                validator = IncomingServerSettingsValidator(),
-                accountStateRepository = PreviewAccountStateRepository(),
-            ),
         )
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
@@ -12,12 +12,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.molecule.ContentLoadingErrorView
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
-import app.k9mail.core.ui.compose.theme.K9Theme
 import app.k9mail.core.ui.compose.theme.MainTheme
-import app.k9mail.core.ui.compose.theme.ThunderbirdTheme
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.ui.loadingerror.rememberContentLoadingErrorViewState
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Event
@@ -61,31 +58,5 @@ internal fun OutgoingServerSettingsContent(
                 )
             }
         }
-    }
-}
-
-@Composable
-@PreviewDevices
-internal fun OutgoingServerSettingsContentK9Preview() {
-    K9Theme {
-        OutgoingServerSettingsContent(
-            mode = InteractionMode.Create,
-            state = State(),
-            onEvent = { },
-            contentPadding = PaddingValues(),
-        )
-    }
-}
-
-@Composable
-@PreviewDevices
-internal fun OutgoingServerSettingsContentThunderbirdPreview() {
-    ThunderbirdTheme {
-        OutgoingServerSettingsContent(
-            mode = InteractionMode.Create,
-            onEvent = { },
-            state = State(),
-            contentPadding = PaddingValues(),
-        )
     }
 }

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/FakeIncomingServerSettingsValidator.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/FakeIncomingServerSettingsValidator.kt
@@ -1,7 +1,6 @@
-package app.k9mail.feature.account.server.settings.ui.incoming.fake
+package app.k9mail.feature.account.server.settings.ui.incoming
 
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
-import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract
 
 class FakeIncomingServerSettingsValidator(
     private val serverAnswer: ValidationResult = ValidationResult.Success,

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/FakeIncomingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/FakeIncomingServerSettingsViewModel.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.account.server.settings.ui.incoming.fake
+package app.k9mail.feature.account.server.settings.ui.incoming
 
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.account.common.domain.entity.InteractionMode

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreenKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsScreenKtTest.kt
@@ -4,7 +4,6 @@ import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
-import app.k9mail.feature.account.server.settings.ui.incoming.fake.FakeIncomingServerSettingsViewModel
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlinx.coroutines.test.runTest

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModelTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModelTest.kt
@@ -21,7 +21,6 @@ import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
-import app.k9mail.feature.account.server.settings.ui.incoming.fake.FakeIncomingServerSettingsValidator
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.AuthType

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/FakeOutgoingServerSettingsValidator.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/FakeOutgoingServerSettingsValidator.kt
@@ -1,7 +1,6 @@
-package app.k9mail.feature.account.server.settings.ui.outgoing.fake
+package app.k9mail.feature.account.server.settings.ui.outgoing
 
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
-import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract
 
 class FakeOutgoingServerSettingsValidator(
     private val serverAnswer: ValidationResult = ValidationResult.Success,

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/FakeOutgoingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/FakeOutgoingServerSettingsViewModel.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.account.server.settings.ui.outgoing.fake
+package app.k9mail.feature.account.server.settings.ui.outgoing
 
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.account.common.domain.entity.InteractionMode

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreenKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsScreenKtTest.kt
@@ -4,7 +4,6 @@ import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
-import app.k9mail.feature.account.server.settings.ui.outgoing.fake.FakeOutgoingServerSettingsViewModel
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlinx.coroutines.test.runTest

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModelTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModelTest.kt
@@ -19,7 +19,6 @@ import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
-import app.k9mail.feature.account.server.settings.ui.outgoing.fake.FakeOutgoingServerSettingsValidator
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.AuthType


### PR DESCRIPTION
Part 2 of changing the features to Theme 2 and move previews to the debug build type.

Existing fake implementation have been moved to debug if needed for previews. When used by tests they moved to test and to avoid complicated dependencies they could be doubled. In the future we could look into automatic fake generation, which would ease the use further.
