### PR TITLE
Rename package/classes to not use plural names

### DIFF
--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -12,9 +12,9 @@ import android.os.SystemClock;
 
 import androidx.annotation.NonNull;
 import com.fsck.k9.helper.Utility;
-import com.fsck.k9.preferences.migrations.DefaultStorageMigrationsHelper;
-import com.fsck.k9.preferences.migrations.StorageMigrations;
-import com.fsck.k9.preferences.migrations.StorageMigrationsHelper;
+import com.fsck.k9.preferences.migration.DefaultStorageMigrationsHelper;
+import com.fsck.k9.preferences.migration.StorageMigrations;
+import com.fsck.k9.preferences.migration.StorageMigrationsHelper;
 import timber.log.Timber;
 
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -12,9 +12,9 @@ import android.os.SystemClock;
 
 import androidx.annotation.NonNull;
 import com.fsck.k9.helper.Utility;
-import com.fsck.k9.preferences.migration.DefaultStorageMigrationsHelper;
+import com.fsck.k9.preferences.migration.DefaultStorageMigrationHelper;
 import com.fsck.k9.preferences.migration.StorageMigrations;
-import com.fsck.k9.preferences.migration.StorageMigrationsHelper;
+import com.fsck.k9.preferences.migration.StorageMigrationHelper;
 import timber.log.Timber;
 
 
