### PR TITLE
Ignore `ForegroundServiceStartNotAllowedException`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/push/PushServiceManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/PushServiceManager.kt
@@ -30,6 +30,16 @@ internal class PushServiceManager(private val context: Context) {
         }
     }
 
+    fun setServiceStarted() {
+        Timber.v("PushServiceManager.setServiceStarted()")
+        isServiceStarted.set(true)
+    }
+
+    fun setServiceStopped() {
+        Timber.v("PushServiceManager.setServiceStopped()")
+        isServiceStarted.set(false)
+    }
+
     private fun startService() {
         try {
             val intent = Intent(context, PushService::class.java)


### PR DESCRIPTION
Try to ignore `ForegroundServiceStartNotAllowedException` when `PushService` is restarted by the system. Since I haven't been able to reliably reproduce this crash, there's no way to tell if this workaround will actually work. We'll have to put it out there in a beta version and see if `ForegroundServiceStartNotAllowedException` crashes reported via Google Play go down.

See #7416