### PR TITLE
Fallback to using setAndAllowWhileIdle if without SCHEDULE_EXACT_ALARM granted

### DIFF
--- a/app/common/src/main/java/com/fsck/k9/backends/AndroidAlarmManager.kt
+++ b/app/common/src/main/java/com/fsck/k9/backends/AndroidAlarmManager.kt
@@ -64,12 +64,21 @@ class AndroidAlarmManager(
     override fun setAlarm(triggerTime: Long, callback: Callback) {
         this.callback.set(callback)
 
-        AlarmManagerCompat.setExactAndAllowWhileIdle(
-            alarmManager,
-            AlarmManager.ELAPSED_REALTIME_WAKEUP,
-            triggerTime,
-            pendingIntent,
-        )
+        if (AlarmManagerCompat.canScheduleExactAlarms(alarmManager)) {
+            AlarmManagerCompat.setExactAndAllowWhileIdle(
+                alarmManager,
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                triggerTime,
+                pendingIntent,
+            )
+        } else {
+            AlarmManagerCompat.setAndAllowWhileIdle(
+                alarmManager,
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                triggerTime,
+                pendingIntent,
+            )
+        }
     }
 
     override fun cancelAlarm() {

--- a/app/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
@@ -164,8 +164,7 @@ class PushController internal constructor(
 
         val shouldDisablePushAccounts = backgroundSyncDisabledViaSystem ||
             backgroundSyncDisabledInApp ||
-            networkNotAvailable ||
-            alarmPermissionMissing
+            networkNotAvailable
 
         val pushAccounts = if (shouldDisablePushAccounts) {
             emptyList()


### PR DESCRIPTION
I tested this on Pixel 6 A14, seems it works well to receive pushes.

Refs:

- https://developer.android.com/training/monitoring-device-state/doze-standby#restrictions
- https://developer.android.com/training/monitoring-device-state/doze-standby#testing_doze_and_app_standby