### PR TITLE
Remove K-9 from strings

### DIFF
--- a/app-k9mail/src/main/AndroidManifest.xml
+++ b/app-k9mail/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         <receiver
             android:name="com.fsck.k9.widget.list.MessageListWidgetProvider"
             android:icon="@drawable/message_list_widget_preview"
-            android:label="@string/mail_list_widget_text"
+            android:label="@string/message_list_widget_label"
             android:enabled="@bool/home_screen_widgets_enabled"
             android:exported="false">
             <intent-filter>

--- a/app-thunderbird/src/main/AndroidManifest.xml
+++ b/app-thunderbird/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         <receiver
             android:name="net.thunderbird.android.widget.provider.MessageListWidgetProvider"
             android:icon="@drawable/message_list_widget_preview"
-            android:label="@string/mail_list_widget_text"
+            android:label="@string/message_list_widget_label"
             android:enabled="@bool/home_screen_widgets_enabled"
             android:exported="false">
             <intent-filter>

--- a/app/ui/legacy/src/main/res/layout/fragment_about.xml
+++ b/app/ui/legacy/src/main/res/layout/fragment_about.xml
@@ -108,7 +108,7 @@
                 <com.google.android.material.textview.MaterialTextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/app_authors"
+                    android:text="@string/about_app_authors_k9"
                     android:textAppearance="?attr/textAppearanceBodyMedium" />
             </LinearLayout>
         </LinearLayout>

--- a/app/ui/legacy/src/main/res/layout/fragment_about.xml
+++ b/app/ui/legacy/src/main/res/layout/fragment_about.xml
@@ -110,6 +110,12 @@
                     android:layout_height="wrap_content"
                     android:text="@string/about_app_authors_k9"
                     android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/about_app_authors_thunderbird"
+                    android:textAppearance="?attr/textAppearanceBodyMedium" />
             </LinearLayout>
         </LinearLayout>
 

--- a/app/ui/legacy/src/main/res/values-ar/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ar/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">رسائل K-9 غير المقروءة</string>
     <!--Used in the about dialog-->
     <string name="app_authors">فريق The K-9 Dog Walkers</string>
     <string name="source_code">الكود المصدري</string>

--- a/app/ui/legacy/src/main/res/values-ar/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ar/strings.xml
@@ -810,7 +810,6 @@
     <string name="crypto_no_provider_title">هذه الرسالة مُعماة</string>
     <string name="crypto_no_provider_message">تم تشفير هذا البريد الإلكتروني باستخدام OpenPGP. \ n لقراءته ، تحتاج إلى تثبيت وتكوين تطبيق OpenPGP متوافق. </string>
     <string name="crypto_no_provider_button">اذهب للاعدادات </string>
-    <string name="mail_list_widget_text">قائمة رسائل K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">التعمية غير ممكنة</string>

--- a/app/ui/legacy/src/main/res/values-ar/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ar/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">فريق The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">فريق The K-9 Dog Walkers</string>
     <string name="source_code">الكود المصدري</string>
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="about_project_title">مشروع مفتوح المصدر</string>

--- a/app/ui/legacy/src/main/res/values-az/strings.xml
+++ b/app/ui/legacy/src/main/res/values-az/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Oxunmayan</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 İt Gəzdirənlər</string>
     <string name="source_code">Mənbə kodu</string>

--- a/app/ui/legacy/src/main/res/values-az/strings.xml
+++ b/app/ui/legacy/src/main/res/values-az/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 İt Gəzdirənlər</string>
+    <string name="about_app_authors_k9">K-9 İt Gəzdirənlər</string>
     <string name="source_code">Mənbə kodu</string>
     <string name="app_license">Apache Lisenziyası, Versiya 2.0</string>
     <string name="about_project_title">Açıq Mənbə Layihəsi</string>

--- a/app/ui/legacy/src/main/res/values-be/strings.xml
+++ b/app/ui/legacy/src/main/res/values-be/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Зыходны код</string>
     <string name="app_license">Ліцэнзія Apache, версія 2.0</string>
     <string name="about_project_title">Праект з адкрытым зыходным кодам</string>

--- a/app/ui/legacy/src/main/res/values-be/strings.xml
+++ b/app/ui/legacy/src/main/res/values-be/strings.xml
@@ -829,7 +829,6 @@
     <string name="crypto_no_provider_title">Ліст зашыфраваны</string>
     <string name="crypto_no_provider_message">Ліст зашыфраваны OpenPGP\nКаб прачытаць, неабходна ўсталяваць і наладзіць праграму OpenPGP.</string>
     <string name="crypto_no_provider_button">Перайсці ў налады</string>
-    <string name="mail_list_widget_text">Лісты K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Зашыфраваць немагчыма</string>

--- a/app/ui/legacy/src/main/res/values-be/strings.xml
+++ b/app/ui/legacy/src/main/res/values-be/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">Не прачытана</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Зыходны код</string>

--- a/app/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bg/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Изходен код</string>
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="about_project_title">Проект с отворен код</string>

--- a/app/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bg/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Непрочетени</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Изходен код</string>

--- a/app/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bg/strings.xml
@@ -755,7 +755,6 @@
     <string name="crypto_no_provider_title">Имейлът е криптиран</string>
     <string name="crypto_no_provider_message">Този имейл е криптиран използвайки OpenPGP.\nЗа да го прочетете, трябва да инсталирате и настроите OpenPGP приложението.</string>
     <string name="crypto_no_provider_button">Към настройки</string>
-    <string name="mail_list_widget_text">K-9 списък със собщения</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Криптирането е невъзможно</string>

--- a/app/ui/legacy/src/main/res/values-br/strings.xml
+++ b/app/ui/legacy/src/main/res/values-br/strings.xml
@@ -732,7 +732,6 @@
     <string name="crypto_no_provider_title">N’eo ket enrineget ar postel-mañ</string>
     <string name="crypto_no_provider_message">Enrineget eo bet ar postel-mañ gant OpenPGP.\nEvit gallout e lenn e rankit staliañ ha kefluniañ un arload OpenPGP keverlec’h.</string>
     <string name="crypto_no_provider_button">Mont d\'an arventennoù</string>
-    <string name="mail_list_widget_text">Roll kemennadennoù K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">N’eo ket posupl enrinegañ</string>

--- a/app/ui/legacy/src/main/res/values-br/strings.xml
+++ b/app/ui/legacy/src/main/res/values-br/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Diorroerien K-9</string>
+    <string name="about_app_authors_k9">Diorroerien K-9</string>
     <string name="app_license">Lañvaz Apache, Handelv 2.0</string>
     <string name="about_libraries">Levraouegoù</string>
     <string name="license">Lañvaz</string>

--- a/app/ui/legacy/src/main/res/values-br/strings.xml
+++ b/app/ui/legacy/src/main/res/values-br/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Anlennet</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Diorroerien K-9</string>
     <string name="app_license">Lañvaz Apache, Handelv 2.0</string>

--- a/app/ui/legacy/src/main/res/values-bs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bs/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="unread_widget_label">K-9 Nepročitano</string>
     <string name="source_code">Izvorni kod</string>
     <string name="app_license">Apache Licenca, Verzija 2.0</string>
     <string name="about_website_title">Veb-sajt</string>

--- a/app/ui/legacy/src/main/res/values-bs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bs/strings.xml
@@ -80,7 +80,7 @@
     <string name="global_settings_show_correspondent_names_summary">Prikaži imena korespodenata umjesto njihove mejl-adrese</string>
     <string name="about_action">O nama</string>
     <string name="prefs_title">Postavke</string>
-    <string name="app_authors">K-9 razvojni tim</string>
+    <string name="about_app_authors_k9">K-9 razvojni tim</string>
     <string name="get_help_title">Zatražite pomoć</string>
     <string name="about_project_title">Projekat otvorenog koda</string>
     <string name="user_forum_title">Korisnički forum</string>

