### PR TITLE
Fix crash when a swipe action is set to "none"

### DIFF
--- a/app/ui/legacy/src/main/res/raw/changelog_master.xml
+++ b/app/ui/legacy/src/main/res/raw/changelog_master.xml
@@ -6,7 +6,7 @@
 -->
 <changelog>
     <release version="6.903" versioncode="39003" date="unreleased">
-        <change>Placeholder</change>
+        <change>Fixed a crash when a message list swipe action was set to "None"</change>
     </release>
     <release version="6.902" versioncode="39002" date="2024-06-21">
         <change>Changed a lot of internals to migrate to Material 3. Please note that the Material 3 UI is still in an early state.</change>


### PR DESCRIPTION
`SwipeResourceProvider` doesn't expect to be asked to provide resources for `SwipeAction.None` and will throw an exception when that happens. PR #7876 introduced some changes that lead to `SwipeResourceProvider` now being asked to provide resource for `SwipeAction.None` which will result in a crash when displaying the message list.

This changes `MessageListSwipeCallback` to make the old assumption true again; `SwipeResourceProvider` won't be asked to provide resources for `SwipeAction.None`.

Fixes #7969