### PR TITLE
Update translations.md

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -41,8 +41,9 @@ When adding a new code module that is including translatable strings, a new comp
 10. Under "Monolingual base language file", enter the path to the string source file,
     e.g. `feature/account/common/src/main/res/values/strings.xml`.
 11. Uncheck "Edit base file".
-12. For "Translation license", select "Apache License 2.0".
-13. Press the "Save" button.
+12. Change "Adding new translation" to "Contact maintainers".
+13. For "Translation license", select "Apache License 2.0".
+14. Press the "Save" button.
 
 ## Things to note
 


### PR DESCRIPTION
Set "Adding new translation" to "Contact maintainers" when adding a new component on Weblate. This is so we can avoid duplicate efforts, e.g. "Portuguese (Portugal)" and "Portuguese (Brazil)" vs. "Portuguese". We also want to avoid having "joke" translations like "English (Middle)".