--- a/app/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ca/strings.xml
@@ -826,7 +826,6 @@
     <string name="crypto_no_provider_message">Aquest missatge ha estat encriptat amb OpenPGP.
 \nPer llegir-lo, us caldrà instal·lar i configurar una aplicació d\'OpenPGP compatible.</string>
     <string name="crypto_no_provider_button">Ves a la configuració</string>
-    <string name="mail_list_widget_text">Llista de missatges del K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Encriptació no possible</string>

--- a/app/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ca/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 no llegits</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Els passejadors de gossos K-9</string>
     <string name="source_code">Codi font</string>

--- a/app/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ca/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Els passejadors de gossos K-9</string>
+    <string name="about_app_authors_k9">Els passejadors de gossos K-9</string>
     <string name="source_code">Codi font</string>
     <string name="app_license">Llicència d\'Apache, versió 2.0</string>
     <string name="about_project_title">Projecte de codi obert</string>

--- a/app/ui/legacy/src/main/res/values-co/strings.xml
+++ b/app/ui/legacy/src/main/res/values-co/strings.xml
@@ -839,7 +839,6 @@
     <string name="crypto_no_provider_title">Stu messaghju hè cifratu</string>
     <string name="crypto_no_provider_button">Andà à i parametri</string>
     <string name="unsigned_text_divider_label">Testu micca firmatu</string>
-    <string name="mail_list_widget_text">Lista di i messaghji di K-9</string>
     <string name="enable_encryption">Attivà a cifratura</string>
     <string name="disable_encryption">Disattivà a cifratura</string>
     <string name="openpgp_enabled_error_title">A cifratura hè impussibule</string>

--- a/app/ui/legacy/src/main/res/values-co/strings.xml
+++ b/app/ui/legacy/src/main/res/values-co/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="unread_widget_label">K-9 à leghje</string>
     <string name="app_authors">Quelle è quelli di u K-9 storicu</string>
     <string name="about_project_title">Prughjettu à codice di fonte apertu</string>
     <string name="about_website_title">Situ web</string>

--- a/app/ui/legacy/src/main/res/values-co/strings.xml
+++ b/app/ui/legacy/src/main/res/values-co/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_authors">Quelle è quelli di u K-9 storicu</string>
+    <string name="about_app_authors_k9">Quelle è quelli di u K-9 storicu</string>
     <string name="about_project_title">Prughjettu à codice di fonte apertu</string>
     <string name="about_website_title">Situ web</string>
     <string name="user_manual_title">Manuale di l’utilizatore</string>

--- a/app/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cs/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Páníčci robopsů K-9</string>
+    <string name="about_app_authors_k9">Páníčci robopsů K-9</string>
     <string name="source_code">Zdrojový kód</string>
     <string name="app_license">Apache License, verze 2.0</string>
     <string name="about_project_title">Projekt s otevřeným zdrojovým kódem</string>

--- a/app/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cs/strings.xml
@@ -830,7 +830,6 @@
     <string name="crypto_no_provider_message">Tento e-mail byl zašifrován pomocí OpenPGP.
 \nPro jeho přečtení je třeba nainstalovat a nastavit kompatibilní OpenPGP aplikaci.</string>
     <string name="crypto_no_provider_button">Přejít do nastavení</string>
-    <string name="mail_list_widget_text">Seznam zpráv K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Šifrování není možné</string>

--- a/app/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cs/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Nepřečtená</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Páníčci robopsů K-9</string>
     <string name="source_code">Zdrojový kód</string>

--- a/app/ui/legacy/src/main/res/values-cy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cy/strings.xml
@@ -814,7 +814,6 @@
     <string name="crypto_no_provider_title">Mae\'r neges e-bost hon wedi ei amgryptio.</string>
     <string name="crypto_no_provider_message">Mae\'r neges e-bost hon wedi ei amgryptio gydag OpenPGP.\nI\'w darllen, rhaid gosod a ffurfweddu ap OpenPGP sy\'n cydweddu.</string>
     <string name="crypto_no_provider_button">Mynd i Osodiadau</string>
-    <string name="mail_list_widget_text">Rhestr Negeseuon K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Dyw amgryptiad ddim ar gael.</string>

--- a/app/ui/legacy/src/main/res/values-cy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cy/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Cod ffynhonnell</string>
     <string name="app_license">Trwydded Apache, Fersiwn 2.0</string>
     <string name="about_project_title">Prosiect Cod Agored</string>

--- a/app/ui/legacy/src/main/res/values-cy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cy/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Heb eu Darllen</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Cod ffynhonnell</string>

--- a/app/ui/legacy/src/main/res/values-da/strings.xml
+++ b/app/ui/legacy/src/main/res/values-da/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 ulæst</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Kildekode</string>

--- a/app/ui/legacy/src/main/res/values-da/strings.xml
+++ b/app/ui/legacy/src/main/res/values-da/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Kildekode</string>
     <string name="app_license">Apache licens, version 2.0</string>
     <string name="about_project_title">Opensource Projekt</string>

--- a/app/ui/legacy/src/main/res/values-da/strings.xml
+++ b/app/ui/legacy/src/main/res/values-da/strings.xml
@@ -812,7 +812,6 @@
     <string name="crypto_no_provider_title">Denne email er krypteret</string>
     <string name="crypto_no_provider_message">Denne email er krypteret med OpenPGP.\nFor at læse den skal du installere en kompatibel OpenPGP applikation.</string>
     <string name="crypto_no_provider_button">Gå til opsætning</string>
-    <string name="mail_list_widget_text">K-9 Meddelelsesliste</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Kryptering var ikke mulig</string>

--- a/app/ui/legacy/src/main/res/values-de/strings.xml
+++ b/app/ui/legacy/src/main/res/values-de/strings.xml
@@ -817,7 +817,6 @@
     <string name="crypto_no_provider_title">Diese E-Mail ist verschlüsselt</string>
     <string name="crypto_no_provider_message">Diese E-Mail ist mit OpenPGP verschlüsselt.\nUm sie zu lesen, muss eine kompatible OpenPGP-App installiert und konfiguriert werden.</string>
     <string name="crypto_no_provider_button">Zu den Einstellungen</string>
-    <string name="mail_list_widget_text">K-9 Nachrichtenliste</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Verschlüsselung nicht möglich</string>

--- a/app/ui/legacy/src/main/res/values-de/strings.xml
+++ b/app/ui/legacy/src/main/res/values-de/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Ungelesen</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Quellcode</string>

--- a/app/ui/legacy/src/main/res/values-de/strings.xml
+++ b/app/ui/legacy/src/main/res/values-de/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Quellcode</string>
     <string name="app_license">Apache-Lizenz, Version 2.0</string>
     <string name="about_project_title">Open Source Projekt</string>

--- a/app/ui/legacy/src/main/res/values-el/strings.xml
+++ b/app/ui/legacy/src/main/res/values-el/strings.xml
@@ -817,7 +817,6 @@
     <string name="crypto_no_provider_title">Αυτό το μήνυμα είναι κρυπτογραφημένο</string>
     <string name="crypto_no_provider_message">Αυτό το μήνυμα έχει κρυπτογραφηθεί με το OpenPGP.\nΓια να το διαβάσετε, πρέπει να εγκαταστήσετε και να ρυθμίσετε τις παραμέτρους μιας συμβατής εφαρμογής OpenPGP.</string>
     <string name="crypto_no_provider_button">Μετάβαση στις Ρυθμίσεις</string>
-    <string name="mail_list_widget_text">Λίστα Μηνυμάτων του K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Δεν είναι δυνατή η κρυπτογράφηση</string>

--- a/app/ui/legacy/src/main/res/values-el/strings.xml
+++ b/app/ui/legacy/src/main/res/values-el/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">Μη αναγνωσμένα K-9</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Πηγαίος κώδικας</string>

