### PR TITLE
Change app_name resource name

### DIFF
--- a/app-thunderbird/src/beta/res/values/strings.xml
+++ b/app-thunderbird/src/beta/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="tb_app_name" translatable="false">Thunderbird Beta</string>
+    <string name="app_name" translatable="false">Thunderbird Beta</string>
 </resources>

--- a/app-thunderbird/src/daily/res/values/strings.xml
+++ b/app-thunderbird/src/daily/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="tb_app_name" translatable="false">Thunderbird Daily</string>
+    <string name="app_name" translatable="false">Thunderbird Daily</string>
 </resources>

--- a/app-thunderbird/src/main/AndroidManifest.xml
+++ b/app-thunderbird/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application
         android:name=".ThunderbirdApp"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/tb_app_name" >
+        android:label="@string/app_name" >
 
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbAppNameProvider.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbAppNameProvider.kt
@@ -8,6 +8,6 @@ class TbAppNameProvider(
     context: Context,
 ) : AppNameProvider {
     override val appName: String by lazy {
-        context.getString(R.string.tb_app_name)
+        context.getString(R.string.app_name)
     }
 }

--- a/app-thunderbird/src/main/res/values/strings.xml
+++ b/app-thunderbird/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="tb_app_name" translatable="false">Thunderbird</string>
+    <string name="app_name" translatable="false">Thunderbird</string>
 </resources>


### PR DESCRIPTION
This changes the Thunderbird for Android `app_name` to be consistent.
