### PR TITLE
Change the way `RealImapFolder` checks for open folders

### DIFF
--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandExpunge.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandExpunge.kt
@@ -12,7 +12,6 @@ internal class CommandExpunge(private val imapStore: ImapStore) {
         val remoteFolder = imapStore.getFolder(folderServerId)
         try {
             remoteFolder.open(OpenMode.READ_WRITE)
-            if (remoteFolder.mode != OpenMode.READ_WRITE) return
 
             remoteFolder.expunge()
 
@@ -26,7 +25,6 @@ internal class CommandExpunge(private val imapStore: ImapStore) {
         val remoteFolder = imapStore.getFolder(folderServerId)
         try {
             remoteFolder.open(OpenMode.READ_WRITE)
-            if (remoteFolder.mode != OpenMode.READ_WRITE) return
 
             remoteFolder.expungeUids(messageServerIds)
         } finally {

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandMarkAllAsRead.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandMarkAllAsRead.kt
@@ -10,7 +10,6 @@ internal class CommandMarkAllAsRead(private val imapStore: ImapStore) {
         val remoteFolder = imapStore.getFolder(folderServerId)
         try {
             remoteFolder.open(OpenMode.READ_WRITE)
-            if (remoteFolder.mode != OpenMode.READ_WRITE) return
 
             remoteFolder.setFlagsForAllMessages(setOf(Flag.SEEN), true)
         } finally {

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandMoveOrCopyMessages.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandMoveOrCopyMessages.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.backend.imap
 
 import com.fsck.k9.logging.Timber
-import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.mail.store.imap.ImapFolder
 import com.fsck.k9.mail.store.imap.ImapStore
 import com.fsck.k9.mail.store.imap.OpenMode
@@ -42,12 +41,6 @@ internal class CommandMoveOrCopyMessages(private val imapStore: ImapStore) {
             }
 
             remoteSrcFolder.open(OpenMode.READ_WRITE)
-            if (remoteSrcFolder.mode != OpenMode.READ_WRITE) {
-                throw MessagingException(
-                    "moveOrCopyMessages: could not open remoteSrcFolder $srcFolder read/write",
-                    true,
-                )
-            }
 
             val messages = uids.map { uid -> remoteSrcFolder.getMessage(uid) }
 

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandSetFlag.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandSetFlag.kt
@@ -12,7 +12,6 @@ internal class CommandSetFlag(private val imapStore: ImapStore) {
         val remoteFolder = imapStore.getFolder(folderServerId)
         try {
             remoteFolder.open(OpenMode.READ_WRITE)
-            if (remoteFolder.mode != OpenMode.READ_WRITE) return
 
             val messages = messageServerIds.map { uid -> remoteFolder.getMessage(uid) }
 

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -1162,11 +1162,8 @@ internal class RealImapFolder(
         }
     }
 
-    @Throws(MessagingException::class)
     private fun checkOpen() {
-        if (!isOpen) {
-            throw MessagingException("Folder $serverId is not open.")
-        }
+        check(isOpen) { "Folder '$serverId' is not open." }
     }
 
     private fun ioExceptionHandler(connection: ImapConnection?, ioe: IOException): MessagingException {

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -40,9 +40,23 @@ internal class RealImapFolder(
     private var canCreateKeywords = false
     private var uidValidity: Long? = null
 
+    /**
+     * Specifies whether the folder was opened in read-only or read-write mode based on the the tagged OK response to
+     * the SELECT or EXAMINE command (READ-ONLY or READ-WRITE).
+     *
+     * Most of the time this will match the [mode] value. But it's possible for the SELECT command to open a folder in
+     * read-only mode. See RFC 3501, section 6.3.1.
+     *
+     * Note: Currently unused.
+     */
+    private var serverOpenMode: OpenMode? = null
+
     override var messageCount = -1
         private set
 
+    /**
+     * The [OpenMode] value that was passed when this folder was [opened][open].
+     */
     override var mode: OpenMode? = null
         private set
 
@@ -84,6 +98,12 @@ internal class RealImapFolder(
         return handleUntaggedResponses(connection!!.executeSimpleCommand(command))
     }
 
+    /**
+     * Opens the folder in either read-only or read-write mode.
+     *
+     * When [OpenMode.READ_ONLY] is passed the EXAMINE command is used to open the folder.
+     * When [OpenMode.READ_WRITE] is passed the SELECT command is used to open the folder.
+     */
     @Throws(MessagingException::class)
     override fun open(mode: OpenMode) {
         internalOpen(mode)
@@ -118,10 +138,6 @@ internal class RealImapFolder(
             val command = String.format("%s %s", openCommand, escapedFolderName)
             val responses = executeSimpleCommand(command)
 
-            /*
-             * If the command succeeds we expect the folder has been opened read-write unless we
-             * are notified otherwise in the responses.
-             */
             this.mode = mode
 
             for (response in responses) {
@@ -160,7 +176,7 @@ internal class RealImapFolder(
     private fun handleSelectOrExamineOkResponse(response: ImapResponse) {
         val selectOrExamineResponse = SelectOrExamineResponse.parse(response) ?: return // This shouldn't happen
         if (selectOrExamineResponse.hasOpenMode()) {
-            mode = selectOrExamineResponse.openMode
+            serverOpenMode = selectOrExamineResponse.openMode
         }
     }
 

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -307,7 +307,7 @@ internal class RealImapFolder(
             return null
         }
 
-        checkOpen()
+        checkOpenWithWriteAccess()
 
         return if (connection.hasCapability(Capabilities.MOVE)) {
             moveMessagesUsingMoveExtension(messages, folder)
@@ -980,7 +980,7 @@ internal class RealImapFolder(
      */
     @Throws(MessagingException::class)
     override fun appendMessages(messages: List<Message>): Map<String, String>? {
-        checkOpen()
+        checkOpenWithWriteAccess()
 
         return try {
             val uidMap: MutableMap<String, String> = HashMap()
@@ -1089,7 +1089,7 @@ internal class RealImapFolder(
 
     @Throws(MessagingException::class)
     override fun expunge() {
-        checkOpen()
+        checkOpenWithWriteAccess()
 
         try {
             executeSimpleCommand("EXPUNGE")
@@ -1099,7 +1099,7 @@ internal class RealImapFolder(
     }
 
     override fun expungeUids(uids: List<String>) {
-        checkOpen()
+        checkOpenWithWriteAccess()
         expungeUids(uids, fullExpungeFallback = true)
     }
 
@@ -1126,7 +1126,7 @@ internal class RealImapFolder(
 
     @Throws(MessagingException::class)
     override fun setFlagsForAllMessages(flags: Set<Flag>, value: Boolean) {
-        checkOpen()
+        checkOpenWithWriteAccess()
 
         val canCreateForwardedFlag = canCreateKeywords ||
             internalImapStore.getPermanentFlagsIndex().contains(Flag.FORWARDED)
@@ -1148,7 +1148,7 @@ internal class RealImapFolder(
 
     @Throws(MessagingException::class)
     override fun setFlags(messages: List<ImapMessage>, flags: Set<Flag>, value: Boolean) {
-        checkOpen()
+        checkOpenWithWriteAccess()
 
         val uids = messages.map { it.uid.toLong() }.toSet()
         val canCreateForwardedFlag = canCreateKeywords ||
@@ -1164,6 +1164,11 @@ internal class RealImapFolder(
 
     private fun checkOpen() {
         check(isOpen) { "Folder '$serverId' is not open." }
+    }
+
+    private fun checkOpenWithWriteAccess() {
+        checkOpen()
+        check(mode == OpenMode.READ_WRITE) { "Folder '$serverId' needs to be opened for read-write access." }
     }
 
     private fun ioExceptionHandler(connection: ImapConnection?, ioe: IOException): MessagingException {

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
@@ -317,6 +317,20 @@ class RealImapFolderTest {
     }
 
     @Test
+    fun `moveMessages() on folder opened as read-only should throw`() {
+        val sourceFolder = createFolder("Folder")
+        prepareImapFolderForOpen(OpenMode.READ_ONLY)
+        sourceFolder.open(OpenMode.READ_ONLY)
+        val destinationFolder = createFolder("Destination")
+        val messages = listOf(createImapMessage("1"))
+
+        assertFailure {
+            sourceFolder.moveMessages(messages, destinationFolder)
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' needs to be opened for read-write access.")
+    }
+
+    @Test
     fun `moveMessages() with MOVE extension and tagged COPYUID response`() {
         val sourceFolder = createFolder("Folder")
         prepareImapFolderForOpen(OpenMode.READ_WRITE)
@@ -1055,6 +1069,19 @@ class RealImapFolderTest {
     }
 
     @Test
+    fun `appendMessages() on folder opened as read-only should throw`() {
+        val folder = createFolder("Folder")
+        prepareImapFolderForOpen(OpenMode.READ_ONLY)
+        folder.open(OpenMode.READ_ONLY)
+        val messages = listOf(createImapMessage("1"))
+
+        assertFailure {
+            folder.appendMessages(messages)
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' needs to be opened for read-write access.")
+    }
+
+    @Test
     fun appendMessages_shouldIssueRespectiveCommand() {
         val folder = createFolder("Folder")
         prepareImapFolderForOpen(OpenMode.READ_WRITE)
@@ -1136,6 +1163,18 @@ class RealImapFolderTest {
     }
 
     @Test
+    fun `expunge() on folder opened as read-only should throw`() {
+        val folder = createFolder("Folder")
+        prepareImapFolderForOpen(OpenMode.READ_ONLY)
+        folder.open(OpenMode.READ_ONLY)
+
+        assertFailure {
+            folder.expunge()
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' needs to be opened for read-write access.")
+    }
+
+    @Test
     fun expunge_shouldIssueExpungeCommand() {
         val folder = createFolder("Folder")
         prepareImapFolderForOpen(OpenMode.READ_WRITE)
@@ -1156,6 +1195,18 @@ class RealImapFolderTest {
             .hasMessage("Folder 'Folder' is not open.")
 
         verifyNoMoreInteractions(imapConnection)
+    }
+
+    @Test
+    fun `expungeUids() on folder opened as read-only should throw`() {
+        val folder = createFolder("Folder")
+        prepareImapFolderForOpen(OpenMode.READ_ONLY)
+        folder.open(OpenMode.READ_ONLY)
+
+        assertFailure {
+            folder.expungeUids(listOf("1"))
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' needs to be opened for read-write access.")
     }
 
     @Test
@@ -1195,6 +1246,18 @@ class RealImapFolderTest {
     }
 
     @Test
+    fun `setFlagsForAllMessages() on folder opened as read-only should throw`() {
+        val folder = createFolder("Folder")
+        prepareImapFolderForOpen(OpenMode.READ_ONLY)
+        folder.open(OpenMode.READ_ONLY)
+
+        assertFailure {
+            folder.setFlagsForAllMessages(setOf(Flag.SEEN), true)
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' needs to be opened for read-write access.")
+    }
+
+    @Test
     fun setFlagsForAllMessages_shouldIssueUidStoreCommand() {
         val folder = createFolder("Folder")
         prepareImapFolderForOpen(OpenMode.READ_WRITE)
@@ -1216,6 +1279,19 @@ class RealImapFolderTest {
             .hasMessage("Folder 'Folder' is not open.")
 
         verifyNoMoreInteractions(imapConnection)
+    }
+
+    @Test
+    fun `setFlags() on folder opened as read-only should throw`() {
+        val folder = createFolder("Folder")
+        prepareImapFolderForOpen(OpenMode.READ_ONLY)
+        folder.open(OpenMode.READ_ONLY)
+        val messages = listOf(createImapMessage("1"))
+
+        assertFailure {
+            folder.setFlags(messages, setOf(Flag.SEEN), true)
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' needs to be opened for read-write access.")
     }
 
     @Test

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
@@ -284,8 +284,8 @@ class RealImapFolderTest {
 
         assertFailure {
             sourceFolder.copyMessages(messages, destinationFolder)
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder Source is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Source' is not open.")
     }
 
     @Test
@@ -300,6 +300,20 @@ class RealImapFolderTest {
         val uidMapping = sourceFolder.copyMessages(messages, destinationFolder)
 
         assertThat(uidMapping).isNotNull().containsOnly("1" to "101")
+    }
+
+    @Test
+    fun `moveMessages() on closed folder should throw`() {
+        val sourceFolder = createFolder("Source")
+        val destinationFolder = createFolder("Destination")
+        val messages = listOf(createImapMessage("1"))
+
+        assertFailure {
+            sourceFolder.moveMessages(messages, destinationFolder)
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Source' is not open.")
+
+        verifyNoMoreInteractions(imapConnection)
     }
 
     @Test
@@ -426,8 +440,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.unreadMessageCount
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder FolderName is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'FolderName' is not open.")
     }
 
     @Test
@@ -462,8 +476,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.flaggedMessageCount
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder FolderName is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'FolderName' is not open.")
     }
 
     @Test
@@ -596,8 +610,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.getMessages(1, 5, null, null)
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder FolderName is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'FolderName' is not open.")
     }
 
     @Test
@@ -606,8 +620,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.getMessages(setOf(1L, 2L, 5L), false, null)
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder FolderName is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'FolderName' is not open.")
     }
 
     @Test
@@ -643,8 +657,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.getMessagesFromUids(listOf("11", "22", "25"))
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder FolderName is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'FolderName' is not open.")
     }
 
     @Test
@@ -666,8 +680,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.areMoreMessagesAvailable(10, Date())
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder FolderName is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'FolderName' is not open.")
     }
 
     @Test
@@ -728,6 +742,25 @@ class RealImapFolderTest {
         folder.fetch(emptyList(), fetchProfile, null, MAX_DOWNLOAD_SIZE)
 
         assertThat(testConnectionManager.numberOfGetConnectionCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun `fetch() on closed folder should throw`() {
+        val folder = createFolder("Folder")
+        val messages = createImapMessages("1")
+        val fetchProfile = createFetchProfile()
+
+        assertFailure {
+            folder.fetch(
+                messages = messages,
+                fetchProfile = fetchProfile,
+                listener = null,
+                maxDownloadSize = MAX_DOWNLOAD_SIZE,
+            )
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' is not open.")
+
+        verifyNoMoreInteractions(imapConnection)
     }
 
     @Test
@@ -948,6 +981,20 @@ class RealImapFolderTest {
     }
 
     @Test
+    fun `fetchPart() on closed folder should throw`() {
+        val folder = createFolder("Folder")
+        val message = createImapMessage("1")
+        val part = createPart("TEXT")
+
+        assertFailure {
+            folder.fetchPart(message = message, part = part, bodyFactory = mock(), maxDownloadSize = 4096)
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' is not open.")
+
+        verifyNoMoreInteractions(imapConnection)
+    }
+
+    @Test
     fun fetchPart_withTextSection_shouldIssueRespectiveCommand() {
         val folder = createFolder("Folder")
         prepareImapFolderForOpen(OpenMode.READ_ONLY)
@@ -1001,8 +1048,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.appendMessages(messages)
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder Folder is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' is not open.")
 
         verifyNoMoreInteractions(imapConnection)
     }
@@ -1082,8 +1129,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.expunge()
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder Folder is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' is not open.")
 
         verifyNoMoreInteractions(imapConnection)
     }
@@ -1105,8 +1152,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.expungeUids(listOf("1"))
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder Folder is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' is not open.")
 
         verifyNoMoreInteractions(imapConnection)
     }
@@ -1141,8 +1188,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.setFlagsForAllMessages(setOf(Flag.SEEN), true)
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder Folder is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' is not open.")
 
         verifyNoMoreInteractions(imapConnection)
     }
@@ -1165,8 +1212,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.setFlags(messages, setOf(Flag.SEEN), true)
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder Folder is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' is not open.")
 
         verifyNoMoreInteractions(imapConnection)
     }
@@ -1189,8 +1236,8 @@ class RealImapFolderTest {
 
         assertFailure {
             folder.search("query", setOf(Flag.SEEN), emptySet(), true)
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Folder Folder is not open.")
+        }.isInstanceOf<IllegalStateException>()
+            .hasMessage("Folder 'Folder' is not open.")
 
         verifyNoMoreInteractions(imapConnection)
     }


### PR DESCRIPTION
- Callers of `ImapFolder.open()` no longer check if the server returned the expected response code (`READ-WRITE` or `READ-ONLY`). This is because the SELECT command could return a `READ-ONLY` response code but still allow write operations (see below). So we're now ignoring the response code and try to perform the write operation regardless of the SELECT response code.
- `checkOpen()` now throws an `IllegalStateException` instead of a `MessagingException`. (The method wasn't renamed to `requireOpen()` to match Kotlin's `check`/`require` pattern.)
- Methods that perform a write operation now check whether the folder was opened using the SELECT command.

From RFC 3501:
> If the client is permitted to modify the mailbox, the server SHOULD prefix the text of the tagged OK response with the "[READ-WRITE]" response code.
>
> If the client is not permitted to modify the mailbox but is permitted read access, the mailbox is selected as read-only, and the server MUST prefix the text of the tagged OK response to SELECT with the "[READ-ONLY]" response code.  Read-only access through SELECT differs from the EXAMINE command in that certain read-only mailboxes MAY permit the change of permanent state on a per-user (as opposed to global) basis.  Netnews messages marked in a server-based .newsrc file are an example of such per-user permanent state that can be modified with read-only mailboxes.