### PR TITLE
Change header area of message compose screen

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.kt
@@ -25,9 +25,7 @@ class RecipientMvpView(private val activity: MessageCompose) : View.OnFocusChang
     private val ccView: RecipientSelectView = activity.findViewById(R.id.cc)
     private val bccView: RecipientSelectView = activity.findViewById(R.id.bcc)
     private val ccWrapper: View = activity.findViewById(R.id.cc_wrapper)
-    private val ccDivider: View = activity.findViewById(R.id.cc_divider)
     private val bccWrapper: View = activity.findViewById(R.id.bcc_wrapper)
-    private val bccDivider: View = activity.findViewById(R.id.bcc_divider)
     private val recipientExpanderContainer: ViewAnimator = activity.findViewById(R.id.recipient_expander_container)
     private val cryptoStatusView: ToolableViewAnimator = activity.findViewById(R.id.crypto_status)
     private val cryptoSpecialModeIndicator: ToolableViewAnimator = activity.findViewById(R.id.crypto_special_mode)
@@ -241,12 +239,10 @@ class RecipientMvpView(private val activity: MessageCompose) : View.OnFocusChang
 
     fun setCcVisibility(visible: Boolean) {
         ccWrapper.isVisible = visible
-        ccDivider.isVisible = visible
     }
 
     fun setBccVisibility(visible: Boolean) {
         bccWrapper.isVisible = visible
-        bccDivider.isVisible = visible
     }
 
     fun setRecipientExpanderVisibility(visible: Boolean) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/ReplyToView.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/ReplyToView.kt
