### PR TITLE
Add Corsican to supported languages

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -50,6 +50,7 @@ android {
                 "bg",
                 "br",
                 "ca",
+                "co",
                 "cs",
                 "cy",
                 "da",

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -50,6 +50,7 @@ android {
                 "bg",
                 "br",
                 "ca",
+                "co",
                 "cs",
                 "cy",
                 "da",

--- a/app/core/src/main/res/values/arrays_general_settings_values.xml
+++ b/app/core/src/main/res/values/arrays_general_settings_values.xml
@@ -8,6 +8,7 @@
         <item>bg</item>
         <item>br</item>
         <item>ca</item>
+        <item>co</item>
         <item>cs</item>
         <item>cy</item>
         <item>da</item>
@@ -65,6 +66,7 @@
         <item>br</item>
         <item>ca</item>
         <item>cs</item>
+        <item>co</item>
         <item>cy</item>
         <item>da</item>
         <item>de</item>

--- a/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
+++ b/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
@@ -11,6 +11,7 @@
         <item>Brezhoneg</item>
         <item>Català</item>
         <item>Čeština</item>
+        <item>Corsu</item>
         <item>Cymraeg</item>
         <item>Dansk</item>
         <item>Deutsch</item>


### PR DESCRIPTION
Add [Corsican](https://en.wikipedia.org/wiki/Corsican_language) to the list of supported languages (and to the list of known languages) because it crossed our translation threshold of 70%.

Closes #7913