### PR TITLE
Fix launcher shortcuts (attempt #2)

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/LauncherShortcuts.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/LauncherShortcuts.kt
@@ -2,9 +2,13 @@ package com.fsck.k9.activity
 
 import android.content.Intent
 import android.content.res.Resources.Theme
+import android.os.Build
 import android.os.Bundle
 import android.util.TypedValue
 import androidx.annotation.AttrRes
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
 import com.fsck.k9.BaseAccount
 import com.fsck.k9.search.SearchAccount
 import com.fsck.k9.ui.R
@@ -30,29 +34,51 @@ class LauncherShortcuts : AccountList() {
 
         val displayName = account.name ?: account.email
         val iconResId = theme.resolveDrawableResourceId(CommonR.attr.appLogo)
-        val iconResource = Intent.ShortcutIconResource.fromContext(this, iconResId)
+        val shortcutId = account.uuid
 
-        setResult(
-            RESULT_OK,
-            createResultIntent(
-                shortcutIntent,
-                displayName,
-                iconResource,
-            ),
-        )
+        val resultIntent = createResultIntent(displayName, iconResId, shortcutIntent, shortcutId)
+
+        setResult(RESULT_OK, resultIntent)
         finish()
     }
 
     private fun createResultIntent(
-        shortcutIntent: Intent,
         displayName: String,
-        iconResource: Intent.ShortcutIconResource,
+        iconResId: Int,
+        shortcutIntent: Intent,
+        shortcutId: String,
     ): Intent {
+        return if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S) {
+            createResultIntentLegacy(displayName, iconResId, shortcutIntent)
+        } else {
+            createResultIntentApi32(shortcutId, displayName, iconResId, shortcutIntent)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun createResultIntentLegacy(displayName: String, iconResId: Int, shortcutIntent: Intent): Intent {
+        val iconResource = Intent.ShortcutIconResource.fromContext(this, iconResId)
+
         return Intent().apply {
             putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent)
             putExtra(Intent.EXTRA_SHORTCUT_NAME, displayName)
             putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, iconResource)
         }
+    }
+
+    private fun createResultIntentApi32(
+        shortcutId: String,
+        displayName: String,
+        iconResId: Int,
+        shortcutIntent: Intent,
+    ): Intent {
+        val shortcut = ShortcutInfoCompat.Builder(this, shortcutId)
+            .setShortLabel(displayName)
+            .setIcon(IconCompat.createWithResource(this, iconResId))
+            .setIntent(shortcutIntent)
+            .build()
+
+        return ShortcutManagerCompat.createShortcutResultIntent(this, shortcut)
     }
 
     private fun Theme.resolveDrawableResourceId(@AttrRes attr: Int): Int {


### PR DESCRIPTION
Combines what we currently have in `main` and what was changed in #7905.

On Android 12 and older the current approach is used. On newer Android versions `ShortcutManagerCompat.createShortcutResultIntent()` is used.

Fixes #7901