--- a/app/ui/legacy/src/main/res/values-el/strings.xml
+++ b/app/ui/legacy/src/main/res/values-el/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Πηγαίος κώδικας</string>
     <string name="app_license">Άδεια χρήσης Apache, έκδοση 2.0</string>
     <string name="about_project_title">Έργο ανοικτού κώδικα</string>

--- a/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
+++ b/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Unread</string>
     <!--Used in the about dialog-->
     <!--Displayed in a "snack bar" at the bottom of the screen when the app was updated.-->
     <!--Button text of the "snack bar" that is displayed when the app was updated.-->

--- a/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
+++ b/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
@@ -141,7 +141,7 @@
     <string name="copy_action">Copy</string>
     <string name="choose_folder_copy_title">Copy to…</string>
     <string name="remove_account_action">Remove account</string>
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="reply_action">Reply</string>
     <string name="show_headers_action">Show headers</string>
     <string name="user_forum_title">User forum</string>

--- a/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
+++ b/app/ui/legacy/src/main/res/values-en-rGB/strings.xml
@@ -734,7 +734,6 @@
     <string name="global_settings_threaded_view_label">Threaded view</string>
     <string name="webview_contextmenu_email_copy_action">Copy address to clipboard</string>
     <string name="push_notification_state_initializing">Initialising…</string>
-    <string name="mail_list_widget_text">K-9 Message List</string>
     <string name="crypto_msg_title_encrypted_signed_e2e">End-to-End encrypted</string>
     <string name="message_list_content_description_unread_prefix">unread, %s</string>
     <string name="general_settings_title">General settings</string>

--- a/app/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eo/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 nelegitaj mesaĝoj</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Programistoj de K-9</string>
     <string name="source_code">Fontkodo</string>

--- a/app/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eo/strings.xml
@@ -771,7 +771,6 @@
     <string name="crypto_no_provider_title">Tiu ĉi retletero estas ĉifrita</string>
     <string name="crypto_no_provider_message">Tiu ĉi retletero estas ĉifrita per OpenPGP.\nPor legi ĝin, vi devas instali kaj agordi kongruan OpenPGP-aplikaĵon.</string>
     <string name="crypto_no_provider_button">Iri al agordoj</string>
-    <string name="mail_list_widget_text">K-9 mesaĝlisto</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Ĉifrado ne eblas</string>

--- a/app/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eo/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Programistoj de K-9</string>
+    <string name="about_app_authors_k9">Programistoj de K-9</string>
     <string name="source_code">Fontkodo</string>
     <string name="app_license">Apache License, versio 2.0</string>
     <string name="about_project_title">Malfermkoda projekto</string>

--- a/app/ui/legacy/src/main/res/values-es/strings.xml
+++ b/app/ui/legacy/src/main/res/values-es/strings.xml
@@ -822,7 +822,6 @@
     <string name="crypto_no_provider_title">Este correo está cifrado</string>
     <string name="crypto_no_provider_message">Este correo ha sido cifrado con OpenPGP.\nPara leerlo es necesario instalar y configurar una aplicación compatible con OpenPGP.</string>
     <string name="crypto_no_provider_button">Ir a los ajustes</string>
-    <string name="mail_list_widget_text">Lista de correos de K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">No es posible cifrar</string>

--- a/app/ui/legacy/src/main/res/values-es/strings.xml
+++ b/app/ui/legacy/src/main/res/values-es/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">Mensaje K-9 no leído</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Los encargados del perrito K-9</string>
     <string name="source_code">Código fuente</string>

--- a/app/ui/legacy/src/main/res/values-es/strings.xml
+++ b/app/ui/legacy/src/main/res/values-es/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Los encargados del perrito K-9</string>
+    <string name="about_app_authors_k9">Los encargados del perrito K-9</string>
     <string name="source_code">Código fuente</string>
     <string name="app_license">Licencia Apache, versión 2.0</string>
     <string name="about_project_title">Proyecto de código abierto</string>

--- a/app/ui/legacy/src/main/res/values-et/strings.xml
+++ b/app/ui/legacy/src/main/res/values-et/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Lugemata</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 Autorid</string>
     <string name="source_code">Lähtekood</string>

--- a/app/ui/legacy/src/main/res/values-et/strings.xml
+++ b/app/ui/legacy/src/main/res/values-et/strings.xml
@@ -817,7 +817,6 @@
     <string name="crypto_no_provider_title">See e-kiri on krüpteeritud</string>
     <string name="crypto_no_provider_message">Selle kirja krüptimisel on kasutusel OpenPGP.\nKirjalugemsieks palun paigalda ja seadista sobilik OpenPGP rakendus.</string>
     <string name="crypto_no_provider_button">Ava sätted</string>
-    <string name="mail_list_widget_text">K-9 kirjade loend</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Krüpteerimine poe võimalik</string>

--- a/app/ui/legacy/src/main/res/values-et/strings.xml
+++ b/app/ui/legacy/src/main/res/values-et/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 Autorid</string>
+    <string name="about_app_authors_k9">K-9 Autorid</string>
     <string name="source_code">Lähtekood</string>
     <string name="app_license">Apache litsents, versioon 2.0</string>
     <string name="about_project_title">Avatud lähtekoodiga projekt</string>

--- a/app/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eu/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 Txakur-paseatzaileak</string>
+    <string name="about_app_authors_k9">K-9 Txakur-paseatzaileak</string>
     <string name="source_code">Iturburu-kodea</string>
     <string name="app_license">Apache lizentzia, 2.0 bertsioa</string>
     <string name="about_project_title">Kode Irekiko Proiektua</string>

--- a/app/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eu/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Irakurri gabe</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 Txakur-paseatzaileak</string>
     <string name="source_code">Iturburu-kodea</string>

--- a/app/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eu/strings.xml
@@ -816,7 +816,6 @@
     <string name="crypto_no_provider_title">Posta hau zifratuta dago</string>
     <string name="crypto_no_provider_message">Posta hau OpenPGPrekin zifratua izan da.\nIrakurtzeko, OpenPGPrekin bateragarria den aplikazio bat instalatu eta konfiguratu behar duzu.</string>
     <string name="crypto_no_provider_button">Joan ezarpenetara</string>
-    <string name="mail_list_widget_text">K-9-ren mezu-zerrenda</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Zifratzea ez da posible</string>

--- a/app/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fa/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">K-9 Dog Walkers</string>
     <string name="source_code">کد منبع</string>
     <string name="app_license">مجوز آپاچی، نسخهٔ 2.0</string>
     <string name="about_project_title">پروژهٔ متن‌باز</string>

--- a/app/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fa/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">نخوانده‌های K-9</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 Dog Walkers</string>
     <string name="source_code">کد منبع</string>

--- a/app/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fa/strings.xml
@@ -816,7 +816,6 @@
     <string name="crypto_no_provider_title">این رایانامه رمزنگاری شده است</string>
     <string name="crypto_no_provider_message">این رایانامه با OpenPGP رمزنگاری شده است.\nبرای خواندن آن، باید برنامه‌ای سازگار با OpenPGP را نصب و پیکربندی کنید.</string>
     <string name="crypto_no_provider_button">برو به تنظیمات</string>
-    <string name="mail_list_widget_text">لیست پیام K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">رمزنگاری ممکن نیست</string>

--- a/app/ui/legacy/src/main/res/values-fi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fi/strings.xml
@@ -816,7 +816,6 @@
     <string name="crypto_no_provider_title">Tämä sähköpostiviesti on salattu</string>
     <string name="crypto_no_provider_message">Tämä viesti on salattu OpenPGP:llä.\nLukeaksesi viestin sinun tulee asentaa ja määrittää yhteensopiva OpenPGP-sovellus.</string>
     <string name="crypto_no_provider_button">Siirry asetuksiin</string>
-    <string name="mail_list_widget_text">K-9-viestiluettelo</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Salaus ei ole mahdollista</string>

