### PR TITLE
Add app name provider

### DIFF
--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -2,16 +2,19 @@ package app.k9mail
 
 import app.k9mail.auth.K9OAuthConfigurationFactory
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.theme2.k9mail.K9MailTheme2
 import app.k9mail.dev.developmentModuleAdditions
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.unread.UnreadWidgetClassProvider
+import app.k9mail.provider.K9AppNameProvider
 import com.fsck.k9.AppConfig
 import com.fsck.k9.BuildConfig
 import com.fsck.k9.activity.LauncherShortcuts
 import com.fsck.k9.activity.MessageCompose
 import com.fsck.k9.provider.UnreadWidgetProvider
 import com.fsck.k9.widget.list.MessageListWidgetProvider
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -20,6 +23,7 @@ val appModule = module {
     single(named("ClientIdAppVersion")) { BuildConfig.VERSION_NAME }
     single<AppConfig> { appConfig }
     single<OAuthConfigurationFactory> { K9OAuthConfigurationFactory() }
+    single<AppNameProvider> { K9AppNameProvider(androidContext()) }
     single<FeatureThemeProvider> { provideFeatureThemeProvider() }
     single<UnreadWidgetClassProvider> {
         UnreadWidgetClassProvider { UnreadWidgetProvider::class.java }

--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -3,11 +3,11 @@ package app.k9mail
 import app.k9mail.auth.K9OAuthConfigurationFactory
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
-import app.k9mail.core.ui.compose.theme2.k9mail.K9MailTheme2
 import app.k9mail.dev.developmentModuleAdditions
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.unread.UnreadWidgetClassProvider
 import app.k9mail.provider.K9AppNameProvider
+import app.k9mail.provider.K9FeatureThemeProvider
 import com.fsck.k9.AppConfig
 import com.fsck.k9.BuildConfig
 import com.fsck.k9.activity.LauncherShortcuts
@@ -24,7 +24,7 @@ val appModule = module {
     single<AppConfig> { appConfig }
     single<OAuthConfigurationFactory> { K9OAuthConfigurationFactory() }
     single<AppNameProvider> { K9AppNameProvider(androidContext()) }
-    single<FeatureThemeProvider> { provideFeatureThemeProvider() }
+    single<FeatureThemeProvider> { K9FeatureThemeProvider() }
     single<UnreadWidgetClassProvider> {
         UnreadWidgetClassProvider { UnreadWidgetProvider::class.java }
     }
@@ -40,9 +40,3 @@ val appConfig = AppConfig(
         MessageListWidgetProvider::class.java,
     ),
 )
-
-private fun provideFeatureThemeProvider(): FeatureThemeProvider = FeatureThemeProvider { content ->
-    K9MailTheme2 {
-        content()
-    }
-}

--- a/app-k9mail/src/main/kotlin/app/k9mail/provider/K9AppNameProvider.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/provider/K9AppNameProvider.kt
@@ -1,0 +1,13 @@
+package app.k9mail.provider
+
+import android.content.Context
+import app.k9mail.core.common.provider.AppNameProvider
+import com.fsck.k9.R
+
+class K9AppNameProvider(
+    context: Context,
+) : AppNameProvider {
+    override val appName: String by lazy {
+        context.getString(R.string.app_name)
+    }
+}

--- a/app-k9mail/src/main/kotlin/app/k9mail/provider/K9FeatureThemeProvider.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/provider/K9FeatureThemeProvider.kt
@@ -1,0 +1,14 @@
+package app.k9mail.provider
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.theme2.k9mail.K9MailTheme2
+import app.k9mail.feature.launcher.FeatureLauncherExternalContract
+
+class K9FeatureThemeProvider : FeatureLauncherExternalContract.FeatureThemeProvider {
+    @Composable
+    override fun WithTheme(content: @Composable () -> Unit) {
+        K9MailTheme2 {
+            content()
+        }
+    }
+}

--- a/app-k9mail/src/main/res/values-ar/strings.xml
+++ b/app-k9mail/src/main/res/values-ar/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">بريد K-9</string>
+</resources>

--- a/app-k9mail/src/main/res/values-az/strings.xml
+++ b/app-k9mail/src/main/res/values-az/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-be/strings.xml
+++ b/app-k9mail/src/main/res/values-be/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">Пошта K-9</string>
+</resources>

--- a/app-k9mail/src/main/res/values-bg/strings.xml
+++ b/app-k9mail/src/main/res/values-bg/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-br/strings.xml
+++ b/app-k9mail/src/main/res/values-br/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-bs/strings.xml
+++ b/app-k9mail/src/main/res/values-bs/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-ca/strings.xml
+++ b/app-k9mail/src/main/res/values-ca/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-co/strings.xml
+++ b/app-k9mail/src/main/res/values-co/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-cs/strings.xml
+++ b/app-k9mail/src/main/res/values-cs/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-cy/strings.xml
+++ b/app-k9mail/src/main/res/values-cy/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-da/strings.xml
+++ b/app-k9mail/src/main/res/values-da/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-de/strings.xml
+++ b/app-k9mail/src/main/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-el/strings.xml
+++ b/app-k9mail/src/main/res/values-el/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-en-rGB/strings.xml
+++ b/app-k9mail/src/main/res/values-en-rGB/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-eo/strings.xml
+++ b/app-k9mail/src/main/res/values-eo/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Retpoŝtilo</string>
+</resources>

--- a/app-k9mail/src/main/res/values-es/strings.xml
+++ b/app-k9mail/src/main/res/values-es/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-et/strings.xml
+++ b/app-k9mail/src/main/res/values-et/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-eu/strings.xml
+++ b/app-k9mail/src/main/res/values-eu/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-fa/strings.xml
+++ b/app-k9mail/src/main/res/values-fa/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">نامهٔ کِی۹</string>
+</resources>

--- a/app-k9mail/src/main/res/values-fi/strings.xml
+++ b/app-k9mail/src/main/res/values-fi/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-fr/strings.xml
+++ b/app-k9mail/src/main/res/values-fr/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">Courriel K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-fy/strings.xml
+++ b/app-k9mail/src/main/res/values-fy/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-gd/strings.xml
+++ b/app-k9mail/src/main/res/values-gd/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">Post</string>
+</resources>

--- a/app-k9mail/src/main/res/values-gl/strings.xml
+++ b/app-k9mail/src/main/res/values-gl/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-hi/strings.xml
+++ b/app-k9mail/src/main/res/values-hi/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">के-9 मेल</string>
+</resources>

--- a/app-k9mail/src/main/res/values-hr/strings.xml
+++ b/app-k9mail/src/main/res/values-hr/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-hu/strings.xml
+++ b/app-k9mail/src/main/res/values-hu/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-hy/strings.xml
+++ b/app-k9mail/src/main/res/values-hy/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Նամակ</string>
+</resources>

--- a/app-k9mail/src/main/res/values-in/strings.xml
+++ b/app-k9mail/src/main/res/values-in/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-is/strings.xml
+++ b/app-k9mail/src/main/res/values-is/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 - Póstur</string>
+</resources>

--- a/app-k9mail/src/main/res/values-it/strings.xml
+++ b/app-k9mail/src/main/res/values-it/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-iw/strings.xml
+++ b/app-k9mail/src/main/res/values-iw/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">דוא\"ל K-9</string>
+</resources>

--- a/app-k9mail/src/main/res/values-ja/strings.xml
+++ b/app-k9mail/src/main/res/values-ja/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-ka/strings.xml
+++ b/app-k9mail/src/main/res/values-ka/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-ko/strings.xml
+++ b/app-k9mail/src/main/res/values-ko/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 메일</string>
+</resources>

--- a/app-k9mail/src/main/res/values-lt/strings.xml
+++ b/app-k9mail/src/main/res/values-lt/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 paštas</string>
+</resources>

--- a/app-k9mail/src/main/res/values-lv/strings.xml
+++ b/app-k9mail/src/main/res/values-lv/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 pasts</string>
+</resources>

--- a/app-k9mail/src/main/res/values-ml/strings.xml
+++ b/app-k9mail/src/main/res/values-ml/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-nb/strings.xml
+++ b/app-k9mail/src/main/res/values-nb/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 e-post</string>
+</resources>

--- a/app-k9mail/src/main/res/values-nl/strings.xml
+++ b/app-k9mail/src/main/res/values-nl/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-nn/strings.xml
+++ b/app-k9mail/src/main/res/values-nn/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 E-post</string>
+</resources>

--- a/app-k9mail/src/main/res/values-pl/strings.xml
+++ b/app-k9mail/src/main/res/values-pl/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-pt-rBR/strings.xml
+++ b/app-k9mail/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-pt-rPT/strings.xml
+++ b/app-k9mail/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-ro/strings.xml
+++ b/app-k9mail/src/main/res/values-ro/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-ru/strings.xml
+++ b/app-k9mail/src/main/res/values-ru/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">Почта K-9</string>
+</resources>

--- a/app-k9mail/src/main/res/values-sk/strings.xml
+++ b/app-k9mail/src/main/res/values-sk/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-sl/strings.xml
+++ b/app-k9mail/src/main/res/values-sl/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">Pošta K-9</string>
+</resources>

--- a/app-k9mail/src/main/res/values-sq/strings.xml
+++ b/app-k9mail/src/main/res/values-sq/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-sr/strings.xml
+++ b/app-k9mail/src/main/res/values-sr/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">К-9 Пошта</string>
+</resources>

--- a/app-k9mail/src/main/res/values-sv/strings.xml
+++ b/app-k9mail/src/main/res/values-sv/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-ta-rIN/strings.xml
+++ b/app-k9mail/src/main/res/values-ta-rIN/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 அஞ்சல்</string>
+</resources>

--- a/app-k9mail/src/main/res/values-tr/strings.xml
+++ b/app-k9mail/src/main/res/values-tr/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Posta</string>
+</resources>

--- a/app-k9mail/src/main/res/values-uk/strings.xml
+++ b/app-k9mail/src/main/res/values-uk/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-vi/strings.xml
+++ b/app-k9mail/src/main/res/values-vi/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">Thư K-9</string>
+</resources>

--- a/app-k9mail/src/main/res/values-zh-rCN/strings.xml
+++ b/app-k9mail/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values-zh-rTW/strings.xml
+++ b/app-k9mail/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">K-9 Mail</string>
+</resources>

--- a/app-k9mail/src/main/res/values/strings.xml
+++ b/app-k9mail/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <!-- Used in AndroidManifest.xml -->
     <string name="app_name">K-9 Mail</string>
 </resources>

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -1,6 +1,7 @@
 package net.thunderbird.android
 
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.theme2.thunderbird.ThunderbirdTheme2
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.unread.UnreadWidgetClassProvider
@@ -10,7 +11,10 @@ import com.fsck.k9.activity.MessageCompose
 import com.fsck.k9.widget.list.MessageListWidgetProvider
 import net.thunderbird.android.auth.ThunderbirdOAuthConfigurationFactory
 import net.thunderbird.android.dev.developmentModuleAdditions
+import net.thunderbird.android.provider.TbAppNameProvider
+import net.thunderbird.android.provider.TbFeatureThemeProvider
 import net.thunderbird.android.widget.provider.UnreadWidgetProvider
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -19,6 +23,7 @@ val appModule = module {
     single(named("ClientIdAppVersion")) { BuildConfig.VERSION_NAME }
     single<AppConfig> { appConfig }
     single<OAuthConfigurationFactory> { ThunderbirdOAuthConfigurationFactory() }
+    single<AppNameProvider> { TbAppNameProvider(androidContext()) }
     single<FeatureThemeProvider> { provideFeatureThemeProvider() }
     single<UnreadWidgetClassProvider> {
         UnreadWidgetClassProvider { UnreadWidgetProvider::class.java }

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -2,7 +2,6 @@ package net.thunderbird.android
 
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
-import app.k9mail.core.ui.compose.theme2.thunderbird.ThunderbirdTheme2
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.unread.UnreadWidgetClassProvider
 import com.fsck.k9.AppConfig
@@ -24,7 +23,7 @@ val appModule = module {
     single<AppConfig> { appConfig }
     single<OAuthConfigurationFactory> { ThunderbirdOAuthConfigurationFactory() }
     single<AppNameProvider> { TbAppNameProvider(androidContext()) }
-    single<FeatureThemeProvider> { provideFeatureThemeProvider() }
+    single<FeatureThemeProvider> { TbFeatureThemeProvider() }
     single<UnreadWidgetClassProvider> {
         UnreadWidgetClassProvider { UnreadWidgetProvider::class.java }
     }
@@ -40,9 +39,3 @@ val appConfig = AppConfig(
         MessageListWidgetProvider::class.java,
     ),
 )
-
-private fun provideFeatureThemeProvider(): FeatureThemeProvider = FeatureThemeProvider { content ->
-    ThunderbirdTheme2 {
-        content()
-    }
-}

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbAppNameProvider.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbAppNameProvider.kt
@@ -1,0 +1,13 @@
+package net.thunderbird.android.provider
+
+import android.content.Context
+import app.k9mail.core.common.provider.AppNameProvider
+import net.thunderbird.android.R
+
+class TbAppNameProvider(
+    context: Context,
+) : AppNameProvider {
+    override val appName: String by lazy {
+        context.getString(R.string.tb_app_name)
+    }
+}

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbFeatureThemeProvider.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbFeatureThemeProvider.kt
@@ -1,0 +1,14 @@
+package net.thunderbird.android.provider
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.theme2.thunderbird.ThunderbirdTheme2
+import app.k9mail.feature.launcher.FeatureLauncherExternalContract
+
+class TbFeatureThemeProvider : FeatureLauncherExternalContract.FeatureThemeProvider {
+    @Composable
+    override fun WithTheme(content: @Composable () -> Unit) {
+        ThunderbirdTheme2 {
+            content()
+        }
+    }
+}

--- a/app/ui/legacy/src/main/res/values-ar/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ar/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">بريد K-9</string>
     <string name="shortcuts_title">حسابات K-9</string>
     <string name="unread_widget_label">رسائل K-9 غير المقروءة</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-az/strings.xml
+++ b/app/ui/legacy/src/main/res/values-az/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 Hesablar</string>
     <string name="unread_widget_label">K-9 Oxunmayan</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-be/strings.xml
+++ b/app/ui/legacy/src/main/res/values-be/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">Пошта K-9</string>
     <string name="shortcuts_title">Акаўнты</string>
     <string name="unread_widget_label">Не прачытана</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bg/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 Профили</string>
     <string name="unread_widget_label">K-9 Непрочетени</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-br/strings.xml
+++ b/app/ui/legacy/src/main/res/values-br/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 Kontoù</string>
     <string name="unread_widget_label">K-9 Anlennet</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-bs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bs/strings.xml
@@ -83,7 +83,6 @@
     <string name="global_settings_show_correspondent_names_summary">Prikaži imena korespodenata umjesto njihove mejl-adrese</string>
     <string name="about_action">O nama</string>
     <string name="prefs_title">Postavke</string>
-    <string name="app_name">K-9 Mail</string>
     <string name="app_authors">K-9 razvojni tim</string>
     <string name="get_help_title">Zatražite pomoć</string>
     <string name="about_project_title">Projekat otvorenog koda</string>

--- a/app/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ca/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Comptes del K-9</string>
     <string name="unread_widget_label">K-9 no llegits</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-co/strings.xml
+++ b/app/ui/legacy/src/main/res/values-co/strings.xml
@@ -46,7 +46,6 @@
     <string name="search_everywhere_action">Ricercà dapertuttu</string>
     <string name="search_results">Risultati di a ricerca</string>
     <string name="new_messages_title">Messaghji novi</string>
-    <string name="app_name">K-9 Mail</string>
     <string name="app_license">Licenza Apache, versione 2.0</string>
     <string name="user_forum_title">Foru di l’utilizatori</string>
     <string name="about_libraries">Bibliuteche</string>

--- a/app/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cs/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Účty K-9</string>
     <string name="unread_widget_label">K-9 Nepřečtená</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-cy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cy/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Cyfrifon K-9</string>
     <string name="unread_widget_label">K-9 Heb eu Darllen</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-da/strings.xml
+++ b/app/ui/legacy/src/main/res/values-da/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 konti</string>
     <string name="unread_widget_label">K-9 ulæst</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-de/strings.xml
+++ b/app/ui/legacy/src/main/res/values-de/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 Konten</string>
     <string name="unread_widget_label">K-9 Ungelesen</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-el/strings.xml
+++ b/app/ui/legacy/src/main/res/values-el/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Λογαριασμοί K-9</string>
     <string name="unread_widget_label">Μη αναγνωσμένα K-9</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
+++ b/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 Accounts</string>
     <string name="unread_widget_label">K-9 Unread</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eo/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Retpoŝtilo</string>
     <string name="shortcuts_title">K-9 kontoj</string>
     <string name="unread_widget_label">K-9 nelegitaj mesaĝoj</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-es/strings.xml
+++ b/app/ui/legacy/src/main/res/values-es/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Cuentas K-9</string>
     <string name="unread_widget_label">Mensaje K-9 no leído</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-et/strings.xml
+++ b/app/ui/legacy/src/main/res/values-et/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 Kontod</string>
     <string name="unread_widget_label">K-9 Lugemata</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eu/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 kontuak</string>
     <string name="unread_widget_label">K-9 Irakurri gabe</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fa/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">نامهٔ کِی۹</string>
     <string name="shortcuts_title">حساب‌های K-9</string>
     <string name="unread_widget_label">نخوانده‌های K-9</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-fi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fi/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9-tilit</string>
     <string name="unread_widget_label">K-9-lukematon</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fr/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">Courriel K-9 Mail</string>
     <string name="shortcuts_title">Comptes K-9</string>
     <string name="unread_widget_label">K-9 non lus</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-fy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fy/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9-accounts</string>
     <string name="unread_widget_label">K-9 Net lêzen</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-gd/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gd/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">Post</string>
     <string name="shortcuts_title">Cunntasan puist</string>
     <string name="unread_widget_label">Post gun leughadh</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-gl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gl/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Contas K-9</string>
     <string name="unread_widget_label">K-9 non lidos</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-hi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hi/strings.xml
@@ -90,7 +90,6 @@
     <string name="search_everywhere_action">हर जगह खोजें</string>
     <string name="send_alternate_action">शेयर करें</string>
     <string name="accounts_title">अकाउंट</string>
-    <string name="app_name">के-9 मेल</string>
     <string name="new_messages_title">नए मैसेज</string>
     <string name="changelog_version_title">वर्ज़न %s</string>
     <string name="status_network_error">कनेक्शन गड़बड़</string>

--- a/app/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hr/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 Računi</string>
     <string name="unread_widget_label">K-9 Nepročitano</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hu/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 fiókok</string>
     <string name="unread_widget_label">K-9 olvasatlan</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-hy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hy/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Նամակ</string>
     <string name="shortcuts_title">Կ֊9 հաշիւներ</string>
     <string name="unread_widget_label">Կ֊9 Չընթերցուած</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-in/strings.xml
+++ b/app/ui/legacy/src/main/res/values-in/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Akun K-9</string>
     <string name="unread_widget_label">K-9 Belum Dibaca</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-is/strings.xml
+++ b/app/ui/legacy/src/main/res/values-is/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 - Póstur</string>
     <string name="shortcuts_title">K-9 - Aðgangar</string>
     <string name="unread_widget_label">K-9 - Ólesið</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-it/strings.xml
+++ b/app/ui/legacy/src/main/res/values-it/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Account di K-9</string>
     <string name="unread_widget_label">K-9 Nuovi messaggi</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/app/ui/legacy/src/main/res/values-iw/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">דוא\"ל K-9</string>
     <string name="shortcuts_title">חשבונות K-9</string>
     <string name="unread_widget_label">K-9 - הודעות שלא נקראו</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ja/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 アカウント</string>
     <string name="unread_widget_label">K-9 未読</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-ka/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ka/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 ანგარიშები</string>
     <string name="unread_widget_label">K-9 წაუკითხავი</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-ko/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ko/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 메일</string>
     <string name="shortcuts_title">K-9 계정</string>
     <string name="unread_widget_label">K-9 읽지 않은 메일</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-lt/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lt/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 paštas</string>
     <string name="shortcuts_title">K-9 paskyros</string>
     <string name="unread_widget_label">K-9 neskaityta</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lv/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 pasts</string>
     <string name="shortcuts_title">K-9 konti</string>
     <string name="unread_widget_label">K-9 nelasītie</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-ml/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ml/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">കെ-9 അക്കൗണ്ടുകൾ</string>
     <string name="unread_widget_label">കെ-9 വായിക്കാത്തവ</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-nb/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nb/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 e-post</string>
     <string name="shortcuts_title">K-9 Konti</string>
     <string name="unread_widget_label">K-9 Ulest</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nl/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 Accounts</string>
     <string name="unread_widget_label">K-9 Ongelezen</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-nn/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nn/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 E-post</string>
     <string name="shortcuts_title">K-9 Kontoar</string>
     <string name="unread_widget_label">K-9 Ulesne</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pl/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Konta K-9</string>
     <string name="unread_widget_label">Nieprzeczytane K-9</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Contas K-9</string>
     <string name="unread_widget_label">K9 - Não lidos</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Contas K-9</string>
     <string name="unread_widget_label">K-9 Não lido</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ro/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Conturi K-9</string>
     <string name="unread_widget_label">K-9 Necitite</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ru/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">Почта K-9</string>
     <string name="shortcuts_title">Учётные записи K-9</string>
     <string name="unread_widget_label">Не прочитано</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-sk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sk/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 Účty</string>
     <string name="unread_widget_label">K-9 Neprečítaná</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sl/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">Pošta K-9</string>
     <string name="shortcuts_title">Računi K-9</string>
     <string name="unread_widget_label">Neprebrano K-9</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sq/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Llogari K-9</string>
     <string name="unread_widget_label">Të palexuar K-9</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sr/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">К-9 Пошта</string>
     <string name="shortcuts_title">К-9 налози</string>
     <string name="unread_widget_label">К-9 непрочитане</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sv/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9-konton</string>
     <string name="unread_widget_label">K-9 olästa</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-ta-rIN/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ta-rIN/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 அஞ்சல்</string>
     <string name="shortcuts_title">K-9 கணக்குகள்</string>
     <string name="unread_widget_label">K-9 புதியவை</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-tr/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Posta</string>
     <string name="shortcuts_title">K-9 Hesaplar</string>
     <string name="unread_widget_label">K-9 Okunmamış</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-uk/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">Облікові записи K-9 Mail</string>
     <string name="unread_widget_label">K-9 Непрочитані</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-vi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-vi/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">Thư K-9</string>
     <string name="shortcuts_title">Tài khoản K-9</string>
     <string name="unread_widget_label">K-9 Chưa đọc</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 账号</string>
     <string name="unread_widget_label">K-9 未读</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="app_name">K-9 Mail</string>
     <string name="shortcuts_title">K-9 帳號</string>
     <string name="unread_widget_label">K-9 未讀</string>
     <!--Used in the about dialog-->

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -4,12 +4,8 @@
 
     <!-- This should make it easier for forks to change the branding -->
 
-    <!-- Used in AndroidManifest.xml -->
-    <string name="app_name">K-9 Mail</string>
-
     <string name="shortcuts_title">K-9 Accounts</string>
     <string name="unread_widget_label">K-9 Unread</string>
-
 
     <!-- Used in the about dialog -->
     <string name="app_authors">The K-9 Dog Walkers</string>

--- a/core/common/src/main/kotlin/app/k9mail/core/common/provider/AppNameProvider.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/provider/AppNameProvider.kt
@@ -1,0 +1,8 @@
+package app.k9mail.core.common.provider
+
+/**
+ * Provides the application name.
+ */
+interface AppNameProvider {
+    val appName: String
+}


### PR DESCRIPTION
This implements the app name providerfor K-9 Mail and Thunderbird for Android, see #7924.

The follow-up pull-request will set this in use.

Tasks once reviewed:

- [x] Lock Weblate
- [x] Pull latest translations from weblate, check if moved resources are affected and update this branch
- [ ] After Merge update weblate to pickup the new module
- [ ] Unlock Weblate