### PR TITLE
Refactor `SettingsImporter` [5/x]

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
@@ -1,12 +1,37 @@
 package com.fsck.k9.preferences
 
 internal class AccountSettingsUpgrader {
+    private val identitySettingsUpgrader = IdentitySettingsUpgrader()
+    private val folderSettingsUpgrader = FolderSettingsUpgrader()
+
     fun upgrade(contentVersion: Int, account: ValidatedSettings.Account): ValidatedSettings.Account {
         val validatedSettings = account.settings.toMutableMap()
         if (contentVersion != Settings.VERSION) {
             AccountSettingsDescriptions.upgrade(contentVersion, validatedSettings)
         }
 
-        return account.copy(settings = validatedSettings.toMap())
+        return account.copy(
+            settings = validatedSettings.toMap(),
+            identities = upgradeIdentities(contentVersion, account.identities),
+            folders = upgradeFolders(contentVersion, account.folders),
+        )
+    }
+
+    private fun upgradeIdentities(
+        contentVersion: Int,
+        identities: List<ValidatedSettings.Identity>,
+    ): List<ValidatedSettings.Identity> {
+        return identities.map { identity ->
+            identitySettingsUpgrader.upgrade(contentVersion, identity)
+        }
+    }
+
+    private fun upgradeFolders(
+        contentVersion: Int,
+        folders: List<ValidatedSettings.Folder>,
+    ): List<ValidatedSettings.Folder> {
+        return folders.map { folder ->
+            folderSettingsUpgrader.upgrade(contentVersion, folder)
+        }
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
@@ -1,0 +1,12 @@
+package com.fsck.k9.preferences
+
+internal class AccountSettingsUpgrader {
+    fun upgrade(contentVersion: Int, account: ValidatedSettings.Account): ValidatedSettings.Account {
+        val validatedSettings = account.settings.toMutableMap()
+        if (contentVersion != Settings.VERSION) {
+            AccountSettingsDescriptions.upgrade(contentVersion, validatedSettings)
+        }
+
+        return account.copy(settings = validatedSettings.toMap())
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsValidator.kt
@@ -1,0 +1,13 @@
+package com.fsck.k9.preferences
+
+internal class AccountSettingsValidator {
+    fun validate(contentVersion: Int, account: SettingsFile.Account): ValidatedSettings.Account {
+        val validatedSettings = AccountSettingsDescriptions.validate(contentVersion, account.settings!!, true)
+
+        return ValidatedSettings.Account(
+            uuid = account.uuid,
+            name = account.name,
+            settings = validatedSettings,
+        )
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsValidator.kt
@@ -1,13 +1,51 @@
 package com.fsck.k9.preferences
 
+import com.fsck.k9.preferences.ServerTypeConverter.toServerSettingsType
+import com.fsck.k9.preferences.Settings.InvalidSettingValueException
+
 internal class AccountSettingsValidator {
     fun validate(contentVersion: Int, account: SettingsFile.Account): ValidatedSettings.Account {
         val validatedSettings = AccountSettingsDescriptions.validate(contentVersion, account.settings!!, true)
 
+        val incomingServer = validateIncomingServer(account.incoming)
+        val outgoingServer = validateOutgoingServer(account.outgoing)
+
         return ValidatedSettings.Account(
             uuid = account.uuid,
             name = account.name,
+            incoming = incomingServer,
+            outgoing = outgoingServer,
             settings = validatedSettings,
+        )
+    }
+
+    private fun validateIncomingServer(incoming: SettingsFile.Server?): ValidatedSettings.Server {
+        if (incoming == null) {
+            throw InvalidSettingValueException("Missing incoming server settings")
+        }
+
+        return validateServerSettings(incoming)
+    }
+
+    private fun validateOutgoingServer(outgoing: SettingsFile.Server?): ValidatedSettings.Server {
+        if (outgoing == null) {
+            throw InvalidSettingValueException("Missing outgoing server settings")
+        }
+
+        return validateServerSettings(outgoing)
+    }
+
+    private fun validateServerSettings(server: SettingsFile.Server): ValidatedSettings.Server {
+        return ValidatedSettings.Server(
+            type = toServerSettingsType(server.type!!),
+            host = server.host,
+            port = server.port?.toIntOrNull() ?: -1,
+            connectionSecurity = server.connectionSecurity!!,
+            authenticationType = server.authenticationType!!,
+            username = server.username!!,
+            password = server.password,
+            clientCertificateAlias = server.clientCertificateAlias,
+            extras = server.extras.orEmpty(),
         )
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
@@ -17,6 +17,9 @@ internal class AccountSettingsWriter(
     private val clock: Clock,
     private val serverSettingsSerializer: ServerSettingsSerializer,
 ) {
+    private val identitySettingsWriter = IdentitySettingsWriter()
+    private val folderSettingsWriter = FolderSettingsWriter()
+
     fun write(editor: StorageEditor, account: ValidatedSettings.Account): Pair<AccountDescription, AccountDescription> {
         val originalAccountName = account.name!!
         val originalAccountUuid = account.uuid
@@ -50,7 +53,26 @@ internal class AccountSettingsWriter(
         writeServerSettings(editor, key = "$accountUuid.$INCOMING_SERVER_SETTINGS_KEY", server = account.incoming)
         writeServerSettings(editor, key = "$accountUuid.$OUTGOING_SERVER_SETTINGS_KEY", server = account.outgoing)
 
+        writeIdentities(editor, accountUuid, account.identities)
+        writeFolders(editor, accountUuid, account.folders)
+
         return originalAccount to writtenAccount
+    }
+
+    private fun writeIdentities(
+        editor: StorageEditor,
+        accountUuid: String,
+        identities: List<ValidatedSettings.Identity>,
+    ) {
+        for ((index, identity) in identities.withIndex()) {
+            identitySettingsWriter.write(editor, accountUuid, index, identity)
+        }
+    }
+
+    private fun writeFolders(editor: StorageEditor, accountUuid: String, folders: List<ValidatedSettings.Folder>) {
+        for (folder in folders) {
+            folderSettingsWriter.write(editor, accountUuid, folder)
+        }
     }
 
     private fun getUniqueAccountUuid(accountUuid: String): String {

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
@@ -1,0 +1,77 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.Account
+import com.fsck.k9.AccountPreferenceSerializer.Companion.ACCOUNT_DESCRIPTION_KEY
+import com.fsck.k9.Preferences
+import java.util.UUID
+import kotlinx.datetime.Clock
+
+internal class AccountSettingsWriter(
+    private val preferences: Preferences,
+    private val clock: Clock,
+) {
+    fun write(editor: StorageEditor, account: ValidatedSettings.Account): Pair<AccountDescription, AccountDescription> {
+        val originalAccountName = account.name!!
+        val originalAccountUuid = account.uuid
+        val originalAccount = AccountDescription(originalAccountName, originalAccountUuid)
+
+        val accountUuid = getUniqueAccountUuid(originalAccountUuid)
+        val accountName = getUniqueAccountName(originalAccountName)
+        val writtenAccount = AccountDescription(accountName, accountUuid)
+
+        editor.putStringWithLogging("$accountUuid.$ACCOUNT_DESCRIPTION_KEY", accountName)
+
+        // Convert account settings to the string representation used in preference storage
+        val stringSettings = AccountSettingsDescriptions.convert(account.settings)
+
+        for ((accountKey, value) in stringSettings) {
+            editor.putStringWithLogging("$accountUuid.$accountKey", value)
+        }
+
+        val newAccountNumber = preferences.generateAccountNumber().toString()
+        editor.putStringWithLogging("$accountUuid.accountNumber", newAccountNumber)
+
+        // When deleting an account and then restoring it using settings import, the same account UUID will be used.
+        // To avoid reusing a previously existing notification channel ID, we need to make sure to use a unique value
+        // for `messagesNotificationChannelVersion`.
+        val messageNotificationChannelVersion = clock.now().epochSeconds.toString()
+        editor.putStringWithLogging(
+            key = "$accountUuid.messagesNotificationChannelVersion",
+            value = messageNotificationChannelVersion,
+        )
+
+        return originalAccount to writtenAccount
+    }
+
+    private fun getUniqueAccountUuid(accountUuid: String): String {
+        val existingAccount = preferences.getAccount(accountUuid)
+        return if (existingAccount != null) {
+            // An account with this UUID already exists. So generate a new UUID.
+            UUID.randomUUID().toString()
+        } else {
+            accountUuid
+        }
+    }
+
+    private fun getUniqueAccountName(accountName: String): String {
+        val accounts = preferences.getAccounts()
+        if (!isAccountNameUsed(accountName, accounts)) {
+            return accountName
+        }
+
+        // Account name is already in use. So generate a new one by appending " (x)", where x is the first
+        // number >= 1 that results in an unused account name.
+        for (i in 1..accounts.size) {
+            val newAccountName = "$accountName ($i)"
+            if (!isAccountNameUsed(newAccountName, accounts)) {
+                return newAccountName
+            }
+        }
+
+        error("Unexpected exit")
+    }
+
+    private fun isAccountNameUsed(name: String?, accounts: List<Account>): Boolean {
+        return accounts.any { it.displayName == name }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
@@ -2,13 +2,20 @@ package com.fsck.k9.preferences
 
 import com.fsck.k9.Account
 import com.fsck.k9.AccountPreferenceSerializer.Companion.ACCOUNT_DESCRIPTION_KEY
+import com.fsck.k9.AccountPreferenceSerializer.Companion.INCOMING_SERVER_SETTINGS_KEY
+import com.fsck.k9.AccountPreferenceSerializer.Companion.OUTGOING_SERVER_SETTINGS_KEY
 import com.fsck.k9.Preferences
+import com.fsck.k9.ServerSettingsSerializer
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
 import java.util.UUID
 import kotlinx.datetime.Clock
 
 internal class AccountSettingsWriter(
     private val preferences: Preferences,
     private val clock: Clock,
+    private val serverSettingsSerializer: ServerSettingsSerializer,
 ) {
     fun write(editor: StorageEditor, account: ValidatedSettings.Account): Pair<AccountDescription, AccountDescription> {
         val originalAccountName = account.name!!
@@ -39,6 +46,9 @@ internal class AccountSettingsWriter(
             key = "$accountUuid.messagesNotificationChannelVersion",
             value = messageNotificationChannelVersion,
         )
+
+        writeServerSettings(editor, key = "$accountUuid.$INCOMING_SERVER_SETTINGS_KEY", server = account.incoming)
+        writeServerSettings(editor, key = "$accountUuid.$OUTGOING_SERVER_SETTINGS_KEY", server = account.outgoing)
 
         return originalAccount to writtenAccount
     }
@@ -73,5 +83,48 @@ internal class AccountSettingsWriter(
 
     private fun isAccountNameUsed(name: String?, accounts: List<Account>): Boolean {
         return accounts.any { it.displayName == name }
+    }
+
+    private fun writeServerSettings(
+        editor: StorageEditor,
+        key: String,
+        server: ValidatedSettings.Server,
+    ) {
+        val serverSettings = createServerSettings(server)
+        val serverSettingsJson = serverSettingsSerializer.serialize(serverSettings)
+        editor.putStringWithLogging(key, serverSettingsJson)
+    }
+
+    private fun createServerSettings(server: ValidatedSettings.Server): ServerSettings {
+        val connectionSecurity = convertConnectionSecurity(server.connectionSecurity)
+        val authenticationType = AuthType.valueOf(server.authenticationType)
+        val password = if (authenticationType == AuthType.XOAUTH2) "" else server.password
+
+        return ServerSettings(
+            server.type,
+            server.host,
+            server.port,
+            connectionSecurity,
+            authenticationType,
+            server.username,
+            password,
+            server.clientCertificateAlias,
+            server.extras,
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun convertConnectionSecurity(connectionSecurity: String): ConnectionSecurity {
+        return try {
+            // TODO: Add proper settings validation and upgrade capability for server settings. Once that exists, move
+            //  this code into a SettingsUpgrader.
+            when (connectionSecurity) {
+                "SSL_TLS_OPTIONAL" -> ConnectionSecurity.SSL_TLS_REQUIRED
+                "STARTTLS_OPTIONAL" -> ConnectionSecurity.STARTTLS_REQUIRED
+                else -> ConnectionSecurity.valueOf(connectionSecurity)
+            }
+        } catch (e: Exception) {
+            ConnectionSecurity.SSL_TLS_REQUIRED
+        }
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/FolderSettingsUpgrader.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/FolderSettingsUpgrader.kt
@@ -1,0 +1,12 @@
+package com.fsck.k9.preferences
+
+internal class FolderSettingsUpgrader {
+    fun upgrade(contentVersion: Int, folder: ValidatedSettings.Folder): ValidatedSettings.Folder {
+        val settings = folder.settings.toMutableMap()
+        if (contentVersion != Settings.VERSION) {
+            FolderSettingsDescriptions.upgrade(contentVersion, settings)
+        }
+
+        return folder.copy(settings = settings.toMap())
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/FolderSettingsValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/FolderSettingsValidator.kt
@@ -1,0 +1,15 @@
+package com.fsck.k9.preferences
+
+internal class FolderSettingsValidator {
+    fun validate(contentVersion: Int, folder: SettingsFile.Folder): ValidatedSettings.Folder {
+        val settings = folder.settings!!
+        val folderName = folder.name!!
+
+        val validatedSettings = FolderSettingsDescriptions.validate(contentVersion, settings, true)
+
+        return ValidatedSettings.Folder(
+            name = folderName,
+            settings = validatedSettings,
+        )
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/FolderSettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/FolderSettingsWriter.kt
@@ -1,0 +1,15 @@
+package com.fsck.k9.preferences
+
+internal class FolderSettingsWriter {
+    fun write(editor: StorageEditor, accountUuid: String, folder: ValidatedSettings.Folder) {
+        // Convert folder settings to the string representation used in preference storage
+        val stringSettings = FolderSettingsDescriptions.convert(folder.settings)
+
+        // Write folder settings
+        val prefix = "$accountUuid.${folder.name}."
+        for ((folderKey, value) in stringSettings) {
+            val key = prefix + folderKey
+            editor.putStringWithLogging(key, value)
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsUpgrader.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsUpgrader.kt
@@ -1,0 +1,12 @@
+package com.fsck.k9.preferences
+
+internal class GeneralSettingsUpgrader {
+    fun upgrade(contentVersion: Int, internalSettings: InternalSettingsMap): InternalSettingsMap {
+        val settings = internalSettings.toMutableMap()
+        if (contentVersion != Settings.VERSION) {
+            GeneralSettingsDescriptions.upgrade(contentVersion, settings)
+        }
+
+        return settings.toMap()
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsValidator.kt
@@ -1,7 +1,5 @@
 package com.fsck.k9.preferences
 
-internal typealias InternalSettingsMap = Map<String, Any>
-
 internal class GeneralSettingsValidator {
     fun validate(contentVersion: Int, settings: SettingsMap): InternalSettingsMap {
         return GeneralSettingsDescriptions.validate(contentVersion, settings)

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsValidator.kt
@@ -1,0 +1,9 @@
+package com.fsck.k9.preferences
+
+internal typealias InternalSettingsMap = Map<String, Any>
+
+internal class GeneralSettingsValidator {
+    fun validate(contentVersion: Int, settings: SettingsMap): InternalSettingsMap {
+        return GeneralSettingsDescriptions.validate(contentVersion, settings)
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsWriter.kt
@@ -1,0 +1,54 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.AccountPreferenceSerializer
+import com.fsck.k9.K9
+import com.fsck.k9.Preferences
+import timber.log.Timber
+
+internal class GeneralSettingsWriter(
+    private val preferences: Preferences,
+) {
+    fun write(settings: InternalSettingsMap): Boolean {
+        // Convert general settings to the string representation used in preference storage
+        val stringSettings = GeneralSettingsDescriptions.convert(settings)
+
+        val editor = preferences.createStorageEditor()
+
+        // Use current general settings as base and overwrite with validated settings read from the import file.
+        val mergedSettings = GeneralSettingsDescriptions.getGlobalSettings(preferences.storage).toMutableMap()
+        mergedSettings.putAll(stringSettings)
+
+        for ((key, value) in mergedSettings) {
+            editor.putStringWithLogging(key, value)
+        }
+
+        return if (editor.commit()) {
+            Timber.v("Committed general settings to the preference storage.")
+            true
+        } else {
+            Timber.v("Failed to commit general settings to the preference storage")
+            false
+        }
+    }
+}
+
+/**
+ * Write to a [StorageEditor] while logging what is written if debug logging is enabled.
+ */
+internal fun StorageEditor.putStringWithLogging(key: String, value: String?) {
+    if (K9.isDebugLoggingEnabled) {
+        var outputValue = value
+        if (!K9.isSensitiveDebugLoggingEnabled &&
+            (
+                key.endsWith("." + AccountPreferenceSerializer.OUTGOING_SERVER_SETTINGS_KEY) ||
+                    key.endsWith("." + AccountPreferenceSerializer.INCOMING_SERVER_SETTINGS_KEY)
+                )
+        ) {
+            outputValue = "*sensitive*"
+        }
+
+        Timber.v("Setting %s=%s", key, outputValue)
+    }
+
+    putString(key, value)
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsWriter.kt
@@ -7,6 +7,7 @@ import timber.log.Timber
 
 internal class GeneralSettingsWriter(
     private val preferences: Preferences,
+    private val generalSettingsManager: RealGeneralSettingsManager,
 ) {
     fun write(settings: InternalSettingsMap): Boolean {
         // Convert general settings to the string representation used in preference storage
@@ -24,6 +25,9 @@ internal class GeneralSettingsWriter(
 
         return if (editor.commit()) {
             Timber.v("Committed general settings to the preference storage.")
+
+            generalSettingsManager.loadSettings()
+
             true
         } else {
             Timber.v("Failed to commit general settings to the preference storage")

--- a/app/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
@@ -94,6 +94,11 @@ class IdentitySettingsDescriptions {
         public String fromString(String value) throws InvalidSettingValueException {
             return value;
         }
+
+        @Override
+        public String toString(String value) {
+            return value;
+        }
     }
 
     private static class OptionalEmailAddressSetting extends SettingsDescription<String> {

--- a/app/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsUpgrader.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsUpgrader.kt
@@ -1,0 +1,14 @@
+package com.fsck.k9.preferences
+
+internal class IdentitySettingsUpgrader {
+    fun upgrade(contentVersion: Int, identity: ValidatedSettings.Identity): ValidatedSettings.Identity {
+        val settings = identity.settings.toMutableMap()
+
+        // Upgrade identity settings to current content version
+        if (contentVersion != Settings.VERSION) {
+            IdentitySettingsDescriptions.upgrade(contentVersion, settings)
+        }
+
+        return identity.copy(settings = settings.toMap())
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsValidator.kt
@@ -1,0 +1,24 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.preferences.Settings.InvalidSettingValueException
+
+internal class IdentitySettingsValidator {
+    fun validate(contentVersion: Int, identity: SettingsFile.Identity): ValidatedSettings.Identity {
+        if (!IdentitySettingsDescriptions.isEmailAddressValid(identity.email)) {
+            throw InvalidSettingValueException("Invalid email address: " + identity.email)
+        }
+
+        val validatedSettings = IdentitySettingsDescriptions.validate(
+            contentVersion,
+            identity.settings.orEmpty(),
+            true,
+        )
+
+        return ValidatedSettings.Identity(
+            name = identity.name.orEmpty(),
+            email = identity.email!!,
+            description = identity.description,
+            settings = validatedSettings,
+        )
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsWriter.kt
@@ -1,0 +1,21 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.AccountPreferenceSerializer.Companion.IDENTITY_DESCRIPTION_KEY
+import com.fsck.k9.AccountPreferenceSerializer.Companion.IDENTITY_EMAIL_KEY
+import com.fsck.k9.AccountPreferenceSerializer.Companion.IDENTITY_NAME_KEY
+
+internal class IdentitySettingsWriter {
+    fun write(editor: StorageEditor, accountUuid: String, index: Int, identity: ValidatedSettings.Identity) {
+        editor.putStringWithLogging("$accountUuid.$IDENTITY_NAME_KEY.$index", identity.name)
+        editor.putStringWithLogging("$accountUuid.$IDENTITY_EMAIL_KEY.$index", identity.email)
+        editor.putStringWithLogging("$accountUuid.$IDENTITY_DESCRIPTION_KEY.$index", identity.description)
+
+        // Convert identity settings to the representation used in preference storage
+        val stringSettings = IdentitySettingsDescriptions.convert(identity.settings)
+
+        for ((identityKey, value) in stringSettings) {
+            val key = "$accountUuid.$identityKey.$index"
+            editor.putStringWithLogging(key, value)
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
@@ -25,15 +25,32 @@ val preferencesModule = module {
     } bind GeneralSettingsManager::class
 
     factory { SettingsFileParser() }
+
+    factory { GeneralSettingsValidator() }
+    factory { GeneralSettingsUpgrader() }
+    factory { GeneralSettingsWriter(preferences = get(), generalSettingsManager = get()) }
+
+    factory { AccountSettingsValidator() }
+    factory { AccountSettingsUpgrader() }
+    factory {
+        AccountSettingsWriter(
+            preferences = get(),
+            localFoldersCreator = get(),
+            clock = get(),
+            serverSettingsSerializer = get(),
+            context = get(),
+        )
+    }
+
     factory {
         SettingsImporter(
             settingsFileParser = get(),
-            preferences = get(),
-            generalSettingsManager = get(),
-            localFoldersCreator = get(),
-            serverSettingsSerializer = get(),
-            clock = get(),
-            context = get(),
+            generalSettingsValidator = get(),
+            accountSettingsValidator = get(),
+            generalSettingsUpgrader = get(),
+            accountSettingsUpgrader = get(),
+            generalSettingsWriter = get(),
+            accountSettingsWriter = get(),
         )
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsFile.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsFile.kt
@@ -1,7 +1,5 @@
 package com.fsck.k9.preferences
 
-import com.fsck.k9.mail.AuthType
-
 internal typealias SettingsMap = Map<String, String>
 
 internal interface SettingsFile {
@@ -26,7 +24,7 @@ internal interface SettingsFile {
         val host: String?,
         val port: String?,
         val connectionSecurity: String?,
-        val authenticationType: AuthType?,
+        val authenticationType: String?,
         val username: String?,
         val password: String?,
         val clientCertificateAlias: String?,

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsFileParser.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsFileParser.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9.preferences
 
-import com.fsck.k9.mail.AuthType
 import com.fsck.k9.preferences.SettingsFile.Account
 import com.fsck.k9.preferences.SettingsFile.Contents
 import com.fsck.k9.preferences.SettingsFile.Folder
@@ -238,7 +237,7 @@ private class XmlSettingsParser(
         var host: String? = null
         var port: String? = null
         var connectionSecurity: String? = null
-        var authenticationType: AuthType? = null
+        var authenticationType: String? = null
         var username: String? = null
         var password: String? = null
         var clientCertificateAlias: String? = null
@@ -259,8 +258,7 @@ private class XmlSettingsParser(
                         connectionSecurity = readText()
                     }
                     SettingsExporter.AUTHENTICATION_TYPE_ELEMENT -> {
-                        val text = readText()
-                        authenticationType = AuthType.valueOf(text)
+                        authenticationType = readText()
                     }
                     SettingsExporter.USERNAME_ELEMENT -> {
                         username = readText()

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -36,7 +36,7 @@ class SettingsImporter internal constructor(
     private val generalSettingsUpgrader = GeneralSettingsUpgrader()
     private val accountSettingsUpgrader = AccountSettingsUpgrader()
 
-    private val generalSettingsWriter = GeneralSettingsWriter(preferences)
+    private val generalSettingsWriter = GeneralSettingsWriter(preferences, generalSettingsManager)
     private val accountSettingsWriter = AccountSettingsWriter(
         preferences,
         localFoldersCreator,
@@ -124,8 +124,6 @@ class SettingsImporter internal constructor(
                     erroneousAccounts.add(AccountDescription(account.name!!, account.uuid))
                 }
             }
-
-            generalSettingsManager.loadSettings()
 
             return ImportResults(globalSettingsImported, importedAccounts, erroneousAccounts)
         } catch (e: SettingsImportExportException) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -41,6 +41,7 @@ class SettingsImporter internal constructor(
     private val generalSettingsValidator = GeneralSettingsValidator()
     private val folderSettingsValidator = FolderSettingsValidator()
     private val identitySettingsValidator = IdentitySettingsValidator()
+    private val accountSettingsValidator = AccountSettingsValidator()
 
     private val generalSettingsUpgrader = GeneralSettingsUpgrader()
     private val folderSettingsUpgrader = FolderSettingsUpgrader()
@@ -311,9 +312,8 @@ class SettingsImporter internal constructor(
             editor.putBoolean(accountKeyPrefix + "enabled", false)
         }
 
-        // Validate account settings
-        val validatedSettings =
-            AccountSettingsDescriptions.validate(contentVersion, account.settings!!, true)
+        val validatedAccount = accountSettingsValidator.validate(contentVersion, account)
+        val validatedSettings = validatedAccount.settings.toMutableMap()
 
         // Upgrade account settings to current content version
         if (contentVersion != Settings.VERSION) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -46,6 +46,7 @@ class SettingsImporter internal constructor(
     private val generalSettingsUpgrader = GeneralSettingsUpgrader()
     private val folderSettingsUpgrader = FolderSettingsUpgrader()
     private val identitySettingsUpgrader = IdentitySettingsUpgrader()
+    private val accountSettingsUpgrader = AccountSettingsUpgrader()
 
     private val generalSettingsWriter = GeneralSettingsWriter(preferences)
     private val folderSettingsWriter = FolderSettingsWriter()
@@ -313,15 +314,11 @@ class SettingsImporter internal constructor(
         }
 
         val validatedAccount = accountSettingsValidator.validate(contentVersion, account)
-        val validatedSettings = validatedAccount.settings.toMutableMap()
 
-        // Upgrade account settings to current content version
-        if (contentVersion != Settings.VERSION) {
-            AccountSettingsDescriptions.upgrade(contentVersion, validatedSettings)
-        }
+        val currentAccount = accountSettingsUpgrader.upgrade(contentVersion, validatedAccount)
 
         // Convert account settings to the string representation used in preference storage
-        val stringSettings = AccountSettingsDescriptions.convert(validatedSettings)
+        val stringSettings = AccountSettingsDescriptions.convert(currentAccount.settings)
 
         // Write account settings
         for ((accountKey, value) in stringSettings) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -39,8 +39,6 @@ class SettingsImporter internal constructor(
     private val accountSettingsUpgrader = AccountSettingsUpgrader()
 
     private val generalSettingsWriter = GeneralSettingsWriter(preferences)
-    private val folderSettingsWriter = FolderSettingsWriter()
-    private val identitySettingsWriter = IdentitySettingsWriter()
     private val accountSettingsWriter = AccountSettingsWriter(preferences, clock, serverSettingsSerializer)
 
     /**
@@ -253,16 +251,6 @@ class SettingsImporter internal constructor(
 
         authorizationNeeded = authorizationNeeded || outgoing.authenticationType == "XOAUTH2"
 
-        val uuid = accountMapping.second.uuid
-
-        // Write identities
-        importIdentities(editor, uuid, currentAccount.identities)
-
-        // Write folder settings
-        for (folder in currentAccount.folders) {
-            importFolder(editor, uuid, folder)
-        }
-
         return AccountDescriptionPair(
             accountMapping.first,
             accountMapping.second,
@@ -272,35 +260,6 @@ class SettingsImporter internal constructor(
             incomingServerName!!,
             outgoingServerName!!,
         )
-    }
-
-    private fun importFolder(
-        editor: StorageEditor,
-        uuid: String,
-        folder: ValidatedSettings.Folder,
-    ) {
-        folderSettingsWriter.write(editor, uuid, folder)
-    }
-
-    @Throws(InvalidSettingValueException::class)
-    private fun importIdentities(
-        editor: StorageEditor,
-        uuid: String,
-        identities: List<ValidatedSettings.Identity>,
-    ) {
-        // Write identities
-        for ((index, identity) in identities.withIndex()) {
-            importIdentity(editor, uuid, index, identity)
-        }
-    }
-
-    private fun importIdentity(
-        editor: StorageEditor,
-        accountUuid: String,
-        index: Int,
-        identity: ValidatedSettings.Identity,
-    ) {
-        identitySettingsWriter.write(editor, accountUuid, index, identity)
     }
 
     /**

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -38,6 +38,8 @@ class SettingsImporter internal constructor(
     private val clock: Clock,
     private val context: Context,
 ) {
+    private val generalSettingsValidator = GeneralSettingsValidator()
+
     /**
      * Parses an import [InputStream] and returns information on whether it contains global settings and/or account
      * settings. For all account configurations found, the name of the account along with the account UUID is returned.
@@ -227,8 +229,7 @@ class SettingsImporter internal constructor(
         contentVersion: Int,
         settings: SettingsMap,
     ) {
-        // Validate global settings
-        val validatedSettings = GeneralSettingsDescriptions.validate(contentVersion, settings)
+        val validatedSettings = generalSettingsValidator.validate(contentVersion, settings).toMutableMap()
 
         // Upgrade global settings to current content version
         if (contentVersion != Settings.VERSION) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -45,6 +45,7 @@ class SettingsImporter internal constructor(
     private val folderSettingsUpgrader = FolderSettingsUpgrader()
 
     private val generalSettingsWriter = GeneralSettingsWriter(preferences)
+    private val folderSettingsWriter = FolderSettingsWriter()
 
     /**
      * Parses an import [InputStream] and returns information on whether it contains global settings and/or account
@@ -372,15 +373,7 @@ class SettingsImporter internal constructor(
 
         val currentFolder = folderSettingsUpgrader.upgrade(contentVersion, validatedFolder)
 
-        // Convert folder settings to the string representation used in preference storage
-        val stringSettings = FolderSettingsDescriptions.convert(currentFolder.settings)
-
-        // Write folder settings
-        val prefix = uuid + "." + currentFolder.name + "."
-        for ((folderKey, value) in stringSettings) {
-            val key = prefix + folderKey
-            putString(editor, key, value)
-        }
+        folderSettingsWriter.write(editor, uuid, currentFolder)
     }
 
     @Throws(InvalidSettingValueException::class)

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -515,7 +515,8 @@ class SettingsImporter internal constructor(
         val type = toServerSettingsType(importedServer.type!!)
         val port = convertPort(importedServer.port)
         val connectionSecurity = convertConnectionSecurity(importedServer.connectionSecurity)
-        val password = if (importedServer.authenticationType == AuthType.XOAUTH2) "" else importedServer.password
+        val authenticationType = convertAuthenticationType(importedServer.authenticationType)
+        val password = if (authenticationType == AuthType.XOAUTH2) "" else importedServer.password
         val extra = importedServer.extras.orEmpty()
 
         return ServerSettings(
@@ -523,7 +524,7 @@ class SettingsImporter internal constructor(
             importedServer.host,
             port,
             connectionSecurity,
-            importedServer.authenticationType!!,
+            authenticationType,
             importedServer.username!!,
             password,
             importedServer.clientCertificateAlias,
@@ -548,5 +549,9 @@ class SettingsImporter internal constructor(
         } catch (e: Exception) {
             return ConnectionSecurity.SSL_TLS_REQUIRED
         }
+    }
+
+    private fun convertAuthenticationType(authenticationType: String?): AuthType {
+        return AuthType.valueOf(authenticationType!!)
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -1,50 +1,19 @@
 package com.fsck.k9.preferences
 
-import android.content.Context
-import com.fsck.k9.Preferences
-import com.fsck.k9.ServerSettingsSerializer
 import com.fsck.k9.helper.mapCollectionToSet
-import com.fsck.k9.mailstore.SpecialLocalFoldersCreator
 import com.fsck.k9.preferences.Settings.InvalidSettingValueException
 import java.io.InputStream
-import kotlinx.datetime.Clock
 import timber.log.Timber
 
-// TODO: Further refactor this class to be able to get rid of these detekt issues.
-@Suppress(
-    "LongMethod",
-    "CyclomaticComplexMethod",
-    "NestedBlockDepth",
-    "TooManyFunctions",
-    "TooGenericExceptionCaught",
-    "SwallowedException",
-    "ReturnCount",
-    "ThrowsCount",
-)
 class SettingsImporter internal constructor(
     private val settingsFileParser: SettingsFileParser,
-    private val preferences: Preferences,
-    private val generalSettingsManager: RealGeneralSettingsManager,
-    private val localFoldersCreator: SpecialLocalFoldersCreator,
-    private val serverSettingsSerializer: ServerSettingsSerializer,
-    private val clock: Clock,
-    private val context: Context,
+    private val generalSettingsValidator: GeneralSettingsValidator,
+    private val accountSettingsValidator: AccountSettingsValidator,
+    private val generalSettingsUpgrader: GeneralSettingsUpgrader,
+    private val accountSettingsUpgrader: AccountSettingsUpgrader,
+    private val generalSettingsWriter: GeneralSettingsWriter,
+    private val accountSettingsWriter: AccountSettingsWriter,
 ) {
-    private val generalSettingsValidator = GeneralSettingsValidator()
-    private val accountSettingsValidator = AccountSettingsValidator()
-
-    private val generalSettingsUpgrader = GeneralSettingsUpgrader()
-    private val accountSettingsUpgrader = AccountSettingsUpgrader()
-
-    private val generalSettingsWriter = GeneralSettingsWriter(preferences, generalSettingsManager)
-    private val accountSettingsWriter = AccountSettingsWriter(
-        preferences,
-        localFoldersCreator,
-        clock,
-        serverSettingsSerializer,
-        context,
-    )
-
     /**
      * Parses an import [InputStream] and returns information on whether it contains global settings and/or account
      * settings. For all account configurations found, the name of the account along with the account UUID is returned.
@@ -55,6 +24,7 @@ class SettingsImporter internal constructor(
      *
      * @throws SettingsImportExportException In case of an error.
      */
+    @Suppress("TooGenericExceptionCaught")
     @Throws(SettingsImportExportException::class)
     fun getImportStreamContents(inputStream: InputStream): ImportContents {
         try {
@@ -91,6 +61,7 @@ class SettingsImporter internal constructor(
      *
      * @throws SettingsImportExportException In case of an error.
      */
+    @Suppress("TooGenericExceptionCaught")
     @Throws(SettingsImportExportException::class)
     fun importSettings(
         inputStream: InputStream,
@@ -155,6 +126,7 @@ class SettingsImporter internal constructor(
         )
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun importGeneralSettings(contentVersion: Int, settings: SettingsMap): Boolean {
         return try {
             val validatedSettings = generalSettingsValidator.validate(contentVersion, settings)

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -36,8 +36,6 @@ class SettingsImporter internal constructor(
     private val accountSettingsValidator = AccountSettingsValidator()
 
     private val generalSettingsUpgrader = GeneralSettingsUpgrader()
-    private val folderSettingsUpgrader = FolderSettingsUpgrader()
-    private val identitySettingsUpgrader = IdentitySettingsUpgrader()
     private val accountSettingsUpgrader = AccountSettingsUpgrader()
 
     private val generalSettingsWriter = GeneralSettingsWriter(preferences)
@@ -258,11 +256,11 @@ class SettingsImporter internal constructor(
         val uuid = accountMapping.second.uuid
 
         // Write identities
-        importIdentities(editor, contentVersion, uuid, currentAccount.identities)
+        importIdentities(editor, uuid, currentAccount.identities)
 
         // Write folder settings
         for (folder in currentAccount.folders) {
-            importFolder(editor, contentVersion, uuid, folder)
+            importFolder(editor, uuid, folder)
         }
 
         return AccountDescriptionPair(
@@ -278,38 +276,31 @@ class SettingsImporter internal constructor(
 
     private fun importFolder(
         editor: StorageEditor,
-        contentVersion: Int,
         uuid: String,
         folder: ValidatedSettings.Folder,
     ) {
-        val currentFolder = folderSettingsUpgrader.upgrade(contentVersion, folder)
-
-        folderSettingsWriter.write(editor, uuid, currentFolder)
+        folderSettingsWriter.write(editor, uuid, folder)
     }
 
     @Throws(InvalidSettingValueException::class)
     private fun importIdentities(
         editor: StorageEditor,
-        contentVersion: Int,
         uuid: String,
         identities: List<ValidatedSettings.Identity>,
     ) {
         // Write identities
         for ((index, identity) in identities.withIndex()) {
-            importIdentity(editor, contentVersion, uuid, index, identity)
+            importIdentity(editor, uuid, index, identity)
         }
     }
 
     private fun importIdentity(
         editor: StorageEditor,
-        contentVersion: Int,
         accountUuid: String,
         index: Int,
         identity: ValidatedSettings.Identity,
     ) {
-        val currentIdentity = identitySettingsUpgrader.upgrade(contentVersion, identity)
-
-        identitySettingsWriter.write(editor, accountUuid, index, currentIdentity)
+        identitySettingsWriter.write(editor, accountUuid, index, identity)
     }
 
     /**

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -44,6 +44,7 @@ class SettingsImporter internal constructor(
 
     private val generalSettingsUpgrader = GeneralSettingsUpgrader()
     private val folderSettingsUpgrader = FolderSettingsUpgrader()
+    private val identitySettingsUpgrader = IdentitySettingsUpgrader()
 
     private val generalSettingsWriter = GeneralSettingsWriter(preferences)
     private val folderSettingsWriter = FolderSettingsWriter()
@@ -426,15 +427,10 @@ class SettingsImporter internal constructor(
             )
         }
 
-        val validatedSettings = validatedIdentity.settings.toMutableMap()
-
-        // Upgrade identity settings to current content version
-        if (contentVersion != Settings.VERSION) {
-            IdentitySettingsDescriptions.upgrade(contentVersion, validatedSettings)
-        }
+        val currentIdentity = identitySettingsUpgrader.upgrade(contentVersion, validatedIdentity)
 
         // Convert identity settings to the representation used in preference storage
-        val stringSettings = IdentitySettingsDescriptions.convert(validatedSettings)
+        val stringSettings = IdentitySettingsDescriptions.convert(currentIdentity.settings)
 
         // Write identity settings
         for ((identityKey, value) in stringSettings) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -42,6 +42,8 @@ class SettingsImporter internal constructor(
     private val folderSettingsValidator = FolderSettingsValidator()
 
     private val generalSettingsUpgrader = GeneralSettingsUpgrader()
+    private val folderSettingsUpgrader = FolderSettingsUpgrader()
+
     private val generalSettingsWriter = GeneralSettingsWriter(preferences)
 
     /**
@@ -368,18 +370,13 @@ class SettingsImporter internal constructor(
     ) {
         val validatedFolder = folderSettingsValidator.validate(contentVersion, folder)
 
-        val validatedSettings = validatedFolder.settings.toMutableMap()
-
-        // Upgrade folder settings to current content version
-        if (contentVersion != Settings.VERSION) {
-            FolderSettingsDescriptions.upgrade(contentVersion, validatedSettings)
-        }
+        val currentFolder = folderSettingsUpgrader.upgrade(contentVersion, validatedFolder)
 
         // Convert folder settings to the string representation used in preference storage
-        val stringSettings = FolderSettingsDescriptions.convert(validatedSettings)
+        val stringSettings = FolderSettingsDescriptions.convert(currentFolder.settings)
 
         // Write folder settings
-        val prefix = uuid + "." + folder.name + "."
+        val prefix = uuid + "." + currentFolder.name + "."
         for ((folderKey, value) in stringSettings) {
             val key = prefix + folderKey
             putString(editor, key, value)

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -39,6 +39,8 @@ class SettingsImporter internal constructor(
     private val context: Context,
 ) {
     private val generalSettingsValidator = GeneralSettingsValidator()
+    private val folderSettingsValidator = FolderSettingsValidator()
+
     private val generalSettingsUpgrader = GeneralSettingsUpgrader()
     private val generalSettingsWriter = GeneralSettingsWriter(preferences)
 
@@ -364,9 +366,9 @@ class SettingsImporter internal constructor(
         uuid: String,
         folder: SettingsFile.Folder,
     ) {
-        // Validate folder settings
-        val validatedSettings =
-            FolderSettingsDescriptions.validate(contentVersion, folder.settings!!, true)
+        val validatedFolder = folderSettingsValidator.validate(contentVersion, folder)
+
+        val validatedSettings = validatedFolder.settings.toMutableMap()
 
         // Upgrade folder settings to current content version
         if (contentVersion != Settings.VERSION) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -39,6 +39,7 @@ class SettingsImporter internal constructor(
     private val context: Context,
 ) {
     private val generalSettingsValidator = GeneralSettingsValidator()
+    private val generalSettingsUpgrader = GeneralSettingsUpgrader()
 
     /**
      * Parses an import [InputStream] and returns information on whether it contains global settings and/or account
@@ -229,15 +230,12 @@ class SettingsImporter internal constructor(
         contentVersion: Int,
         settings: SettingsMap,
     ) {
-        val validatedSettings = generalSettingsValidator.validate(contentVersion, settings).toMutableMap()
+        val validatedSettings = generalSettingsValidator.validate(contentVersion, settings)
 
-        // Upgrade global settings to current content version
-        if (contentVersion != Settings.VERSION) {
-            GeneralSettingsDescriptions.upgrade(contentVersion, validatedSettings)
-        }
+        val currentSettings = generalSettingsUpgrader.upgrade(contentVersion, validatedSettings).toMutableMap()
 
         // Convert global settings to the string representation used in preference storage
-        val stringSettings = GeneralSettingsDescriptions.convert(validatedSettings)
+        val stringSettings = GeneralSettingsDescriptions.convert(currentSettings)
 
         // Use current global settings as base and overwrite with validated settings read from the import file.
         val mergedSettings = GeneralSettingsDescriptions.getGlobalSettings(storage).toMutableMap()

--- a/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
@@ -1,0 +1,39 @@
+package com.fsck.k9.preferences
+
+internal typealias InternalSettingsMap = Map<String, Any?>
+
+interface ValidatedSettings {
+    data class Account(
+        val uuid: String,
+        val name: String?,
+        val incoming: Server,
+        val outgoing: Server,
+        val settings: InternalSettingsMap,
+        val identities: List<Identity>,
+        val folders: List<Folder>,
+    )
+
+    data class Server(
+        val type: String,
+        val host: String?,
+        val port: Int,
+        val connectionSecurity: String,
+        val authenticationType: String,
+        val username: String,
+        val password: String?,
+        val clientCertificateAlias: String?,
+        val extras: Map<String, String?>,
+    )
+
+    data class Identity(
+        val name: String?,
+        val email: String,
+        val description: String?,
+        val settings: InternalSettingsMap,
+    )
+
+    data class Folder(
+        val name: String,
+        val settings: InternalSettingsMap,
+    )
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
@@ -6,8 +6,8 @@ interface ValidatedSettings {
     data class Account(
         val uuid: String,
         val name: String?,
-//        val incoming: Server,
-//        val outgoing: Server,
+        val incoming: Server,
+        val outgoing: Server,
         val settings: InternalSettingsMap,
 //        val identities: List<Identity>,
 //        val folders: List<Folder>,

--- a/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
@@ -6,11 +6,11 @@ interface ValidatedSettings {
     data class Account(
         val uuid: String,
         val name: String?,
-        val incoming: Server,
-        val outgoing: Server,
+//        val incoming: Server,
+//        val outgoing: Server,
         val settings: InternalSettingsMap,
-        val identities: List<Identity>,
-        val folders: List<Folder>,
+//        val identities: List<Identity>,
+//        val folders: List<Folder>,
     )
 
     data class Server(

--- a/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
@@ -9,8 +9,8 @@ interface ValidatedSettings {
         val incoming: Server,
         val outgoing: Server,
         val settings: InternalSettingsMap,
-//        val identities: List<Identity>,
-//        val folders: List<Folder>,
+        val identities: List<Identity>,
+        val folders: List<Folder>,
     )
 
     data class Server(

--- a/app/core/src/test/java/com/fsck/k9/preferences/SettingsFileParserTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/SettingsFileParserTest.kt
@@ -10,7 +10,6 @@ import assertk.assertions.index
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.prop
-import com.fsck.k9.mail.AuthType
 import com.fsck.k9.preferences.SettingsFile.Account
 import com.fsck.k9.preferences.SettingsFile.Identity
 import com.fsck.k9.preferences.SettingsFile.Server
@@ -101,6 +100,6 @@ class SettingsFileParserTest : RobolectricTest() {
             .prop(Account::incoming)
             .isNotNull()
             .prop(Server::authenticationType)
-            .isEqualTo(AuthType.CRAM_MD5)
+            .isEqualTo("CRAM_MD5")
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9.preferences
 
-import android.content.Context
 import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
@@ -14,33 +13,13 @@ import assertk.assertions.isTrue
 import assertk.assertions.prop
 import com.fsck.k9.K9RobolectricTest
 import com.fsck.k9.Preferences
-import com.fsck.k9.ServerSettingsSerializer
-import com.fsck.k9.mailstore.SpecialLocalFoldersCreator
 import java.util.UUID
-import kotlinx.datetime.Clock
 import org.junit.Before
 import org.junit.Test
-import org.koin.core.component.inject
 import org.koin.test.inject
-import org.robolectric.RuntimeEnvironment
 
 class SettingsImporterTest : K9RobolectricTest() {
-    private val context: Context = RuntimeEnvironment.getApplication()
-    private val preferences: Preferences by inject()
-    private val realGeneralSettingsManager: RealGeneralSettingsManager by inject()
-    private val specialLocalFoldersCreator: SpecialLocalFoldersCreator by inject()
-    private val serverSettingsSerializer: ServerSettingsSerializer by inject()
-    private val clock: Clock by inject()
-
-    private val settingsImporter = SettingsImporter(
-        settingsFileParser = SettingsFileParser(),
-        preferences = preferences,
-        generalSettingsManager = realGeneralSettingsManager,
-        localFoldersCreator = specialLocalFoldersCreator,
-        serverSettingsSerializer = serverSettingsSerializer,
-        clock = clock,
-        context = context,
-    )
+    private val settingsImporter: SettingsImporter by inject()
 
     @Before
     fun before() {


### PR DESCRIPTION
This breaks `SettingsImporter` into smaller pieces and starts rearranging them.

One goal is to be able to support an upgrade step that has access to all settings (general settings and account settings). That's necessary for changing the way Push folders are configured (#7761).

The more immediate goal is to make it easier to add an upgrade mechanism for server settings so `AuthType.NONE` can be added (#7682).

