### PR TITLE
[Backport] Ignore `ForegroundServiceStartNotAllowedException`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/push/PushServiceManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/PushServiceManager.kt
@@ -30,6 +30,16 @@ internal class PushServiceManager(private val context: Context) {
         }
     }
 
+    fun setServiceStarted() {
+        Timber.v("PushServiceManager.setServiceStarted()")
+        isServiceStarted.set(true)
+    }
+
+    fun setServiceStopped() {
+        Timber.v("PushServiceManager.setServiceStopped()")
+        isServiceStarted.set(false)
+    }
+
     private fun startService() {
         try {
             val intent = Intent(context, PushService::class.java)


### PR DESCRIPTION
This backports the change from #7789 to the maintenance branch.

With K-9 Mail 6.901 the change has been exposed to beta users for over two weeks. So far no crashes or bugs related to this change have been reported.

The commits from the original pull request were cherry-picked and applied cleanly.