### PR TITLE
Add `ServerSettingsDescriptions` to validate and upgrade server settings

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
@@ -3,6 +3,7 @@ package com.fsck.k9.preferences
 internal class AccountSettingsUpgrader {
     private val identitySettingsUpgrader = IdentitySettingsUpgrader()
     private val folderSettingsUpgrader = FolderSettingsUpgrader()
+    private val serverSettingsUpgrader = ServerSettingsUpgrader()
 
     fun upgrade(contentVersion: Int, account: ValidatedSettings.Account): ValidatedSettings.Account {
         val validatedSettings = account.settings.toMutableMap()
@@ -12,6 +13,8 @@ internal class AccountSettingsUpgrader {
 
         return account.copy(
             settings = validatedSettings.toMap(),
+            incoming = serverSettingsUpgrader.upgrade(contentVersion, account.incoming),
+            outgoing = serverSettingsUpgrader.upgrade(contentVersion, account.outgoing),
             identities = upgradeIdentities(contentVersion, account.identities),
             folders = upgradeFolders(contentVersion, account.folders),
         )

--- a/app/core/src/main/java/com/fsck/k9/preferences/NoDefaultStringEnumSetting.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/NoDefaultStringEnumSetting.kt
@@ -1,0 +1,12 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.preferences.Settings.InvalidSettingValueException
+import com.fsck.k9.preferences.Settings.StringSetting
+
+internal class NoDefaultStringEnumSetting(
+    private val values: Set<String>,
+) : StringSetting(null) {
+    override fun fromString(value: String?): String {
+        return value?.takeIf { it in values } ?: throw InvalidSettingValueException("Unsupported value: $value")
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
@@ -1,0 +1,76 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.preferences.Settings.IntegerRangeSetting
+import com.fsck.k9.preferences.Settings.SettingsDescription
+import com.fsck.k9.preferences.Settings.SettingsUpgrader
+import com.fsck.k9.preferences.Settings.StringSetting
+import java.util.TreeMap
+
+/**
+ * Contains information to validate imported server settings with a given content version, and to upgrade those server
+ * settings to the latest content version.
+ */
+@Suppress("MagicNumber")
+internal class ServerSettingsDescriptions {
+    val settings: Map<String, TreeMap<Int, SettingsDescription<*>>> by lazy {
+        mapOf(
+            HOST to versions(
+                1 to StringSetting(null),
+            ),
+            PORT to versions(
+                1 to IntegerRangeSetting(1, 65535, -1),
+            ),
+            CONNECTION_SECURITY to versions(
+                1 to StringEnumSetting(
+                    defaultValue = "SSL_TLS_REQUIRED",
+                    values = setOf(
+                        "NONE",
+                        "STARTTLS_OPTIONAL",
+                        "STARTTLS_REQUIRED",
+                        "SSL_TLS_OPTIONAL",
+                        "SSL_TLS_REQUIRED",
+                    ),
+                ),
+            ),
+            AUTHENTICATION_TYPE to versions(
+                1 to NoDefaultStringEnumSetting(
+                    values = setOf(
+                        "PLAIN",
+                        "CRAM_MD5",
+                        "EXTERNAL",
+                        "XOAUTH2",
+                        "AUTOMATIC",
+                        "LOGIN",
+                    ),
+                ),
+            ),
+            USERNAME to versions(
+                1 to StringSetting(""),
+            ),
+            PASSWORD to versions(
+                1 to StringSetting(null),
+            ),
+            CLIENT_CERTIFICATE_ALIAS to versions(
+                1 to StringSetting(null),
+            ),
+        )
+    }
+
+    val upgraders: Map<Int, SettingsUpgrader> by lazy {
+        emptyMap()
+    }
+
+    companion object {
+        const val HOST = "host"
+        const val PORT = "port"
+        const val CONNECTION_SECURITY = "connectionSecurity"
+        const val AUTHENTICATION_TYPE = "authenticationType"
+        const val USERNAME = "username"
+        const val PASSWORD = "password"
+        const val CLIENT_CERTIFICATE_ALIAS = "clientCertificateAlias"
+    }
+}
+
+private fun versions(vararg versions: Pair<Int, SettingsDescription<*>>): TreeMap<Int, SettingsDescription<*>> {
+    return TreeMap(versions.toMap())
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
@@ -4,6 +4,7 @@ import com.fsck.k9.preferences.Settings.IntegerRangeSetting
 import com.fsck.k9.preferences.Settings.SettingsDescription
 import com.fsck.k9.preferences.Settings.SettingsUpgrader
 import com.fsck.k9.preferences.Settings.StringSetting
+import com.fsck.k9.preferences.upgrader.ServerSettingsUpgraderTo92
 import java.util.TreeMap
 
 /**
@@ -28,6 +29,13 @@ internal class ServerSettingsDescriptions {
                         "STARTTLS_OPTIONAL",
                         "STARTTLS_REQUIRED",
                         "SSL_TLS_OPTIONAL",
+                        "SSL_TLS_REQUIRED",
+                    ),
+                ),
+                92 to NoDefaultStringEnumSetting(
+                    values = setOf(
+                        "NONE",
+                        "STARTTLS_REQUIRED",
                         "SSL_TLS_REQUIRED",
                     ),
                 ),
@@ -57,7 +65,9 @@ internal class ServerSettingsDescriptions {
     }
 
     val upgraders: Map<Int, SettingsUpgrader> by lazy {
-        emptyMap()
+        mapOf(
+            92 to ServerSettingsUpgraderTo92(),
+        )
     }
 
     companion object {

--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsUpgrader.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsUpgrader.kt
@@ -1,0 +1,22 @@
+package com.fsck.k9.preferences
+
+internal class ServerSettingsUpgrader(
+    private val serverSettingsDescriptions: ServerSettingsDescriptions = ServerSettingsDescriptions(),
+) {
+    fun upgrade(contentVersion: Int, server: ValidatedSettings.Server): ValidatedSettings.Server {
+        if (contentVersion == Settings.VERSION) {
+            return server
+        }
+
+        val settings = server.settings.toMutableMap()
+
+        Settings.upgrade(
+            contentVersion,
+            serverSettingsDescriptions.upgraders,
+            serverSettingsDescriptions.settings,
+            settings,
+        )
+
+        return server.copy(settings = settings.toMap())
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsValidator.kt
@@ -1,0 +1,48 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.AUTHENTICATION_TYPE
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CLIENT_CERTIFICATE_ALIAS
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CONNECTION_SECURITY
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.HOST
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PASSWORD
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PORT
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.USERNAME
+import com.fsck.k9.preferences.ServerTypeConverter.toServerSettingsType
+import com.fsck.k9.preferences.Settings.InvalidSettingValueException
+
+internal class ServerSettingsValidator(
+    private val serverSettingsDescriptions: ServerSettingsDescriptions = ServerSettingsDescriptions(),
+) {
+    fun validate(contentVersion: Int, server: SettingsFile.Server): ValidatedSettings.Server {
+        val settings = convertServerSettingsToMap(server)
+
+        val validatedSettings = Settings.validate(contentVersion, serverSettingsDescriptions.settings, settings, true)
+
+        return ValidatedSettings.Server(
+            type = toServerSettingsType(server.type!!),
+            host = validatedSettings[HOST] as? String,
+            port = validatedSettings[PORT] as Int,
+            connectionSecurity = validatedSettings[CONNECTION_SECURITY] as String,
+            authenticationType = validatedSettings[AUTHENTICATION_TYPE] as? String
+                ?: throw InvalidSettingValueException("Missing '$AUTHENTICATION_TYPE' value"),
+            username = validatedSettings[USERNAME] as String,
+            password = validatedSettings[PASSWORD] as? String,
+            clientCertificateAlias = validatedSettings[CLIENT_CERTIFICATE_ALIAS] as? String,
+            extras = server.extras.orEmpty(),
+        )
+    }
+
+    private fun convertServerSettingsToMap(server: SettingsFile.Server): SettingsMap {
+        return buildMap {
+            server.host?.let { host -> put(HOST, host) }
+            server.port?.let { port -> put(PORT, port) }
+            server.connectionSecurity?.let { connectionSecurity -> put(CONNECTION_SECURITY, connectionSecurity) }
+            server.authenticationType?.let { authenticationType -> put(AUTHENTICATION_TYPE, authenticationType) }
+            server.username?.let { username -> put(USERNAME, username) }
+            server.password?.let { password -> put(PASSWORD, password) }
+            server.clientCertificateAlias?.let { clientCertificateAlias ->
+                put(CLIENT_CERTIFICATE_ALIAS, clientCertificateAlias)
+            }
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsValidator.kt
@@ -22,6 +22,10 @@ internal class ServerSettingsValidator(
             throw InvalidSettingValueException("Missing '$AUTHENTICATION_TYPE' value")
         }
 
+        if (validatedSettings[CONNECTION_SECURITY] !is String) {
+            throw InvalidSettingValueException("Missing '$CONNECTION_SECURITY' value")
+        }
+
         return ValidatedSettings.Server(
             type = toServerSettingsType(server.type!!),
             settings = validatedSettings,

--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsValidator.kt
@@ -18,16 +18,13 @@ internal class ServerSettingsValidator(
 
         val validatedSettings = Settings.validate(contentVersion, serverSettingsDescriptions.settings, settings, true)
 
+        if (validatedSettings[AUTHENTICATION_TYPE] !is String) {
+            throw InvalidSettingValueException("Missing '$AUTHENTICATION_TYPE' value")
+        }
+
         return ValidatedSettings.Server(
             type = toServerSettingsType(server.type!!),
-            host = validatedSettings[HOST] as? String,
-            port = validatedSettings[PORT] as Int,
-            connectionSecurity = validatedSettings[CONNECTION_SECURITY] as String,
-            authenticationType = validatedSettings[AUTHENTICATION_TYPE] as? String
-                ?: throw InvalidSettingValueException("Missing '$AUTHENTICATION_TYPE' value"),
-            username = validatedSettings[USERNAME] as String,
-            password = validatedSettings[PASSWORD] as? String,
-            clientCertificateAlias = validatedSettings[CLIENT_CERTIFICATE_ALIAS] as? String,
+            settings = validatedSettings,
             extras = server.extras.orEmpty(),
         )
     }

--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsWriter.kt
@@ -1,0 +1,53 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.ServerSettingsSerializer
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
+
+internal class ServerSettingsWriter(
+    private val serverSettingsSerializer: ServerSettingsSerializer,
+) {
+    fun writeServerSettings(
+        editor: StorageEditor,
+        key: String,
+        server: ValidatedSettings.Server,
+    ) {
+        val serverSettings = createServerSettings(server)
+        val serverSettingsJson = serverSettingsSerializer.serialize(serverSettings)
+        editor.putStringWithLogging(key, serverSettingsJson)
+    }
+
+    private fun createServerSettings(server: ValidatedSettings.Server): ServerSettings {
+        val connectionSecurity = convertConnectionSecurity(server.connectionSecurity)
+        val authenticationType = AuthType.valueOf(server.authenticationType)
+        val password = if (authenticationType == AuthType.XOAUTH2) "" else server.password
+
+        return ServerSettings(
+            server.type,
+            server.host,
+            server.port,
+            connectionSecurity,
+            authenticationType,
+            server.username,
+            password,
+            server.clientCertificateAlias,
+            server.extras,
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun convertConnectionSecurity(connectionSecurity: String): ConnectionSecurity {
+        return try {
+            // TODO: Add proper settings validation and upgrade capability for server settings. Once that exists, move
+            //  this code into a SettingsUpgrader.
+            when (connectionSecurity) {
+                "SSL_TLS_OPTIONAL" -> ConnectionSecurity.SSL_TLS_REQUIRED
+                "STARTTLS_OPTIONAL" -> ConnectionSecurity.STARTTLS_REQUIRED
+                else -> ConnectionSecurity.valueOf(connectionSecurity)
+            }
+        } catch (e: Exception) {
+            ConnectionSecurity.SSL_TLS_REQUIRED
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsWriter.kt
@@ -30,7 +30,7 @@ internal class ServerSettingsWriter(
 
         val host = validatedSettings[HOST] as? String
         val port = validatedSettings[PORT] as Int
-        val connectionSecurity = convertConnectionSecurity(validatedSettings[CONNECTION_SECURITY] as String)
+        val connectionSecurity = ConnectionSecurity.valueOf(validatedSettings[CONNECTION_SECURITY] as String)
         val authenticationType = AuthType.valueOf(validatedSettings[AUTHENTICATION_TYPE] as String)
         val username = validatedSettings[USERNAME] as String
         val rawPassword = validatedSettings[PASSWORD] as? String
@@ -48,20 +48,5 @@ internal class ServerSettingsWriter(
             clientCertificateAlias,
             server.extras,
         )
-    }
-
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    private fun convertConnectionSecurity(connectionSecurity: String): ConnectionSecurity {
-        return try {
-            // TODO: Add proper settings validation and upgrade capability for server settings. Once that exists, move
-            //  this code into a SettingsUpgrader.
-            when (connectionSecurity) {
-                "SSL_TLS_OPTIONAL" -> ConnectionSecurity.SSL_TLS_REQUIRED
-                "STARTTLS_OPTIONAL" -> ConnectionSecurity.STARTTLS_REQUIRED
-                else -> ConnectionSecurity.valueOf(connectionSecurity)
-            }
-        } catch (e: Exception) {
-            ConnectionSecurity.SSL_TLS_REQUIRED
-        }
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsWriter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsWriter.kt
@@ -4,6 +4,13 @@ import com.fsck.k9.ServerSettingsSerializer
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.AUTHENTICATION_TYPE
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CLIENT_CERTIFICATE_ALIAS
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CONNECTION_SECURITY
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.HOST
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PASSWORD
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PORT
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.USERNAME
 
 internal class ServerSettingsWriter(
     private val serverSettingsSerializer: ServerSettingsSerializer,
@@ -19,19 +26,26 @@ internal class ServerSettingsWriter(
     }
 
     private fun createServerSettings(server: ValidatedSettings.Server): ServerSettings {
-        val connectionSecurity = convertConnectionSecurity(server.connectionSecurity)
-        val authenticationType = AuthType.valueOf(server.authenticationType)
-        val password = if (authenticationType == AuthType.XOAUTH2) "" else server.password
+        val validatedSettings = server.settings
+
+        val host = validatedSettings[HOST] as? String
+        val port = validatedSettings[PORT] as Int
+        val connectionSecurity = convertConnectionSecurity(validatedSettings[CONNECTION_SECURITY] as String)
+        val authenticationType = AuthType.valueOf(validatedSettings[AUTHENTICATION_TYPE] as String)
+        val username = validatedSettings[USERNAME] as String
+        val rawPassword = validatedSettings[PASSWORD] as? String
+        val password = if (authenticationType == AuthType.XOAUTH2) "" else rawPassword
+        val clientCertificateAlias = validatedSettings[CLIENT_CERTIFICATE_ALIAS] as? String
 
         return ServerSettings(
             server.type,
-            server.host,
-            server.port,
+            host,
+            port,
             connectionSecurity,
             authenticationType,
-            server.username,
+            username,
             password,
-            server.clientCertificateAlias,
+            clientCertificateAlias,
             server.extras,
         )
     }

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 91;
+    public static final int VERSION = 92;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -1,6 +1,10 @@
 package com.fsck.k9.preferences
 
 import com.fsck.k9.helper.mapCollectionToSet
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.AUTHENTICATION_TYPE
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.HOST
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PASSWORD
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.USERNAME
 import com.fsck.k9.preferences.Settings.InvalidSettingValueException
 import java.io.InputStream
 import timber.log.Timber
@@ -151,20 +155,25 @@ class SettingsImporter internal constructor(
         val accountMapping = accountSettingsWriter.write(currentAccount)
 
         val incoming = currentAccount.incoming
-        val incomingServerName = incoming.host
+        val incomingServerName = incoming.settings[HOST] as? String
+        val incomingAuthenticationType = incoming.settings[AUTHENTICATION_TYPE] as String
+        val incomingPassword = incoming.settings[PASSWORD] as? String
         val incomingPasswordNeeded =
-            incoming.authenticationType != "EXTERNAL" && incoming.authenticationType != "XOAUTH2" &&
-                incoming.password.isNullOrEmpty()
+            incomingAuthenticationType != "EXTERNAL" && incomingAuthenticationType != "XOAUTH2" &&
+                incomingPassword.isNullOrEmpty()
 
-        var authorizationNeeded = incoming.authenticationType == "XOAUTH2"
+        var authorizationNeeded = incomingAuthenticationType == "XOAUTH2"
 
         val outgoing = currentAccount.outgoing
-        val outgoingServerName = outgoing.host
+        val outgoingServerName = outgoing.settings[HOST] as? String
+        val outgoingAuthenticationType = outgoing.settings[AUTHENTICATION_TYPE] as String
+        val outgoingUsername = outgoing.settings[USERNAME] as String
+        val outgoingPassword = outgoing.settings[PASSWORD] as? String
         val outgoingPasswordNeeded =
-            outgoing.authenticationType != "EXTERNAL" && outgoing.authenticationType != "XOAUTH2" &&
-                outgoing.username.isNotEmpty() && outgoing.password.isNullOrEmpty()
+            outgoingAuthenticationType != "EXTERNAL" && outgoingAuthenticationType != "XOAUTH2" &&
+                outgoingUsername.isNotEmpty() && outgoingPassword.isNullOrEmpty()
 
-        authorizationNeeded = authorizationNeeded || outgoing.authenticationType == "XOAUTH2"
+        authorizationNeeded = authorizationNeeded || outgoingAuthenticationType == "XOAUTH2"
 
         return AccountDescriptionPair(
             accountMapping.first,

--- a/app/core/src/main/java/com/fsck/k9/preferences/StringEnumSetting.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/StringEnumSetting.kt
@@ -1,0 +1,12 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.preferences.Settings.StringSetting
+
+internal class StringEnumSetting(
+    defaultValue: String,
+    private val values: Set<String>,
+) : StringSetting(defaultValue) {
+    override fun fromString(value: String?): String {
+        return value?.takeIf { it in values } ?: defaultValue
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ValidatedSettings.kt
@@ -15,13 +15,7 @@ interface ValidatedSettings {
 
     data class Server(
         val type: String,
-        val host: String?,
-        val port: Int,
-        val connectionSecurity: String,
-        val authenticationType: String,
-        val username: String,
-        val password: String?,
-        val clientCertificateAlias: String?,
+        val settings: InternalSettingsMap,
         val extras: Map<String, String?>,
     )
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92.kt
@@ -1,0 +1,21 @@
+package com.fsck.k9.preferences.upgrader
+
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CONNECTION_SECURITY
+import com.fsck.k9.preferences.Settings.SettingsUpgrader
+
+class ServerSettingsUpgraderTo92 : SettingsUpgrader {
+    override fun upgrade(settings: MutableMap<String, Any?>): Set<String> {
+        val oldConnectionSecurity = settings[CONNECTION_SECURITY] as? String
+
+        settings[CONNECTION_SECURITY] = when (oldConnectionSecurity) {
+            "NONE" -> "NONE"
+            "STARTTLS_OPTIONAL" -> "STARTTLS_REQUIRED"
+            "STARTTLS_REQUIRED" -> "STARTTLS_REQUIRED"
+            "SSL_TLS_OPTIONAL" -> "SSL_TLS_REQUIRED"
+            "SSL_TLS_REQUIRED" -> "SSL_TLS_REQUIRED"
+            else -> "SSL_TLS_REQUIRED"
+        }
+
+        return emptySet()
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/preferences/ServerSettingsUpgraderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/ServerSettingsUpgraderTest.kt
@@ -1,0 +1,34 @@
+package com.fsck.k9.preferences
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class ServerSettingsUpgraderTest {
+    private val upgrader = ServerSettingsUpgrader()
+
+    @Test
+    fun `upgrade from version 1 to 92`() {
+        val server = ValidatedSettings.Server(
+            type = "SMTP",
+            settings = mapOf(
+                "host" to "smtp.domain.example",
+                "port" to 465,
+                "connectionSecurity" to "SSL_TLS_OPTIONAL",
+                "authenticationType" to "PLAIN",
+                "username" to "user",
+                "password" to null,
+                "clientCertificateAlias" to null,
+            ),
+            extras = emptyMap(),
+        )
+
+        val upgradedServer = upgrader.upgrade(contentVersion = 1, server)
+
+        assertThat(upgradedServer).isEqualTo(
+            server.copy(
+                settings = server.settings + ("connectionSecurity" to "SSL_TLS_REQUIRED"),
+            ),
+        )
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/preferences/ServerSettingsValidatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/ServerSettingsValidatorTest.kt
@@ -1,0 +1,159 @@
+package com.fsck.k9.preferences
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import com.fsck.k9.preferences.Settings.InvalidSettingValueException
+import kotlin.test.Test
+
+class ServerSettingsValidatorTest {
+    private val validator = ServerSettingsValidator()
+
+    @Test
+    fun `valid server settings`() {
+        val result = validator.validate(contentVersion = 1, SERVER)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER)
+    }
+
+    @Test
+    fun `valid server settings with password`() {
+        val server = SERVER.copy(password = "password")
+
+        val result = validator.validate(contentVersion = 1, server)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(password = "password"))
+    }
+
+    @Test
+    fun `valid server settings with client certificate alias`() {
+        val server = SERVER.copy(clientCertificateAlias = "alias")
+
+        val result = validator.validate(contentVersion = 1, server)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(clientCertificateAlias = "alias"))
+    }
+
+    @Test
+    fun `valid server settings with arbitrary extras`() {
+        val extras = mapOf("extra1" to "value1", "extra2" to "value2")
+        val server = SERVER.copy(extras = extras)
+
+        val result = validator.validate(contentVersion = 1, server)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(extras = extras))
+    }
+
+    // TODO: We currently allow the host value to be missing, but probably shouldn't
+    @Test
+    fun `missing host value`() {
+        val server = SERVER.copy(host = null)
+
+        val result = validator.validate(contentVersion = 1, server)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(host = null))
+    }
+
+    // TODO: We currently fall back to a default value of -1, but probably shouldn't
+    @Test
+    fun `missing port value`() {
+        val server = SERVER.copy(port = null)
+
+        val result = validator.validate(contentVersion = 1, server)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(port = -1))
+    }
+
+    // TODO: We currently fall back to a default value of -1, but probably shouldn't
+    @Test
+    fun `invalid port value`() {
+        val server = SERVER.copy(port = "invalid")
+
+        val result = validator.validate(contentVersion = 1, server)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(port = -1))
+    }
+
+    // TODO: We currently fall back to a default value of SSL_TLS_REQUIRED, but probably shouldn't
+    @Test
+    fun `missing connection security value`() {
+        val server = SERVER.copy(connectionSecurity = null)
+
+        val result = validator.validate(contentVersion = 1, server)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(connectionSecurity = "SSL_TLS_REQUIRED"))
+    }
+
+    // TODO: We currently fall back to a default value of SSL_TLS_REQUIRED, but probably shouldn't
+    @Test
+    fun `invalid connection security value`() {
+        val server = SERVER.copy(connectionSecurity = "invalid")
+
+        val result = validator.validate(contentVersion = 1, server)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(connectionSecurity = "SSL_TLS_REQUIRED"))
+    }
+
+    @Test
+    fun `missing authentication type value`() {
+        val server = SERVER.copy(authenticationType = null)
+
+        assertFailure {
+            validator.validate(contentVersion = 1, server)
+        }.isInstanceOf<InvalidSettingValueException>()
+            .hasMessage("Missing 'authenticationType' value")
+    }
+
+    @Test
+    fun `invalid authentication type value`() {
+        val server = SERVER.copy(authenticationType = "invalid")
+
+        assertFailure {
+            validator.validate(contentVersion = 1, server)
+        }.isInstanceOf<InvalidSettingValueException>()
+            .hasMessage("Missing 'authenticationType' value")
+    }
+
+    @Test
+    fun `missing username value`() {
+        val server = SERVER.copy(username = null)
+
+        val result = validator.validate(contentVersion = 1, server)
+
+        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(username = ""))
+    }
+
+    companion object {
+        private val SERVER = SettingsFile.Server(
+            type = "IMAP",
+            host = "imap.domain.example",
+            port = "993",
+            connectionSecurity = "SSL_TLS_REQUIRED",
+            authenticationType = "PLAIN",
+            username = "user",
+            password = null,
+            clientCertificateAlias = null,
+            extras = mapOf(
+                "autoDetectNamespace" to "true",
+                "PATH_PREFIX_KEY" to "",
+            ),
+        )
+
+        private val VALIDATED_SERVER = ValidatedSettings.Server(
+            type = "imap",
+            host = "imap.domain.example",
+            port = 993,
+            connectionSecurity = "SSL_TLS_REQUIRED",
+            authenticationType = "PLAIN",
+            username = "user",
+            password = null,
+            clientCertificateAlias = null,
+            extras = mapOf(
+                "autoDetectNamespace" to "true",
+                "PATH_PREFIX_KEY" to "",
+            ),
+        )
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/preferences/ServerSettingsValidatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/ServerSettingsValidatorTest.kt
@@ -24,7 +24,9 @@ class ServerSettingsValidatorTest {
 
         val result = validator.validate(contentVersion = 1, server)
 
-        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(password = "password"))
+        assertThat(result).isEqualTo(
+            VALIDATED_SERVER.copy(settings = VALIDATED_SERVER.settings + ("password" to "password")),
+        )
     }
 
     @Test
@@ -33,7 +35,9 @@ class ServerSettingsValidatorTest {
 
         val result = validator.validate(contentVersion = 1, server)
 
-        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(clientCertificateAlias = "alias"))
+        assertThat(result).isEqualTo(
+            VALIDATED_SERVER.copy(settings = VALIDATED_SERVER.settings + ("clientCertificateAlias" to "alias")),
+        )
     }
 
     @Test
@@ -53,7 +57,9 @@ class ServerSettingsValidatorTest {
 
         val result = validator.validate(contentVersion = 1, server)
 
-        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(host = null))
+        assertThat(result).isEqualTo(
+            VALIDATED_SERVER.copy(settings = VALIDATED_SERVER.settings + ("host" to null)),
+        )
     }
 
     // TODO: We currently fall back to a default value of -1, but probably shouldn't
@@ -63,7 +69,9 @@ class ServerSettingsValidatorTest {
 
         val result = validator.validate(contentVersion = 1, server)
 
-        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(port = -1))
+        assertThat(result).isEqualTo(
+            VALIDATED_SERVER.copy(settings = VALIDATED_SERVER.settings + ("port" to -1)),
+        )
     }
 
     // TODO: We currently fall back to a default value of -1, but probably shouldn't
@@ -73,7 +81,9 @@ class ServerSettingsValidatorTest {
 
         val result = validator.validate(contentVersion = 1, server)
 
-        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(port = -1))
+        assertThat(result).isEqualTo(
+            VALIDATED_SERVER.copy(settings = VALIDATED_SERVER.settings + ("port" to -1)),
+        )
     }
 
     // TODO: We currently fall back to a default value of SSL_TLS_REQUIRED, but probably shouldn't
@@ -83,7 +93,9 @@ class ServerSettingsValidatorTest {
 
         val result = validator.validate(contentVersion = 1, server)
 
-        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(connectionSecurity = "SSL_TLS_REQUIRED"))
+        assertThat(result).isEqualTo(
+            VALIDATED_SERVER.copy(settings = VALIDATED_SERVER.settings + ("connectionSecurity" to "SSL_TLS_REQUIRED")),
+        )
     }
 
     // TODO: We currently fall back to a default value of SSL_TLS_REQUIRED, but probably shouldn't
@@ -93,7 +105,9 @@ class ServerSettingsValidatorTest {
 
         val result = validator.validate(contentVersion = 1, server)
 
-        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(connectionSecurity = "SSL_TLS_REQUIRED"))
+        assertThat(result).isEqualTo(
+            VALIDATED_SERVER.copy(settings = VALIDATED_SERVER.settings + ("connectionSecurity" to "SSL_TLS_REQUIRED")),
+        )
     }
 
     @Test
@@ -122,7 +136,9 @@ class ServerSettingsValidatorTest {
 
         val result = validator.validate(contentVersion = 1, server)
 
-        assertThat(result).isEqualTo(VALIDATED_SERVER.copy(username = ""))
+        assertThat(result).isEqualTo(
+            VALIDATED_SERVER.copy(settings = VALIDATED_SERVER.settings + ("username" to "")),
+        )
     }
 
     companion object {
@@ -143,13 +159,15 @@ class ServerSettingsValidatorTest {
 
         private val VALIDATED_SERVER = ValidatedSettings.Server(
             type = "imap",
-            host = "imap.domain.example",
-            port = 993,
-            connectionSecurity = "SSL_TLS_REQUIRED",
-            authenticationType = "PLAIN",
-            username = "user",
-            password = null,
-            clientCertificateAlias = null,
+            settings = mapOf(
+                "host" to "imap.domain.example",
+                "port" to 993,
+                "connectionSecurity" to "SSL_TLS_REQUIRED",
+                "authenticationType" to "PLAIN",
+                "username" to "user",
+                "password" to null,
+                "clientCertificateAlias" to null,
+            ),
             extras = mapOf(
                 "autoDetectNamespace" to "true",
                 "PATH_PREFIX_KEY" to "",

--- a/app/core/src/test/java/com/fsck/k9/preferences/ServerSettingsValidatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/ServerSettingsValidatorTest.kt
@@ -141,6 +141,16 @@ class ServerSettingsValidatorTest {
         )
     }
 
+    @Test
+    fun `missing connection security value in version 92`() {
+        val server = SERVER.copy(connectionSecurity = null)
+
+        assertFailure {
+            validator.validate(contentVersion = 92, server)
+        }.isInstanceOf<InvalidSettingValueException>()
+            .hasMessage("Missing 'connectionSecurity' value")
+    }
+
     companion object {
         private val SERVER = SettingsFile.Server(
             type = "IMAP",

--- a/app/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92Test.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92Test.kt
@@ -1,0 +1,73 @@
+package com.fsck.k9.preferences.upgrader
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class ServerSettingsUpgraderTo92Test {
+    private val upgrader = ServerSettingsUpgraderTo92()
+
+    @Test
+    fun `STARTTLS_OPTIONAL should be rewritten to STARTTLS_REQUIRED`() {
+        val mutableSettings = mutableMapOf<String, Any?>("connectionSecurity" to "STARTTLS_OPTIONAL")
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(mapOf<String, Any?>("connectionSecurity" to "STARTTLS_REQUIRED"))
+    }
+
+    @Test
+    fun `SSL_TLS_OPTIONAL should be rewritten to SSL_TLS_REQUIRED`() {
+        val mutableSettings = mutableMapOf<String, Any?>("connectionSecurity" to "SSL_TLS_OPTIONAL")
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(mapOf<String, Any?>("connectionSecurity" to "SSL_TLS_REQUIRED"))
+    }
+
+    @Test
+    fun `NONE should be left unchanged`() {
+        val settings = mapOf<String, Any?>("connectionSecurity" to "NONE")
+        val mutableSettings = settings.toMutableMap()
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(settings)
+    }
+
+    @Test
+    fun `STARTTLS_REQUIRED should be left unchanged`() {
+        val settings = mapOf<String, Any?>("connectionSecurity" to "STARTTLS_REQUIRED")
+        val mutableSettings = settings.toMutableMap()
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(settings)
+    }
+
+    @Test
+    fun `SSL_TLS_REQUIRED should be left unchanged`() {
+        val settings = mapOf<String, Any?>("connectionSecurity" to "SSL_TLS_REQUIRED")
+        val mutableSettings = settings.toMutableMap()
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(settings)
+    }
+
+    @Test
+    fun `Unsupported values should be changed to SSL_TLS_REQUIRED`() {
+        val mutableSettings = mutableMapOf<String, Any?>("connectionSecurity" to "unsupported")
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(mapOf<String, Any?>("connectionSecurity" to "SSL_TLS_REQUIRED"))
+    }
+}


### PR DESCRIPTION
Migrate existing server settings validation and upgrade code to a similar structure that is already used for general settings, account settings, identity settings, and folder settings.