### PR TITLE
Change message list swipe to Material 3

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -336,7 +336,7 @@ class MessageListFragment :
         val itemTouchHelper = ItemTouchHelper(
             MessageListSwipeCallback(
                 requireContext(),
-                resourceProvider = SwipeResourceProvider(requireActivity().theme),
+                resourceProvider = SwipeResourceProvider(requireActivity()),
                 swipeActionSupportProvider,
                 swipeRightAction = K9.swipeRightAction,
                 swipeLeftAction = K9.swipeLeftAction,

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -336,7 +336,7 @@ class MessageListFragment :
         val itemTouchHelper = ItemTouchHelper(
             MessageListSwipeCallback(
                 requireContext(),
-                resourceProvider = SwipeResourceProvider(requireActivity()),
+                resourceProvider = SwipeResourceProvider(requireContext()),
                 swipeActionSupportProvider,
                 swipeRightAction = K9.swipeRightAction,
                 swipeLeftAction = K9.swipeLeftAction,

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListSwipeCallback.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListSwipeCallback.kt
@@ -32,7 +32,11 @@ class MessageListSwipeCallback(
     private val backgroundColorPaint = Paint()
 
     private val swipeRightLayout: View
+    private val swipeRightIcon: ImageView
+    private val swipeRightText: TextView
     private val swipeLeftLayout: View
+    private val swipeLeftIcon: ImageView
+    private val swipeLeftText: TextView
 
     private var maxSwipeRightDistance: Int = -1
     private var maxSwipeLeftDistance: Int = -1
@@ -42,6 +46,12 @@ class MessageListSwipeCallback(
 
         swipeRightLayout = layoutInflater.inflate(R.layout.swipe_right_action, null, false)
         swipeLeftLayout = layoutInflater.inflate(R.layout.swipe_left_action, null, false)
+
+        swipeRightIcon = swipeRightLayout.findViewById(R.id.swipe_action_icon)
+        swipeRightText = swipeRightLayout.findViewById(R.id.swipe_action_text)
+
+        swipeLeftIcon = swipeLeftLayout.findViewById(R.id.swipe_action_icon)
+        swipeLeftText = swipeLeftLayout.findViewById(R.id.swipe_action_text)
     }
 
     override fun isFlingEnabled(): Boolean {
@@ -175,6 +185,8 @@ class MessageListSwipeCallback(
 
         val swipeLayout = if (swipeRight) swipeRightLayout else swipeLeftLayout
         val swipeAction = if (swipeRight) swipeRightAction else swipeLeftAction
+        val swipeIcon = if (swipeRight) swipeRightIcon else swipeLeftIcon
+        val swipeText = if (swipeRight) swipeRightText else swipeLeftText
 
         val foregroundColor: Int
         val backgroundColor: Int
@@ -191,12 +203,10 @@ class MessageListSwipeCallback(
         val icon = resourceProvider.getIcon(item, swipeAction)
         icon.setTint(foregroundColor)
 
-        val iconView = swipeLayout.findViewById<ImageView>(R.id.swipe_action_icon)
-        iconView.setImageDrawable(icon)
+        swipeIcon.setImageDrawable(icon)
 
-        val textView = swipeLayout.findViewById<TextView>(R.id.swipe_action_text)
-        textView.setTextColor(foregroundColor)
-        textView.text = resourceProvider.getActionName(item, swipeAction, isSelected)
+        swipeText.text = resourceProvider.getActionName(item, swipeAction, isSelected)
+        swipeText.setTextColor(foregroundColor)
 
         if (swipeLayout.isDirty) {
             val widthMeasureSpec = MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY)
@@ -205,9 +215,9 @@ class MessageListSwipeCallback(
             swipeLayout.layout(0, 0, width, height)
 
             if (swipeRight) {
-                maxSwipeRightDistance = textView.right + swipePadding
+                maxSwipeRightDistance = swipeText.right + swipePadding
             } else {
-                maxSwipeLeftDistance = swipeLayout.width - textView.left + swipePadding
+                maxSwipeLeftDistance = swipeLayout.width - swipeText.left + swipePadding
             }
         }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
@@ -50,13 +50,13 @@ class SwipeResourceProvider(private val context: Context) {
         return context.resolveColorAttribute(
             when (action) {
                 SwipeAction.None -> error("action == SwipeAction.None")
-                SwipeAction.ToggleSelection -> R.attr.messageListSwipeSelectBackgroundColor
-                SwipeAction.ToggleRead -> R.attr.messageListSwipeToggleReadBackgroundColor
-                SwipeAction.ToggleStar -> R.attr.messageListSwipeToggleStarBackgroundColor
-                SwipeAction.Archive -> R.attr.messageListSwipeArchiveBackgroundColor
-                SwipeAction.Delete -> R.attr.messageListSwipeDeleteBackgroundColor
-                SwipeAction.Spam -> R.attr.messageListSwipeSpamBackgroundColor
-                SwipeAction.Move -> R.attr.messageListSwipeMoveBackgroundColor
+                SwipeAction.ToggleSelection -> R.attr.messageListSwipeSelectColor
+                SwipeAction.ToggleRead -> R.attr.messageListSwipeToggleReadColor
+                SwipeAction.ToggleStar -> R.attr.messageListSwipeToggleStarColor
+                SwipeAction.Archive -> R.attr.messageListSwipeArchiveColor
+                SwipeAction.Delete -> R.attr.messageListSwipeDeleteColor
+                SwipeAction.Spam -> R.attr.messageListSwipeSpamColor
+                SwipeAction.Move -> R.attr.messageListSwipeMoveColor
             },
         )
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
@@ -10,28 +10,18 @@ import androidx.core.content.res.ResourcesCompat
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import com.fsck.k9.SwipeAction
 import com.fsck.k9.ui.R
+import com.google.android.material.color.ColorRoles
+import com.google.android.material.color.MaterialColors
 
 class SwipeResourceProvider(private val context: Context) {
 
-    val iconTint = context.resolveColorAttribute(R.attr.messageListSwipeIconTint)
-
-    fun getIcon(item: MessageListItem, action: SwipeAction): Drawable {
+    fun getActionIcon(action: SwipeAction): Drawable {
         return context.loadDrawable(
             when (action) {
                 SwipeAction.None -> error("action == SwipeAction.None")
                 SwipeAction.ToggleSelection -> Icons.Outlined.CheckCircle
-                SwipeAction.ToggleRead -> if (item.isRead) {
-                    Icons.Outlined.MarkEmailUnread
-                } else {
-                    Icons.Outlined.MarkEmailRead
-                }
-
-                SwipeAction.ToggleStar -> if (item.isStarred) {
-                    Icons.Outlined.Star
-                } else {
-                    Icons.Filled.Star
-                }
-
+                SwipeAction.ToggleRead -> Icons.Outlined.MarkEmailRead
+                SwipeAction.ToggleStar -> Icons.Filled.Star
                 SwipeAction.Archive -> Icons.Outlined.Archive
                 SwipeAction.Delete -> Icons.Outlined.Delete
                 SwipeAction.Spam -> Icons.Outlined.Report
@@ -40,11 +30,26 @@ class SwipeResourceProvider(private val context: Context) {
         )
     }
 
+    fun getActionIconToggled(action: SwipeAction): Drawable? {
+        return when (action) {
+            SwipeAction.None -> error("action == SwipeAction.None")
+            SwipeAction.ToggleRead -> context.loadDrawable(Icons.Outlined.MarkEmailUnread)
+            SwipeAction.ToggleStar -> context.loadDrawable(Icons.Outlined.Star)
+
+            else -> null
+        }
+    }
+
+    fun getActionColorRoles(action: SwipeAction): ColorRoles {
+        val harmonizedColor = MaterialColors.harmonizeWithPrimary(context, getActionColor(action))
+        return MaterialColors.getColorRoles(context, harmonizedColor)
+    }
+
     @ColorInt
-    fun getBackgroundColor(action: SwipeAction): Int {
+    private fun getActionColor(action: SwipeAction): Int {
         return context.resolveColorAttribute(
             when (action) {
-                SwipeAction.None -> R.attr.messageListSwipeDisabledBackgroundColor
+                SwipeAction.None -> error("action == SwipeAction.None")
                 SwipeAction.ToggleSelection -> R.attr.messageListSwipeSelectBackgroundColor
                 SwipeAction.ToggleRead -> R.attr.messageListSwipeToggleReadBackgroundColor
                 SwipeAction.ToggleStar -> R.attr.messageListSwipeToggleStarBackgroundColor
@@ -56,34 +61,30 @@ class SwipeResourceProvider(private val context: Context) {
         )
     }
 
-    fun getActionName(item: MessageListItem, action: SwipeAction, isSelected: Boolean): String {
+    fun getActionName(action: SwipeAction): String {
         return context.loadString(
             when (action) {
                 SwipeAction.None -> error("action == SwipeAction.None")
-                SwipeAction.ToggleSelection -> if (isSelected) {
-                    R.string.swipe_action_deselect
-                } else {
-                    R.string.swipe_action_select
-                }
-
-                SwipeAction.ToggleRead -> if (item.isRead) {
-                    R.string.swipe_action_mark_as_unread
-                } else {
-                    R.string.swipe_action_mark_as_read
-                }
-
-                SwipeAction.ToggleStar -> if (item.isStarred) {
-                    R.string.swipe_action_remove_star
-                } else {
-                    R.string.swipe_action_add_star
-                }
-
+                SwipeAction.ToggleSelection -> R.string.swipe_action_select
+                SwipeAction.ToggleRead -> R.string.swipe_action_mark_as_read
+                SwipeAction.ToggleStar -> R.string.swipe_action_add_star
                 SwipeAction.Archive -> R.string.swipe_action_archive
                 SwipeAction.Delete -> R.string.swipe_action_delete
                 SwipeAction.Spam -> R.string.swipe_action_spam
                 SwipeAction.Move -> R.string.swipe_action_move
             },
         )
+    }
+
+    fun getActionNameToggled(action: SwipeAction): String? {
+        return when (action) {
+            SwipeAction.None -> error("action == SwipeAction.None")
+            SwipeAction.ToggleSelection -> context.loadString(R.string.swipe_action_deselect)
+            SwipeAction.ToggleRead -> context.loadString(R.string.swipe_action_mark_as_unread)
+            SwipeAction.ToggleStar -> context.loadString(R.string.swipe_action_remove_star)
+
+            else -> null
+        }
     }
 }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
@@ -1,97 +1,108 @@
 package com.fsck.k9.ui.messagelist
 
-import android.content.res.Resources.Theme
+import android.content.Context
 import android.graphics.drawable.Drawable
+import android.util.TypedValue
+import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.core.content.res.ResourcesCompat
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import com.fsck.k9.SwipeAction
 import com.fsck.k9.ui.R
-import com.fsck.k9.ui.resolveColorAttribute
 
-class SwipeResourceProvider(val theme: Theme) {
-    val iconTint = theme.resolveColorAttribute(R.attr.messageListSwipeIconTint)
+class SwipeResourceProvider(private val context: Context) {
 
-    private val selectIcon: Drawable
-        get() = theme.loadDrawable(Icons.Outlined.CheckCircle)
-    private val markAsReadIcon: Drawable
-        get() = theme.loadDrawable(Icons.Outlined.MarkEmailRead)
-    private val markAsUnreadIcon: Drawable
-        get() = theme.loadDrawable(Icons.Outlined.MarkEmailUnread)
-    private val addStarIcon: Drawable
-        get() = theme.loadDrawable(Icons.Filled.Star)
-    private val removeStarIcon: Drawable
-        get() = theme.loadDrawable(Icons.Outlined.Star)
-    private val archiveIcon: Drawable
-        get() = theme.loadDrawable(Icons.Outlined.Archive)
-    private val deleteIcon: Drawable
-        get() = theme.loadDrawable(Icons.Outlined.Delete)
-    private val spamIcon: Drawable
-        get() = theme.loadDrawable(Icons.Outlined.Report)
-    private val moveIcon: Drawable
-        get() = theme.loadDrawable(Icons.Outlined.DriveFileMove)
-
-    private val noActionColor = theme.resolveColorAttribute(R.attr.messageListSwipeDisabledBackgroundColor)
-    private val selectColor = theme.resolveColorAttribute(R.attr.messageListSwipeSelectBackgroundColor)
-    private val toggleReadColor = theme.resolveColorAttribute(R.attr.messageListSwipeToggleReadBackgroundColor)
-    private val toggleStarColor = theme.resolveColorAttribute(R.attr.messageListSwipeToggleStarBackgroundColor)
-    private val archiveColor = theme.resolveColorAttribute(R.attr.messageListSwipeArchiveBackgroundColor)
-    private val deleteColor = theme.resolveColorAttribute(R.attr.messageListSwipeDeleteBackgroundColor)
-    private val spamColor = theme.resolveColorAttribute(R.attr.messageListSwipeSpamBackgroundColor)
-    private val moveColor = theme.resolveColorAttribute(R.attr.messageListSwipeMoveBackgroundColor)
-
-    private val selectText = theme.resources.getString(R.string.swipe_action_select)
-    private val deselectText = theme.resources.getString(R.string.swipe_action_deselect)
-    private val markAsReadText = theme.resources.getString(R.string.swipe_action_mark_as_read)
-    private val markAsUnreadText = theme.resources.getString(R.string.swipe_action_mark_as_unread)
-    private val addStarText = theme.resources.getString(R.string.swipe_action_add_star)
-    private val removeStarText = theme.resources.getString(R.string.swipe_action_remove_star)
-    private val archiveText = theme.resources.getString(R.string.swipe_action_archive)
-    private val deleteText = theme.resources.getString(R.string.swipe_action_delete)
-    private val spamText = theme.resources.getString(R.string.swipe_action_spam)
-    private val moveText = theme.resources.getString(R.string.swipe_action_move)
+    val iconTint = context.resolveColorAttribute(R.attr.messageListSwipeIconTint)
 
     fun getIcon(item: MessageListItem, action: SwipeAction): Drawable {
-        return when (action) {
-            SwipeAction.None -> error("action == SwipeAction.None")
-            SwipeAction.ToggleSelection -> selectIcon
-            SwipeAction.ToggleRead -> if (item.isRead) markAsUnreadIcon else markAsReadIcon
-            SwipeAction.ToggleStar -> if (item.isStarred) removeStarIcon else addStarIcon
-            SwipeAction.Archive -> archiveIcon
-            SwipeAction.Delete -> deleteIcon
-            SwipeAction.Spam -> spamIcon
-            SwipeAction.Move -> moveIcon
-        }
+        return context.loadDrawable(
+            when (action) {
+                SwipeAction.None -> error("action == SwipeAction.None")
+                SwipeAction.ToggleSelection -> Icons.Outlined.CheckCircle
+                SwipeAction.ToggleRead -> if (item.isRead) {
+                    Icons.Outlined.MarkEmailUnread
+                } else {
+                    Icons.Outlined.MarkEmailRead
+                }
+
+                SwipeAction.ToggleStar -> if (item.isStarred) {
+                    Icons.Outlined.Star
+                } else {
+                    Icons.Filled.Star
+                }
+
+                SwipeAction.Archive -> Icons.Outlined.Archive
+                SwipeAction.Delete -> Icons.Outlined.Delete
+                SwipeAction.Spam -> Icons.Outlined.Report
+                SwipeAction.Move -> Icons.Outlined.DriveFileMove
+            },
+        )
     }
 
+    @ColorInt
     fun getBackgroundColor(action: SwipeAction): Int {
-        return when (action) {
-            SwipeAction.None -> noActionColor
-            SwipeAction.ToggleSelection -> selectColor
-            SwipeAction.ToggleRead -> toggleReadColor
-            SwipeAction.ToggleStar -> toggleStarColor
-            SwipeAction.Archive -> archiveColor
-            SwipeAction.Delete -> deleteColor
-            SwipeAction.Spam -> spamColor
-            SwipeAction.Move -> moveColor
-        }
+        return context.resolveColorAttribute(
+            when (action) {
+                SwipeAction.None -> R.attr.messageListSwipeDisabledBackgroundColor
+                SwipeAction.ToggleSelection -> R.attr.messageListSwipeSelectBackgroundColor
+                SwipeAction.ToggleRead -> R.attr.messageListSwipeToggleReadBackgroundColor
+                SwipeAction.ToggleStar -> R.attr.messageListSwipeToggleStarBackgroundColor
+                SwipeAction.Archive -> R.attr.messageListSwipeArchiveBackgroundColor
+                SwipeAction.Delete -> R.attr.messageListSwipeDeleteBackgroundColor
+                SwipeAction.Spam -> R.attr.messageListSwipeSpamBackgroundColor
+                SwipeAction.Move -> R.attr.messageListSwipeMoveBackgroundColor
+            },
+        )
     }
 
     fun getActionName(item: MessageListItem, action: SwipeAction, isSelected: Boolean): String {
-        return when (action) {
-            SwipeAction.None -> error("action == SwipeAction.None")
-            SwipeAction.ToggleSelection -> if (isSelected) deselectText else selectText
-            SwipeAction.ToggleRead -> if (item.isRead) markAsUnreadText else markAsReadText
-            SwipeAction.ToggleStar -> if (item.isStarred) removeStarText else addStarText
-            SwipeAction.Archive -> archiveText
-            SwipeAction.Delete -> deleteText
-            SwipeAction.Spam -> spamText
-            SwipeAction.Move -> moveText
-        }
+        return context.loadString(
+            when (action) {
+                SwipeAction.None -> error("action == SwipeAction.None")
+                SwipeAction.ToggleSelection -> if (isSelected) {
+                    R.string.swipe_action_deselect
+                } else {
+                    R.string.swipe_action_select
+                }
+
+                SwipeAction.ToggleRead -> if (item.isRead) {
+                    R.string.swipe_action_mark_as_unread
+                } else {
+                    R.string.swipe_action_mark_as_read
+                }
+
+                SwipeAction.ToggleStar -> if (item.isStarred) {
+                    R.string.swipe_action_remove_star
+                } else {
+                    R.string.swipe_action_add_star
+                }
+
+                SwipeAction.Archive -> R.string.swipe_action_archive
+                SwipeAction.Delete -> R.string.swipe_action_delete
+                SwipeAction.Spam -> R.string.swipe_action_spam
+                SwipeAction.Move -> R.string.swipe_action_move
+            },
+        )
     }
 }
 
-private fun Theme.loadDrawable(@DrawableRes drawableResId: Int): Drawable {
+private fun Context.loadDrawable(@DrawableRes drawableResId: Int): Drawable {
     // mutate() is called to ensure that the drawable can be modified and doesn't affect other drawables
-    return ResourcesCompat.getDrawable(resources, drawableResId, this)!!.mutate()
+    return ResourcesCompat.getDrawable(resources, drawableResId, theme)!!.mutate()
+}
+
+fun Context.resolveColorAttribute(attrId: Int): Int {
+    val typedValue = TypedValue()
+
+    val found = theme.resolveAttribute(attrId, typedValue, true)
+    if (!found) {
+        error("Couldn't resolve attribute ($attrId)")
+    }
+
+    return typedValue.data
+}
+
+private fun Context.loadString(@StringRes stringResId: Int): String {
+    return resources.getString(stringResId)
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
@@ -83,5 +83,6 @@ class SwipeResourceProvider(val theme: Theme) {
 }
 
 private fun Theme.loadDrawable(@DrawableRes drawableResId: Int): Drawable {
-    return ResourcesCompat.getDrawable(resources, drawableResId, this)!!
+    // mutate() is called to ensure that the drawable can be modified and doesn't affect other drawables
+    return ResourcesCompat.getDrawable(resources, drawableResId, this)!!.mutate()
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SwipeResourceProvider.kt
@@ -12,15 +12,24 @@ import com.fsck.k9.ui.resolveColorAttribute
 class SwipeResourceProvider(val theme: Theme) {
     val iconTint = theme.resolveColorAttribute(R.attr.messageListSwipeIconTint)
 
-    private val selectIcon = theme.loadDrawable(Icons.Outlined.CheckCircle)
-    private val markAsReadIcon = theme.loadDrawable(Icons.Outlined.MarkEmailRead)
-    private val markAsUnreadIcon = theme.loadDrawable(Icons.Outlined.MarkEmailUnread)
-    private val addStarIcon = theme.loadDrawable(Icons.Filled.Star)
-    private val removeStarIcon = theme.loadDrawable(Icons.Outlined.Star)
-    private val archiveIcon = theme.loadDrawable(Icons.Outlined.Archive)
-    private val deleteIcon = theme.loadDrawable(Icons.Outlined.Delete)
-    private val spamIcon = theme.loadDrawable(Icons.Outlined.Report)
-    private val moveIcon = theme.loadDrawable(Icons.Outlined.DriveFileMove)
+    private val selectIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.CheckCircle)
+    private val markAsReadIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.MarkEmailRead)
+    private val markAsUnreadIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.MarkEmailUnread)
+    private val addStarIcon: Drawable
+        get() = theme.loadDrawable(Icons.Filled.Star)
+    private val removeStarIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.Star)
+    private val archiveIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.Archive)
+    private val deleteIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.Delete)
+    private val spamIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.Report)
+    private val moveIcon: Drawable
+        get() = theme.loadDrawable(Icons.Outlined.DriveFileMove)
 
     private val noActionColor = theme.resolveColorAttribute(R.attr.messageListSwipeDisabledBackgroundColor)
     private val selectColor = theme.resolveColorAttribute(R.attr.messageListSwipeSelectBackgroundColor)

--- a/app/ui/legacy/src/main/res/layout/swipe_left_action.xml
+++ b/app/ui/legacy/src/main/res/layout/swipe_left_action.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    tools:background="?attr/messageListSwipeSelectBackgroundColor"
+    tools:background="?attr/messageListSwipeSelectColor"
     tools:ignore="RtlHardcoded"
     tools:layout_height="?android:listPreferredItemHeight">
 

--- a/app/ui/legacy/src/main/res/layout/swipe_left_action.xml
+++ b/app/ui/legacy/src/main/res/layout/swipe_left_action.xml
@@ -21,8 +21,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="@drawable/ic_mark_email_unread"
-        tools:tint="?attr/messageListSwipeIconTint" />
+        tools:src="@drawable/ic_mark_email_unread" />
 
     <TextView
         android:id="@+id/swipe_action_text"
@@ -36,7 +35,6 @@
         android:gravity="right"
         android:maxLines="1"
         android:textAppearance="?attr/textAppearanceBody2"
-        android:textColor="?attr/messageListSwipeIconTint"
         app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHorizontal_bias="1.0"

--- a/app/ui/legacy/src/main/res/layout/swipe_left_action.xml
+++ b/app/ui/legacy/src/main/res/layout/swipe_left_action.xml
@@ -21,7 +21,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="?attr/messageListSwipeMarkAsReadIcon"
+        tools:src="@drawable/ic_mark_email_unread"
         tools:tint="?attr/messageListSwipeIconTint" />
 
     <TextView

--- a/app/ui/legacy/src/main/res/layout/swipe_right_action.xml
+++ b/app/ui/legacy/src/main/res/layout/swipe_right_action.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    tools:background="?attr/messageListSwipeSelectBackgroundColor"
+    tools:background="?attr/messageListSwipeSelectColor"
     tools:ignore="RtlHardcoded"
     tools:layout_height="?android:listPreferredItemHeight">
 

--- a/app/ui/legacy/src/main/res/layout/swipe_right_action.xml
+++ b/app/ui/legacy/src/main/res/layout/swipe_right_action.xml
@@ -21,7 +21,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="?attr/messageListSwipeSelectIcon"
+        tools:src="@drawable/ic_check"
         tools:tint="?attr/messageListSwipeIconTint" />
 
     <TextView

--- a/app/ui/legacy/src/main/res/layout/swipe_right_action.xml
+++ b/app/ui/legacy/src/main/res/layout/swipe_right_action.xml
@@ -21,8 +21,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="@drawable/ic_check"
-        tools:tint="?attr/messageListSwipeIconTint" />
+        tools:src="@drawable/ic_check" />
 
     <TextView
         android:id="@+id/swipe_action_text"
@@ -36,7 +35,6 @@
         android:gravity="left"
         android:maxLines="1"
         android:textAppearance="?attr/textAppearanceBody2"
-        android:textColor="?attr/messageListSwipeIconTint"
         app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHorizontal_bias="0.0"

--- a/app/ui/legacy/src/main/res/values/attrs.xml
+++ b/app/ui/legacy/src/main/res/values/attrs.xml
@@ -16,13 +16,13 @@
         <attr name="messageListReadTextColor" format="reference|color"/>
         <attr name="messageListPreviewTextColor" format="reference|color"/>
         <attr name="messageListDividerColor" format="reference|color"/>
-        <attr name="messageListSwipeSelectBackgroundColor" format="reference|color"/>
-        <attr name="messageListSwipeToggleReadBackgroundColor" format="reference|color"/>
-        <attr name="messageListSwipeToggleStarBackgroundColor" format="reference|color"/>
-        <attr name="messageListSwipeArchiveBackgroundColor" format="reference|color"/>
-        <attr name="messageListSwipeDeleteBackgroundColor" format="reference|color"/>
-        <attr name="messageListSwipeSpamBackgroundColor" format="reference|color"/>
-        <attr name="messageListSwipeMoveBackgroundColor" format="reference|color"/>
+        <attr name="messageListSwipeSelectColor" format="reference|color"/>
+        <attr name="messageListSwipeToggleReadColor" format="reference|color"/>
+        <attr name="messageListSwipeToggleStarColor" format="reference|color"/>
+        <attr name="messageListSwipeArchiveColor" format="reference|color"/>
+        <attr name="messageListSwipeDeleteColor" format="reference|color"/>
+        <attr name="messageListSwipeSpamColor" format="reference|color"/>
+        <attr name="messageListSwipeMoveColor" format="reference|color"/>
         <attr name="messageDetailsDividerColor" format="reference|color"/>
         <attr name="composerBackgroundColor" format="color"/>
         <attr name="contactPictureFallbackDefaultBackgroundColor" format="reference|color"/>

--- a/app/ui/legacy/src/main/res/values/attrs.xml
+++ b/app/ui/legacy/src/main/res/values/attrs.xml
@@ -16,8 +16,6 @@
         <attr name="messageListReadTextColor" format="reference|color"/>
         <attr name="messageListPreviewTextColor" format="reference|color"/>
         <attr name="messageListDividerColor" format="reference|color"/>
-        <attr name="messageListSwipeIconTint" format="reference|color"/>
-        <attr name="messageListSwipeDisabledBackgroundColor" format="reference|color"/>
         <attr name="messageListSwipeSelectBackgroundColor" format="reference|color"/>
         <attr name="messageListSwipeToggleReadBackgroundColor" format="reference|color"/>
         <attr name="messageListSwipeToggleStarBackgroundColor" format="reference|color"/>

--- a/app/ui/legacy/src/main/res/values/themes.xml
+++ b/app/ui/legacy/src/main/res/values/themes.xml
@@ -83,8 +83,6 @@
         <item name="messageListPreviewTextColor">#ff444444</item>
         <item name="messageListDividerColor">#ffcccccc</item>
 
-        <item name="messageListSwipeIconTint">#ffffff</item>
-        <item name="messageListSwipeDisabledBackgroundColor">@color/material_gray_200</item>
         <item name="messageListSwipeSelectBackgroundColor">@color/material_blue_600</item>
         <item name="messageListSwipeToggleReadBackgroundColor">@color/material_blue_600</item>
         <item name="messageListSwipeToggleStarBackgroundColor">@color/material_orange_600</item>
@@ -197,8 +195,6 @@
         <item name="messageListPreviewTextColor">#ffaaaaaa</item>
         <item name="messageListDividerColor">#ff333333</item>
 
-        <item name="messageListSwipeIconTint">#ffffff</item>
-        <item name="messageListSwipeDisabledBackgroundColor">@color/material_gray_900</item>
         <item name="messageListSwipeSelectBackgroundColor">@color/material_blue_700</item>
         <item name="messageListSwipeToggleReadBackgroundColor">@color/material_blue_700</item>
         <item name="messageListSwipeToggleStarBackgroundColor">@color/material_orange_700</item>

--- a/app/ui/legacy/src/main/res/values/themes.xml
+++ b/app/ui/legacy/src/main/res/values/themes.xml
@@ -83,13 +83,13 @@
         <item name="messageListPreviewTextColor">#ff444444</item>
         <item name="messageListDividerColor">#ffcccccc</item>
 
-        <item name="messageListSwipeSelectBackgroundColor">@color/material_blue_600</item>
-        <item name="messageListSwipeToggleReadBackgroundColor">@color/material_blue_600</item>
-        <item name="messageListSwipeToggleStarBackgroundColor">@color/material_orange_600</item>
-        <item name="messageListSwipeArchiveBackgroundColor">@color/material_green_600</item>
-        <item name="messageListSwipeDeleteBackgroundColor">@color/material_red_600</item>
-        <item name="messageListSwipeSpamBackgroundColor">@color/material_red_700</item>
-        <item name="messageListSwipeMoveBackgroundColor">@color/material_purple_500</item>
+        <item name="messageListSwipeSelectColor">@color/material_blue_600</item>
+        <item name="messageListSwipeToggleReadColor">@color/material_blue_600</item>
+        <item name="messageListSwipeToggleStarColor">@color/material_orange_600</item>
+        <item name="messageListSwipeArchiveColor">@color/material_green_600</item>
+        <item name="messageListSwipeDeleteColor">@color/material_red_600</item>
+        <item name="messageListSwipeSpamColor">@color/material_red_700</item>
+        <item name="messageListSwipeMoveColor">@color/material_purple_500</item>
 
         <item name="messageDetailsDividerColor">#ffcccccc</item>
         <item name="contactPictureFallbackDefaultBackgroundColor">#ffababab</item>
@@ -195,13 +195,13 @@
         <item name="messageListPreviewTextColor">#ffaaaaaa</item>
         <item name="messageListDividerColor">#ff333333</item>
 
-        <item name="messageListSwipeSelectBackgroundColor">@color/material_blue_700</item>
-        <item name="messageListSwipeToggleReadBackgroundColor">@color/material_blue_700</item>
-        <item name="messageListSwipeToggleStarBackgroundColor">@color/material_orange_700</item>
-        <item name="messageListSwipeArchiveBackgroundColor">@color/material_green_700</item>
-        <item name="messageListSwipeDeleteBackgroundColor">@color/material_red_700</item>
-        <item name="messageListSwipeSpamBackgroundColor">@color/material_red_800</item>
-        <item name="messageListSwipeMoveBackgroundColor">@color/material_purple_600</item>
+        <item name="messageListSwipeSelectColor">@color/material_blue_700</item>
+        <item name="messageListSwipeToggleReadColor">@color/material_blue_700</item>
+        <item name="messageListSwipeToggleStarColor">@color/material_orange_700</item>
+        <item name="messageListSwipeArchiveColor">@color/material_green_700</item>
+        <item name="messageListSwipeDeleteColor">@color/material_red_700</item>
+        <item name="messageListSwipeSpamColor">@color/material_red_800</item>
+        <item name="messageListSwipeMoveColor">@color/material_purple_600</item>
 
         <item name="messageDetailsDividerColor">#ff555555</item>
         <item name="contactTokenBackgroundColor">#313131</item>


### PR DESCRIPTION
This changes the message list swipe actions to Material 3 colors. This ensures that the swipe action colors are harmonized to the currently used primary color and could be used alongside Material You, too.

Fixes #7868