@@ -17,7 +17,6 @@ private const val VIEW_INDEX_REPLY_TO_EXPANDER_HIDDEN = 1
 class ReplyToView(activity: MessageCompose) {
     private val replyToView: RecipientSelectView = activity.findViewById(R.id.reply_to)
     private val replyToWrapper: View = activity.findViewById(R.id.reply_to_wrapper)
-    private val replyToDivider: View = activity.findViewById(R.id.reply_to_divider)
     private val replyToExpanderContainer: ViewAnimator = activity.findViewById(R.id.reply_to_expander_container)
     private val replyToExpander: View = activity.findViewById(R.id.reply_to_expander)
 
@@ -37,7 +36,6 @@ class ReplyToView(activity: MessageCompose) {
     var isVisible: Boolean
         get() = replyToWrapper.isVisible
         set(visible) {
-            replyToDivider.isVisible = visible
             replyToView.isVisible = visible
             replyToWrapper.isVisible = visible
 

--- a/app/ui/legacy/src/main/res/drawable/message_compose_header_row_background.xml
+++ b/app/ui/legacy/src/main/res/drawable/message_compose_header_row_background.xml
@@ -1,0 +1,41 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_focused="true">
+        <layer-list>
+            <!-- Background -->
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="?attr/colorSurfaceContainerHigh" />
+                </shape>
+            </item>
+
+            <!-- Bottom line -->
+            <item android:gravity="bottom">
+                <shape android:shape="rectangle">
+                    <size android:height="3dp" />
+                    <solid android:color="?attr/colorPrimary" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+
+    <item>
+        <layer-list>
+            <!-- Background -->
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="?attr/colorSurfaceContainerLow" />
+                </shape>
+            </item>
+
+            <!-- Bottom line -->
+            <item android:gravity="bottom">
+                <shape android:shape="rectangle">
+                    <size android:height="1dp" />
+                    <solid android:color="?attr/colorOnSurfaceVariant" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+
+</selector>

--- a/app/ui/legacy/src/main/res/layout/message_compose_content.xml
+++ b/app/ui/legacy/src/main/res/layout/message_compose_content.xml
@@ -44,11 +44,6 @@ the 'composer theme' setting).
                 />
         </LinearLayout>
 
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="?android:attr/listDivider" />
-
         <!-- We have to use "wrap_content" (not "0dip") for "layout_height", otherwise the
              EditText won't properly grow in height while the user is typing the message -->
         <EditText

--- a/app/ui/legacy/src/main/res/layout/message_compose_content.xml
+++ b/app/ui/legacy/src/main/res/layout/message_compose_content.xml
@@ -24,7 +24,8 @@ the 'composer theme' setting).
             android:layout_width="match_parent"
             android:gravity="center_vertical"
             android:orientation="horizontal"
-            android:background="?attr/colorSurfaceContainerLow"
+            android:background="@drawable/message_compose_header_row_background"
+            android:addStatesFromChildren="true"
             android:minHeight="50dp">
 
             <EditText

--- a/app/ui/legacy/src/main/res/layout/message_compose_recipients.xml
+++ b/app/ui/legacy/src/main/res/layout/message_compose_recipients.xml
@@ -5,14 +5,16 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/colorSurfaceContainerLow"
     android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginStart="12dp"
+        android:paddingStart="12dp"
+        android:paddingEnd="0dp"
+        android:background="@drawable/message_compose_header_row_background"
+        android:addStatesFromChildren="true"
         android:minHeight="50dp"
         android:animateLayoutChanges="true">
 
@@ -197,8 +199,10 @@
         android:visibility="gone"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:layout_marginLeft="12dip"
-        android:layout_marginRight="12dip"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:background="@drawable/message_compose_header_row_background"
+        android:addStatesFromChildren="true"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:minHeight="50dp">
@@ -236,8 +240,10 @@
         android:id="@+id/to_wrapper"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:layout_marginLeft="12dp"
-        android:layout_marginRight="12dp"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:background="@drawable/message_compose_header_row_background"
+        android:addStatesFromChildren="true"
         android:minHeight="50dp">
 
         <TextView
@@ -304,8 +310,10 @@
         android:visibility="gone"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:layout_marginLeft="12dip"
-        android:layout_marginRight="12dip"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:background="@drawable/message_compose_header_row_background"
+        android:addStatesFromChildren="true"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:minHeight="50dp">
@@ -344,8 +352,10 @@
         android:visibility="gone"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:layout_marginLeft="12dip"
-        android:layout_marginRight="12dip"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:background="@drawable/message_compose_header_row_background"
+        android:addStatesFromChildren="true"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:minHeight="50dp">

--- a/app/ui/legacy/src/main/res/layout/message_compose_recipients.xml
+++ b/app/ui/legacy/src/main/res/layout/message_compose_recipients.xml
@@ -192,13 +192,6 @@
 
     </LinearLayout>
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:visibility="gone"
-        android:id="@+id/reply_to_divider"
-        android:background="?android:attr/listDivider" />
-
     <LinearLayout
         android:id="@+id/reply_to_wrapper"
         android:visibility="gone"
@@ -238,11 +231,6 @@
             />
 
     </LinearLayout>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider" />
 
     <RelativeLayout
         android:id="@+id/to_wrapper"
@@ -311,11 +299,6 @@
 
     </RelativeLayout>
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider" />
-
     <LinearLayout
         android:id="@+id/cc_wrapper"
         android:visibility="gone"
@@ -356,13 +339,6 @@
 
     </LinearLayout>
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:visibility="gone"
-        android:id="@+id/cc_divider"
-        android:background="?android:attr/listDivider" />
-
     <LinearLayout
         android:id="@+id/bcc_wrapper"
         android:visibility="gone"
@@ -402,12 +378,5 @@
             />
 
     </LinearLayout>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:visibility="gone"
-        android:id="@+id/bcc_divider"
-        android:background="?android:attr/listDivider" />
 
 </LinearLayout>


### PR DESCRIPTION
This changes the header area of the message compose screen to match the focus behavior from the design.

It doesn't feel particularly great to me. I'll check with the design team to make sure this is really what we want to go with.

![image](https://github.com/thunderbird/thunderbird-android/assets/218061/921dddf5-d277-4494-aa89-3abea401891f)
