### PR TITLE
Remove `onBackPressed()` usage [1/x]

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/ManageIdentities.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/ManageIdentities.java
@@ -131,9 +131,11 @@ public class ManageIdentities extends ChooseIdentity {
 
 
     @Override
-    public void onBackPressed() {
+    public void onStop() {
+        // TODO: Instead of saving the changes when the activity is stopped, save the changes (in a background thread)
+        //  immediately after modifying the list of identities.
         saveIdentities();
-        super.onBackPressed();
+        super.onStop();
     }
 
     private void saveIdentities() {
@@ -141,6 +143,5 @@ public class ManageIdentities extends ChooseIdentity {
             mAccount.setIdentities(identities);
             Preferences.getPreferences().saveAccount(mAccount);
         }
-        finish();
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
@@ -111,7 +111,7 @@ public class AccountSetupComposition extends K9Activity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            finish();
             return true;
         }
 
@@ -133,9 +133,11 @@ public class AccountSetupComposition extends K9Activity {
     }
 
     @Override
-    public void onBackPressed() {
+    public void onStop() {
+        // TODO: Instead of saving the changes when the activity is stopped, add buttons to explicitly save or discard
+        //  changes.
         saveSettings();
-        super.onBackPressed();
+        super.onStop();
     }
 
     @Override

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
@@ -38,11 +38,11 @@ class ManageFoldersActivity : K9Activity() {
     }
 
     override fun onSupportNavigateUp(): Boolean {
-        return navController.navigateUp() || super.onSupportNavigateUp() || navigateUpBySimulatedBackButtonPress()
+        return navController.navigateUp() || super.onSupportNavigateUp() || finishActivity()
     }
 
-    private fun navigateUpBySimulatedBackButtonPress(): Boolean {
-        onBackPressed()
+    private fun finishActivity(): Boolean {
+        finish()
         return true
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsActivity.kt
@@ -29,11 +29,11 @@ class SettingsActivity : K9Activity() {
     }
 
     override fun onSupportNavigateUp(): Boolean {
-        return navController.navigateUp() || super.onSupportNavigateUp() || navigateUpBySimulatedBackButtonPress()
+        return navController.navigateUp() || super.onSupportNavigateUp() || finishActivity()
     }
 
-    private fun navigateUpBySimulatedBackButtonPress(): Boolean {
-        onBackPressed()
+    private fun finishActivity(): Boolean {
+        finish()
         return true
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
@@ -98,7 +98,7 @@ class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsActivity.kt
@@ -118,12 +118,6 @@ class GeneralSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback, S
         return super.onOptionsItemSelected(item)
     }
 
-    override fun onBackPressed() {
-        if (!searchPreferenceActionView.cancelSearch()) {
-            super.onBackPressed()
-        }
-    }
-
     override fun onPreferenceStartScreen(
         caller: PreferenceFragmentCompat,
         preferenceScreen: PreferenceScreen,

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsActivity.kt
@@ -111,7 +111,7 @@ class GeneralSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback, S
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
 


### PR DESCRIPTION
A first step in removing custom `onBackPressed()` implementations and calls to this method.

See #6476