--- a/app/ui/legacy/src/main/res/values-fi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fi/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Lähdekoodi</string>
     <string name="app_license">Apache-lisenssi, versio 2.0</string>
     <string name="about_project_title">Avoimen lähdekoodin projekti</string>

--- a/app/ui/legacy/src/main/res/values-fi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fi/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9-lukematon</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Lähdekoodi</string>

--- a/app/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fr/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Les auteurs de Courriel K-9 Mail</string>
+    <string name="about_app_authors_k9">Les auteurs de Courriel K-9 Mail</string>
     <string name="source_code">Code source</string>
     <string name="app_license">Licence Apache, Version 2.0</string>
     <string name="about_project_title">Projet à code source ouvert</string>

--- a/app/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fr/strings.xml
@@ -823,7 +823,6 @@
     <string name="crypto_no_provider_title">Le courriel est chiffré</string>
     <string name="crypto_no_provider_message">Ce courriel a été chiffré avec OpenPGP.\nPour le lire, vous devez installer et configurer une appli compatible avec OpenPGP.</string>
     <string name="crypto_no_provider_button">Aller dans Paramètres</string>
-    <string name="mail_list_widget_text">Liste des courriels de K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Le chiffrement est impossible</string>

--- a/app/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fr/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 non lus</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Les auteurs de Courriel K-9 Mail</string>
     <string name="source_code">Code source</string>

--- a/app/ui/legacy/src/main/res/values-fy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fy/strings.xml
@@ -820,7 +820,6 @@
     <string name="crypto_no_provider_message">Dit e-mailberjocht is mei OpenPGP fersifere.
 \nYnstallearje en stel in OpenPGP-app yn om it e-mailberjocht te lêzen.</string>
     <string name="crypto_no_provider_button">Gean nei Ynstellingen</string>
-    <string name="mail_list_widget_text">K-9-berjochtelist</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Fersifering net mooglik</string>

--- a/app/ui/legacy/src/main/res/values-fy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fy/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Net lêzen</string>
     <!--Used in the about dialog-->
     <string name="app_authors">It K-9-ûntwikkelteam</string>
     <string name="source_code">Boarnekoade</string>

--- a/app/ui/legacy/src/main/res/values-fy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fy/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">It K-9-ûntwikkelteam</string>
+    <string name="about_app_authors_k9">It K-9-ûntwikkelteam</string>
     <string name="source_code">Boarnekoade</string>
     <string name="app_license">Apache-lisinsje, ferzje 2.0</string>
     <string name="about_project_title">Iepenboarnekoadeprojekt</string>

--- a/app/ui/legacy/src/main/res/values-gd/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gd/strings.xml
@@ -742,7 +742,6 @@
     <string name="crypto_no_provider_message">Chaidh am post-d seo a chrioptachadh le OpenPGP.
 \nFeumaidh tu aplacaid a tha comasach air OpenPGP a stàladh is a rèiteachadh mus urrainn dhut a leughadh.</string>
     <string name="crypto_no_provider_button">Tagh aplacaid OpenPGP</string>
-    <string name="mail_list_widget_text">Liosta theachdaireachdan puist</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Cha ghabh a chrioptachadh</string>

--- a/app/ui/legacy/src/main/res/values-gd/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gd/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Google, luchd-coiseachd nan con K-9.</string>
+    <string name="about_app_authors_k9">Google, luchd-coiseachd nan con K-9.</string>
     <string name="source_code">An còd tùsail</string>
     <string name="app_license">Fo cheadachas Apache, tionndadh 2.0.</string>
     <string name="about_project_title">Pròiseact le tùs fosgailte</string>

--- a/app/ui/legacy/src/main/res/values-gd/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gd/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">Post gun leughadh</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Google, luchd-coiseachd nan con K-9.</string>
     <string name="source_code">An còd tùsail</string>

--- a/app/ui/legacy/src/main/res/values-gl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gl/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Os paseadores de cans K-9</string>
+    <string name="about_app_authors_k9">Os paseadores de cans K-9</string>
     <string name="source_code">Código fonte</string>
     <string name="app_license">Licenza Apache, Versión 2.0</string>
     <string name="about_project_title">Proxecto de código aberto</string>

--- a/app/ui/legacy/src/main/res/values-gl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gl/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 non lidos</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Os paseadores de cans K-9</string>
     <string name="source_code">Código fonte</string>

--- a/app/ui/legacy/src/main/res/values-gl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gl/strings.xml
@@ -776,7 +776,6 @@
     <string name="crypto_no_provider_message">Este correo foi cifrado con OpenPGP.
 \nPara lelo, precisa instalar e configurar un app compatible con OpenPGP.</string>
     <string name="crypto_no_provider_button">Ir a Configuración</string>
-    <string name="mail_list_widget_text">Lista de mensaxes K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Cifrado non posible</string>

--- a/app/ui/legacy/src/main/res/values-hi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hi/strings.xml
@@ -69,7 +69,7 @@
     <string name="copy_action">कॉपी करें</string>
     <string name="choose_folder_copy_title">कॉपी ले जाएं…</string>
     <string name="remove_account_action">अकाउंट हटाएं</string>
-    <string name="app_authors">के-9 डॉग वॉकर</string>
+    <string name="about_app_authors_k9">के-9 डॉग वॉकर</string>
     <string name="reply_action">जवाब दें</string>
     <string name="show_headers_action">हैडर दिखाएं</string>
     <string name="user_forum_title">यूज़र फॉरम</string>

--- a/app/ui/legacy/src/main/res/values-hi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hi/strings.xml
@@ -22,7 +22,6 @@
     <string name="add_account_action">अकाउंट जोड़ें</string>
     <string name="spam_action">स्पैम</string>
     <string name="read_receipt_disabled">पढ़ा रसीद नहीं मांगेंगे</string>
-    <string name="unread_widget_label">के-9 नहीं पढ़ा</string>
     <plurals name="copy_address_to_clipboard">
         <item quantity="one">पता क्लिपबोर्ड पे कॉपी किया गया</item>
         <item quantity="other">पते क्लिपबोर्ड पे कॉपी किए गए</item>

--- a/app/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hr/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Nepročitano</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 Šetač Pasa</string>
     <string name="app_license">Apache Licenca, Verzija 2.0</string>

--- a/app/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hr/strings.xml
@@ -736,7 +736,6 @@
     <string name="crypto_no_provider_title">Vaš email je šifriran</string>
     <string name="crypto_no_provider_message">Ova e-poruka je šifrirana korištenjem OpenPGP.\nDa bi ste je pročitali, potrebno je da instalirate i postavite odgovarajuću OpenPGP aplikaciju.</string>
     <string name="crypto_no_provider_button">Idi u Postavke</string>
-    <string name="mail_list_widget_text">K-9 Popis Poruka</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Šifriranje nije moguće</string>

--- a/app/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hr/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 Šetač Pasa</string>
+    <string name="about_app_authors_k9">K-9 Šetač Pasa</string>
     <string name="app_license">Apache Licenca, Verzija 2.0</string>
     <string name="about_libraries">Knjižnice</string>
     <string name="license">Licenca</string>

--- a/app/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hu/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 olvasatlan</string>
     <!--Used in the about dialog-->
     <string name="app_authors">A K-9 Kutyasétáltatók</string>
     <string name="source_code">Forráskód</string>

--- a/app/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hu/strings.xml
@@ -816,7 +816,6 @@
     <string name="crypto_no_provider_title">Ez az e-mail titkosított</string>
     <string name="crypto_no_provider_message">Az e-mail titkosítva lett OpenPGP használatával.\nAz elolvasásához egy megfelelő OpenPGP alkalmazást kell telepítenie és beállítania.</string>
     <string name="crypto_no_provider_button">Ugrás a beállításokhoz</string>
-    <string name="mail_list_widget_text">K-9 üzenetlista</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">A titkosítás nem lehetséges</string>

