### PR TITLE
Don't delay showing the notification for the Push foreground service

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/PushNotificationManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/PushNotificationManager.kt
@@ -63,6 +63,7 @@ internal class PushNotificationManager(
             .setBadgeIconType(NotificationCompat.BADGE_ICON_NONE)
             .setLocalOnly(true)
             .setShowWhen(false)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .build()
     }
 


### PR DESCRIPTION
Use [FOREGROUND_SERVICE_IMMEDIATE](https://developer.android.com/reference/android/app/Notification#FOREGROUND_SERVICE_IMMEDIATE) to immediately show the notification when our Push foreground service is started.

(We're not performing a potentially short operation where we start the service and is stops soon after. In those cases the default behavior of deferring the notification can avoid flashing a notification.)

Changing the behavior to `FOREGROUND_SERVICE_IMMEDIATE` provides a more timely feedback to the user when they enable Push via settings.