### PR TITLE
Fix toolbar height in account settings

### DIFF
--- a/app/ui/base/src/main/res/values/dimensions.xml
+++ b/app/ui/base/src/main/res/values/dimensions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="toolbarTitleMarginVertical">8dp</dimen>
+</resources>

--- a/app/ui/legacy/src/main/res/layout/activity_account_settings.xml
+++ b/app/ui/legacy/src/main/res/layout/activity_account_settings.xml
@@ -6,7 +6,7 @@
     android:orientation="vertical"
     tools:context=".settings.account.AccountSettingsActivity">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
         style="?attr/toolbarStyle"
         android:layout_width="match_parent"
@@ -21,7 +21,7 @@
             android:layout_marginVertical="@dimen/toolbarTitleMarginVertical"
             tools:listitem="@layout/account_spinner_item"/>
 
-    </androidx.appcompat.widget.Toolbar>
+    </com.google.android.material.appbar.MaterialToolbar>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/accountSettingsContainer"

--- a/app/ui/legacy/src/main/res/layout/activity_account_settings.xml
+++ b/app/ui/legacy/src/main/res/layout/activity_account_settings.xml
@@ -10,13 +10,15 @@
         android:id="@+id/toolbar"
         style="?attr/toolbarStyle"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
         tools:navigationIcon="@drawable/ic_arrow_back">
 
         <com.fsck.k9.ui.settings.account.AccountSelectionSpinner
             android:id="@+id/accountSpinner"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginVertical="@dimen/toolbarTitleMarginVertical"
             tools:listitem="@layout/account_spinner_item"/>
 
     </androidx.appcompat.widget.Toolbar>


### PR DESCRIPTION
- Use `wrap_content` for the toolbar height, so increasing the system font size doesn't break the layout.
- Also switches from `androidx.appcompat.widget.Toolbar` to `MaterialToolbar`.

|Before|After|
|-|-|
|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/b0b2c37b-606c-4e47-9d90-f02bcd7de3a5)|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/c23e8fc0-46d4-4bb2-b831-2058e4793c31)|

Related to #7854