--- a/app/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hu/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">A K-9 Kutyasétáltatók</string>
+    <string name="about_app_authors_k9">A K-9 Kutyasétáltatók</string>
     <string name="source_code">Forráskód</string>
     <string name="app_license">Apache licenc, 2.0-s verzió</string>
     <string name="about_project_title">Nyílt forráskódú projekt</string>

--- a/app/ui/legacy/src/main/res/values-hy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hy/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">Կ֊9 Չընթերցուած</string>
     <!--Used in the about dialog-->
     <!--Displayed in a "snack bar" at the bottom of the screen when the app was updated.-->
     <!--Button text of the "snack bar" that is displayed when the app was updated.-->

--- a/app/ui/legacy/src/main/res/values-in/strings.xml
+++ b/app/ui/legacy/src/main/res/values-in/strings.xml
@@ -752,7 +752,6 @@
     <string name="crypto_no_provider_message">Surel ini telah dienkripsi dengan OpenPGP.
 \nUntuk membacanya, Anda perlu menginstal dan mengatur Aplikasi OpenPGP yang kompatibel.</string>
     <string name="crypto_no_provider_button">Pergi ke Pengaturan</string>
-    <string name="mail_list_widget_text">Daftar pesan K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Enkripsi tidak mungkin dilakukan</string>

--- a/app/ui/legacy/src/main/res/values-in/strings.xml
+++ b/app/ui/legacy/src/main/res/values-in/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Kode Sumber</string>
     <string name="app_license">Lisensi Apache, Versi 2.0</string>
     <string name="about_project_title">Proyek Sumber Terbuka</string>

--- a/app/ui/legacy/src/main/res/values-in/strings.xml
+++ b/app/ui/legacy/src/main/res/values-in/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Belum Dibaca</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Kode Sumber</string>

--- a/app/ui/legacy/src/main/res/values-is/strings.xml
+++ b/app/ui/legacy/src/main/res/values-is/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 - Ólesið</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 hundatemjararnir</string>
     <string name="source_code">Grunnkóði</string>

--- a/app/ui/legacy/src/main/res/values-is/strings.xml
+++ b/app/ui/legacy/src/main/res/values-is/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 hundatemjararnir</string>
+    <string name="about_app_authors_k9">K-9 hundatemjararnir</string>
     <string name="source_code">Grunnkóði</string>
     <string name="app_license">Apache notkunarleyfi, útgáfa 2.0</string>
     <string name="about_project_title">Verkefni með opnum grunnkóða</string>

--- a/app/ui/legacy/src/main/res/values-is/strings.xml
+++ b/app/ui/legacy/src/main/res/values-is/strings.xml
@@ -817,7 +817,6 @@
     <string name="crypto_no_provider_title">Þessi tölvupóstur er dulritaður</string>
     <string name="crypto_no_provider_message">Þessi tölvupóstur var dulritaður með OpenPGP.\nTil að lesa hann verður þú að setja upp og stilla samhæft OpenPGP-forrit.</string>
     <string name="crypto_no_provider_button">Fara í stillingar</string>
-    <string name="mail_list_widget_text">Skilaboðalisti K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Dulritun er ekki möguleg</string>

--- a/app/ui/legacy/src/main/res/values-it/strings.xml
+++ b/app/ui/legacy/src/main/res/values-it/strings.xml
@@ -826,7 +826,6 @@
     <string name="crypto_no_provider_message">Questo messaggio è stato criptato con OpenPGP.
 \nPer leggerlo, devi installare e configurare un\'applicazione compatibile con OpenPGP.</string>
     <string name="crypto_no_provider_button">Vai alle impostazioni</string>
-    <string name="mail_list_widget_text">Lista messaggi di K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Criptatura non possibile</string>

--- a/app/ui/legacy/src/main/res/values-it/strings.xml
+++ b/app/ui/legacy/src/main/res/values-it/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Codice sorgente</string>
     <string name="app_license">Apache License, Versione 2.0</string>
     <string name="about_project_title">Progetto Open Source</string>

--- a/app/ui/legacy/src/main/res/values-it/strings.xml
+++ b/app/ui/legacy/src/main/res/values-it/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Nuovi messaggi</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Codice sorgente</string>

--- a/app/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/app/ui/legacy/src/main/res/values-iw/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 - הודעות שלא נקראו</string>
     <!--Used in the about dialog-->
     <string name="source_code">קוד מקור</string>
     <string name="app_license">רישיון Apache, גירסה 2.0</string>

--- a/app/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/app/ui/legacy/src/main/res/values-iw/strings.xml
@@ -753,7 +753,6 @@
     <string name="account_settings_crypto_hide_sign_only_off">כל החתימות יוצגו</string>
     <string name="crypto_no_provider_message">הדוא\"ל הזה הוצפן עם OpenPGP.
 \nעל מנת לקרוא אותו, עליך להתקין ולהגדיר יישומון OpenPGP תואם.</string>
-    <string name="mail_list_widget_text">רשימת הודעות K-9</string>
     <string name="openpgp_enabled_error_title">הצפנה לא אפשרית</string>
     <string name="openpgp_description_text3">הצפנה תופיע רק אם היא נתמכת ע\"י כל הנמענים, והם שלחו לך דוא\"ל בעבר.</string>
     <string name="account_settings_open_notification_settings_miscellaneous_summary">הגדרת התראות שגיאה ומצב</string>

--- a/app/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/app/ui/legacy/src/main/res/values-iw/strings.xml
@@ -567,7 +567,7 @@
     <!--A user visible label for the name and email address copied to the clipboard-->
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="app_authors">מוליכי הכלבים של K-9</string>
+<string name="about_app_authors_k9">מוליכי הכלבים של K-9</string>
     <string name="about_website_title">אתר אינטרנט</string>
     <string name="user_manual_title">מדריך משתמש</string>
     <string name="get_help_title">קבל עזרה</string>

--- a/app/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ja/strings.xml
@@ -816,7 +816,6 @@
     <string name="crypto_no_provider_message">このメールは OpenPGP で暗号化されました。
 \nメールを読むためには、OpenPGP と互換性のあるアプリをインストールして設定する必要があります。</string>
     <string name="crypto_no_provider_button">設定に移動</string>
-    <string name="mail_list_widget_text">K-9 メッセージ一覧</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">暗号化できません</string>

--- a/app/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ja/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">ソースコード</string>
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="about_project_title">オープンソースプロジェクト</string>

--- a/app/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ja/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 未読</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">ソースコード</string>

--- a/app/ui/legacy/src/main/res/values-ka/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ka/strings.xml
@@ -488,7 +488,6 @@
     <string name="unsigned_text_divider_label">ხელმოუწერელი ტექსტი</string>
     <string name="crypto_no_provider_title">ეს წერილი დაშიფრულია</string>
     <string name="crypto_no_provider_button">პარამეტრებში შესვლა</string>
-    <string name="mail_list_widget_text">K-9 მესიჯების ნუსხა</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">შიფრაცია შეუძლებელია</string>

--- a/app/ui/legacy/src/main/res/values-ka/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ka/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 წაუკითხავი</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="app_license">ლიცენზია: Apache, ვერსია 2.0</string>

--- a/app/ui/legacy/src/main/res/values-ka/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ka/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="app_license">ლიცენზია: Apache, ვერსია 2.0</string>
     <string name="about_libraries">ბიბლიოთეკები</string>
     <string name="license">ლიცენზია</string>

--- a/app/ui/legacy/src/main/res/values-ko/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ko/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 개발자들</string>
+    <string name="about_app_authors_k9">K-9 개발자들</string>
     <string name="source_code">소소 코드</string>
     <string name="app_license">아파치 라이선스, 버전 2.0</string>
     <string name="about_project_title">오픈 소스 프로젝트</string>

--- a/app/ui/legacy/src/main/res/values-ko/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ko/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 읽지 않은 메일</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 개발자들</string>
     <string name="source_code">소소 코드</string>

