### PR TITLE
Clean up `FolderIconProvider`

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -279,7 +279,7 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
         sliderView.addStickyFooterItem(
             PrimaryDrawerItem().apply {
                 nameRes = R.string.folders_action
-                iconRes = folderIconProvider.iconFolderResId
+                iconRes = Icons.Outlined.Folder
                 identifier = DRAWER_ID_FOLDERS
                 isSelectable = false
             },

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/folders/FolderIconProvider.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/folders/FolderIconProvider.kt
@@ -4,23 +4,14 @@ import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import com.fsck.k9.mailstore.FolderType
 
 class FolderIconProvider {
-    private val iconFolderInboxResId: Int = Icons.Outlined.Inbox
-    private val iconFolderOutboxResId: Int = Icons.Outlined.Outbox
-    private val iconFolderSentResId: Int = Icons.Outlined.Send
-    private val iconFolderTrashResId: Int = Icons.Outlined.Delete
-    private val iconFolderDraftsResId: Int = Icons.Outlined.Draft
-    private val iconFolderArchiveResId: Int = Icons.Outlined.Archive
-    private val iconFolderSpamResId: Int = Icons.Outlined.Report
-    var iconFolderResId: Int = Icons.Outlined.Folder
-
     fun getFolderIcon(type: FolderType): Int = when (type) {
-        FolderType.INBOX -> iconFolderInboxResId
-        FolderType.OUTBOX -> iconFolderOutboxResId
-        FolderType.SENT -> iconFolderSentResId
-        FolderType.TRASH -> iconFolderTrashResId
-        FolderType.DRAFTS -> iconFolderDraftsResId
-        FolderType.ARCHIVE -> iconFolderArchiveResId
-        FolderType.SPAM -> iconFolderSpamResId
-        else -> iconFolderResId
+        FolderType.INBOX -> Icons.Outlined.Inbox
+        FolderType.OUTBOX -> Icons.Outlined.Outbox
+        FolderType.SENT -> Icons.Outlined.Send
+        FolderType.TRASH -> Icons.Outlined.Delete
+        FolderType.DRAFTS -> Icons.Outlined.Draft
+        FolderType.ARCHIVE -> Icons.Outlined.Archive
+        FolderType.SPAM -> Icons.Outlined.Report
+        FolderType.REGULAR -> Icons.Outlined.Folder
     }
 }


### PR DESCRIPTION
I noticed this opportunity to trim down `FolderIconProvider` during a PR review.