### PR TITLE
Replace app name usage - Part 1

### DIFF
--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
@@ -10,19 +10,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextDisplayMedium
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme2.MainTheme
-import app.k9mail.feature.account.common.R
 
 private const val TITLE_ICON_SIZE_DP = 56
 
 @Composable
 fun AppTitleTopHeader(
+    title: String,
     modifier: Modifier = Modifier,
-    title: String = stringResource(id = R.string.account_common_title),
 ) {
     ResponsiveWidthContainer(
         modifier = Modifier

--- a/feature/account/common/src/main/res/values-az/strings.xml
+++ b/feature/account/common/src/main/res/values-az/strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="account_common_button_next">Növbəti</string>
     <string name="account_common_button_back">Geri</string>
-    <string name="account_common_title">K-9 Mail</string>
 </resources>

--- a/feature/account/common/src/main/res/values-bg/strings.xml
+++ b/feature/account/common/src/main/res/values-bg/strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="account_common_button_next">Напред</string>
     <string name="account_common_button_back">Назад</string>
-    <string name="account_common_title">К-9 Поща</string>
 </resources>

--- a/feature/account/common/src/main/res/values-bs/strings.xml
+++ b/feature/account/common/src/main/res/values-bs/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_button_next">Sljedeći</string>
     <string name="account_common_button_back">Nazad</string>
     <string name="account_common_error_server_message">Server je odgovorio ovom porukom:

--- a/feature/account/common/src/main/res/values-ca/strings.xml
+++ b/feature/account/common/src/main/res/values-ca/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Endavant</string>
     <string name="account_common_button_back">Enrere</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">El servidor ha retornat en següent missatge:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-co/strings.xml
+++ b/feature/account/common/src/main/res/values-co/strings.xml
@@ -4,5 +4,4 @@
     <string name="account_common_button_back">Ritornu</string>
     <string name="account_common_error_server_message">U servitore hà mandatu quessu messaghju :
 \n%s</string>
-    <string name="account_common_title">K-9 Mail</string>
 </resources>

--- a/feature/account/common/src/main/res/values-cs/strings.xml
+++ b/feature/account/common/src/main/res/values-cs/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Další</string>
     <string name="account_common_button_back">Zpět</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Server vrátil následující zprávu:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-da/strings.xml
+++ b/feature/account/common/src/main/res/values-da/strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="account_common_button_next">Næste</string>
     <string name="account_common_button_back">Tilbage</string>
-    <string name="account_common_title">K-9 Mail</string>
 </resources>

--- a/feature/account/common/src/main/res/values-de/strings.xml
+++ b/feature/account/common/src/main/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_button_next">Weiter</string>
     <string name="account_common_button_back">Zurück</string>
     <string name="account_common_error_server_message">Der Server hat die folgende Nachricht zurückgegeben:

--- a/feature/account/common/src/main/res/values-el/strings.xml
+++ b/feature/account/common/src/main/res/values-el/strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="account_common_button_next">Επόμενο</string>
     <string name="account_common_button_back">Πίσω</string>
-    <string name="account_common_title">K-9 Mail</string>
 </resources>

--- a/feature/account/common/src/main/res/values-en-rGB/strings.xml
+++ b/feature/account/common/src/main/res/values-en-rGB/strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="account_common_button_next">Next</string>
     <string name="account_common_button_back">Back</string>
-    <string name="account_common_title">K-9 Mail</string>
 </resources>

--- a/feature/account/common/src/main/res/values-eo/strings.xml
+++ b/feature/account/common/src/main/res/values-eo/strings.xml
@@ -4,5 +4,4 @@
 \n%s</string>
     <string name="account_common_button_next">Sekven</string>
     <string name="account_common_button_back">Reen</string>
-    <string name="account_common_title">K-9 Retpoŝtilo</string>
 </resources>

--- a/feature/account/common/src/main/res/values-es/strings.xml
+++ b/feature/account/common/src/main/res/values-es/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Siguiente</string>
     <string name="account_common_button_back">Atrás</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">El servidor devolvió el siguiente mensaje:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-et/strings.xml
+++ b/feature/account/common/src/main/res/values-et/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Edasi</string>
     <string name="account_common_button_back">Tagasi</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Serveri vastuses sisaldus selline sõnum:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-eu/strings.xml
+++ b/feature/account/common/src/main/res/values-eu/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Hurrengoa</string>
     <string name="account_common_button_back">Aurrekoa</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Zerbitzariak mezu hau itzuli du:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-fa/strings.xml
+++ b/feature/account/common/src/main/res/values-fa/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">بعدی</string>
     <string name="account_common_button_back">بازگشت</string>
-    <string name="account_common_title">نامهٔ کِی۹</string>
     <string name="account_common_error_server_message">کارساز، پیام زیر را برگردانده است:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-fi/strings.xml
+++ b/feature/account/common/src/main/res/values-fi/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Seuraava</string>
     <string name="account_common_button_back">Takaisin</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Palvelin palautti seuraavan viestin:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-fr/strings.xml
+++ b/feature/account/common/src/main/res/values-fr/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Suivant</string>
     <string name="account_common_button_back">Précédent</string>
-    <string name="account_common_title">Courriel K-9 Mail</string>
     <string name="account_common_error_server_message">Le message suivant a été retourné par le serveur :
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-fy/strings.xml
+++ b/feature/account/common/src/main/res/values-fy/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Folgjende</string>
     <string name="account_common_button_back">Tebek</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">De server joech it folgjende berjocht werom:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-hi/strings.xml
+++ b/feature/account/common/src/main/res/values-hi/strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="account_common_button_next">अगला</string>
     <string name="account_common_button_back">पिछला</string>
-    <string name="account_common_title">K-9 मेल</string>
 </resources>

--- a/feature/account/common/src/main/res/values-hu/strings.xml
+++ b/feature/account/common/src/main/res/values-hu/strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="account_common_button_next">Következő</string>
     <string name="account_common_button_back">Vissza</string>
-    <string name="account_common_title">K-9 Mail</string>
 </resources>

--- a/feature/account/common/src/main/res/values-in/strings.xml
+++ b/feature/account/common/src/main/res/values-in/strings.xml
@@ -4,5 +4,4 @@
 \n%s</string>
     <string name="account_common_button_next">Berikutnya</string>
     <string name="account_common_button_back">Kembali</string>
-    <string name="account_common_title">K-9 Mail</string>
 </resources>

--- a/feature/account/common/src/main/res/values-is/strings.xml
+++ b/feature/account/common/src/main/res/values-is/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Næsta</string>
     <string name="account_common_button_back">Til baka</string>
-    <string name="account_common_title">K-9 - Póstur</string>
     <string name="account_common_error_server_message">Póstþjónninn svaraði með eftirfarandi skilaboðum:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-it/strings.xml
+++ b/feature/account/common/src/main/res/values-it/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Successivo</string>
     <string name="account_common_button_back">Precedente</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Il server ha restituito il seguente messaggio:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-iw/strings.xml
+++ b/feature/account/common/src/main/res/values-iw/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_error_server_message">השרת החזיר את השגיאה הבאה:
 \n%s</string>
-    <string name="account_common_title">דוא\"ל K-9</string>
     <string name="account_common_button_next">הבא</string>
     <string name="account_common_button_back">הקודם</string>
 </resources>

--- a/feature/account/common/src/main/res/values-ja/strings.xml
+++ b/feature/account/common/src/main/res/values-ja/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">次へ</string>
     <string name="account_common_button_back">戻る</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">サーバーから以下のメッセージが返答されました:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-ko/strings.xml
+++ b/feature/account/common/src/main/res/values-ko/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">다음</string>
     <string name="account_common_button_back">이전</string>
-    <string name="account_common_title">K-9 메일</string>
     <string name="account_common_error_server_message">서버가 다음의 메시지를 보냈습니다:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-lt/strings.xml
+++ b/feature/account/common/src/main/res/values-lt/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_error_server_message">Serverio grąžintas pranešimas:
 \n%s</string>
-    <string name="account_common_title">K-9 paštas</string>
     <string name="account_common_button_next">Toliau</string>
     <string name="account_common_button_back">Atgal</string>
 </resources>

--- a/feature/account/common/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/account/common/src/main/res/values-nb-rNO/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Neste</string>
     <string name="account_common_button_back">Tilbake</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Tjeneren svarte følgende:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-nl/strings.xml
+++ b/feature/account/common/src/main/res/values-nl/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Volgende</string>
     <string name="account_common_button_back">Terug</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">De server gaf het volgende bericht terug:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-pl/strings.xml
+++ b/feature/account/common/src/main/res/values-pl/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Dalej</string>
     <string name="account_common_button_back">Cofnij</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Serwer zwrócił następujący komunikat:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/account/common/src/main/res/values-pt-rBR/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Próximo</string>
     <string name="account_common_button_back">Voltar</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">O servidor retornou a seguinte mensagem:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-pt-rPT/strings.xml
+++ b/feature/account/common/src/main/res/values-pt-rPT/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Próximo</string>
     <string name="account_common_button_back">Anterior</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">O servidor retornou a seguinte mensagem:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-ro/strings.xml
+++ b/feature/account/common/src/main/res/values-ro/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Înainte</string>
     <string name="account_common_button_back">Înapoi</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Serverul a returnat următorul mesaj:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-ru/strings.xml
+++ b/feature/account/common/src/main/res/values-ru/strings.xml
@@ -4,5 +4,4 @@
     <string name="account_common_button_back">Назад</string>
     <string name="account_common_error_server_message">Сервер вернул следующее сообщение:
 \n%s</string>
-    <string name="account_common_title">K-9 Mail</string>
 </resources>

--- a/feature/account/common/src/main/res/values-sk/strings.xml
+++ b/feature/account/common/src/main/res/values-sk/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Ďalej</string>
     <string name="account_common_button_back">Späť</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Server vrátil nasledujúcu správu:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-sl/strings.xml
+++ b/feature/account/common/src/main/res/values-sl/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Naslednji</string>
     <string name="account_common_button_back">Prejšnji</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Strežnik je vrnil naslednje sporočilo:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-sq/strings.xml
+++ b/feature/account/common/src/main/res/values-sq/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Pasuesi</string>
     <string name="account_common_button_back">Mbrapsht</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">Shërbyesi ktheu mesazhin vijues:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-sv/strings.xml
+++ b/feature/account/common/src/main/res/values-sv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_button_next">Nästa</string>
     <string name="account_common_button_back">Tillbaka</string>
     <string name="account_common_error_server_message">Servern returnerade följande meddelande:

--- a/feature/account/common/src/main/res/values-tr/strings.xml
+++ b/feature/account/common/src/main/res/values-tr/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">İleri</string>
     <string name="account_common_button_back">Geri</string>
-    <string name="account_common_title">K-9 Posta</string>
     <string name="account_common_error_server_message">Sunucu aşağıdaki hatayı döndürdü:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-vi/strings.xml
+++ b/feature/account/common/src/main/res/values-vi/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">Kế tiếp</string>
     <string name="account_common_button_back">Quay lại</string>
-    <string name="account_common_title">Thư K-9</string>
     <string name="account_common_error_server_message">Máy chủ trả lại tin nhắn sau:
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/account/common/src/main/res/values-zh-rCN/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_common_button_next">下一步</string>
     <string name="account_common_button_back">返回</string>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_error_server_message">服务器返回了以下消息：
 \n%s</string>
 </resources>

--- a/feature/account/common/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/account/common/src/main/res/values-zh-rTW/strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="account_common_button_next">下一步</string>
     <string name="account_common_button_back">返回</string>
-    <string name="account_common_title">K-9 Mail</string>
 </resources>

--- a/feature/account/common/src/main/res/values/strings.xml
+++ b/feature/account/common/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="account_common_title">K-9 Mail</string>
     <string name="account_common_button_next">Next</string>
     <string name="account_common_button_back">Back</string>
 

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
@@ -14,6 +14,7 @@ import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSett
 import app.k9mail.feature.account.server.validation.ui.IncomingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.ServerValidationScreen
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 
 private const val NESTED_NAVIGATION_ROUTE_MODIFY = "modify"
@@ -57,6 +58,7 @@ fun EditIncomingServerSettingsNavHost(
                 viewModel = koinViewModel<IncomingServerValidationViewModel> {
                     parametersOf(accountUuid)
                 },
+                appNameProvider = koinInject(),
             )
         }
         composable(route = NESTED_NAVIGATION_ROUTE_SAVE) {

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
@@ -14,6 +14,7 @@ import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSett
 import app.k9mail.feature.account.server.validation.ui.OutgoingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.ServerValidationScreen
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 
 private const val NESTED_NAVIGATION_ROUTE_MODIFY = "modify"
@@ -57,6 +58,7 @@ fun EditOutgoingServerSettingsNavHost(
                 viewModel = koinViewModel<OutgoingServerValidationViewModel> {
                     parametersOf(accountUuid)
                 },
+                appNameProvider = koinInject(),
             )
         }
         composable(route = NESTED_NAVIGATION_ROUTE_SAVE) {

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreenPreview.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreenPreview.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
+import app.k9mail.feature.account.server.validation.ui.fake.FakeAppNameProvider
 import app.k9mail.feature.account.server.validation.ui.fake.FakeIncomingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.fake.FakeOutgoingServerValidationViewModel
 
@@ -15,6 +16,7 @@ internal fun IncomingServerValidationMainScreenPreview() {
             viewModel = FakeIncomingServerValidationViewModel(
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
+            appNameProvider = FakeAppNameProvider,
         )
     }
 }
@@ -27,6 +29,7 @@ internal fun OutgoingServerValidationMainScreenPreview() {
             viewModel = FakeOutgoingServerValidationViewModel(
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
+            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenPreview.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenPreview.kt
@@ -6,6 +6,7 @@ import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
 import app.k9mail.feature.account.server.certificate.data.InMemoryServerCertificateErrorRepository
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
+import app.k9mail.feature.account.server.validation.ui.fake.FakeAppNameProvider
 import com.fsck.k9.mail.server.ServerSettingsValidationResult
 
 @Composable
@@ -22,6 +23,7 @@ internal fun IncomingServerValidationScreenPreview() {
                 certificateErrorRepository = InMemoryServerCertificateErrorRepository(),
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
+            appNameProvider = FakeAppNameProvider,
         )
     }
 }
@@ -40,6 +42,7 @@ internal fun OutgoingServerValidationScreenPreview() {
                 certificateErrorRepository = InMemoryServerCertificateErrorRepository(),
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
+            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/fake/FakeAppNameProvider.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/fake/FakeAppNameProvider.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.account.server.validation.ui.fake
+
+import app.k9mail.core.common.provider.AppNameProvider
+
+internal object FakeAppNameProvider : AppNameProvider {
+    override val appName: String = "Fake App Name"
+}

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreen.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.account.server.validation.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observeWithoutEffect
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.AppTitleTopHeader
@@ -13,13 +14,16 @@ import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.
 @Composable
 internal fun ServerValidationMainScreen(
     viewModel: ViewModel,
+    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observeWithoutEffect()
 
     Scaffold(
         topBar = {
-            AppTitleTopHeader()
+            AppTitleTopHeader(
+                title = appNameProvider.appName,
+            )
         },
         bottomBar = {
             WizardNavigationBar(

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorScreen
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Effect
@@ -16,6 +17,7 @@ fun ServerValidationScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
+    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
     title: String? = null,
 ) {
@@ -50,6 +52,7 @@ fun ServerValidationScreen(
         } else {
             ServerValidationMainScreen(
                 viewModel = viewModel,
+                appNameProvider = appNameProvider,
                 modifier = modifier,
             )
         }

--- a/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenKtTest.kt
+++ b/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenKtTest.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.account.server.validation.ui
 
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Effect
@@ -23,6 +24,7 @@ class ServerValidationScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
+                appNameProvider = FakeAppNameProvider,
             )
         }
 
@@ -38,5 +40,9 @@ class ServerValidationScreenKtTest : ComposeTest() {
 
         assertThat(onNextCounter).isEqualTo(1)
         assertThat(onBackCounter).isEqualTo(1)
+    }
+
+    private object FakeAppNameProvider : AppNameProvider {
+        override val appName: String = "K-9 Mail"
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContentPreview.kt
@@ -15,6 +15,7 @@ internal fun AccountAutoDiscoveryContentPreview() {
             state = AccountAutoDiscoveryContract.State(),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
+            appName = "AppName",
         )
     }
 }
@@ -29,6 +30,7 @@ internal fun AccountAutoDiscoveryContentEmailPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
+            appName = "AppName",
         )
     }
 }
