### PR TITLE
Fix `ResponsiveContentWithSurface` to use the correct surface color

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContentWithSurface.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContentWithSurface.kt
@@ -19,7 +19,7 @@ fun ResponsiveContentWithSurface(
     ResponsiveContent {
         Surface(
             modifier = modifier,
-            color = MainTheme.colors.surfaceContainer,
+            color = MainTheme.colors.surface,
         ) {
             content()
         }


### PR DESCRIPTION
This fixes `ResponsiveContentWithSurface` to use the `surface` color instead of `surfaceContainer`