@@ -23,7 +23,7 @@ public class K9StoragePersister implements StoragePersister {
     private static final String DB_NAME = "preferences_storage";
 
     private final Context context;
-    private final StorageMigrationsHelper migrationsHelper = new DefaultStorageMigrationsHelper();
+    private final StorageMigrationHelper migrationHelper = new DefaultStorageMigrationHelper();
 
     public K9StoragePersister(Context context) {
         this.context = context;
@@ -42,7 +42,7 @@ public class K9StoragePersister implements StoragePersister {
             if (db.getVersion() < 1) {
                 createStorageDatabase(db);
             } else {
-                StorageMigrations.upgradeDatabase(db, migrationsHelper);
+                StorageMigrations.upgradeDatabase(db, migrationHelper);
             }
 
             db.setVersion(DB_VERSION);

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/DefaultStorageMigrationHelper.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/DefaultStorageMigrationHelper.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.android.common.database.getStringOrThrow
 import app.k9mail.core.android.common.database.map
 import timber.log.Timber
 
-class DefaultStorageMigrationsHelper : StorageMigrationsHelper {
+class DefaultStorageMigrationHelper : StorageMigrationHelper {
     override fun readAllValues(db: SQLiteDatabase): Map<String, String> {
         return db.query(TABLE_NAME, arrayOf(KEY_COLUMN, VALUE_COLUMN), null, null, null, null, null).use {
             it.map { cursor ->

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/DefaultStorageMigrationsHelper.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/DefaultStorageMigrationsHelper.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 import androidx.core.content.contentValuesOf

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationHelper.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationHelper.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 
-interface StorageMigrationsHelper {
+interface StorageMigrationHelper {
     fun readAllValues(db: SQLiteDatabase): Map<String, String>
     fun readValue(db: SQLiteDatabase, key: String): String?
     fun writeValue(db: SQLiteDatabase, key: String, value: String?)

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo10.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo10.kt
@@ -11,7 +11,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo10(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     private val folderKeyPattern = Regex("[^.]+\\..+\\.([^.]+)")
     private val folderSettingKeys = setOf(

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo10.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo10.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo11.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo11.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 import com.fsck.k9.preferences.upgrader.GeneralSettingsUpgraderTo31

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo11.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo11.kt
@@ -12,7 +12,7 @@ import com.fsck.k9.preferences.upgrader.GeneralSettingsUpgraderTo31
  */
 class StorageMigrationTo11(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun upgradeMessageViewContentFontSize() {
         val newFontSizeValue = migrationsHelper.readValue(db, "fontSizeMessageViewContentPercent")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo12.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo12.kt
@@ -13,7 +13,7 @@ import com.fsck.k9.preferences.migration.migration12.WebDavStoreUriDecoder
  */
 class StorageMigrationTo12(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     private val serverSettingsSerializer = ServerSettingsSerializer()
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo12.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo12.kt
@@ -1,12 +1,12 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 import com.fsck.k9.ServerSettingsSerializer
 import com.fsck.k9.mail.filter.Base64
-import com.fsck.k9.preferences.migrations.migration12.ImapStoreUriDecoder
-import com.fsck.k9.preferences.migrations.migration12.Pop3StoreUriDecoder
-import com.fsck.k9.preferences.migrations.migration12.SmtpTransportUriDecoder
-import com.fsck.k9.preferences.migrations.migration12.WebDavStoreUriDecoder
+import com.fsck.k9.preferences.migration.migration12.ImapStoreUriDecoder
+import com.fsck.k9.preferences.migration.migration12.Pop3StoreUriDecoder
+import com.fsck.k9.preferences.migration.migration12.SmtpTransportUriDecoder
+import com.fsck.k9.preferences.migration.migration12.WebDavStoreUriDecoder
 
 /**
  * Convert server settings from the old URI format to the new JSON format

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo13.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo13.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo13(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun renameHideSpecialAccounts() {
         val hideSpecialAccounts = migrationsHelper.readValue(db, "hideSpecialAccounts")?.toBoolean() ?: false

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo13.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo13.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo14.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo14.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 import app.k9mail.core.common.mail.Protocols

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo14.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo14.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.ServerSettingsSerializer
  */
 class StorageMigrationTo14(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     private val serverSettingsSerializer = ServerSettingsSerializer()
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo15.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo15.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo15.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo15.kt
@@ -10,7 +10,7 @@ private const val MINIMUM_IDLE_REFRESH_MINUTES = 2
  */
 class StorageMigrationTo15(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun rewriteIdleRefreshInterval() {
         val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo16.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo16.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo16(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun changeDefaultRegisteredNameColor() {
         val registeredNameColorValue = migrationsHelper.readValue(db, "registeredNameColor")?.toInt()

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo16.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo16.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo17.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo17.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo17(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun rewriteNotificationLightSettings() {
         val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo17.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo17.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo18.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo18.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo18(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun rewriteImapCompressionSettings() {
         val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo18.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo18.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo19.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo19.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 import com.squareup.moshi.Moshi

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo19.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo19.kt
@@ -16,7 +16,7 @@ import com.squareup.moshi.Types
  */
 class StorageMigrationTo19(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun markGmailAccounts() {
         val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo2.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo2.java
@@ -11,7 +11,7 @@ import timber.log.Timber;
 
 
 public class StorageMigrationTo2 {
-    public static void urlEncodeUserNameAndPassword(SQLiteDatabase db, StorageMigrationsHelper migrationsHelper) {
+    public static void urlEncodeUserNameAndPassword(SQLiteDatabase db, StorageMigrationHelper migrationsHelper) {
         Timber.i("Updating preferences to urlencoded username/password");
 
         String accountUuids = migrationsHelper.readValue(db, "accountUuids");

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo2.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo2.java
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations;
+package com.fsck.k9.preferences.migration;
 
 
 import java.net.URI;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo20.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo20.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 import com.fsck.k9.mail.Address

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo20.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo20.kt
@@ -13,7 +13,7 @@ import com.fsck.k9.mail.Address
  */
 class StorageMigrationTo20(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun fixIdentities() {
         val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo21.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo21.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo21(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun createPostRemoveNavigationSetting() {
         val messageViewReturnToList = migrationsHelper.readValue(db, "messageViewReturnToList").toBoolean()

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo21.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo21.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo22.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo22.kt
@@ -10,7 +10,7 @@ import com.squareup.moshi.Types
  */
 class StorageMigrationTo22(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun fixServerSettings() {
         val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo22.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo22.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 import com.squareup.moshi.JsonAdapter

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo3.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo3.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo3(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun rewriteFolderNone() {
         val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo3.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo3.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo4.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo4.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo4(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun insertSpecialFolderSelectionValues() {
         val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo4.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo4.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo5.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo5.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo5.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo5.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo5(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun fixMailCheckFrequencies() {
         val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo6.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo6.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo6(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun performLegacyMigrations() {
         rewriteTheme()

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo6.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo6.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo7.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo7.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo7(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun rewriteEnumOrdinalsToNames() {
         rewriteTheme()

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo7.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo7.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo8.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo8.kt
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase
  */
 class StorageMigrationTo8(
     private val db: SQLiteDatabase,
-    private val migrationsHelper: StorageMigrationsHelper,
+    private val migrationsHelper: StorageMigrationHelper,
 ) {
     fun rewriteTheme() {
         val theme = migrationsHelper.readValue(db, "theme")

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo8.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo8.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
@@ -5,7 +5,7 @@ import android.database.sqlite.SQLiteDatabase
 internal object StorageMigrations {
     @Suppress("MagicNumber", "CyclomaticComplexMethod")
     @JvmStatic
-    fun upgradeDatabase(db: SQLiteDatabase, migrationsHelper: StorageMigrationsHelper) {
+    fun upgradeDatabase(db: SQLiteDatabase, migrationsHelper: StorageMigrationHelper) {
         val oldVersion = db.version
 
         if (oldVersion < 2) StorageMigrationTo2.urlEncodeUserNameAndPassword(db, migrationsHelper)

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationsHelper.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationsHelper.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/migration12/ImapStoreUriDecoder.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/migration12/ImapStoreUriDecoder.java
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations.migration12;
+package com.fsck.k9.preferences.migration.migration12;
 
 
 import java.net.URI;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/migration12/Pop3StoreUriDecoder.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/migration12/Pop3StoreUriDecoder.java
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations.migration12;
+package com.fsck.k9.preferences.migration.migration12;
 
 
 import java.net.URI;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/migration12/SmtpTransportUriDecoder.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/migration12/SmtpTransportUriDecoder.java
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations.migration12;
+package com.fsck.k9.preferences.migration.migration12;
 
 
 import java.io.UnsupportedEncodingException;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/migration12/WebDavStoreUriDecoder.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/migration12/WebDavStoreUriDecoder.java
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations.migration12;
+package com.fsck.k9.preferences.migration.migration12;
 
 
 import com.fsck.k9.mail.AuthType;

--- a/app/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo22Test.kt
+++ b/app/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo22Test.kt
@@ -16,8 +16,8 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class StorageMigrationTo22Test {
     private val database = createPreferencesDatabase()
-    private val migrationsHelper = DefaultStorageMigrationsHelper()
-    private val migration = StorageMigrationTo22(database, migrationsHelper)
+    private val migrationHelper = DefaultStorageMigrationHelper()
+    private val migration = StorageMigrationTo22(database, migrationHelper)
 
     @After
     fun tearDown() {
@@ -75,7 +75,7 @@ class StorageMigrationTo22Test {
 
         migration.fixServerSettings()
 
-        assertThat(migrationsHelper.readAllValues(database)).all {
+        assertThat(migrationHelper.readAllValues(database)).all {
             key("$accountOne.incomingServerSettings").isEqualTo(
                 """
                 {
@@ -138,14 +138,14 @@ class StorageMigrationTo22Test {
 
     private fun writeAccountUuids(vararg accounts: String) {
         val accountUuids = accounts.joinToString(separator = ",")
-        migrationsHelper.insertValue(database, "accountUuids", accountUuids)
+        migrationHelper.insertValue(database, "accountUuids", accountUuids)
     }
 
     private fun createAccount(vararg pairs: Pair<String, String>): String {
         val accountUuid = UUID.randomUUID().toString()
 
         for ((key, value) in pairs) {
-            migrationsHelper.insertValue(database, "$accountUuid.$key", value)
+            migrationHelper.insertValue(database, "$accountUuid.$key", value)
         }
 
         return accountUuid

--- a/app/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo22Test.kt
+++ b/app/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo22Test.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.preferences.migrations
+package com.fsck.k9.preferences.migration
 
 import assertk.all
 import assertk.assertThat


### PR DESCRIPTION
A follow-up to #7891.

- Rename package `com.fsck.k9.preferences.migrations` to `com.fsck.k9.preferences.migration`.
- Rename class `StorageMigrationsHelper` to `StorageMigrationHelper`
- Rename class `DefaultStorageMigrationsHelper` to `DefaultStorageMigrationHelper`