### PR TITLE
Remove legacy `AuthType` values

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
@@ -5,6 +5,7 @@ import com.fsck.k9.preferences.Settings.SettingsDescription
 import com.fsck.k9.preferences.Settings.SettingsUpgrader
 import com.fsck.k9.preferences.Settings.StringSetting
 import com.fsck.k9.preferences.upgrader.ServerSettingsUpgraderTo92
+import com.fsck.k9.preferences.upgrader.ServerSettingsUpgraderTo94
 import java.util.TreeMap
 
 /**
@@ -51,6 +52,14 @@ internal class ServerSettingsDescriptions {
                         "LOGIN",
                     ),
                 ),
+                94 to NoDefaultStringEnumSetting(
+                    values = setOf(
+                        "PLAIN",
+                        "CRAM_MD5",
+                        "EXTERNAL",
+                        "XOAUTH2",
+                    ),
+                ),
             ),
             USERNAME to versions(
                 1 to StringSetting(""),
@@ -67,6 +76,7 @@ internal class ServerSettingsDescriptions {
     val upgraders: Map<Int, SettingsUpgrader> by lazy {
         mapOf(
             92 to ServerSettingsUpgraderTo92(),
+            94 to ServerSettingsUpgraderTo94(),
         )
     }
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94.kt
@@ -1,0 +1,27 @@
+package com.fsck.k9.preferences.upgrader
+
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.AUTHENTICATION_TYPE
+import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CONNECTION_SECURITY
+import com.fsck.k9.preferences.Settings.SettingsUpgrader
+
+/**
+ * Removes legacy authentication values.
+ *
+ * Replaces the authentication value "AUTOMATIC" with "PLAIN" when TLS is used, "CRAM_MD5" otherwise.
+ * Replaces the authentication value "LOGIN" with "PLAIN".
+ */
+class ServerSettingsUpgraderTo94 : SettingsUpgrader {
+    override fun upgrade(settings: MutableMap<String, Any?>): Set<String> {
+        val connectionSecurity = settings[CONNECTION_SECURITY] as? String
+        val isSecure = connectionSecurity == "STARTTLS_REQUIRED" || connectionSecurity == "SSL_TLS_REQUIRED"
+        val authenticationType = settings[AUTHENTICATION_TYPE] as? String
+
+        settings[AUTHENTICATION_TYPE] = when (authenticationType) {
+            "AUTOMATIC" -> if (isSecure) "PLAIN" else "CRAM_MD5"
+            "LOGIN" -> "PLAIN"
+            else -> authenticationType
+        }
+
+        return emptySet()
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94Test.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94Test.kt
@@ -1,0 +1,124 @@
+package com.fsck.k9.preferences.upgrader
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class ServerSettingsUpgraderTo94Test {
+    private val upgrader = ServerSettingsUpgraderTo94()
+
+    @Test
+    fun `AUTOMATIC with STARTTLS_REQUIRED should be rewritten to PLAIN`() {
+        val mutableSettings = mutableMapOf<String, Any?>(
+            "authenticationType" to "AUTOMATIC",
+            "connectionSecurity" to "STARTTLS_REQUIRED",
+        )
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(
+            mapOf<String, Any?>(
+                "authenticationType" to "PLAIN",
+                "connectionSecurity" to "STARTTLS_REQUIRED",
+            ),
+        )
+    }
+
+    @Test
+    fun `AUTOMATIC with SSL_TLS_REQUIRED should be rewritten to PLAIN`() {
+        val mutableSettings = mutableMapOf<String, Any?>(
+            "authenticationType" to "AUTOMATIC",
+            "connectionSecurity" to "SSL_TLS_REQUIRED",
+        )
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(
+            mapOf<String, Any?>(
+                "authenticationType" to "PLAIN",
+                "connectionSecurity" to "SSL_TLS_REQUIRED",
+            ),
+        )
+    }
+
+    @Test
+    fun `AUTOMATIC with NONE should be rewritten to CRAM_MD5`() {
+        val mutableSettings = mutableMapOf<String, Any?>(
+            "authenticationType" to "AUTOMATIC",
+            "connectionSecurity" to "NONE",
+        )
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(
+            mapOf<String, Any?>(
+                "authenticationType" to "CRAM_MD5",
+                "connectionSecurity" to "NONE",
+            ),
+        )
+    }
+
+    @Test
+    fun `LOGIN should be rewritten to PLAIN`() {
+        val mutableSettings = mutableMapOf<String, Any?>(
+            "authenticationType" to "LOGIN",
+            "connectionSecurity" to "SSL_TLS_REQUIRED",
+        )
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(
+            mapOf<String, Any?>(
+                "authenticationType" to "PLAIN",
+                "connectionSecurity" to "SSL_TLS_REQUIRED",
+            ),
+        )
+    }
+
+    @Test
+    fun `PLAIN should not be rewritten`() {
+        val settings = mapOf<String, Any?>(
+            "authenticationType" to "PLAIN",
+            "connectionSecurity" to "SSL_TLS_REQUIRED",
+        )
+        val mutableSettings = settings.toMutableMap()
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(settings)
+    }
+
+    @Test
+    fun `EXTERNAL should not be rewritten`() {
+        val settings = mapOf<String, Any?>(
+            "authenticationType" to "EXTERNAL",
+            "connectionSecurity" to "NONE",
+        )
+        val mutableSettings = settings.toMutableMap()
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(settings)
+    }
+
+    @Test
+    fun `XOAUTH2 should not be rewritten`() {
+        val settings = mapOf<String, Any?>(
+            "authenticationType" to "XOAUTH2",
+            "connectionSecurity" to "STARTTLS_REQUIRED",
+        )
+        val mutableSettings = settings.toMutableMap()
+
+        val result = upgrader.upgrade(mutableSettings)
+
+        assertThat(result).isEmpty()
+        assertThat(mutableSettings).isEqualTo(settings)
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -19,7 +19,7 @@ import timber.log.Timber;
 
 
 public class K9StoragePersister implements StoragePersister {
-    private static final int DB_VERSION = 23;
+    private static final int DB_VERSION = 24;
     private static final String DB_NAME = "preferences_storage";
 
     private final Context context;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo24.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo24.kt
@@ -1,0 +1,80 @@
+package com.fsck.k9.preferences.migration
+
+import android.database.sqlite.SQLiteDatabase
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+
+/**
+ * Clean up the authentication type in outgoing server settings.
+ *
+ * Replaces the authentication value "AUTOMATIC" with "PLAIN" when TLS is used, "CRAM_MD5" otherwise.
+ * Replaces the authentication value "LOGIN" with "PLAIN".
+ */
+class StorageMigrationTo24(
+    private val db: SQLiteDatabase,
+    private val migrationsHelper: StorageMigrationHelper,
+) {
+    fun removeLegacyAuthenticationModes() {
+        val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")
+        if (accountUuidsListValue.isNullOrEmpty()) {
+            return
+        }
+
+        val accountUuids = accountUuidsListValue.split(",")
+        for (accountUuid in accountUuids) {
+            removeLegacyAuthenticationModesForAccount(accountUuid)
+        }
+    }
+
+    private fun removeLegacyAuthenticationModesForAccount(accountUuid: String) {
+        val outgoingServerSettingsJson = migrationsHelper.readValue(db, "$accountUuid.outgoingServerSettings") ?: return
+
+        val adapter = createJsonAdapter()
+
+        adapter.fromJson(outgoingServerSettingsJson)?.let { settings ->
+            createUpdatedServerSettings(settings)?.let { newSettings ->
+                val json = adapter.toJson(newSettings)
+                migrationsHelper.writeValue(db, "$accountUuid.outgoingServerSettings", json)
+            }
+        }
+    }
+
+    private fun createUpdatedServerSettings(serverSettings: Map<String, Any?>): Map<String, Any?>? {
+        val isSecure = serverSettings["connectionSecurity"] == "STARTTLS_REQUIRED" ||
+            serverSettings["connectionSecurity"] == "SSL_TLS_REQUIRED"
+
+        return when (serverSettings["authenticationType"]) {
+            "AUTOMATIC" -> {
+                serverSettings.toMutableMap().apply {
+                    fixPortType()
+                    this["authenticationType"] = if (isSecure) "PLAIN" else "CRAM_MD5"
+                }
+            }
+
+            "LOGIN" -> {
+                serverSettings.toMutableMap().apply {
+                    fixPortType()
+                    this["authenticationType"] = "PLAIN"
+                }
+            }
+
+            else -> {
+                null
+            }
+        }
+    }
+
+    private fun MutableMap<String, Any?>.fixPortType() {
+        // This is so we don't end up with a port value of e.g. "993.0". It would still work, but it looks odd.
+        this["port"] = (this["port"] as? Double)?.toInt()
+    }
+
+    private fun createJsonAdapter(): JsonAdapter<Map<String, Any?>> {
+        val moshi = Moshi.Builder().build()
+
+        return moshi.adapter<Map<String, Any?>>(
+            Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java),
+        ).serializeNulls()
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
@@ -30,5 +30,6 @@ internal object StorageMigrations {
         if (oldVersion < 21) StorageMigrationTo21(db, migrationsHelper).createPostRemoveNavigationSetting()
         if (oldVersion < 22) StorageMigrationTo22(db, migrationsHelper).fixServerSettings()
         if (oldVersion < 23) StorageMigrationTo23(db, migrationsHelper).renameSendClientId()
+        if (oldVersion < 24) StorageMigrationTo24(db, migrationsHelper).removeLegacyAuthenticationModes()
     }
 }

--- a/app/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo24Test.kt
+++ b/app/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo24Test.kt
@@ -1,0 +1,223 @@
+package com.fsck.k9.preferences.migration
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.key
+import com.fsck.k9.preferences.createPreferencesDatabase
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import java.util.UUID
+import kotlin.test.Test
+import org.junit.After
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StorageMigrationTo24Test {
+    private val database = createPreferencesDatabase()
+    private val migrationHelper = DefaultStorageMigrationHelper()
+    private val migration = StorageMigrationTo24(database, migrationHelper)
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `AUTOMATIC with SSL_TLS_REQUIRED should be migrated to PLAIN`() {
+        val account = createAccount(
+            "outgoingServerSettings" to toJson(
+                "type" to "smtp",
+                "host" to "irrelevant.invalid",
+                "port" to 465,
+                "connectionSecurity" to "SSL_TLS_REQUIRED",
+                "authenticationType" to "AUTOMATIC",
+                "username" to "username",
+                "password" to null,
+                "clientCertificateAlias" to null,
+            ),
+        )
+        writeAccountUuids(account)
+
+        migration.removeLegacyAuthenticationModes()
+
+        assertThat(migrationHelper.readAllValues(database))
+            .key("$account.outgoingServerSettings")
+            .isEqualTo(
+                """
+                {
+                    "type": "smtp",
+                    "host": "irrelevant.invalid",
+                    "port": 465,
+                    "connectionSecurity": "SSL_TLS_REQUIRED",
+                    "authenticationType": "PLAIN",
+                    "username": "username",
+                    "password": null,
+                    "clientCertificateAlias": null
+                }
+                """.toCompactJson(),
+            )
+    }
+
+    @Test
+    fun `AUTOMATIC with STARTTLS_REQUIRED should be migrated to PLAIN`() {
+        val account = createAccount(
+            "outgoingServerSettings" to toJson(
+                "type" to "smtp",
+                "host" to "irrelevant.invalid",
+                "port" to 465,
+                "connectionSecurity" to "STARTTLS_REQUIRED",
+                "authenticationType" to "AUTOMATIC",
+                "username" to "username",
+                "password" to null,
+                "clientCertificateAlias" to null,
+            ),
+        )
+        writeAccountUuids(account)
+
+        migration.removeLegacyAuthenticationModes()
+
+        assertThat(migrationHelper.readAllValues(database))
+            .key("$account.outgoingServerSettings")
+            .isEqualTo(
+                """
+                {
+                    "type": "smtp",
+                    "host": "irrelevant.invalid",
+                    "port": 465,
+                    "connectionSecurity": "STARTTLS_REQUIRED",
+                    "authenticationType": "PLAIN",
+                    "username": "username",
+                    "password": null,
+                    "clientCertificateAlias": null
+                }
+                """.toCompactJson(),
+            )
+    }
+
+    @Test
+    fun `AUTOMATIC with NONE should be migrated to CRAM_MD5`() {
+        val account = createAccount(
+            "outgoingServerSettings" to toJson(
+                "type" to "smtp",
+                "host" to "irrelevant.invalid",
+                "port" to 465,
+                "connectionSecurity" to "NONE",
+                "authenticationType" to "AUTOMATIC",
+                "username" to "username",
+                "password" to null,
+                "clientCertificateAlias" to null,
+            ),
+        )
+        writeAccountUuids(account)
+
+        migration.removeLegacyAuthenticationModes()
+
+        assertThat(migrationHelper.readAllValues(database))
+            .key("$account.outgoingServerSettings")
+            .isEqualTo(
+                """
+                {
+                    "type": "smtp",
+                    "host": "irrelevant.invalid",
+                    "port": 465,
+                    "connectionSecurity": "NONE",
+                    "authenticationType": "CRAM_MD5",
+                    "username": "username",
+                    "password": null,
+                    "clientCertificateAlias": null
+                }
+                """.toCompactJson(),
+            )
+    }
+
+    @Test
+    fun `LOGIN should be migrated to PLAIN`() {
+        val accountOne = createAccount(
+            "outgoingServerSettings" to toJson(
+                "type" to "smtp",
+                "host" to "irrelevant.invalid",
+                "port" to 465,
+                "connectionSecurity" to "SSL_TLS_REQUIRED",
+                "authenticationType" to "LOGIN",
+                "username" to "username",
+                "password" to null,
+                "clientCertificateAlias" to null,
+            ),
+        )
+        val accountTwo = createAccount(
+            "outgoingServerSettings" to toJson(
+                "type" to "smtp",
+                "host" to "another.irrelevant.invalid",
+                "port" to 465,
+                "connectionSecurity" to "STARTTLS_REQUIRED",
+                "authenticationType" to "LOGIN",
+                "username" to "user",
+                "password" to "pass",
+                "clientCertificateAlias" to null,
+            ),
+        )
+        writeAccountUuids(accountOne, accountTwo)
+
+        migration.removeLegacyAuthenticationModes()
+
+        assertThat(migrationHelper.readAllValues(database)).all {
+            key("$accountOne.outgoingServerSettings").isEqualTo(
+                """
+                {
+                    "type": "smtp",
+                    "host": "irrelevant.invalid",
+                    "port": 465,
+                    "connectionSecurity": "SSL_TLS_REQUIRED",
+                    "authenticationType": "PLAIN",
+                    "username": "username",
+                    "password": null,
+                    "clientCertificateAlias": null
+                }
+                """.toCompactJson(),
+            )
+            key("$accountTwo.outgoingServerSettings").isEqualTo(
+                """
+                {
+                    "type": "smtp",
+                    "host": "another.irrelevant.invalid",
+                    "port": 465,
+                    "connectionSecurity": "STARTTLS_REQUIRED",
+                    "authenticationType": "PLAIN",
+                    "username": "user",
+                    "password": "pass",
+                    "clientCertificateAlias": null
+                }
+                """.toCompactJson(),
+            )
+        }
+    }
+
+    private fun writeAccountUuids(vararg accounts: String) {
+        val accountUuids = accounts.joinToString(separator = ",")
+        migrationHelper.insertValue(database, "accountUuids", accountUuids)
+    }
+
+    private fun createAccount(vararg pairs: Pair<String, String>): String {
+        val accountUuid = UUID.randomUUID().toString()
+
+        for ((key, value) in pairs) {
+            migrationHelper.insertValue(database, "$accountUuid.$key", value)
+        }
+
+        return accountUuid
+    }
+
+    private fun toJson(vararg pairs: Pair<String, Any?>): String {
+        val moshi = Moshi.Builder().build()
+        val adapter = moshi.adapter<Map<String, Any?>>(
+            Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java),
+        ).serializeNulls()
+
+        return adapter.toJson(pairs.toMap()) ?: error("Failed to create JSON")
+    }
+
+    // Note: This only works for JSON strings where keys and values don't contain any spaces
+    private fun String.toCompactJson(): String = replace(" ", "").replace("\n", "")
+}

--- a/app/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.java
+++ b/app/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.java
@@ -411,7 +411,7 @@ public class StoreSchemaDefinitionTest extends K9RobolectricTest {
         when(account.getLocalStorageProviderId()).thenReturn(StorageManager.InternalStorageProvider.ID);
 
         ServerSettings incomingServerSettings = new ServerSettings("dummy", "", -1, ConnectionSecurity.NONE,
-                AuthType.AUTOMATIC, "", "", null);
+                AuthType.PLAIN, "", "", null);
         when(account.getIncomingServerSettings()).thenReturn(incomingServerSettings);
         return account;
     }

--- a/feature/autodiscovery/demo/src/main/kotlin/app/k9mail/autodiscovery/demo/DemoAutoDiscovery.kt
+++ b/feature/autodiscovery/demo/src/main/kotlin/app/k9mail/autodiscovery/demo/DemoAutoDiscovery.kt
@@ -38,7 +38,7 @@ object DemoServerSettings : IncomingServerSettings, OutgoingServerSettings {
         host = "irrelevant",
         port = 23,
         connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
-        authenticationType = AuthType.AUTOMATIC,
+        authenticationType = AuthType.PLAIN,
         username = "irrelevant",
         password = "irrelevant",
         clientCertificateAlias = null,

--- a/mail/common/src/main/java/com/fsck/k9/mail/AuthType.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/AuthType.java
@@ -22,13 +22,4 @@ public enum AuthType {
      * https://developers.google.com/gmail/xoauth2_protocol#the_sasl_xoauth2_mechanism
      */
     XOAUTH2,
-
-    /*
-     * The following are obsolete authentication settings that were used with
-     * SMTP. They are no longer presented to the user as options, but they may
-     * still exist in a user's settings from a previous version or may be found
-     * when importing settings.
-     */
-    AUTOMATIC,
-    LOGIN
 }

--- a/mail/protocols/pop3/src/test/java/com/fsck/k9/mail/store/pop3/Pop3ConnectionTest.kt
+++ b/mail/protocols/pop3/src/test/java/com/fsck/k9/mail/store/pop3/Pop3ConnectionTest.kt
@@ -7,7 +7,6 @@ import assertk.assertions.prop
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.AuthType.CRAM_MD5
 import com.fsck.k9.mail.AuthType.EXTERNAL
-import com.fsck.k9.mail.AuthType.LOGIN
 import com.fsck.k9.mail.AuthType.PLAIN
 import com.fsck.k9.mail.AuthenticationFailedException
 import com.fsck.k9.mail.CertificateChainException
@@ -384,7 +383,7 @@ class Pop3ConnectionTest {
     }
 
     private fun MockPop3Server.createSettings(
-        authType: AuthType = LOGIN,
+        authType: AuthType = PLAIN,
         connectionSecurity: ConnectionSecurity = NONE,
     ): Pop3Settings {
         return SimplePop3Settings().apply {

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
@@ -152,7 +152,7 @@ class SmtpTransport(
                 (!password.isNullOrEmpty() || AuthType.EXTERNAL == authType || AuthType.XOAUTH2 == authType)
             ) {
                 when (authType) {
-                    AuthType.LOGIN, AuthType.PLAIN -> {
+                    AuthType.PLAIN -> {
                         // try saslAuthPlain first, because it supports UTF-8 explicitly
                         if (authPlainSupported) {
                             saslAuthPlain()
@@ -185,32 +185,6 @@ class SmtpTransport(
                             saslAuthExternal()
                         } else {
                             throw MissingCapabilityException("AUTH EXTERNAL")
-                        }
-                    }
-                    AuthType.AUTOMATIC -> {
-                        if (secureConnection) {
-                            // try saslAuthPlain first, because it supports UTF-8 explicitly
-                            if (authPlainSupported) {
-                                saslAuthPlain()
-                            } else if (authLoginSupported) {
-                                saslAuthLogin()
-                            } else if (authCramMD5Supported) {
-                                saslAuthCramMD5()
-                            } else {
-                                throw MissingCapabilityException("AUTH PLAIN")
-                            }
-                        } else {
-                            if (authCramMD5Supported) {
-                                saslAuthCramMD5()
-                            } else {
-                                // We refuse to insecurely transmit the password using the obsolete AUTOMATIC setting
-                                // because of the potential for a MITM attack. Affected users must choose a different
-                                // setting.
-                                throw MessagingException(
-                                    "Update your outgoing server authentication setting. " +
-                                        "AUTOMATIC authentication is unavailable.",
-                                )
-                            }
                         }
                     }
                     else -> {

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.kt
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.kt
@@ -465,54 +465,6 @@ class SmtpTransportTest {
     }
 
     @Test
-    fun `open() with automatic auth and no transport security and AUTH CRAM-MD5 extension should use CRAM-MD5`() {
-        val server = MockSmtpServer().apply {
-            output("220 localhost Simple Mail Transfer Service Ready")
-            expect("EHLO [127.0.0.1]")
-            output("250-localhost Hello client.localhost")
-            output("250 AUTH CRAM-MD5")
-            expect("AUTH CRAM-MD5")
-            output("334 " + Base64.encode("<24609.1047914046@localhost>"))
-            expect("dXNlciAyZDBlNTcwYzZlYWI0ZjY3ZDUyZmFkN2Q1NGExZDJhYQ==")
-            output("235 2.7.0 Authentication successful")
-        }
-        val transport = startServerAndCreateSmtpTransport(
-            server,
-            authenticationType = AuthType.AUTOMATIC,
-            connectionSecurity = ConnectionSecurity.NONE,
-        )
-
-        transport.open()
-
-        server.verifyConnectionStillOpen()
-        server.verifyInteractionCompleted()
-    }
-
-    @Test
-    fun `open() with automatic auth and no transport security and AUTH PLAIN extension should throw`() {
-        val server = MockSmtpServer()
-        server.output("220 localhost Simple Mail Transfer Service Ready")
-        server.expect("EHLO [127.0.0.1]")
-        server.output("250-localhost Hello client.localhost")
-        server.output("250 AUTH PLAIN LOGIN")
-        server.expect("QUIT")
-        server.output("221 BYE")
-        val transport = startServerAndCreateSmtpTransport(
-            server,
-            authenticationType = AuthType.AUTOMATIC,
-            connectionSecurity = ConnectionSecurity.NONE,
-        )
-
-        assertFailure {
-            transport.open()
-        }.isInstanceOf<MessagingException>()
-            .hasMessage("Update your outgoing server authentication setting. AUTOMATIC authentication is unavailable.")
-
-        server.verifyConnectionClosed()
-        server.verifyInteractionCompleted()
-    }
-
-    @Test
     fun `open() with EHLO failing should try HELO`() {
         val server = MockSmtpServer().apply {
             output("220 localhost Simple Mail Transfer Service Ready")


### PR DESCRIPTION
This removes the legacy values `AuthType.AUTOMATIC` and `AuthType.LOGIN`. They haven't been used for a long time and are mainly still around because there was no infrastructure in place to migrate server settings when importing settings. With the recent refactoring of the settings import code this change finally became easy to make.