### PR TITLE
Fix toolbar height in message list

### DIFF
--- a/app/ui/base/src/main/res/layout/toolbar.xml
+++ b/app/ui/base/src/main/res/layout/toolbar.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't use a this layout when using a subtitle. See https://issuetracker.google.com/issues/135865267 -->
 <com.google.android.material.appbar.MaterialToolbar xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -12,9 +12,11 @@ import android.view.MenuItem
 import android.view.View
 import android.view.animation.AnimationUtils
 import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.SearchView
+import androidx.core.view.isGone
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.drawerlayout.widget.DrawerLayout.DrawerListener
 import androidx.fragment.app.FragmentManager
@@ -525,6 +527,7 @@ open class MessageList :
     private fun initializeActionBar() {
         actionBar = supportActionBar!!
         actionBar.setDisplayHomeAsUpEnabled(true)
+        actionBar.setDisplayShowTitleEnabled(false)
     }
 
     private fun initializeDrawer(savedInstanceState: Bundle?) {
@@ -930,9 +933,17 @@ open class MessageList :
         searchView?.isIconified = false
     }
 
-    fun setActionBarTitle(title: String, subtitle: String? = null) {
-        actionBar.title = title
-        actionBar.subtitle = subtitle
+    private fun setActionBarTitle(title: String, subtitle: String? = null) {
+        findViewById<TextView>(R.id.toolbarTitle).text = title
+        findViewById<TextView>(R.id.toolbarSubtitle).apply {
+            if (subtitle != null) {
+                text = subtitle
+                isGone = false
+            } else {
+                text = null
+                isGone = true
+            }
+        }
     }
 
     override fun setMessageListTitle(title: String, subtitle: String?) {

--- a/app/ui/legacy/src/main/res/layout/message_list.xml
+++ b/app/ui/legacy/src/main/res/layout/message_list.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawerLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,12 +12,48 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <include
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
-            layout="@layout/toolbar"
+            style="?attr/toolbarStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentTop="true" />
+            android:minHeight="?attr/actionBarSize"
+            android:layout_alignParentTop="true"
+            tools:navigationIcon="@drawable/ic_arrow_back">
+
+            <!-- We're not using MaterialToolbar's title/subtitle support because it is broken when using large system
+                 font sizes. See https://issuetracker.google.com/issues/135865267 -->
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginVertical="@dimen/toolbarTitleMarginVertical">
+
+                <TextView
+                    android:id="@+id/toolbarTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:singleLine="true"
+                    android:ellipsize="end"
+                    android:textAppearance="?attr/textAppearanceTitleLarge"
+                    android:textColor="?attr/colorOnSurface"
+                    tools:text="Inbox" />
+
+                <TextView
+                    android:id="@+id/toolbarSubtitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:singleLine="true"
+                    android:ellipsize="end"
+                    android:textAppearance="?attr/textAppearanceTitleMedium"
+                    android:textColor="?attr/colorOnSurfaceVariant"
+                    android:visibility="gone"
+                    tools:visibility="visible"
+                    tools:text="demo@domain.example" />
+
+            </LinearLayout>
+
+        </com.google.android.material.appbar.MaterialToolbar>
 
         <ProgressBar
             android:id="@+id/message_list_progress"


### PR DESCRIPTION
Use a custom view in the toolbar for the title and the subtitle. This works around a bug in AndroidX's Toolbar implementation: https://issuetracker.google.com/issues/135865267

Depends on #7860

|Before|After|
|-|-|
|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/c0e93d43-7ee0-4802-9edf-6986a8fef3af)|![image](https://github.com/thunderbird/thunderbird-android/assets/218061/3c7b36a1-f170-40a3-be66-61bbac8288bc)|

Note: Even when using the default font size this does slightly increase the toolbar height when using a subtitle vs. when not using a subtitle. We could change that by using a value smaller than `@dimen/toolbarTitleMarginVertical`.

Fixes #7854