### PR TITLE
Set `targetSdkVersion` to 34

### DIFF
--- a/build-plugin/src/main/kotlin/ThunderbirdProjectConfig.kt
+++ b/build-plugin/src/main/kotlin/ThunderbirdProjectConfig.kt
@@ -5,6 +5,6 @@ object ThunderbirdProjectConfig {
     val javaCompatibilityVersion = JavaVersion.VERSION_11
 
     const val androidSdkMin = 21
-    const val androidSdkTarget = 33
+    const val androidSdkTarget = 34
     const val androidSdkCompile = 34
 }


### PR DESCRIPTION
The relevant changes to be able to target Android 14 were:
- #7742
- #7743
- #7772
- #7729 (also #7398 and #7765)
