### PR TITLE
IMAP: Make expunge logic part of low-level delete operation

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.controller
 
 import com.fsck.k9.Account
-import com.fsck.k9.Account.Expunge
 import com.fsck.k9.K9
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend
@@ -115,7 +114,7 @@ internal class DraftOperations(
             uploadMessage(backend, account, localFolder, localMessage)
         }
 
-        deleteMessage(backend, account, localFolder, command.deleteMessageId)
+        deleteMessage(backend, localFolder, command.deleteMessageId)
     }
 
     private fun uploadMessage(
@@ -152,7 +151,7 @@ internal class DraftOperations(
         }
     }
 
-    private fun deleteMessage(backend: Backend, account: Account, localFolder: LocalFolder, messageId: Long) {
+    private fun deleteMessage(backend: Backend, localFolder: LocalFolder, messageId: Long) {
         val messageServerId = localFolder.getMessageUidById(messageId) ?: run {
             Timber.i("Couldn't find local copy of message [ID: %d] to be deleted. Skipping delete.", messageId)
             return
@@ -161,10 +160,6 @@ internal class DraftOperations(
         val messageServerIds = listOf(messageServerId)
         val folderServerId = localFolder.serverId
         backend.deleteMessages(folderServerId, messageServerIds)
-
-        if (backend.supportsExpunge && account.expungePolicy == Expunge.EXPUNGE_IMMEDIATELY) {
-            backend.expungeMessages(folderServerId, messageServerIds)
-        }
 
         messagingController.destroyPlaceholderMessages(localFolder, messageServerIds)
     }

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2094,10 +2094,6 @@ public class MessagingController {
         Backend backend = getBackend(account);
         backend.deleteAllMessages(trashFolderServerId);
 
-        if (account.getExpungePolicy() == Expunge.EXPUNGE_IMMEDIATELY && backend.getSupportsExpunge()) {
-            backend.expunge(trashFolderServerId);
-        }
-
         // Remove all messages marked as deleted
         folder.destroyDeletedMessages();
 

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -29,7 +29,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.DeletePolicy;
-import com.fsck.k9.Account.Expunge;
 import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
@@ -991,10 +990,6 @@ public class MessagingController {
         Backend backend = getBackend(account);
         String folderServerId = getFolderServerId(account, folderId);
         backend.deleteMessages(folderServerId, uids);
-
-        if (backend.getSupportsExpunge() && account.getExpungePolicy() == Expunge.EXPUNGE_IMMEDIATELY) {
-            backend.expungeMessages(folderServerId, uids);
-        }
 
         LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
@@ -42,9 +42,6 @@ interface Backend {
     fun expunge(folderServerId: String)
 
     @Throws(MessagingException::class)
-    fun expungeMessages(folderServerId: String, messageServerIds: List<String>)
-
-    @Throws(MessagingException::class)
     fun deleteMessages(folderServerId: String, messageServerIds: List<String>)
 
     @Throws(MessagingException::class)

--- a/backend/demo/src/main/java/app/k9mail/backend/demo/DemoBackend.kt
+++ b/backend/demo/src/main/java/app/k9mail/backend/demo/DemoBackend.kt
@@ -104,10 +104,6 @@ class DemoBackend(private val backendStorage: BackendStorage) : Backend {
         throw UnsupportedOperationException("not implemented")
     }
 
-    override fun expungeMessages(folderServerId: String, messageServerIds: List<String>) {
-        throw UnsupportedOperationException("not implemented")
-    }
-
     override fun deleteMessages(folderServerId: String, messageServerIds: List<String>) = Unit
 
     override fun deleteAllMessages(folderServerId: String) = Unit

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandDelete.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandDelete.kt
@@ -1,0 +1,22 @@
+package com.fsck.k9.backend.imap
+
+import com.fsck.k9.mail.MessagingException
+import com.fsck.k9.mail.store.imap.ImapStore
+import com.fsck.k9.mail.store.imap.OpenMode
+
+internal class CommandDelete(private val imapStore: ImapStore) {
+
+    @Throws(MessagingException::class)
+    fun deleteMessages(folderServerId: String, messageServerIds: List<String>) {
+        val remoteFolder = imapStore.getFolder(folderServerId)
+        try {
+            remoteFolder.open(OpenMode.READ_WRITE)
+
+            val messages = messageServerIds.map { uid -> remoteFolder.getMessage(uid) }
+
+            remoteFolder.deleteMessages(messages)
+        } finally {
+            remoteFolder.close()
+        }
+    }
+}

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandDeleteAll.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandDeleteAll.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9.backend.imap
 
-import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.mail.store.imap.ImapStore
 import com.fsck.k9.mail.store.imap.OpenMode
@@ -13,7 +12,7 @@ internal class CommandDeleteAll(private val imapStore: ImapStore) {
         try {
             remoteFolder.open(OpenMode.READ_WRITE)
 
-            remoteFolder.setFlagsForAllMessages(setOf(Flag.DELETED), true)
+            remoteFolder.deleteAllMessages()
         } finally {
             remoteFolder.close()
         }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.kt
@@ -80,10 +80,6 @@ class ImapBackend(
         commandExpunge.expunge(folderServerId)
     }
 
-    override fun expungeMessages(folderServerId: String, messageServerIds: List<String>) {
-        commandExpunge.expungeMessages(folderServerId, messageServerIds)
-    }
-
     override fun deleteMessages(folderServerId: String, messageServerIds: List<String>) {
         commandDelete.deleteMessages(folderServerId, messageServerIds)
     }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.kt
@@ -30,6 +30,7 @@ class ImapBackend(
     private val commandMarkAllAsRead = CommandMarkAllAsRead(imapStore)
     private val commandExpunge = CommandExpunge(imapStore)
     private val commandMoveOrCopyMessages = CommandMoveOrCopyMessages(imapStore)
+    private val commandDelete = CommandDelete(imapStore)
     private val commandDeleteAll = CommandDeleteAll(imapStore)
     private val commandSearch = CommandSearch(imapStore)
     private val commandDownloadMessage = CommandDownloadMessage(backendStorage, imapStore)
@@ -84,7 +85,7 @@ class ImapBackend(
     }
 
     override fun deleteMessages(folderServerId: String, messageServerIds: List<String>) {
-        commandSetFlag.setFlag(folderServerId, messageServerIds, Flag.DELETED, true)
+        commandDelete.deleteMessages(folderServerId, messageServerIds)
     }
 
     override fun deleteAllMessages(folderServerId: String) {

--- a/backend/imap/src/test/java/com/fsck/k9/backend/imap/TestImapFolder.kt
+++ b/backend/imap/src/test/java/com/fsck/k9/backend/imap/TestImapFolder.kt
@@ -171,6 +171,10 @@ open class TestImapFolder(override val serverId: String) : ImapFolder {
         throw UnsupportedOperationException("not implemented")
     }
 
+    override fun deleteAllMessages() {
+        setFlagsForAllMessages(setOf(Flag.DELETED), true)
+    }
+
     override fun expunge() {
         mode = OpenMode.READ_WRITE
         wasExpunged = true

--- a/backend/imap/src/test/java/com/fsck/k9/backend/imap/TestImapFolder.kt
+++ b/backend/imap/src/test/java/com/fsck/k9/backend/imap/TestImapFolder.kt
@@ -171,6 +171,10 @@ open class TestImapFolder(override val serverId: String) : ImapFolder {
         throw UnsupportedOperationException("not implemented")
     }
 
+    override fun deleteMessages(messages: List<ImapMessage>) {
+        setFlags(messages, setOf(Flag.DELETED), true)
+    }
+
     override fun deleteAllMessages() {
         setFlagsForAllMessages(setOf(Flag.DELETED), true)
     }

--- a/backend/jmap/src/main/java/com/fsck/k9/backend/jmap/JmapBackend.kt
+++ b/backend/jmap/src/main/java/com/fsck/k9/backend/jmap/JmapBackend.kt
@@ -72,10 +72,6 @@ class JmapBackend(
         throw UnsupportedOperationException("not implemented")
     }
 
-    override fun expungeMessages(folderServerId: String, messageServerIds: List<String>) {
-        throw UnsupportedOperationException("not implemented")
-    }
-
     override fun deleteMessages(folderServerId: String, messageServerIds: List<String>) {
         commandDelete.deleteMessages(messageServerIds)
     }

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
@@ -66,10 +66,6 @@ class Pop3Backend(
         throw UnsupportedOperationException("not supported")
     }
 
-    override fun expungeMessages(folderServerId: String, messageServerIds: List<String>) {
-        throw UnsupportedOperationException("not supported")
-    }
-
     override fun deleteMessages(folderServerId: String, messageServerIds: List<String>) {
         commandSetFlag.setFlag(folderServerId, messageServerIds, Flag.DELETED, true)
     }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
@@ -82,6 +82,9 @@ interface ImapFolder {
     fun moveMessages(messages: List<ImapMessage>, folder: ImapFolder): Map<String, String>?
 
     @Throws(MessagingException::class)
+    fun deleteAllMessages()
+
+    @Throws(MessagingException::class)
     fun expunge()
 
     @Throws(MessagingException::class)

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
@@ -82,6 +82,9 @@ interface ImapFolder {
     fun moveMessages(messages: List<ImapMessage>, folder: ImapFolder): Map<String, String>?
 
     @Throws(MessagingException::class)
+    fun deleteMessages(messages: List<ImapMessage>)
+
+    @Throws(MessagingException::class)
     fun deleteAllMessages()
 
     @Throws(MessagingException::class)

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -1088,6 +1088,11 @@ internal class RealImapFolder(
     }
 
     @Throws(MessagingException::class)
+    override fun deleteAllMessages() {
+        setFlagsForAllMessages(setOf(Flag.DELETED), true)
+    }
+
+    @Throws(MessagingException::class)
     override fun expunge() {
         checkOpenWithWriteAccess()
 

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -1089,7 +1089,13 @@ internal class RealImapFolder(
 
     @Throws(MessagingException::class)
     override fun deleteAllMessages() {
+        checkOpenWithWriteAccess()
+
         setFlagsForAllMessages(setOf(Flag.DELETED), true)
+
+        if (internalImapStore.config.isExpungeImmediately()) {
+            expunge()
+        }
     }
 
     @Throws(MessagingException::class)

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -1089,7 +1089,14 @@ internal class RealImapFolder(
 
     @Throws(MessagingException::class)
     override fun deleteMessages(messages: List<ImapMessage>) {
+        checkOpenWithWriteAccess()
+
         setFlags(messages, setOf(Flag.DELETED), true)
+
+        if (internalImapStore.config.isExpungeImmediately()) {
+            val uids = messages.map { it.uid }
+            expungeUids(uids)
+        }
     }
 
     @Throws(MessagingException::class)

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -1088,6 +1088,11 @@ internal class RealImapFolder(
     }
 
     @Throws(MessagingException::class)
+    override fun deleteMessages(messages: List<ImapMessage>) {
+        setFlags(messages, setOf(Flag.DELETED), true)
+    }
+
+    @Throws(MessagingException::class)
     override fun deleteAllMessages() {
         checkOpenWithWriteAccess()
 

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapFolder.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapFolder.kt
@@ -112,6 +112,10 @@ internal open class TestImapFolder(
         throw UnsupportedOperationException("not implemented")
     }
 
+    override fun deleteAllMessages() {
+        throw UnsupportedOperationException("not implemented")
+    }
+
     override fun expunge() {
         throw UnsupportedOperationException("not implemented")
     }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapFolder.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapFolder.kt
@@ -112,6 +112,10 @@ internal open class TestImapFolder(
         throw UnsupportedOperationException("not implemented")
     }
 
+    override fun deleteMessages(messages: List<ImapMessage>) {
+        throw UnsupportedOperationException("not implemented")
+    }
+
     override fun deleteAllMessages() {
         throw UnsupportedOperationException("not implemented")
     }


### PR DESCRIPTION
The decision whether to issue an EXPUNGE or UID EXPUNGE command when deleting a message was part of `MessagingController`. But this functionality is IMAP-specific. So it should be part of `ImapBackend`. However, we can go one step further and move the logic into `RealImapFolder` (we already did so for the MOVE command).

This allows us to remove `Backend.expungeMessages()`.