@@ -45,6 +47,7 @@ internal fun AccountAutoDiscoveryContentPasswordPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
+            appName = "AppName",
         )
     }
 }
@@ -61,6 +64,7 @@ internal fun AccountAutoDiscoveryContentPasswordUntrustedSettingsPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
+            appName = "AppName",
         )
     }
 }
@@ -76,6 +80,7 @@ internal fun AccountAutoDiscoveryContentPasswordNoSettingsPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
+            appName = "AppName",
         )
     }
 }
@@ -92,6 +97,7 @@ internal fun AccountAutoDiscoveryContentOAuthPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
+            appName = "AppName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenPreview.kt
@@ -6,10 +6,11 @@ import app.k9mail.core.ui.compose.common.annotation.PreviewDevicesWithBackground
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
+import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
 
 @Composable
 @PreviewDevicesWithBackground
-internal fun AccountAutoDiscoveryScreenK9Preview() {
+internal fun AccountAutoDiscoveryScreenPreview() {
     PreviewWithTheme {
         AccountAutoDiscoveryScreen(
             onNext = {},
@@ -20,6 +21,7 @@ internal fun AccountAutoDiscoveryScreenK9Preview() {
                 accountStateRepository = FakeAccountStateRepository(),
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
+            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenPreview.kt
@@ -5,6 +5,7 @@ import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.data.InMemoryAccountStateRepository
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
+import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
 
 @Composable
 @PreviewDevices
@@ -17,6 +18,7 @@ internal fun AccountOptionsScreenK9Preview() {
                 createAccount = { AccountCreatorResult.Success("irrelevant") },
                 accountStateRepository = InMemoryAccountStateRepository(),
             ),
+            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/fake/FakeAppNameProvider.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/fake/FakeAppNameProvider.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.account.setup.ui.fake
+
+import app.k9mail.core.common.provider.AppNameProvider
+
+internal object FakeAppNameProvider : AppNameProvider {
+    override val appName: String = "Fake App Name"
+}

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContentPreview.kt
@@ -13,6 +13,7 @@ internal fun DisplayOptionsContentPreview() {
             state = DisplayOptionsContract.State(),
             onEvent = {},
             contentPadding = PaddingValues(),
+            appName = "AppName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenPreview.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
+import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
 
 @Composable
 @Preview(showBackground = true)
@@ -17,6 +18,7 @@ internal fun DisplayOptionsScreenPreview() {
                 accountStateRepository = FakeAccountStateRepository(),
                 accountOwnerNameProvider = { null },
             ),
+            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContentPreview.kt
@@ -13,6 +13,7 @@ internal fun SyncOptionsContentPreview() {
             state = SyncOptionsContract.State(),
             onEvent = {},
             contentPadding = PaddingValues(),
+            appName = "AppName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenPreview.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
+import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
 
 @Composable
 @Preview(showBackground = true)
@@ -15,6 +16,7 @@ internal fun SyncOptionsScreenPreview() {
             viewModel = SyncOptionsViewModel(
                 accountStateRepository = FakeAccountStateRepository(),
             ),
+            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContentPreview.kt
@@ -15,6 +15,7 @@ internal fun SpecialFoldersContentLoadingPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
+            appName = "AppName",
         )
     }
 }
@@ -29,6 +30,7 @@ internal fun SpecialFoldersContentFormPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
+            appName = "AppName",
         )
     }
 }
@@ -44,6 +46,7 @@ internal fun SpecialFoldersContentSuccessPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
+            appName = "AppName",
         )
     }
 }