--- a/app/ui/legacy/src/main/res/values-lt/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lt/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 šunų vedžiotojai</string>
+    <string name="about_app_authors_k9">K-9 šunų vedžiotojai</string>
     <string name="source_code">Šaltinio kodas</string>
     <string name="app_license">Apache licencija, versija 2.0</string>
     <string name="about_project_title">Atvirojo kodo projektas</string>

--- a/app/ui/legacy/src/main/res/values-lt/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lt/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 neskaityta</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 šunų vedžiotojai</string>
     <string name="source_code">Šaltinio kodas</string>

--- a/app/ui/legacy/src/main/res/values-lt/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lt/strings.xml
@@ -819,7 +819,6 @@
     <string name="crypto_no_provider_title">Šis el. laiškas yra užšifruotas</string>
     <string name="crypto_no_provider_message">Šis el. laiškas užšifruotas naudojant OpenPGP.\nKad jį perskaitytumėte, turite įdiegti ir sukonfigūruoti suderinamą OpenPGP programėlę.</string>
     <string name="crypto_no_provider_button">Eiti į Nustatymus</string>
-    <string name="mail_list_widget_text">K-9 laiškų sąrašas</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Šifravimas neįmanomas</string>

--- a/app/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lv/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 Suņu staidzinātāji</string>
+    <string name="about_app_authors_k9">K-9 Suņu staidzinātāji</string>
     <string name="source_code">Pirmkods</string>
     <string name="app_license">Apache licence, Versija 2.0</string>
     <string name="about_project_title">Atklātā koda projekts</string>

--- a/app/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lv/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 nelasītie</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 Suņu staidzinātāji</string>
     <string name="source_code">Pirmkods</string>

--- a/app/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lv/strings.xml
@@ -826,7 +826,6 @@ pat <xliff:g id="messages_to_load">%d</xliff:g> vairāk</string>
     <string name="crypto_no_provider_title">Epasts ir šifrēts</string>
     <string name="crypto_no_provider_message">Šis epasts ir šifrēts ar OpenPGP. Lai to apskatītu, jāuzstāda un jāiestata saderīga OpenPGP lietotne.</string>
     <string name="crypto_no_provider_button">Doties uz Iestatījumiem</string>
-    <string name="mail_list_widget_text">K-9 Ziņu saraksts</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Šifrēšana nav iespējama</string>

--- a/app/ui/legacy/src/main/res/values-ml/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ml/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">സോഴ്സ് കോഡ്</string>
     <string name="app_license">അപ്പാച്ചെ ലൈസൻസ്, പതിപ്പ് 2.0</string>
     <string name="about_project_title">ഓപ്പൺ സോഴ്സ് പ്രോജക്റ്റ്</string>

--- a/app/ui/legacy/src/main/res/values-ml/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ml/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">കെ-9 വായിക്കാത്തവ</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">സോഴ്സ് കോഡ്</string>

--- a/app/ui/legacy/src/main/res/values-ml/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ml/strings.xml
@@ -776,7 +776,6 @@
     <string name="crypto_no_provider_title">ഈ ഇമെയിൽ എൻ‌ക്രിപ്റ്റ് ചെയ്തതാണ്</string>
     <string name="crypto_no_provider_message">ഈ ഇമെയിൽ ഓപ്പൺപിജിപി ഉപയോഗിച്ച് എൻക്രിപ്റ്റുചെയ്‌തതാണ്.\nഇത് വായിക്കാൻ, നിങ്ങൾ ഒരു അനുയോജ്യമായ ഓപ്പൺപിജിപി അപ്ലിക്കേഷൻ ഇൻസ്റ്റാളുചെയ്‌ത് ക്രമീകരിക്കേണ്ടതുണ്ട്. </string>
     <string name="crypto_no_provider_button">ക്രമീകരണങ്ങളിലേക്ക് പോകുക</string>
-    <string name="mail_list_widget_text">കെ-9 സന്ദേശ പട്ടിക</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">എൻക്രിപ്ഷൻ സാധ്യമല്ല</string>

--- a/app/ui/legacy/src/main/res/values-nb/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nb/strings.xml
@@ -746,7 +746,6 @@ til <xliff:g id="messages_to_load">%d</xliff:g> flere</string>
     <string name="crypto_no_provider_title">Denne e-posten er kryptert</string>
     <string name="crypto_no_provider_message">Denne e-posten har blitt kryptert med OpenPGP.\nFor å lese den, må du installere og sette opp et kompatibelt OpenPGP-program.</string>
     <string name="crypto_no_provider_button">Gå til \"Innstillinger\"</string>
-    <string name="mail_list_widget_text">K-9 meldingsliste</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Kryptering er ikke mulig</string>

--- a/app/ui/legacy/src/main/res/values-nb/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nb/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Ulest</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">kildekode</string>

--- a/app/ui/legacy/src/main/res/values-nb/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nb/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">kildekode</string>
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="about_project_title">Åpen kildekode prosjekt</string>

--- a/app/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nl/strings.xml
@@ -820,7 +820,6 @@
     <string name="crypto_no_provider_message">Dit e-mailbericht is met OpenPGP versleuteld.
 \nInstalleer en stel een OpenPGP-app in om het e-mailbericht te lezen.</string>
     <string name="crypto_no_provider_button">Ga naar Instellingen</string>
-    <string name="mail_list_widget_text">K-9-berichtenlijst</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Versleuteling niet mogelijk</string>

--- a/app/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nl/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Het K-9-ontwikkelteam</string>
+    <string name="about_app_authors_k9">Het K-9-ontwikkelteam</string>
     <string name="source_code">Broncode</string>
     <string name="app_license">Apache-licentie, versie 2.0</string>
     <string name="about_project_title">Openbroncodeproject</string>

--- a/app/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nl/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Ongelezen</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Het K-9-ontwikkelteam</string>
     <string name="source_code">Broncode</string>

--- a/app/ui/legacy/src/main/res/values-nn/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nn/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <!--Displayed in a "snack bar" at the bottom of the screen when the app was updated.-->
     <!--Button text of the "snack bar" that is displayed when the app was updated.-->
     <!--Default signature-->

--- a/app/ui/legacy/src/main/res/values-nn/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nn/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Ulesne</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <!--Displayed in a "snack bar" at the bottom of the screen when the app was updated.-->

--- a/app/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pl/strings.xml
@@ -831,7 +831,6 @@
     <string name="crypto_no_provider_title">Ta wiadomość e-mail jest zaszyfrowana</string>
     <string name="crypto_no_provider_message">Ta wiadomość e-mail została zaszyfrowana z użyciem OpenPGP.\n Aby ją odczytać, należy zainstalować i skonfigurować zgodną aplikację OpenPGP.</string>
     <string name="crypto_no_provider_button">Przejdź do ustawień</string>
-    <string name="mail_list_widget_text">Lista wiadomości K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Szyfrowanie nie jest możliwe</string>

--- a/app/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pl/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Autorzy K-9 Mail</string>
+    <string name="about_app_authors_k9">Autorzy K-9 Mail</string>
     <string name="source_code">Kod źródłowy</string>
     <string name="app_license">Licencja Apache, wersja 2.0</string>
     <string name="about_project_title">Projekt otwartoźródłowy</string>

--- a/app/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pl/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">Nieprzeczytane K-9</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Autorzy K-9 Mail</string>
     <string name="source_code">Kod źródłowy</string>

--- a/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Criadores do K-9</string>
+    <string name="about_app_authors_k9">Criadores do K-9</string>
     <string name="source_code">Código-fonte</string>
     <string name="app_license">Licença Apache, Versão 2.0</string>
     <string name="about_project_title">Projeto de código aberto</string>

