### PR TITLE
Switch to custom version of TokenAutoComplete

### DIFF
--- a/app-k9mail/dependencies/releaseRuntimeClasspath.txt
+++ b/app-k9mail/dependencies/releaseRuntimeClasspath.txt
@@ -142,7 +142,6 @@ com.mikepenz:fastadapter-extensions-swipe:5.7.0
 com.mikepenz:fastadapter-extensions-utils:5.7.0
 com.mikepenz:fastadapter:5.7.0
 com.mikepenz:materialdrawer:9.0.2
-com.splitwise:tokenautocomplete:4.0.0-beta01
 com.squareup.moshi:moshi:1.15.1
 com.squareup.okhttp3:okhttp:4.12.0
 com.squareup.okio:okio-jvm:3.9.0
@@ -155,6 +154,7 @@ com.takisoft.preferencex:preferencex:1.1.0
 commons-io:commons-io:2.16.1
 de.cketti.library.changelog:ckchangelog-core:2.0.0-beta02
 de.cketti.safecontentresolver:safe-content-resolver-v21:1.0.0
+de.cketti.temp:tokenautocomplete:4.0.0-beta01-k9mail02
 de.hdodenhof:circleimageview:3.1.0
 io.insert-koin:koin-android:3.5.6
 io.insert-koin:koin-androidx-compose:3.5.6

--- a/app-thunderbird/dependencies/releaseRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/releaseRuntimeClasspath.txt
@@ -142,7 +142,6 @@ com.mikepenz:fastadapter-extensions-swipe:5.7.0
 com.mikepenz:fastadapter-extensions-utils:5.7.0
 com.mikepenz:fastadapter:5.7.0
 com.mikepenz:materialdrawer:9.0.2
-com.splitwise:tokenautocomplete:4.0.0-beta01
 com.squareup.moshi:moshi:1.15.1
 com.squareup.okhttp3:okhttp:4.12.0
 com.squareup.okio:okio-jvm:3.9.0
@@ -155,6 +154,7 @@ com.takisoft.preferencex:preferencex:1.1.0
 commons-io:commons-io:2.16.1
 de.cketti.library.changelog:ckchangelog-core:2.0.0-beta02
 de.cketti.safecontentresolver:safe-content-resolver-v21:1.0.0
+de.cketti.temp:tokenautocomplete:4.0.0-beta01-k9mail02
 de.hdodenhof:circleimageview:3.1.0
 io.insert-koin:koin-android:3.5.6
 io.insert-koin:koin-androidx-compose:3.5.6

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -141,7 +141,7 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         // Since the recipient chip views are not part of the view hierarchy we need to manually invalidate this
         // RecipientSelectView whenever a contact picture was loaded in order for the image to be drawn.
         RecipientCircleImageView contactPhotoView = view.findViewById(R.id.contact_photo);
-        contactPhotoView.setOnSetImageDrawableListener(this::postInvalidate);
+        contactPhotoView.setOnSetImageDrawableListener(this::redrawTokens);
 
         return view;
     }
@@ -301,6 +301,7 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         }
 
         invalidate();
+        redrawTokens();
         invalidateCursorPositionHack();
     }
 
@@ -484,6 +485,7 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         }
 
         invalidate();
+        redrawTokens();
         invalidateCursorPositionHack();
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,7 +90,7 @@ safeContentResolver = "1.0.0"
 searchPreference = "v2.3.0"
 spotlessPlugin = "6.25.0"
 timber = "5.0.1"
-tokenautocomplete = "4.0.0-beta01"
+tokenautocomplete = "4.0.0-beta01-k9mail02"
 turbine = "0.13.0"
 xmlpull = "1.0"
 
@@ -223,7 +223,7 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 safeContentResolver = { module = "de.cketti.safecontentresolver:safe-content-resolver-v21", version.ref = "safeContentResolver" }
 searchPreference = { module = "com.github.ByteHamster:SearchPreference", version.ref = "searchPreference" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
-tokenautocomplete = { module = "com.splitwise:tokenautocomplete", version.ref = "tokenautocomplete" }
+tokenautocomplete = { module = "de.cketti.temp:tokenautocomplete", version.ref = "tokenautocomplete" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 xmlpull = { module = "com.github.cketti:xmlpull-extracted-from-android", version.ref = "xmlpull" }
 


### PR DESCRIPTION
`de.cketti.temp:tokenautocomplete:4.0.0-beta01-k9mail02` is based on `com.splitwise:tokenautocomplete:4.0.0-beta01` and includes a fix for a crash that K-9 Mail users regularly run into. https://github.com/cketti/TokenAutoComplete/compare/4.0.0-beta01...4.0.0-beta01-k9mail02

We avoided upgrading to 4.0.0-beta02 (that also includes the fix) and beyond because there are other changes included that break our code. Given that TokenAutoComplete isn't very actively maintained, we want to switch away from it rather than adapt our code to the changes in the library. This is only a temporary solution to improve our users' experience with the app.

I published the fork of the library on Maven Central under my private domain/account because we currently have no infrastructure in place to do this as the Thunderbird project.

Fixes #3951