@@ -59,6 +62,7 @@ internal fun SpecialFoldersContentErrorPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
+            appName = "AppName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenPreview.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.account.setup.ui.specialfolders
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
 import app.k9mail.feature.account.setup.ui.specialfolders.fake.FakeSpecialFoldersViewModel
 
 @Composable
@@ -13,6 +14,7 @@ internal fun SpecialFoldersScreenPreview() {
             onNext = {},
             onBack = {},
             viewModel = FakeSpecialFoldersViewModel(),
+            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
@@ -66,6 +66,7 @@ fun AccountSetupNavHost(
                 },
                 onBack = onBack,
                 viewModel = koinViewModel<AccountAutoDiscoveryViewModel>(),
+                appNameProvider = koinInject(),
             )
         }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
@@ -27,6 +27,7 @@ import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsViewModel
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersScreen
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersViewModel
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 
 private const val NESTED_NAVIGATION_AUTO_CONFIG = "autoconfig"
 private const val NESTED_NAVIGATION_INCOMING_SERVER_CONFIG = "incoming-server/config"
@@ -94,6 +95,7 @@ fun AccountSetupNavHost(
                 },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<IncomingServerValidationViewModel>(),
+                appNameProvider = koinInject(),
             )
         }
 
@@ -124,6 +126,7 @@ fun AccountSetupNavHost(
                 },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<OutgoingServerValidationViewModel>(),
+                appNameProvider = koinInject(),
             )
         }
 
@@ -144,6 +147,7 @@ fun AccountSetupNavHost(
                 },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<SpecialFoldersViewModel>(),
+                appNameProvider = koinInject(),
             )
         }
 
@@ -152,6 +156,7 @@ fun AccountSetupNavHost(
                 onNext = { navController.navigate(NESTED_NAVIGATION_SYNC_OPTIONS) },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<DisplayOptionsViewModel>(),
+                appNameProvider = koinInject(),
             )
         }
 
@@ -160,6 +165,7 @@ fun AccountSetupNavHost(
                 onNext = { navController.navigate(NESTED_NAVIGATION_CREATE_ACCOUNT) },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<SyncOptionsViewModel>(),
+                appNameProvider = koinInject(),
             )
         }
 
@@ -168,6 +174,7 @@ fun AccountSetupNavHost(
                 onNext = { accountUuid -> onFinish(accountUuid.value) },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<CreateAccountViewModel>(),
+                appNameProvider = koinInject(),
             )
         }
     }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