--- a/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -824,7 +824,6 @@
     <string name="crypto_no_provider_title">Esta mensagem está criptografada</string>
     <string name="crypto_no_provider_message">Esta mensagem foi criptografada com OpenPGP.\nPara ler, precisa instalar e configurar um aplicativo OpenPGP compatível.</string>
     <string name="crypto_no_provider_button">Ir para as configurações</string>
-    <string name="mail_list_widget_text">Lista de mensagens do K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Não foi possível criptografar</string>

--- a/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K9 - Não lidos</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Criadores do K-9</string>
     <string name="source_code">Código-fonte</string>

--- a/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -823,7 +823,6 @@
     <string name="crypto_no_provider_title">Este email está encriptado</string>
     <string name="crypto_no_provider_message">Este email foi encriptado com OpenPGP.\nPara o ler, necessita de instalar e configurar uma aplicação OpenPGP compatível.</string>
     <string name="crypto_no_provider_button">Ir para as configurações</string>
-    <string name="mail_list_widget_text">K-9 Lista de mensagens</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Não é possível encriptar</string>

--- a/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Não lido</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Código-fonte</string>

--- a/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Código-fonte</string>
     <string name="app_license">Licença Apache, versão 2.0</string>
     <string name="about_project_title">Projeto de Código Aberto</string>

--- a/app/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ro/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Necitite</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 Dog Walkers</string>
     <string name="source_code">Codul sursă</string>

--- a/app/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ro/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">K-9 Dog Walkers</string>
     <string name="source_code">Codul sursă</string>
     <string name="app_license">Licență Apache, Versiunea 2.0</string>
     <string name="about_project_title">Proiect Open Source</string>

--- a/app/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ro/strings.xml
@@ -823,7 +823,6 @@ cel mult încă <xliff:g id="messages_to_load">%d</xliff:g></string>
     <string name="crypto_no_provider_title">Acest mesaj este criptat</string>
     <string name="crypto_no_provider_message">Acest mesaj a fost criptat cu OpenPGP.\nPentru a-l citi trebuie să instalezi și să configurezi o aplicație OpenPGP compatibilă.</string>
     <string name="crypto_no_provider_button">Mergi la Setări</string>
-    <string name="mail_list_widget_text">Listă mesaje K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Criptarea nu este posibilă</string>

--- a/app/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ru/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">Не прочитано</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Исходный код</string>

--- a/app/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ru/strings.xml
@@ -830,7 +830,6 @@
     <string name="crypto_no_provider_title">Сообщение зашифровано</string>
     <string name="crypto_no_provider_message">Сообщение зашифровано OpenPGP.\nЧтобы прочесть его, необходимо установить и настроить подходящее OpenPGP-приложение.</string>
     <string name="crypto_no_provider_button">В Настройки</string>
-    <string name="mail_list_widget_text">Сообщения K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Шифрование невозможно</string>

--- a/app/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ru/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Исходный код</string>
     <string name="app_license">Лицензия Apache версии 2.0</string>
     <string name="about_project_title">Проект с открытым исходным кодом</string>

--- a/app/ui/legacy/src/main/res/values-sk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sk/strings.xml
@@ -713,7 +713,6 @@
     <string name="unsigned_text_divider_label">Nepodpísaný text</string>
     <string name="crypto_no_provider_title">Táto správa je zašifrovaná</string>
     <string name="crypto_no_provider_message">Táto správa bola zašifrovaná pomocou OpenPGP\nJe potrebné nakonfigurovať kompatibilnú OpenPGP aplikáciu.</string>
-    <string name="mail_list_widget_text">Zoznam správ K-9</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_back">Späť</string>

--- a/app/ui/legacy/src/main/res/values-sk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sk/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Zdrojový kód</string>
     <string name="app_license">Licencované pod licenciou Apache 2.0.</string>
     <string name="about_project_title">Projekt s otvoreným zdrojovým kódom</string>

--- a/app/ui/legacy/src/main/res/values-sk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sk/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Neprečítaná</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Zdrojový kód</string>

--- a/app/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sl/strings.xml
@@ -825,7 +825,6 @@ dodatnih <xliff:g id="messages_to_load">%d</xliff:g> sporočil</string>
     <string name="crypto_no_provider_title">Sporočilo je šifrirano</string>
     <string name="crypto_no_provider_message">Sporočilo je šifrirano s programom OpenPGP.\nZa ogled vsebine je treba namestiti ustrezen podprt program OpenPGP.</string>
     <string name="crypto_no_provider_button">Pojdi v Nastavitve</string>
-    <string name="mail_list_widget_text">Seznami sporočil</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Šifriranje ni mogoče</string>

--- a/app/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sl/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">Neprebrano K-9</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Sprehajalci psov v skupini The K-9 Dog Walkers</string>
     <string name="source_code">Izvorna koda</string>

--- a/app/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sl/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Sprehajalci psov v skupini The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">Sprehajalci psov v skupini The K-9 Dog Walkers</string>
     <string name="source_code">Izvorna koda</string>
     <string name="app_license">Dovoljenje Apache, različica 2.0</string>
     <string name="about_project_title">Odprtokodni projekt</string>

--- a/app/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sq/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">Të palexuar K-9</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Kod burim</string>

--- a/app/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sq/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Kod burim</string>
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="about_project_title">Projekt Me Burim të Hapët</string>

--- a/app/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sq/strings.xml
@@ -819,7 +819,6 @@
     <string name="crypto_no_provider_message">Ky email është fshehtëzuar me OpenPGP.
 \nQë ta lexoni, lypset të instaloni dhe formësoni një aplikacion të përputhshëm me OpenPGP-në.</string>
     <string name="crypto_no_provider_button">Kaloni te Rregullimet</string>
-    <string name="mail_list_widget_text">Listë K-9 Mesazhesh</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Fshehtëzim jo i mundshëm</string>

--- a/app/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sr/strings.xml
@@ -759,7 +759,6 @@
     <string name="crypto_no_provider_title">Ова е-порука је шифрована</string>
     <string name="crypto_no_provider_message">Ова е-порука је шифрована помоћу у ОпенПГП-а.\nДа бисте је прочитали, треба да инсталирате и подесите компатибилну ОпенПГП апликацију.</string>
     <string name="crypto_no_provider_button">Иди на Поставке</string>
-    <string name="mail_list_widget_text">К-9 списак порука</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Шифровање није могуће</string>

--- a/app/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sr/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">К-9 развојни тим</string>
+    <string name="about_app_authors_k9">К-9 развојни тим</string>
     <string name="source_code">Изворни код</string>
     <string name="app_license">Апач лиценца, верзије 2.0</string>
     <string name="about_project_title">Пројекат отвореног кода</string>

--- a/app/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sr/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">К-9 непрочитане</string>
     <!--Used in the about dialog-->
     <string name="app_authors">К-9 развојни тим</string>
     <string name="source_code">Изворни код</string>

--- a/app/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sv/strings.xml
@@ -817,7 +817,6 @@
     <string name="crypto_no_provider_title">Detta e-postmeddelande är krypterat</string>
     <string name="crypto_no_provider_message">Detta e-postmeddelande har krypterats med OpenPGP.\nFör att läsa det, måste du installera och konfigurera en kompatibel OpenPGP-app.</string>
     <string name="crypto_no_provider_button">Gå till inställningar</string>
-    <string name="mail_list_widget_text">K-9 Meddelandelista</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Kryptering inte möjligt</string>

--- a/app/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sv/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Källkod</string>
     <string name="app_license">Apachelicens, version 2.0</string>
     <string name="about_project_title">Projekt med öppen källkod</string>

--- a/app/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sv/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 olästa</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Källkod</string>

--- a/app/ui/legacy/src/main/res/values-ta-rIN/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ta-rIN/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 புதியவை</string>
     <!--Used in the about dialog-->
     <!--Displayed in a "snack bar" at the bottom of the screen when the app was updated.-->
     <!--Button text of the "snack bar" that is displayed when the app was updated.-->

