### PR TITLE
Fix action bar icons wrongly colored

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
@@ -83,5 +83,6 @@ class SwipeResourceProvider(val theme: Theme) {
 }
 
 private fun Theme.loadDrawable(@DrawableRes drawableResId: Int): Drawable {
-    return ResourcesCompat.getDrawable(resources, drawableResId, this)!!
+    // mutate() is called to ensure that the drawable can be modified and doesn't affect other drawables
+    return ResourcesCompat.getDrawable(resources, drawableResId, this)!!.mutate()
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
@@ -12,15 +12,24 @@ import com.fsck.k9.ui.resolveColorAttribute
 class SwipeResourceProvider(val theme: Theme) {
     val iconTint = theme.resolveColorAttribute(R.attr.messageListSwipeIconTint)
 
-    private val selectIcon = theme.loadDrawable(Icons.Outlined.CheckCircle)
-    private val markAsReadIcon = theme.loadDrawable(Icons.Outlined.MarkEmailRead)
-    private val markAsUnreadIcon = theme.loadDrawable(Icons.Outlined.MarkEmailUnread)
-    private val addStarIcon = theme.loadDrawable(Icons.Filled.Star)
-    private val removeStarIcon = theme.loadDrawable(Icons.Outlined.Star)
-    private val archiveIcon = theme.loadDrawable(Icons.Outlined.Archive)
-    private val deleteIcon = theme.loadDrawable(Icons.Outlined.Delete)
-    private val spamIcon = theme.loadDrawable(Icons.Outlined.Report)
-    private val moveIcon = theme.loadDrawable(Icons.Outlined.DriveFileMove)
+    private val selectIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.CheckCircle)
+    private val markAsReadIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.MarkEmailRead)
+    private val markAsUnreadIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.MarkEmailUnread)
+    private val addStarIcon: Drawable
+        get() = theme.loadDrawable(Icons.Filled.Star)
+    private val removeStarIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.Star)
+    private val archiveIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.Archive)
+    private val deleteIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.Delete)
+    private val spamIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.Report)
+    private val moveIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.DriveFileMove)
 
     private val noActionColor = theme.resolveColorAttribute(R.attr.messageListSwipeDisabledBackgroundColor)
     private val selectColor = theme.resolveColorAttribute(R.attr.messageListSwipeSelectBackgroundColor)

--- a/app/ui/legacy/src/main/res/layout/swipe_left_action.xml
+++ b/app/ui/legacy/src/main/res/layout/swipe_left_action.xml
@@ -21,7 +21,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="?attr/messageListSwipeMarkAsReadIcon"
+        tools:src="@drawable/ic_mark_email_unread"
         tools:tint="?attr/messageListSwipeIconTint" />
 
     <TextView

--- a/app/ui/legacy/src/main/res/layout/swipe_right_action.xml
+++ b/app/ui/legacy/src/main/res/layout/swipe_right_action.xml
@@ -21,7 +21,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="?attr/messageListSwipeSelectIcon"
+        tools:src="@drawable/ic_check"
         tools:tint="?attr/messageListSwipeIconTint" />
 
     <TextView


### PR DESCRIPTION
This fixes the wrongly colored icons in the action bar. The issue was caused by changing the icon tint globally when `MessageListSwipeCallback` uses icons provided by `SwipeResourceProvider`. `Theme.loadDrawable` now ensures that drawables are loaded with `mutate()` to prevent side effects.

Steps to reproduce:
- Configure swipe actions to include delete and mark as read/unread
- Swipe left or right on the message list to reveal the swipe action icons, but only so far that the the swipe background color does not change 
- Open a message

Fixes #7868