@@ -39,6 +39,7 @@ internal fun AccountAutoDiscoveryContent(
     state: State,
     onEvent: (Event) -> Unit,
     oAuthViewModel: AccountOAuthContract.ViewModel,
+    appName: String,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -59,7 +60,7 @@ internal fun AccountAutoDiscoveryContent(
                     .imePadding(),
             ) {
                 AppTitleTopHeader(
-                    title = stringResource(id = R.string.account_setup_title),
+                    title = appName,
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 AutoDiscoveryContent(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreen.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.account.setup.ui.autodiscovery
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.AutoDiscoveryUiResult
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.Effect
@@ -14,6 +15,7 @@ internal fun AccountAutoDiscoveryScreen(
     onNext: (AutoDiscoveryUiResult) -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
+    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -31,6 +33,7 @@ internal fun AccountAutoDiscoveryScreen(
         state = state.value,
         onEvent = { dispatch(it) },
         oAuthViewModel = viewModel.oAuthViewModel,
+        appName = appNameProvider.appName,
         modifier = modifier,
     )
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.AppTitleTopHeader
@@ -19,6 +20,7 @@ internal fun CreateAccountScreen(
     onNext: (AccountUuid) -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
+    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -38,7 +40,9 @@ internal fun CreateAccountScreen(
 
     Scaffold(
         topBar = {
-            AppTitleTopHeader()
+            AppTitleTopHeader(
+                title = appNameProvider.appName,
+            )
         },
         bottomBar = {
             WizardNavigationBar(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
@@ -33,6 +33,7 @@ internal fun DisplayOptionsContent(
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
+    appName: String,
     modifier: Modifier = Modifier,
 ) {
     val resources = LocalContext.current.resources
@@ -52,7 +53,9 @@ internal fun DisplayOptionsContent(
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {
             item {
-                AppTitleTopHeader()
+                AppTitleTopHeader(
+                    title = appName,
+                )
             }
 
             item {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
@@ -16,6 +17,7 @@ internal fun DisplayOptionsScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
+    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -46,6 +48,7 @@ internal fun DisplayOptionsScreen(
             state = state.value,
             onEvent = { dispatch(it) },
             contentPadding = innerPadding,
+            appName = appNameProvider.appName,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContent.kt
@@ -36,6 +36,7 @@ internal fun SyncOptionsContent(
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
+    appName: String,
     modifier: Modifier = Modifier,
 ) {
     val resources = LocalContext.current.resources
@@ -55,7 +56,9 @@ internal fun SyncOptionsContent(
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {
             item {
-                AppTitleTopHeader()
+                AppTitleTopHeader(
+                    title = appName,
+                )
             }
 
             item {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
@@ -16,6 +17,7 @@ internal fun SyncOptionsScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
+    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -46,6 +48,7 @@ internal fun SyncOptionsScreen(
             state = state.value,
             onEvent = { dispatch(it) },
             contentPadding = innerPadding,
+            appName = appNameProvider.appName,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
@@ -26,6 +26,7 @@ fun SpecialFoldersContent(
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
+    appName: String,
     modifier: Modifier = Modifier,
 ) {
     ResponsiveWidthContainer(
@@ -35,7 +36,9 @@ fun SpecialFoldersContent(
             .then(modifier),
     ) {
         Column {
-            AppTitleTopHeader()
+            AppTitleTopHeader(
+                title = appName,
+            )
 
             ContentLoadingErrorView(
                 state = rememberContentLoadingErrorViewState(state = state),

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
@@ -17,6 +18,7 @@ fun SpecialFoldersScreen(
     onNext: (isManualSetup: Boolean) -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
+    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -50,6 +52,7 @@ fun SpecialFoldersScreen(
             state = state.value,
             onEvent = { dispatch(it) },
             contentPadding = innerPadding,
+            appName = appNameProvider.appName,
         )
     }
 }

--- a/feature/account/setup/src/main/res/values-bg/strings.xml
+++ b/feature/account/setup/src/main/res/values-bg/strings.xml
@@ -17,7 +17,6 @@
     <string name="account_setup_error_network">Мрежа</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_invalid">Имейл адресът не беше разпознат като валиден.</string>
     <string name="account_setup_auto_discovery_loading_message">Намиране на данни за имейла</string>
-    <string name="account_setup_title">K-9 Поща</string>
     <string name="account_setup_options_account_name_error_blank">Името на акаунта не може да бъде празно.</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Този имейл адрес не е разрешен.</string>
     <string name="account_setup_options_account_check_frequency_label">Интервал на проверка</string>

--- a/feature/account/setup/src/main/res/values-ca/strings.xml
+++ b/feature/account/setup/src/main/res/values-ca/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_options_account_name_error_blank">El nom del compte no pot estar en blanc.</string>
     <string name="account_setup_options_account_check_frequency_label">Freqüència de comprovació</string>
     <string name="account_setup_auto_discovery_result_header_subtitle_configuration_trusted">Configura automàticament</string>

--- a/feature/account/setup/src/main/res/values-co/strings.xml
+++ b/feature/account/setup/src/main/res/values-co/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_required">L’indirizzu elettronicu hè richiestu.</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">St’indirizzu elettronicu ùn hè micca permessu.</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_invalid">St’indirizzu elettronicu ùn hè micca ricunnisciutu cum’è accettevule.</string>

--- a/feature/account/setup/src/main/res/values-cs/strings.xml
+++ b/feature/account/setup/src/main/res/values-cs/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Nastavení synchronizace</string>
     <string name="account_setup_options_show_notifications_label">Zobrazovat oznámení</string>
     <string name="account_setup_options_section_display_options">Nastavení zobrazení</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Tato e-mailová adresa není dovolena.</string>
     <string name="account_setup_create_account_created">Účet úspěšně vytvořen</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Tato e-mailová adresa není podporována.</string>

--- a/feature/account/setup/src/main/res/values-da/strings.xml
+++ b/feature/account/setup/src/main/res/values-da/strings.xml
@@ -19,5 +19,4 @@
     <string name="account_setup_options_section_sync_options">Synkroniserings indstillinger</string>
     <string name="account_setup_options_show_notifications_label">Vis notifikationer</string>
     <string name="account_setup_options_section_display_options">Visningsindstillinger</string>
-    <string name="account_setup_title">K-9 Mail</string>
 </resources>

--- a/feature/account/setup/src/main/res/values-de/strings.xml
+++ b/feature/account/setup/src/main/res/values-de/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Synchronisierungsoptionen</string>
     <string name="account_setup_options_show_notifications_label">Benachrichtigungen anzeigen</string>
     <string name="account_setup_options_section_display_options">Anzeigeoptionen</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Diese E-Mail Adresse ist nicht erlaubt.</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Diese E-Mail Adresse wird nicht unterstützt.</string>
     <string name="account_setup_create_account_created">Konto erfolgreich erstellt</string>

--- a/feature/account/setup/src/main/res/values-el/strings.xml
+++ b/feature/account/setup/src/main/res/values-el/strings.xml
@@ -33,5 +33,4 @@
     <string name="account_setup_options_section_sync_options">Επιλογές συγχρονισμού</string>
     <string name="account_setup_options_show_notifications_label">Εμφάνιση ειδοποιήσεων</string>
     <string name="account_setup_options_section_display_options">Επιλογές εμφάνισης</string>
-    <string name="account_setup_title">K-9 Mail</string>
 </resources>

--- a/feature/account/setup/src/main/res/values-en-rGB/strings.xml
+++ b/feature/account/setup/src/main/res/values-en-rGB/strings.xml
@@ -34,5 +34,4 @@
     <string name="account_setup_options_section_sync_options">Sync options</string>
     <string name="account_setup_options_show_notifications_label">Show notifications</string>
     <string name="account_setup_options_section_display_options">Display options</string>
-    <string name="account_setup_title">K-9 Mail</string>
 </resources>

--- a/feature/account/setup/src/main/res/values-es/strings.xml
+++ b/feature/account/setup/src/main/res/values-es/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Ajustes de sincronización</string>
     <string name="account_setup_options_show_notifications_label">Mostrar notificaciones</string>
     <string name="account_setup_options_section_display_options">Ajustes de pantalla</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Esta dirección de correo electrónico no está permitida.</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Esta dirección de correo electrónico no es compatible.</string>
     <string name="account_setup_create_account_created">Cuenta creada correctamente</string>

--- a/feature/account/setup/src/main/res/values-et/strings.xml
+++ b/feature/account/setup/src/main/res/values-et/strings.xml
@@ -16,7 +16,6 @@
     <string name="account_setup_error_network">Võrk</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_invalid">See e-posti aadress ei tundu olema korrektne.</string>
     <string name="account_setup_auto_discovery_loading_message">Tuvastame e-posti konto seadistusi…</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_options_account_name_error_blank">Kasutajakonto nimi ei saa olla tühi.</string>
     <string name="account_setup_options_account_check_frequency_label">Kirjade kontrollimise sagedus</string>
     <string name="account_setup_options_email_signature_label">E-kirja allkiri</string>

--- a/feature/account/setup/src/main/res/values-eu/strings.xml
+++ b/feature/account/setup/src/main/res/values-eu/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Sinkronizazio ezarpenak</string>
     <string name="account_setup_options_show_notifications_label">Erakutsi jakinarazpenak</string>
     <string name="account_setup_options_section_display_options">Pantaila ezarpenak</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Helbide elektroniko hau ez dago onartuta.</string>
     <string name="account_setup_create_account_created">Kontua sortu da</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Helbide elektroniko hau ez da bateragarria.</string>

--- a/feature/account/setup/src/main/res/values-fa/strings.xml
+++ b/feature/account/setup/src/main/res/values-fa/strings.xml
@@ -46,7 +46,6 @@
     <string name="account_setup_options_show_notifications_label">نمایش اعلان‌ها</string>
     <string name="account_setup_options_section_display_options">گزینه‌های نمایش</string>
     <string name="account_setup_special_folders_form_description_automatic">تنظیم \"خودکار\" تغییراتی که توسط سرور به طور خودکار انجام می شود را اعمال می‌کند. مقدار فعلی در داخل پرانتز نمایش داده می‌شود.</string>
-    <string name="account_setup_title">نامهٔ کِی۹</string>
     <string name="account_setup_auto_discovery_validation_error_password_required">رمز عبور مورد نیاز است</string>
     <plurals name="account_setup_options_email_check_frequency_minutes">
         <item quantity="one">هر %d دقیقه</item>

--- a/feature/account/setup/src/main/res/values-fi/strings.xml
+++ b/feature/account/setup/src/main/res/values-fi/strings.xml
@@ -28,7 +28,6 @@
     <string name="account_setup_options_section_sync_options">Synkronointiasetukset</string>
     <string name="account_setup_options_show_notifications_label">Näytä ilmoitukset</string>
     <string name="account_setup_options_section_display_options">Näkymäasetukset</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Tämä sähköpostiosoite ei ole sallittu.</string>
     <string name="account_setup_create_account_created">Tili luotu onnistuneesti</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Tämä sähköpostiosoite ei ole tuettu.</string>

--- a/feature/account/setup/src/main/res/values-fr/strings.xml
+++ b/feature/account/setup/src/main/res/values-fr/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Options de synchronisation</string>
     <string name="account_setup_options_show_notifications_label">Afficher les notifications</string>
     <string name="account_setup_options_section_display_options">Options d’affichage</string>
-    <string name="account_setup_title">Courriel K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Cette adresse courriel n’est pas permise.</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Cette adresse courriel n’est pas prise en charge.</string>
     <string name="account_setup_create_account_created">Le compte a été créé</string>

--- a/feature/account/setup/src/main/res/values-fy/strings.xml
+++ b/feature/account/setup/src/main/res/values-fy/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Syngronisaasjeopsjes</string>
     <string name="account_setup_options_show_notifications_label">Meldingen toane</string>
     <string name="account_setup_options_section_display_options">Werjefteopsjes</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Dit e-mailadres is net tastien.</string>
     <string name="account_setup_create_account_created">Account mei sukses oanmakke</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Dit e-mailadres wurdt net stipe.</string>

--- a/feature/account/setup/src/main/res/values-hi/strings.xml
+++ b/feature/account/setup/src/main/res/values-hi/strings.xml
@@ -29,6 +29,5 @@
     <string name="account_setup_options_section_sync_options">सिंक ऑप्शन</string>
     <string name="account_setup_options_show_notifications_label">नोटिफिकेशन दिखाएं</string>
     <string name="account_setup_options_section_display_options">डिस्प्ले ऑप्शन</string>
-    <string name="account_setup_title">K-9 मेल</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">ये ईमेल पता गलत है।</string>
 </resources>

--- a/feature/account/setup/src/main/res/values-hu/strings.xml
+++ b/feature/account/setup/src/main/res/values-hu/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Szinkronizálási opciók</string>
     <string name="account_setup_options_show_notifications_label">Értesítések megjelenítése</string>
     <string name="account_setup_options_section_display_options">Megjelenítési opciók</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Ez az email cím nem engedélyezett.</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Ez az email cím nem támogatott.</string>
 </resources>

--- a/feature/account/setup/src/main/res/values-in/strings.xml
+++ b/feature/account/setup/src/main/res/values-in/strings.xml
@@ -32,7 +32,6 @@
     <string name="account_setup_create_account_creating">Membuat akun…</string>
     <string name="account_setup_create_account_error">Terjadi galat saat mencoba untuk membuat akun</string>
     <string name="account_setup_create_account_created">Akun berhasil dibuat</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_error_network">Jaringan</string>
     <string name="account_setup_error_unknown">Galat tak diketahui</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_required">Alamat surel diperlukan.</string>

--- a/feature/account/setup/src/main/res/values-is/strings.xml
+++ b/feature/account/setup/src/main/res/values-is/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_setup_error_network">Netkerfi</string>
-    <string name="account_setup_title">K-9 - Póstur</string>
     <string name="account_setup_options_account_name_error_blank">Heiti notandaaðgangs má ekki vera tómt.</string>
     <string name="account_setup_options_account_check_frequency_label">Tíðni athugana</string>
     <string name="account_setup_auto_discovery_result_header_subtitle_configuration_trusted">Stilla sjálfvirkt</string>

--- a/feature/account/setup/src/main/res/values-it/strings.xml
+++ b/feature/account/setup/src/main/res/values-it/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Opzioni di sincronizzazione</string>
     <string name="account_setup_options_show_notifications_label">Mostra notifiche</string>
     <string name="account_setup_options_section_display_options">Opzioni di visualizzazione</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Questo indirizzo email non è consentito</string>
     <string name="account_setup_create_account_created">Creazione account completata</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Questo indirizzo email non è supportato</string>

--- a/feature/account/setup/src/main/res/values-iw/strings.xml
+++ b/feature/account/setup/src/main/res/values-iw/strings.xml
@@ -21,7 +21,6 @@
     <string name="account_setup_options_section_display_options">הצג אפשרויות</string>
     <string name="account_setup_options_section_sync_options">אפשרויות סנכרון</string>
     <string name="account_setup_options_email_display_count_label">כמות הודעות להצגה</string>
-    <string name="account_setup_title">דוא\"ל K-9</string>
     <string name="account_setup_error_network">רשת</string>
     <string name="account_setup_error_unknown">שגיאה לא ידועה</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_required">דרושה כתובת דוא\"ל.</string>

--- a/feature/account/setup/src/main/res/values-ja/strings.xml
+++ b/feature/account/setup/src/main/res/values-ja/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">同期設定</string>
     <string name="account_setup_options_show_notifications_label">通知を表示する</string>
     <string name="account_setup_options_section_display_options">表示設定</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">このメールアドレスは許可されていません。</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">このメールアドレスには対応していません。</string>
     <string name="account_setup_create_account_created">アカウントは正常に作成されました</string>

--- a/feature/account/setup/src/main/res/values-ko/strings.xml
+++ b/feature/account/setup/src/main/res/values-ko/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="account_setup_error_unknown">알 수 없는 오류</string>
     <string name="account_setup_error_network">네트워크</string>
-    <string name="account_setup_title">K-9 메일</string>
     <string name="account_setup_special_folders_archive_folder_label">보관함</string>
     <string name="account_setup_special_folders_error_message">서버에서 폴더 목록을 가져오지 못했습니다</string>
     <string name="account_setup_special_folders_sent_folder_label">보낸편지함</string>

--- a/feature/account/setup/src/main/res/values-lt/strings.xml
+++ b/feature/account/setup/src/main/res/values-lt/strings.xml
@@ -41,7 +41,6 @@
     <string name="account_setup_options_section_sync_options">Sinchronizavimo nustatymai</string>
     <string name="account_setup_create_account_creating">Kuriama paskyra…</string>
     <string name="account_setup_create_account_created">Paskyra sėkmingai sukurta</string>
-    <string name="account_setup_title">K-9 paštas</string>
     <string name="account_setup_error_network">Tinklas</string>
     <string name="account_setup_error_unknown">Nenumatyta klaida</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_required">El. pašto adresą įvesti būtina.</string>

--- a/feature/account/setup/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/account/setup/src/main/res/values-nb-rNO/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Synkroniseringsalternativer</string>
     <string name="account_setup_options_show_notifications_label">Vis merknader</string>
     <string name="account_setup_options_section_display_options">Visningsalternativer</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Denne e-postadressen tillates ikke.</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Denne e-postadressen støttes ikke.</string>
     <string name="account_setup_special_folders_form_description">Angi spesialmapper for din konto.</string>

--- a/feature/account/setup/src/main/res/values-nl/strings.xml
+++ b/feature/account/setup/src/main/res/values-nl/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Synchronisatieopties</string>
     <string name="account_setup_options_show_notifications_label">Meldingen tonen</string>
     <string name="account_setup_options_section_display_options">Weergaveopties</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Dit e-mailadres is niet toegestaan.</string>
     <string name="account_setup_create_account_created">Account met succes aangemaakt</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Dit e-mailadres wordt niet ondersteund.</string>

--- a/feature/account/setup/src/main/res/values-pl/strings.xml
+++ b/feature/account/setup/src/main/res/values-pl/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Opcje synchronizacji</string>
     <string name="account_setup_options_show_notifications_label">Pokaż powiadomienia</string>
     <string name="account_setup_options_section_display_options">Opcje wyświetlania</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Ten adres e-mail jest niedozwolony.</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Ten adres e-mail nie jest obsługiwany.</string>
     <string name="account_setup_create_account_created">Konto pomyślnie utworzone</string>

--- a/feature/account/setup/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/account/setup/src/main/res/values-pt-rBR/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Opções de sincronização</string>
     <string name="account_setup_options_show_notifications_label">Mostrar notificações</string>
     <string name="account_setup_options_section_display_options">Opções de visualização</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Este endereço eletrônico não é permitido.</string>
     <string name="account_setup_create_account_created">Conta criada com sucesso</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Este endereço eletrônico não é suportado.</string>

--- a/feature/account/setup/src/main/res/values-pt-rPT/strings.xml
+++ b/feature/account/setup/src/main/res/values-pt-rPT/strings.xml
@@ -34,7 +34,6 @@
     <string name="account_setup_options_section_sync_options">Opções de sincronização</string>
     <string name="account_setup_options_show_notifications_label">Mostrar notificações</string>
     <string name="account_setup_options_section_display_options">Opções de visualização</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_special_folders_form_description">Por favor indique as pastas especiais para a sua conta.</string>
     <string name="account_setup_special_folders_form_description_automatic">A entrada \"Automático\" seguirá automaticamente as alterações efetuadas pelo servidor. O valor atual do servidor é apresentado entre parênteses.</string>
     <string name="account_setup_special_folders_loading_message">A obter a lista de pastas…</string>

--- a/feature/account/setup/src/main/res/values-ro/strings.xml
+++ b/feature/account/setup/src/main/res/values-ro/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">Opțiuni de sincronizare</string>
     <string name="account_setup_options_show_notifications_label">Afișare notificări</string>
     <string name="account_setup_options_section_display_options">Opțiuni de afișare</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">Această adresă de e-mail nu este permisă.</string>
     <string name="account_setup_create_account_created">Cont creat cu succes</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Această adresă de e-mail nu este acceptată.</string>

--- a/feature/account/setup/src/main/res/values-ru/strings.xml
+++ b/feature/account/setup/src/main/res/values-ru/strings.xml
@@ -33,7 +33,6 @@
     <string name="account_setup_options_account_name_error_blank">Имя учётной записи не может быть пустым.</string>
     <string name="account_setup_create_account_created">Учётная запись успешно создана</string>
     <string name="account_setup_options_display_name_error_required">Необходимо указать ваше имя.</string>
-    <string name="account_setup_title">Почта K-9</string>
     <string name="account_setup_error_network">Сеть</string>
     <string name="account_setup_error_unknown">Неизвестная ошибка</string>
     <string name="account_setup_auto_discovery_connection_security_ssl">SSL/TLS</string>

--- a/feature/account/setup/src/main/res/values-sk/strings.xml
+++ b/feature/account/setup/src/main/res/values-sk/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="account_setup_error_network">Sieť</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_connection_security_start_tls">StartTLS</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">Táto e-mailová adresa nie je podporovaná.</string>
     <string name="account_setup_auto_discovery_connection_security_ssl">SSL/TLS</string>

--- a/feature/account/setup/src/main/res/values-sl/strings.xml
+++ b/feature/account/setup/src/main/res/values-sl/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="account_setup_title">K-9 Mail</string>
-</resources>

--- a/feature/account/setup/src/main/res/values-sq/strings.xml
+++ b/feature/account/setup/src/main/res/values-sq/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_options_account_name_error_blank">Emri i llogarisë s’mund të jetë i zbrazët.</string>
     <string name="account_setup_options_account_check_frequency_label">Shpeshti kontrolli</string>
     <string name="account_setup_auto_discovery_result_header_subtitle_configuration_trusted">Formësoje automatikisht</string>

--- a/feature/account/setup/src/main/res/values-sv/strings.xml
+++ b/feature/account/setup/src/main/res/values-sv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_options_account_name_error_blank">Kontonamn kan inte vara tomt.</string>
     <string name="account_setup_options_account_check_frequency_label">Kolla efter ny e-post frekvens</string>
     <string name="account_setup_auto_discovery_result_header_subtitle_configuration_trusted">Konfigurera automatiskt</string>

--- a/feature/account/setup/src/main/res/values-tr/strings.xml
+++ b/feature/account/setup/src/main/res/values-tr/strings.xml
@@ -25,7 +25,6 @@
     <string name="account_setup_auto_discovery_loading_message">Yapılandırma aranıyor…</string>
     <string name="account_setup_options_section_sync_options">Eşzamanlama seçenekleri</string>
     <string name="account_setup_options_section_display_options">Görüntüleme seçenekleri</string>
-    <string name="account_setup_title">K-9 Posta</string>
     <string name="account_setup_options_account_check_frequency_label">Denetleme sıklığı</string>
     <string name="account_setup_options_email_display_count_label">Görüntülenecek ileti sayısı</string>
     <string name="account_setup_options_email_check_frequency_never">Hiçbir zaman</string>

--- a/feature/account/setup/src/main/res/values-vi/strings.xml
+++ b/feature/account/setup/src/main/res/values-vi/strings.xml
@@ -31,7 +31,6 @@
     <string name="account_setup_options_section_sync_options">Tùy chọn đồng bộ hóa</string>
     <string name="account_setup_options_show_notifications_label">Hiển thị thông báo</string>
     <string name="account_setup_options_section_display_options">Tùy chọn hiển thị</string>
-    <string name="account_setup_title">Thư K-9</string>
     <string name="account_setup_create_account_created">Tạo tài khoản thành công</string>
     <string name="account_setup_create_account_creating">Đang tạo tài khoản…</string>
     <string name="account_setup_create_account_error">Đã xảy ra lỗi khi cố gắng tạo tài khoản</string>

--- a/feature/account/setup/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/account/setup/src/main/res/values-zh-rCN/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">同步选项</string>
     <string name="account_setup_options_show_notifications_label">显示通知</string>
     <string name="account_setup_options_section_display_options">显示选项</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">不允许此电子邮件地址。</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">不支持此电子邮件地址。</string>
     <string name="account_setup_create_account_created">账号已成功创建</string>

--- a/feature/account/setup/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/account/setup/src/main/res/values-zh-rTW/strings.xml
@@ -29,7 +29,6 @@
     <string name="account_setup_options_section_sync_options">同步選項</string>
     <string name="account_setup_options_show_notifications_label">顯示通知</string>
     <string name="account_setup_options_section_display_options">顯示選項</string>
-    <string name="account_setup_title">K-9 Mail</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_allowed">此郵箱地址不允許使用。</string>
     <string name="account_setup_create_account_created">建立帳戶成功</string>
     <string name="account_setup_auto_discovery_validation_error_email_address_not_supported">不支援此電子郵件地址。</string>

--- a/feature/account/setup/src/main/res/values/strings.xml
+++ b/feature/account/setup/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="account_setup_title">K-9 Mail</string>
 
     <string name="account_setup_error_network">Network </string>
     <string name="account_setup_error_unknown">Unknown error</string>

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.account.setup
 import android.content.Context
 import app.k9mail.autodiscovery.api.AutoDiscovery
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.feature.account.common.AccountCommonExternalContract
 import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
@@ -13,6 +14,7 @@ import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSett
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
+import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract
 import app.k9mail.feature.account.setup.ui.createaccount.CreateAccountContract
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract
@@ -64,6 +66,7 @@ class AccountSetupModuleKtTest : KoinTest {
         single<AccountCommonExternalContract.AccountStateLoader> { mock() }
         factory<AccountSetupExternalContract.AccountOwnerNameProvider> { mock() }
         single<List<AutoDiscovery>>(named("extraAutoDiscoveries")) { emptyList() }
+        single<AppNameProvider> { FakeAppNameProvider }
     }
 
     @Test

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/FakeAppNameProvider.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/FakeAppNameProvider.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.account.setup.ui
+
+import app.k9mail.core.common.provider.AppNameProvider
+
+internal object FakeAppNameProvider : AppNameProvider {
+    override val appName: String = "Fake App Name"
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenKtTest.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.account.setup.ui.autodiscovery
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
+import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.Effect
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.State
 import assertk.assertThat
@@ -24,6 +25,7 @@ class AccountAutoDiscoveryScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
+                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenTest.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.account.setup.ui.createaccount
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.setup.domain.entity.AccountUuid
+import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
 import app.k9mail.feature.account.setup.ui.createaccount.CreateAccountContract.Effect
 import app.k9mail.feature.account.setup.ui.createaccount.CreateAccountContract.State
 import assertk.assertThat
@@ -30,6 +31,7 @@ class CreateAccountScreenTest : ComposeTest() {
                 onNext = { accountUuid -> navigateNextArguments.add(accountUuid) },
                 onBack = { navigateBackCounter++ },
                 viewModel = viewModel,
+                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenKtTest.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.account.setup.ui.options.display
 
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Effect
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.State
 import assertk.assertThat
@@ -23,6 +24,7 @@ class DisplayOptionsScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
+                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenKtTest.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.account.setup.ui.options.sync
 
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
 import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsContract.Effect
 import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsContract.State
 import assertk.assertThat
@@ -23,6 +24,7 @@ class SyncOptionsScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
+                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenKtTest.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.account.setup.ui.specialfolders
 
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersContract.Effect
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersContract.State
 import app.k9mail.feature.account.setup.ui.specialfolders.fake.FakeSpecialFoldersViewModel
@@ -24,6 +25,7 @@ class SpecialFoldersScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
+                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/onboarding/main/build.gradle.kts
+++ b/feature/onboarding/main/build.gradle.kts
@@ -8,6 +8,7 @@ android {
 }
 
 dependencies {
+    implementation(projects.core.common)
     implementation(projects.core.ui.compose.designsystem)
     implementation(projects.feature.onboarding.welcome)
     implementation(projects.feature.account.setup)

--- a/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
+++ b/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
@@ -53,6 +53,7 @@ fun OnboardingNavHost(
             WelcomeScreen(
                 onStartClick = { navController.navigateToAccountSetup() },
                 onImportClick = { navController.navigateToSettingsImport() },
+                appNameProvider = koinInject(),
             )
         }
 

--- a/feature/onboarding/permissions/build.gradle.kts
+++ b/feature/onboarding/permissions/build.gradle.kts
@@ -8,7 +8,8 @@ android {
 }
 
 dependencies {
-    implementation(projects.core.ui.compose.designsystem)
+    implementation(projects.core.common)
     implementation(projects.core.android.permissions)
+    implementation(projects.core.ui.compose.designsystem)
     implementation(projects.feature.account.common)
 }

--- a/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionContentPreview.kt
+++ b/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionContentPreview.kt
@@ -17,6 +17,7 @@ internal fun PermissionContentPreview() {
                 isNextButtonVisible = false,
             ),
             onEvent = {},
+            appName = "AppName",
         )
     }
 }

--- a/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionScreenPreview.kt
+++ b/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionScreenPreview.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.onboarding.permissions.ui
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.android.permissions.PermissionState
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import kotlinx.coroutines.Dispatchers
@@ -15,6 +16,9 @@ internal fun PermissionScreenPreview() {
                 checkPermission = { PermissionState.Denied },
                 backgroundDispatcher = Dispatchers.Main.immediate,
             ),
+            appNameProvider = object : AppNameProvider {
+                override val appName: String = "AppName"
+            },
             onNext = {},
         )
     }

--- a/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
+++ b/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
@@ -39,6 +39,7 @@ import app.k9mail.feature.account.common.R as CommonR
 internal fun PermissionsContent(
     state: State,
     onEvent: (Event) -> Unit,
+    appName: String,
 ) {
     val scrollState = rememberScrollState()
 
@@ -59,7 +60,7 @@ internal fun PermissionsContent(
                     .fillMaxHeight()
                     .verticalScroll(state = scrollState),
             ) {
-                HeaderArea()
+                HeaderArea(appName = appName)
 
                 ContentArea(state, onEvent)
 
@@ -72,11 +73,15 @@ internal fun PermissionsContent(
 }
 
 @Composable
-private fun HeaderArea() {
+private fun HeaderArea(
+    appName: String,
+) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        AppTitleTopHeader()
+        AppTitleTopHeader(
+            title = appName,
+        )
 
         TextHeadlineSmall(
             text = stringResource(R.string.onboarding_permissions_screen_title),

--- a/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsScreen.kt
+++ b/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsScreen.kt
@@ -8,14 +8,17 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.feature.onboarding.permissions.ui.PermissionsContract.Effect
 import app.k9mail.feature.onboarding.permissions.ui.PermissionsContract.Event
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 
 @Composable
 fun PermissionsScreen(
     viewModel: PermissionsContract.ViewModel = koinViewModel<PermissionsViewModel>(),
+    appNameProvider: AppNameProvider = koinInject(),
     onNext: () -> Unit,
 ) {
     val contactsPermissionLauncher = rememberLauncherForActivityResult(RequestPermission()) { success ->
@@ -45,6 +48,7 @@ fun PermissionsScreen(
     PermissionsContent(
         state = state.value,
         onEvent = dispatch,
+        appName = appNameProvider.appName,
     )
 }
 

--- a/feature/onboarding/welcome/build.gradle.kts
+++ b/feature/onboarding/welcome/build.gradle.kts
@@ -8,5 +8,6 @@ android {
 }
 
 dependencies {
+    implementation(projects.core.common)
     implementation(projects.core.ui.compose.designsystem)
 }

--- a/feature/onboarding/welcome/src/debug/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContentPreview.kt
+++ b/feature/onboarding/welcome/src/debug/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContentPreview.kt
@@ -11,6 +11,7 @@ internal fun WelcomeContentPreview() {
         WelcomeContent(
             onStartClick = {},
             onImportClick = {},
+            appName = "AppName",
         )
     }
 }

--- a/feature/onboarding/welcome/src/debug/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeScreenPreview.kt
+++ b/feature/onboarding/welcome/src/debug/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeScreenPreview.kt
@@ -1,16 +1,20 @@
 package app.k9mail.feature.onboarding.welcome.ui
 
 import androidx.compose.runtime.Composable
+import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 
 @Composable
 @PreviewDevices
-internal fun WelcomeScreenThunderbirdPreview() {
+internal fun WelcomeScreenPreview() {
     PreviewWithTheme {
         WelcomeScreen(
             onStartClick = {},
             onImportClick = {},
+            appNameProvider = object : AppNameProvider {
+                override val appName: String = "AppName"
+            },
         )
     }
 }

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
@@ -37,6 +37,7 @@ private const val LOGO_SIZE_DP = 200
 internal fun WelcomeContent(
     onStartClick: () -> Unit,
     onImportClick: () -> Unit,
+    appName: String,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -65,6 +66,7 @@ internal fun WelcomeContent(
                 }
                 item {
                     WelcomeTitle(
+                        title = appName,
                         modifier = Modifier.defaultItemModifier(),
                     )
                 }
@@ -105,6 +107,7 @@ private fun WelcomeLogo(
 
 @Composable
 private fun WelcomeTitle(
+    title: String,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -112,7 +115,7 @@ private fun WelcomeTitle(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         TextDisplayMedium(
-            text = stringResource(id = R.string.onboarding_welcome_title),
+            text = title,
         )
     }
 }

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
@@ -73,6 +73,7 @@ internal fun WelcomeContent(
                 item {
                     WelcomeMessage(
                         modifier = Modifier.defaultItemModifier(),
+                        appName = appName,
                     )
                 }
             }
@@ -122,6 +123,7 @@ private fun WelcomeTitle(
 
 @Composable
 private fun WelcomeMessage(
+    appName: String,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -131,7 +133,7 @@ private fun WelcomeMessage(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         TextBodyLarge(
-            text = stringResource(id = R.string.onboarding_welcome_message),
+            text = stringResource(id = R.string.onboarding_welcome_message, appName),
         )
     }
 }

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeScreen.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeScreen.kt
@@ -1,14 +1,17 @@
 package app.k9mail.feature.onboarding.welcome.ui
 
 import androidx.compose.runtime.Composable
+import app.k9mail.core.common.provider.AppNameProvider
 
 @Composable
 fun WelcomeScreen(
     onStartClick: () -> Unit,
     onImportClick: () -> Unit,
+    appNameProvider: AppNameProvider,
 ) {
     WelcomeContent(
         onStartClick = onStartClick,
         onImportClick = onImportClick,
+        appName = appNameProvider.appName,
     )
 }

--- a/feature/onboarding/welcome/src/main/res/values-ar/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-ar/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Začít</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importovat nastavení</string>
     <string name="onboarding_welcome_message">Vítejte v K-9 Mail, e-mailovém klientu pro Android navrženém pro bezpečnost, snadné přizpůsobení a jednotnou správu všech vašich e-mailových účtů.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-az/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-az/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Başlat</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_message">K-9 Mail-ə Xoş Gəlmisiniz!
 \nTəkmil təhlükəsizlik, rahat fərdiləşdirmə və bütün e-poçt hesablarınızın qüsursuz idarə edilməsi üçün tərtib edilən Android e-poçt müştərisidir.</string>
     <string name="onboarding_welcome_import_button">Tənzimləmələri idxal et</string>

--- a/feature/onboarding/welcome/src/main/res/values-be/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-be/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Comenzar</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importar ajustes</string>
     <string name="onboarding_welcome_message">Te damos la bienvenida a K-9 Mail, el cliente de correo electrónico para Android que proporciona una seguridad avanzada, una personalización accesible y el poder aglutinar todas tus cuentas en una única línea temporal.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-bg/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-bg/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Alusta</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Impordi seadistused</string>
     <string name="onboarding_welcome_message">Tere tulemast kasutama K-9 Maili! Tegemiston Androidile mõeldud e-posti kliendiga, millel on tõhus turvalisus, mugav kohendatavus ning mugavad võimalused sinu kõikide e-postikontode haldamiseks.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-br/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-br/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Hasi</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Ezarpenak inportatu</string>
     <string name="onboarding_welcome_message">Ongi etorri K-9 Mail-era, segurtasun handiagoa, pertsonalizazio erraza eta posta elektronikoko kontu guztiak pitzadurarik gabe kudeatzeko diseinatutako Android-erako posta elektronikoko bezerora.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-bs/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-bs/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_message">Dobrodošli u K-9 Mail, Android mejl klijent dizajniran za jaku sigurnost, lako prilagođavanje i brzo upravljanje svim vašim mejl računima.</string>
     <string name="onboarding_welcome_start_button">Počnimo</string>
     <string name="onboarding_welcome_import_button">Uvezite postavke</string>

--- a/feature/onboarding/welcome/src/main/res/values-ca/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-ca/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Inicia</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importa una configuració</string>
     <string name="onboarding_welcome_message">Us donem la benvinguda al K-9 Mail, el client d\'Android de correu electrònic dissenyat per a millorar la seguretat, facilitar la personalització i gestionar sense problemes tots els vostres comptes de correu.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-co/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-co/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_start_button">Principià</string>
     <string name="onboarding_welcome_import_button">Impurtà i parametri</string>
     <string name="onboarding_welcome_message">Benvenuta in K-9 Mail, l’appiecazione di messaghjeria per Android, cuncepita per una sicurità amendata, una persunalizazione faciule è una ghjestione senza straziu di tutti i vostri conti di messaghjeria.</string>

--- a/feature/onboarding/welcome/src/main/res/values-cs/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-cs/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Začít</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importovat nastavení</string>
     <string name="onboarding_welcome_message">Vítejte v K-9 Mail, e-mailovém klientu pro Android navrženém pro bezpečnost, snadné přizpůsobení a jednotnou správu všech vašich e-mailových účtů.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-cy/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-cy/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Démarrer</string>
-    <string name="onboarding_welcome_title">Courriel K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importer les paramètres</string>
     <string name="onboarding_welcome_message">Bienvenue sur Courriel K-9 Mail, le client de courriel pour Android conçu pour une sécurité accrue, une personnalisation facilitée et une gestion optimisée de tous vos comptes de courriel.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-da/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-da/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Start</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importér indstillinger</string>
     <string name="onboarding_welcome_message">Velkommen til K-9 Mail, en Android email klient designet til forbedret sikkerhed, nem tilpasning og problemfri håndtering af alle dine email konti.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-de/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-de/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Los</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Einstellungen importieren</string>
     <string name="onboarding_welcome_message">Willkommen bei K-9 Mail, dem Android-E-Mail-Client, der für mehr Sicherheit, einfache Anpassung und nahtlose Verwaltung aller deiner E-Mail-Konten entwickelt wurde.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-el/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-el/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Start</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Ynstellingen ymportearje</string>
     <string name="onboarding_welcome_message">Wolkom by K-9 Mail, de Android e-mailclient ûntwurpen foar ferbettere befeiliging, ienfâldige oanpasmooglikheden en maklik behear fan al jo e-mailaccounts.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-en-rGB/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-en-rGB/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_start_button">Start</string>
     <string name="onboarding_welcome_import_button">Import settings</string>
     <string name="onboarding_welcome_message">Welcome to K-9 Mail, the Android email client designed for enhanced security, easy customisation, and seamless management of all your email accounts.</string>

--- a/feature/onboarding/welcome/src/main/res/values-eo/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-eo/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Start</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Instellingen importeren</string>
     <string name="onboarding_welcome_message">Welkom bij K-9 Mail, de Android e-mailclient ontworpen voor verbeterde beveiliging, eenvoudige aanpasmogelijkheden en naadloos beheer van al uw e-mailaccounts.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-es/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-es/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Comenzar</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importar ajustes</string>
     <string name="onboarding_welcome_message">Te damos la bienvenida a K-9 Mail, el cliente de correo electrónico para Android que proporciona una seguridad avanzada, una personalización accesible y el poder aglutinar todas tus cuentas en una única línea temporal.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-et/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-et/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Starta</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_message">Välkommen till K-9 Mail, Android-e-postklienten designad för förbättrad säkerhet, enkel anpassning och sömlös hantering av alla dina e-postkonton.</string>
     <string name="onboarding_welcome_import_button">Importera inställningar</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-eu/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-eu/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">開始</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">匯入設定</string>
     <string name="onboarding_welcome_message">歡迎使用 K-9 Mail，這是一款旨在為增強安全性、輕鬆自訂以及無縫管理您所有的電子郵件帳號而設計的 Android 電子郵件用戶端。</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-fa/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-fa/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="onboarding_welcome_title">نامهٔ کِی۹</string>
     <string name="onboarding_welcome_start_button">شروع</string>
     <string name="onboarding_welcome_import_button">درون‌برد تنظیمات</string>
     <string name="onboarding_welcome_message">به کارخواه رایانامهٔ اندرویدی کی۹ که برای امنیت پیشرفته، سفارشی سازی آسان و مدیریت یکپارچه تمام حساب‌های رایانامه‌تان طرّاحی شده خوش آمدید.</string>

--- a/feature/onboarding/welcome/src/main/res/values-fi/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-fi/strings.xml
@@ -2,6 +2,5 @@
 <resources>
     <string name="onboarding_welcome_start_button">Aloita</string>
     <string name="onboarding_welcome_import_button">Tuo asetukset</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_message">Tervetuloa K-9 Mailiin, Android-sähköpostiohjelmaan, joka on suunniteltu parannettua turvallisuutta, helppoa mukauttamista ja saumatonta tilien hallintaa ajatellen.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-fr/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Démarrer</string>
-    <string name="onboarding_welcome_title">Courriel K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importer les paramètres</string>
     <string name="onboarding_welcome_message">Bienvenue sur Courriel K-9 Mail, le client de courriel pour Android conçu pour une sécurité accrue, une personnalisation facilitée et une gestion optimisée de tous vos comptes de courriel.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-fy/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-fy/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Starte</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Ynstellingen ymportearje</string>
     <string name="onboarding_welcome_message">Wolkom by K-9 Mail, de Android e-mailclient ûntwurpen foar ferbettere befeiliging, maklike oanpassingen en noflik behear fan al jo e-mailaccounts.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-hi/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-hi/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">शुरू करें</string>
-    <string name="onboarding_welcome_title">के-9 मेल</string>
     <string name="onboarding_welcome_import_button">सेटिंग इंपोर्ट करें</string>
     <string name="onboarding_welcome_message">ज़्यादा सेफ्टी, सीधे-साधे सेटिंग, और आपके सारे ईमेल अकाउंट के आसान मैनेजमेंट के लिए डिज़ाइन किया गया एक एंड्रॉइड ईमेल क्लाइंट। के-9 मेल में स्वागत है।</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-hu/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-hu/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Indulás</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Beállítások importálása</string>
     <string name="onboarding_welcome_message">Üdvözlet a K-9 Mail alkalmazásban, az Android e-mail klienst a megerősített biztonság, a könnyű testreszabás és az összes e-mail fiók zökkenőmentes kezelése érdekében tervezték.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-in/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-in/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_message">Selamat datang di K-9 Mail, klien surel Android yang dirancang untuk meningkatkan keamanan, pengaturan yang mudah, dan manajemen yang lancar untuk semua akun surel Anda.</string>
     <string name="onboarding_welcome_start_button">Mulai</string>
     <string name="onboarding_welcome_import_button">Impor pengaturan</string>

--- a/feature/onboarding/welcome/src/main/res/values-is/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-is/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Byrja</string>
-    <string name="onboarding_welcome_title">K-9 Póstur</string>
     <string name="onboarding_welcome_import_button">Flytja inn stillingar</string>
     <string name="onboarding_welcome_message">Velkomin í K-9 Póstinn, tölvupóstforrit fyrir Android sem er hannað til að auka öryggi, að vera auðvelt að sérsníða, og sem auðveldi umsýslu með tölvupósti og notendaðgöngum.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-it/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-it/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Iniziamo</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importa impostazioni</string>
     <string name="onboarding_welcome_message">Benvenuto in K-9 Mail, il client di posta elettronica Android progettato per la sicurezza, la personalizzazione e la gestione di tutti i tuoi account email</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-iw/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-iw/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="onboarding_welcome_title">דוא\"ל K-9</string>
     <string name="onboarding_welcome_message">ברוכים הבאים לדוא\"ל K-9, לקוח הדואר האלקטרוני של אנדרואיד שתוכנן עבור אבטחה משופרת, התאמה אישית קלה וניהול חלק של כל חשבונות הדואר האלקטרוני שלכם.</string>
     <string name="onboarding_welcome_start_button">התחל</string>
     <string name="onboarding_welcome_import_button">ייבוא הגדרות</string>

--- a/feature/onboarding/welcome/src/main/res/values-ja/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-ja/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">開始</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">設定をインポート</string>
     <string name="onboarding_welcome_message">強固なセキュリティと簡単なカスタマイズ、複数アカウントのシームレスな管理のために設計された Android メールクライアント、K-9 Mail にようこそ。</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-ko/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-ko/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">시작하기</string>
-    <string name="onboarding_welcome_title">K-9 메일</string>
     <string name="onboarding_welcome_import_button">설정 가져오기</string>
     <string name="onboarding_welcome_message">강력한 보안, 쉬운 커스터마이징, 여러 이메일 계정의 원활한 관리를 위해 설계된 Android 이메일 클라이언트인 K-9 Mail에 오신 것을 환영합니다.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-lt/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-lt/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_message">Sveiki! Tai – „K-9 paštas“, el. pašto programa „Android“ aplinkai, orientuota į didesnį saugumą, patogų tinkinimą ir paprastą el. pašto paskyrų tvarkymą.</string>
-    <string name="onboarding_welcome_title">K-9 paštas</string>
     <string name="onboarding_welcome_start_button">Pradėti</string>
     <string name="onboarding_welcome_import_button">Importuoti nustatymus</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-nb-rNO/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Start</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importer innstillinger</string>
     <string name="onboarding_welcome_message">Velkommen til K-9 Mail, Android-e-postklienten er designet for bedret sikkerhet, enklere tilpasning, og sømløs håndtering av alle e-postkontoene dine.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-nl/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-nl/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Starten</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Instellingen importeren</string>
     <string name="onboarding_welcome_message">Welkom bij K-9 Mail, de Android-e-mailclient ontworpen voor verbeterde beveiliging, gemakkelijke aanpassingen en eenvoudig beheer van al uw e-mailaccounts.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-pl/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-pl/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Rozpocznij</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importuj ustawienia</string>
     <string name="onboarding_welcome_message">Witamy w K-9 Mail, kliencie poczty e-mail dla systemu Android zaprojektowanym z myślą o większym bezpieczeństwie, łatwym dostosowywaniu i bezproblemowym zarządzaniu wszystkimi kontami e-mail.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-pt-rBR/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Começar</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importar configurações</string>
     <string name="onboarding_welcome_message">Bem-vindo ao K-9 Mail, o cliente de correio eletrônico para Android projetado para proporcionar maior segurança, personalização fácil e gestão integrada de todas as suas contas.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-pt-rPT/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-pt-rPT/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Iniciar</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importar configurações</string>
     <string name="onboarding_welcome_message">Bem-vindo ao K-9 Mail, o cliente de correio eletrónico para Android concebido para aumentar a segurança, facilitar a personalização e gerir sem problemas todas as suas contas de correio eletrónico.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-ro/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-ro/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Start</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importă setările</string>
     <string name="onboarding_welcome_message">Bine ai venit la K-9 Mail, clientul de e-mail Android conceput pentru securitate sporită, personalizare ușoară și gestionarea fără probleme a tuturor conturilor de e-mail.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-ru/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="onboarding_welcome_title">Почта K-9</string>
     <string name="onboarding_welcome_start_button">Начать</string>
     <string name="onboarding_welcome_import_button">Импорт настроек</string>
     <string name="onboarding_welcome_message">Добро пожаловать в Почту K-9 - почтовый клиент для Android, обеспечивающий повышенную безопасность, лёгкую настройку и удобное управление всеми учётными записями электронной почты.</string>

--- a/feature/onboarding/welcome/src/main/res/values-sk/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-sk/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Začať</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_message">Vitajte v K-9 Mail, e-mailovej aplikácii pre Android navrhnutej pre bezpečnosť a jednoduché prispôsobovanie a správu všetkých vašich e-mailových účtov.</string>
     <string name="onboarding_welcome_import_button">Importovať nastavenia</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-sq/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-sq/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Nisjani</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importo rregullime</string>
     <string name="onboarding_welcome_message">Mirë se vini në K-9 Mail, klient email për Android i hartuar për siguri të thelluar, përshtatje të lehtë dhe administrim pa të metë të krejt llogarive tuaja email.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-sv/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-sv/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Starta</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">Importera inställningar</string>
     <string name="onboarding_welcome_message">Välkommen till K-9 Mail, Android-e-postklienten designad för förbättrad säkerhet, enkel anpassning och sömlös hantering av alla dina e-postkonton.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-tr/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-tr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Başla</string>
-    <string name="onboarding_welcome_title">K-9 Posta</string>
     <string name="onboarding_welcome_import_button">Ayarları içe aktar</string>
     <string name="onboarding_welcome_message">Gelişmiş güvenlik, kolay özelleştirme ve tüm e-posta hesaplarınızın sorunsuz yönetimi için tasarlanan Android e-posta istemcisi K-9 Posta\'ya hoş geldiniz.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-vi/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-vi/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">Bắt đầu</string>
-    <string name="onboarding_welcome_title">Thư K-9</string>
     <string name="onboarding_welcome_import_button">Nhập thiết đặt</string>
     <string name="onboarding_welcome_message">Chào mừng bạn đến với Thư K-9, ứng dụng email khách Android được thiết kế để tăng cường bảo mật, tùy chỉnh dễ dàng và quản lý liền mạch tất cả tài khoản email của bạn.</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-zh-rCN/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">开始</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">导入设置</string>
     <string name="onboarding_welcome_message">欢迎使用 K-9 Mail，这是一款 Android 电子邮件客户端，旨在增强安全性、轻松定制和无缝管理您的所有电子邮件账号。</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values-zh-rTW/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="onboarding_welcome_start_button">開始</string>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_import_button">匯入設定</string>
     <string name="onboarding_welcome_message">歡迎使用 K-9 Mail，這是一款旨在為增強安全性、輕鬆自訂以及無縫管理您所有的電子郵件帳號而設計的 Android 電子郵件用戶端。</string>
 </resources>

--- a/feature/onboarding/welcome/src/main/res/values/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="onboarding_welcome_title">K-9 Mail</string>
     <string name="onboarding_welcome_message">Welcome to K-9 Mail, the Android email client designed for enhanced security, easy customization, and seamless management of all your email accounts.</string>
     <string name="onboarding_welcome_start_button">Start</string>
     <string name="onboarding_welcome_import_button">Import settings</string>

--- a/feature/onboarding/welcome/src/main/res/values/strings.xml
+++ b/feature/onboarding/welcome/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="onboarding_welcome_message">Welcome to K-9 Mail, the Android email client designed for enhanced security, easy customization, and seamless management of all your email accounts.</string>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="onboarding_welcome_message">Welcome to <xliff:g id="app_name">%s</xliff:g>, the Android email client designed for enhanced security, easy customization, and seamless management of all your email accounts.</string>
     <string name="onboarding_welcome_start_button">Start</string>
     <string name="onboarding_welcome_import_button">Import settings</string>
 </resources>

--- a/feature/settings/import/src/main/res/values/strings.xml
+++ b/feature/settings/import/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="settings_import_outgoing_server_password_hint">Outgoing server password</string>
     <string name="settings_import_use_same_password_for_outgoing_server">Use same password for outgoing server</string>
     <string name="settings_import_server_name_format">Server name: <xliff:g id="hostname">%s</xliff:g></string>
-    <string name="settings_import_oauth_description">To use this email account with K-9 Mail, you need to sign in and grant the app access to your emails.</string>
+    <string name="settings_import_oauth_description">To use this email account, you need to sign in and grant the app access to your emails.</string>
     <string name="settings_import_oauth_sign_in">Sign in</string>
     <string name="settings_import_oauth_sign_in_with_google">Sign in with Google</string>
     <string name="settings_import_oauth_error_oauth_flow_canceled">Authorization canceled</string>


### PR DESCRIPTION
Follow up on #7924. The hard coded app name is replaced by using the new `AppNameProvider`, part 1. 