--- a/app/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-tr/strings.xml
@@ -803,7 +803,6 @@
     <string name="crypto_no_provider_message">Bu e-posta OpenPGP ile şifrelendi.
 \nOkumak için uyumlu bir OpenPGP uygulaması kurup yapılandırmalısınız.</string>
     <string name="crypto_no_provider_button">Ayarlara Git</string>
-    <string name="mail_list_widget_text">K-9 İleti Listesi</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Şifreleme yapılamaz</string>

--- a/app/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-tr/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Okunmamış</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 Köpek Gezdiricileri</string>
     <string name="source_code">Kaynak kodu</string>

--- a/app/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-tr/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 Köpek Gezdiricileri</string>
+    <string name="about_app_authors_k9">K-9 Köpek Gezdiricileri</string>
     <string name="source_code">Kaynak kodu</string>
     <string name="app_license">Apache Lisansı, Versiyon 2.0</string>
     <string name="about_project_title">Açık Kaynak Projesi</string>

--- a/app/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-uk/strings.xml
@@ -829,7 +829,6 @@
     <string name="crypto_no_provider_title">Цей електронний лист зашифровано</string>
     <string name="crypto_no_provider_message">Цей електронний лист було зашифровано за допомогою OpenPGP.\nЩоб його прочитати, необхідно встановити та налаштувати сумісний OpenPGP-додаток.</string>
     <string name="crypto_no_provider_button">Перейти до Налаштувань</string>
-    <string name="mail_list_widget_text">K-9 Список повідомлень</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">Шифрування неможливе</string>

--- a/app/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-uk/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Непрочитані</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Програмний код</string>

--- a/app/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-uk/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Програмний код</string>
     <string name="app_license">Ліцензія Apache версії 2.0</string>
     <string name="about_project_title">Проект з відкритим кодом</string>

--- a/app/ui/legacy/src/main/res/values-vi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-vi/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 Chưa đọc</string>
     <!--Used in the about dialog-->
     <string name="app_authors">Người dắt chó K-9</string>
     <string name="source_code">Mã nguồn</string>

--- a/app/ui/legacy/src/main/res/values-vi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-vi/strings.xml
@@ -352,7 +352,6 @@
     <!--A user visible label for the email address copied to the clipboard-->
     <string name="clipboard_label_email_address">Địa chỉ email</string>
     <string name="account_setup_options_mail_check_frequency_30min">Mỗi 30 phút</string>
-    <string name="mail_list_widget_text">Danh sách tin nhắn K-9</string>
     <string name="account_setup_options_mail_check_frequency_1hour">Mỗi giờ</string>
     <string name="message_list_content_description_unread_prefix">chưa đọc, %s</string>
     <string name="account_setup_options_mail_check_frequency_12hour">Mỗi 12 giờ</string>

--- a/app/ui/legacy/src/main/res/values-vi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-vi/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">Người dắt chó K-9</string>
+    <string name="about_app_authors_k9">Người dắt chó K-9</string>
     <string name="source_code">Mã nguồn</string>
     <string name="app_license">Giấy phép Apache, phiên bản 2.0</string>
     <string name="about_project_title">Dự án mã nguồn mở</string>

--- a/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -814,7 +814,6 @@
     <string name="crypto_no_provider_message">此电子邮件已使用 OpenPGP 加密。
 \n要阅读它，您需要安装和配置兼容的 OpenPGP 应用。</string>
     <string name="crypto_no_provider_button">转到设置</string>
-    <string name="mail_list_widget_text">K-9 邮件列表</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">无法加密</string>

--- a/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 未读</string>
     <!--Used in the about dialog-->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">源代码</string>

--- a/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">源代码</string>
     <string name="app_license">Apache 许可证，2.0 版</string>
     <string name="about_project_title">开源项目</string>

--- a/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
@@ -3,7 +3,6 @@
     <!--=== App-specific strings =============================================================-->
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
-    <string name="unread_widget_label">K-9 未讀</string>
     <!--Used in the about dialog-->
     <string name="app_authors">K-9 使用者</string>
     <string name="source_code">原始碼</string>

--- a/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
@@ -810,7 +810,6 @@
     <string name="crypto_no_provider_title">郵件已被加密</string>
     <string name="crypto_no_provider_message">這封郵件使用 OpenPGP 進行了加密。\n請安裝並設定一個相容 OpenPGP 的應用程式來查看郵件。</string>
     <string name="crypto_no_provider_button">前往設定</string>
-    <string name="mail_list_widget_text">K-9 訊息列表</string>
     <!--Displayed in the the message list widget when the app hasn't had a chance to send content to it yet-->
     <!--Might be displayed in the message list widget when the list is scrolled and new data can't be fetched fast enough-->
     <string name="openpgp_enabled_error_title">無法加密</string>

--- a/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
@@ -4,7 +4,7 @@
     <!--This should make it easier for forks to change the branding-->
     <!--Used in AndroidManifest.xml-->
     <!--Used in the about dialog-->
-    <string name="app_authors">K-9 使用者</string>
+    <string name="about_app_authors_k9">K-9 使用者</string>
     <string name="source_code">原始碼</string>
     <string name="app_license">Apache 授權條款， 版本 2.0</string>
     <string name="about_project_title">開放原始碼專案</string>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Used in the about dialog -->
     <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_thunderbird">Thunderbird Mobile Team</string>
     <string name="source_code">Source code</string>
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="about_project_title">Open Source Project</string>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -2,10 +2,6 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <!-- === App-specific strings ============================================================= -->
 
-    <!-- This should make it easier for forks to change the branding -->
-
-    <string name="unread_widget_label">K-9 Unread</string>
-
     <!-- Used in the about dialog -->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="source_code">Source code</string>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <!-- === App-specific strings ============================================================= -->
 
     <!-- Used in the about dialog -->
-    <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="about_app_authors_k9">The K-9 Dog Walkers</string>
     <string name="source_code">Source code</string>
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="about_project_title">Open Source Project</string>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -304,7 +304,7 @@
     <string name="general_settings_ui_density_relaxed">Relaxed</string>
 
     <string name="global_settings_privacy_hide_useragent">Hide mail client</string>
-    <string name="global_settings_privacy_hide_useragent_detail">Remove K-9 User-Agent from mail headers</string>
+    <string name="global_settings_privacy_hide_useragent_detail">Remove User-Agent from mail headers</string>
     <string name="global_settings_privacy_hide_timezone">Hide timezone</string>
     <string name="global_settings_privacy_hide_timezone_detail">Use UTC instead of local timezone in mail headers and reply header</string>
 

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -1000,8 +1000,6 @@
     <string name="crypto_no_provider_message">This email has been encrypted with OpenPGP.\nTo read it, you need to install and configure a compatible OpenPGP App.</string>
     <string name="crypto_no_provider_button">Go to Settings</string>
 
-    <string name="mail_list_widget_text">K-9 Message List</string>
-
     <string name="openpgp_enabled_error_title">Encryption not possible</string>
     <string name="openpgp_enabled_error_msg">Some of the selected recipients don\'t support this feature!</string>
     <string name="enable_encryption">Enable Encryption</string>

--- a/feature/widget/message-list/src/main/res/values/strings.xml
+++ b/feature/widget/message-list/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="message_list_widget_list_item_loading">Loading…</string>
     <string name="message_list_widget_initializing">Loading…</string>
     <string name="message_list_widget_inbox_title">Unified Inbox</string>
+    <string name="message_list_widget_label">Message List</string>
 </resources>

--- a/feature/widget/unread/src/main/res/values/strings.xml
+++ b/feature/widget/unread/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="unread_widget_account_not_selected">No account selected</string>
     <string name="unread_widget_folder_not_selected">No folder selected</string>
     <string name="unread_widget_choose_account_title">Choose Account</string>
+    <string name="unread_widget_label">Unread count</string>
 </resources>


### PR DESCRIPTION
This replaces the use of K-9 by neutral text to work for 2 apps.

Depends on #7973 
