### PR TITLE
Revert "Replace app name usage - Part 2"

### DIFF
--- a/app/common/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
+++ b/app/common/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
@@ -1,17 +1,13 @@
 package com.fsck.k9.resources
 
 import android.content.Context
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.notification.PushNotificationState
 import com.fsck.k9.ui.R
 
-class K9CoreResourceProvider(
-    private val context: Context,
-    private val appNameProvider: AppNameProvider,
-) : CoreResourceProvider {
-    override fun defaultSignature(): String = context.getString(R.string.default_signature, appNameProvider.appName)
+class K9CoreResourceProvider(private val context: Context) : CoreResourceProvider {
+    override fun defaultSignature(): String = context.getString(R.string.default_signature)
     override fun defaultIdentityDescription(): String = context.getString(R.string.default_identity_description)
 
     override fun contactDisplayNamePrefix(): String = context.getString(R.string.message_to_label)

--- a/app/common/src/main/java/com/fsck/k9/resources/KoinModule.kt
+++ b/app/common/src/main/java/com/fsck/k9/resources/KoinModule.kt
@@ -5,15 +5,6 @@ import com.fsck.k9.autocrypt.AutocryptStringProvider
 import org.koin.dsl.module
 
 val resourcesModule = module {
-    single<CoreResourceProvider> {
-        K9CoreResourceProvider(
-            context = get(),
-            appNameProvider = get(),
-        )
-    }
-    single<AutocryptStringProvider> {
-        K9AutocryptStringProvider(
-            context = get(),
-        )
-    }
+    single<CoreResourceProvider> { K9CoreResourceProvider(get()) }
+    single<AutocryptStringProvider> { K9AutocryptStringProvider(get()) }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/push/PushInfoFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/push/PushInfoFragment.kt
@@ -13,7 +13,6 @@ import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import app.k9mail.core.common.provider.AppNameProvider
 import com.fsck.k9.controller.push.PushController
 import com.fsck.k9.notification.NotificationChannelManager
 import com.fsck.k9.ui.R
@@ -26,7 +25,6 @@ private const val LEARN_MORE_URL = "https://k9mail.app/go/push-info"
 class PushInfoFragment : Fragment() {
     private val notificationChannelManager: NotificationChannelManager by inject()
     private val pushController: PushController by inject()
-    private val appNameProvider: AppNameProvider by inject()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_push_info, container, false)
@@ -39,26 +37,19 @@ class PushInfoFragment : Fragment() {
 
     private fun initializeNotificationSection(view: View) {
         val notificationTextView = view.findViewById<MaterialTextView>(R.id.notificationText)
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val configureNotificationText = getString(R.string.push_info_configure_notification_text)
             notificationTextView.text = getString(
                 R.string.push_info_notification_explanation_text,
-                appNameProvider.appName,
                 configureNotificationText,
             )
-
             val configureNotificationButton = view.findViewById<MaterialButton>(R.id.configureNotificationButton)
             configureNotificationButton.isVisible = true
             configureNotificationButton.setOnClickListener {
                 launchNotificationSettings()
             }
         } else {
-            notificationTextView.text = getString(
-                R.string.push_info_notification_explanation_text,
-                appNameProvider.appName,
-                "",
-            )
+            notificationTextView.text = getString(R.string.push_info_notification_explanation_text, "")
         }
 
         view.findViewById<MaterialButton>(R.id.learnMoreButton).setOnClickListener {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/AboutFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/AboutFragment.kt
@@ -14,24 +14,17 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import app.k9mail.core.common.provider.AppNameProvider
 import com.fsck.k9.ui.R
 import com.google.android.material.textview.MaterialTextView
-import org.koin.android.ext.android.inject
 import timber.log.Timber
 
 class AboutFragment : Fragment() {
-    private val appNameProvider: AppNameProvider by inject()
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_about, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        val titleTextView = view.findViewById<MaterialTextView>(R.id.about_title)
-        titleTextView.text = getString(R.string.about_title, appNameProvider.appName)
 
         val versionTextView = view.findViewById<MaterialTextView>(R.id.version)
         versionTextView.text = getVersionNumber()

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -13,7 +13,6 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreference
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.feature.launcher.FeatureLauncherActivity
 import com.fsck.k9.Account
 import com.fsck.k9.account.BackgroundAccountRemover
@@ -53,7 +52,6 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     private val notificationChannelManager: NotificationChannelManager by inject()
     private val notificationSettingsUpdater: NotificationSettingsUpdater by inject()
     private val vibrator: Vibrator by inject()
-    private val appNameProvider: AppNameProvider by inject()
 
     private lateinit var dataStore: AccountSettingsDataStore
 
@@ -401,7 +399,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         val dialogFragment = ConfirmationDialogFragment.newInstance(
             DIALOG_DELETE_ACCOUNT,
             getString(R.string.account_delete_dlg_title),
-            getString(R.string.account_delete_dlg_instructions_fmt, getAccount().displayName, appNameProvider.appName),
+            getString(R.string.account_delete_dlg_instructions_fmt, getAccount().displayName),
             getString(BaseR.string.okay_action),
             getString(BaseR.string.cancel_action),
         )

--- a/app/ui/legacy/src/main/res/layout/fragment_about.xml
+++ b/app/ui/legacy/src/main/res/layout/fragment_about.xml
@@ -20,7 +20,6 @@
             app:srcCompat="@drawable/ic_app_logo" />
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/about_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingHorizontal="16dp"

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -30,18 +30,18 @@
 
 
     <!-- Default signature -->
-    <string name="default_signature">-- \nSent from my Android device with <xliff:g id="app_name">%s</xliff:g>. Please excuse my brevity.</string>
+    <string name="default_signature">-- \nSent from my Android device with K-9 Mail. Please excuse my brevity.</string>
 
 
     <!-- General strings that include the app name -->
-    <string name="account_delete_dlg_instructions_fmt">The account \"<xliff:g id="account">%s</xliff:g>\" will be removed from <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">The account \"<xliff:g id="account">%s</xliff:g>\" will be removed from K-9 Mail.</string>
 
 
     <!-- === General strings ================================================================== -->
 
     <string name="authors">Authors</string>
 
-    <string name="about_title">About <xliff:g id="app_name">%s</xliff:g></string>
+    <string name="about_title">About K-9 Mail</string>
     <string name="accounts_title">Accounts</string>
 
     <string name="compose_title_compose">Compose</string>
@@ -1034,7 +1034,7 @@
 
     <string name="dialog_openkeychain_info_title">No OpenPGP app installed</string>
     <string name="dialog_openkeychain_info_install">Install</string>
-    <string name="dialog_openkeychain_info_text">The app OpenKeychain is required to enable support for end-to-end encryption.</string>
+    <string name="dialog_openkeychain_info_text">K-9 Mail requires OpenKeychain for end-to-end encryption.</string>
 
     <string name="encrypted_subject">"Encrypted Message"</string>
     <string name="account_settings_crypto_encrypt_subject">Encrypt message subjects</string>
@@ -1078,7 +1078,7 @@ You can keep this message and use it as a backup for your secret key. If you wan
     <string name="push_notification_grant_alarm_permission">Tap to grant permission.</string>
 
     <string name="push_info_title">Push Info</string>
-    <string name="push_info_notification_explanation_text">When using Push, <xliff:g id="app_name">%1$s</xliff:g> maintains a connection to the mail server. Android requires displaying an ongoing notification while the app is active in the background. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
+    <string name="push_info_notification_explanation_text">When using Push, K-9 Mail maintains a connection to the mail server. Android requires displaying an ongoing notification while the app is active in the background. %s</string>
     <string name="push_info_configure_notification_text">However, Android also allows you to hide the notification.</string>
     <string name="push_info_learn_more_text">Learn more</string>
     <string name="push_info_configure_notification_action">Configure notification</string>


### PR DESCRIPTION
Reverts thunderbird/thunderbird-android#7943

As Weblate can't update the placeholders automatically, need to patch them first.