### PR TITLE
Fix use of GlobalScope for coroutines

### DIFF
--- a/app/common/src/main/java/com/fsck/k9/CommonApp.kt
+++ b/app/common/src/main/java/com/fsck/k9/CommonApp.kt
@@ -12,13 +12,11 @@ import com.fsck.k9.ui.base.ThemeManager
 import com.fsck.k9.ui.base.extensions.currentLocale
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.plus
 import org.koin.android.ext.android.inject
 import org.koin.core.module.Module
 import timber.log.Timber
@@ -33,7 +31,7 @@ abstract class CommonApp : Application(), WorkManagerConfiguration.Provider {
     private val messageListWidgetManager: MessageListWidgetManager by inject()
     private val workManagerConfigurationProvider: WorkManagerConfigurationProvider by inject()
 
-    private val appCoroutineScope: CoroutineScope = GlobalScope + Dispatchers.Main
+    private val appCoroutineScope: CoroutineScope = MainScope()
     private var appLanguageManagerInitialized = false
 
     override fun onCreate() {

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/AppLanguageManager.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/AppLanguageManager.kt
@@ -7,12 +7,10 @@ import com.fsck.k9.ui.base.locale.SystemLocaleChangeListener
 import com.fsck.k9.ui.base.locale.SystemLocaleManager
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 
 /**
  * Manages app language changes.
@@ -22,7 +20,7 @@ import kotlinx.coroutines.plus
  */
 class AppLanguageManager(
     private val systemLocaleManager: SystemLocaleManager,
-    private val coroutineScope: CoroutineScope = GlobalScope + Dispatchers.Main,
+    private val coroutineScope: CoroutineScope = MainScope(),
 ) {
     private var currentOverrideLocale: Locale? = null
     private val _overrideLocale = MutableSharedFlow<Locale?>(replay = 1)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferPresenter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferPresenter.kt
@@ -4,8 +4,8 @@ import android.app.PendingIntent
 import androidx.lifecycle.LifecycleOwner
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import org.openintents.openpgp.OpenPgpApiManager
 import org.openintents.openpgp.OpenPgpApiManager.OpenPgpApiManagerCallback
@@ -18,6 +18,7 @@ class AutocryptKeyTransferPresenter internal constructor(
     private val preferences: Preferences,
     private val viewModel: AutocryptKeyTransferViewModel,
     private val view: AutocryptKeyTransferActivity,
+    private val presenterScope: CoroutineScope = MainScope(),
 ) {
 
     private lateinit var account: Account
@@ -67,7 +68,7 @@ class AutocryptKeyTransferPresenter internal constructor(
     fun onClickTransferSend() {
         view.sceneGeneratingAndSending()
 
-        GlobalScope.launch(Dispatchers.Main) {
+        presenterScope.launch {
             view.uxDelay()
             view.setLoadingStateGenerating()
 
@@ -97,6 +98,7 @@ class AutocryptKeyTransferPresenter internal constructor(
                 view.setLoadingStateFinished()
                 view.sceneFinished()
             }
+
             is AutocryptSetupTransferResult.Failure -> {
                 Timber.e(result.exception, "Error sending setup message")
                 view.setLoadingStateSendingFailed()

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupMessageLiveEvent.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupMessageLiveEvent.kt
@@ -10,20 +10,25 @@ import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.Message
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.openintents.openpgp.util.OpenPgpApi
 
 class AutocryptSetupMessageLiveEvent(
     val messageCreator: AutocryptTransferMessageCreator,
+    private val eventScope: CoroutineScope = MainScope(),
 ) : SingleLiveEvent<AutocryptSetupMessage>() {
+
     fun loadAutocryptSetupMessageAsync(openPgpApi: OpenPgpApi, account: Account) {
-        GlobalScope.launch(Dispatchers.Main) {
-            value = withContext(Dispatchers.IO) {
+        eventScope.launch {
+            val result = withContext(Dispatchers.IO) {
                 loadAutocryptSetupMessage(openPgpApi, account)
             }
+
+            value = result
         }
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupTransferLiveEvent.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupTransferLiveEvent.kt
@@ -4,18 +4,20 @@ import android.app.PendingIntent
 import com.fsck.k9.Account
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.helper.SingleLiveEvent
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class AutocryptSetupTransferLiveEvent(
     private val messagingController: MessagingController,
+    private val eventScope: CoroutineScope = MainScope(),
 ) : SingleLiveEvent<AutocryptSetupTransferResult>() {
 
     fun sendMessageAsync(account: Account, setupMsg: AutocryptSetupMessage) {
-        GlobalScope.launch(Dispatchers.Main) {
+        eventScope.launch {
             val setupMessage = async(Dispatchers.IO) {
                 messagingController.sendMessageBlocking(account, setupMsg.setupMessage)
             }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsDataStore.kt
@@ -7,15 +7,15 @@ import com.fsck.k9.mailstore.FolderDetails
 import com.fsck.k9.mailstore.FolderRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 class FolderSettingsDataStore(
     private val folderRepository: FolderRepository,
     private val account: Account,
     private var folder: FolderDetails,
+    private val saveScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) : PreferenceDataStore() {
-    private val saveScope = CoroutineScope(GlobalScope.coroutineContext + Dispatchers.IO)
 
     override fun getBoolean(key: String?, defValue: Boolean): Boolean {
         return when (key) {
@@ -50,15 +50,19 @@ class FolderSettingsDataStore(
             "folder_settings_folder_display_mode" -> {
                 updateFolder(folder.copy(displayClass = FolderClass.valueOf(newValue)))
             }
+
             "folder_settings_folder_sync_mode" -> {
                 updateFolder(folder.copy(syncClass = FolderClass.valueOf(newValue)))
             }
+
             "folder_settings_folder_notify_mode" -> {
                 updateFolder(folder.copy(notifyClass = FolderClass.valueOf(newValue)))
             }
+
             "folder_settings_folder_push_mode" -> {
                 updateFolder(folder.copy(pushClass = FolderClass.valueOf(newValue)))
             }
+
             else -> error("Unknown key: $key")
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
@@ -2,28 +2,30 @@ package com.fsck.k9.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.fsck.k9.Account
 import com.fsck.k9.preferences.AccountManager
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 internal class SettingsViewModel(
     private val accountManager: AccountManager,
-    private val coroutineScope: CoroutineScope = GlobalScope,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
     val accounts = accountManager.getAccountsFlow().asLiveData()
 
     fun moveAccount(account: Account, newPosition: Int) {
-        coroutineScope.launch(coroutineDispatcher) {
+        viewModelScope.launch(coroutineDispatcher) {
             // Delay saving the account so the animation is not disturbed
             delay(500)
 
-            accountManager.moveAccount(account, newPosition)
+            withContext(NonCancellable) {
+                accountManager.moveAccount(account, newPosition)
+            }
         }
     }
 }

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportViewModel.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportViewModel.kt
@@ -18,7 +18,7 @@ import com.fsck.k9.preferences.SettingsImporter
 import com.fsck.k9.ui.base.bundle.getEnum
 import com.fsck.k9.ui.base.bundle.putEnum
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -228,9 +228,11 @@ internal class SettingsImportViewModel(
             updateCloseButtonAndImportStatusText()
         }
 
-        GlobalScope.launch(Dispatchers.IO) {
-            with(result) {
-                accountActivator.enableAccount(accountUuid, incomingServerPassword, outgoingServerPassword)
+        viewModelScope.launch(Dispatchers.IO) {
+            withContext(NonCancellable) {
+                with(result) {
+                    accountActivator.enableAccount(accountUuid, incomingServerPassword, outgoingServerPassword)
+                }
             }
         }
     }
@@ -244,8 +246,10 @@ internal class SettingsImportViewModel(
                 updateCloseButtonAndImportStatusText()
             }
 
-            GlobalScope.launch(Dispatchers.IO) {
-                accountActivator.enableAccount(accountUuid)
+            viewModelScope.launch(Dispatchers.IO) {
+                withContext(NonCancellable) {
+                    accountActivator.enableAccount(accountUuid)
+                }
             }
         }
     }

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/BaseUnreadWidgetProvider.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/BaseUnreadWidgetProvider.kt
@@ -10,8 +10,9 @@ import android.widget.RemoteViews
 import androidx.core.app.PendingIntentCompat
 import com.fsck.k9.EarlyInit
 import com.fsck.k9.inject
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -47,11 +48,12 @@ import timber.log.Timber
  */
 abstract class BaseUnreadWidgetProvider : AppWidgetProvider(), EarlyInit {
     private val repository: UnreadWidgetRepository by inject()
+    private val widgetScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
         val pendingResult = goAsync()
 
-        GlobalScope.launch(Dispatchers.IO) {
+        widgetScope.launch {
             updateWidgets(context, appWidgetManager, appWidgetIds)
             pendingResult.finish()
         }


### PR DESCRIPTION
The app currently uses the coroutine `GlobalScope` in a couple of places. This approach should be avoided whenever possible, as it can lead to issues like memory leaks and unpredictable behavior. Coroutines launched with `GlobalScope` are not tied to any specific lifecycle and continue running even if the component that started them is destroyed.

This changes use of `GlobalScope` to more appropriate scopes if available.

Left open:

- `KoinModule`: `mainModule` still uses a `GlobalScope` to provide the `AppCoroutineScope` and it's used in a couple of places that I won't cover in this pull-request
- `PushController`: `GlobalScope` might still be needed, but I'm not too deep into that part of the code yet to decide.
