### PR TITLE
Fix split screen toolbar layout

### DIFF
--- a/app/ui/legacy/src/main/res/layout/message_list.xml
+++ b/app/ui/legacy/src/main/res/layout/message_list.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawerLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -12,48 +11,12 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <com.google.android.material.appbar.MaterialToolbar
+        <include
             android:id="@+id/toolbar"
-            style="?attr/toolbarStyle"
+            layout="@layout/message_list_toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:minHeight="?attr/actionBarSize"
-            android:layout_alignParentTop="true"
-            tools:navigationIcon="@drawable/ic_arrow_back">
-
-            <!-- We're not using MaterialToolbar's title/subtitle support because it is broken when using large system
-                 font sizes. See https://issuetracker.google.com/issues/135865267 -->
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:layout_marginVertical="@dimen/toolbarTitleMarginVertical">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/toolbarTitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:ellipsize="end"
-                    android:textAppearance="?attr/textAppearanceTitleLarge"
-                    android:textColor="?attr/colorOnSurface"
-                    tools:text="Inbox" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/toolbarSubtitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:ellipsize="end"
-                    android:textAppearance="?attr/textAppearanceTitleMedium"
-                    android:textColor="?attr/colorOnSurfaceVariant"
-                    android:visibility="gone"
-                    tools:visibility="visible"
-                    tools:text="demo@domain.example" />
-
-            </LinearLayout>
-
-        </com.google.android.material.appbar.MaterialToolbar>
+            android:layout_alignParentTop="true" />
 
         <ProgressBar
             android:id="@+id/message_list_progress"

--- a/app/ui/legacy/src/main/res/layout/message_list_toolbar.xml
+++ b/app/ui/legacy/src/main/res/layout/message_list_toolbar.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.appbar.MaterialToolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/toolbar"
+    style="?attr/toolbarStyle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_alignParentTop="true"
+    android:minHeight="?attr/actionBarSize"
+    tools:navigationIcon="@drawable/ic_arrow_back">
+
+    <!-- We're not using MaterialToolbar's title/subtitle support because it is broken when using large system
+         font sizes. See https://issuetracker.google.com/issues/135865267 -->
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/toolbarTitleMarginVertical"
+        android:orientation="vertical">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/toolbarTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textAppearance="?attr/textAppearanceTitleLarge"
+            android:textColor="?attr/colorOnSurface"
+            tools:text="Inbox" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/toolbarSubtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:visibility="gone"
+            tools:text="demo@domain.example"
+            tools:visibility="visible" />
+
+    </LinearLayout>
+
+</com.google.android.material.appbar.MaterialToolbar>

--- a/app/ui/legacy/src/main/res/layout/split_message_list.xml
+++ b/app/ui/legacy/src/main/res/layout/split_message_list.xml
@@ -13,7 +13,7 @@
 
         <include
             android:id="@+id/toolbar"
-            layout="@layout/toolbar"
+            layout="@layout/message_list_toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true" />


### PR DESCRIPTION
The split screen layout was using the normal toolbar layout instead of the version with title and subtitle.

Fixes #7988 #7987
