### PR TITLE
Validate recipient email addresses to prevent invalid ending characters

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/UserInputEmailAddressParser.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/UserInputEmailAddressParser.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.view
 
+import app.k9mail.core.common.net.HostNameUtils
 import com.fsck.k9.mail.Address
 import org.apache.james.mime4j.util.CharsetUtil
 
@@ -18,6 +19,7 @@ internal class UserInputEmailAddressParser {
                 when {
                     address.isIncomplete() -> null
                     address.isNonAsciiAddress() -> throw NonAsciiEmailAddressException(address.address)
+                    address.isInvalidDomainPart() -> null
                     else -> Address.parse(address.toEncodedString()).firstOrNull()
                 }
             }
@@ -26,6 +28,8 @@ internal class UserInputEmailAddressParser {
     private fun Address.isIncomplete() = hostname.isNullOrBlank()
 
     private fun Address.isNonAsciiAddress() = !CharsetUtil.isASCII(address)
+
+    private fun Address.isInvalidDomainPart() = HostNameUtils.isLegalHostNameOrIP(hostname) == null
 }
 
 internal class NonAsciiEmailAddressException(message: String) : Exception(message)

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/view/UserInputEmailAddressParserTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/view/UserInputEmailAddressParserTest.kt
@@ -150,4 +150,19 @@ class UserInputEmailAddressParserTest {
 
         assertThat(addresses).containsExactly(Address("user@domain.example", "Firstname \"Nickname\" LastName"))
     }
+
+    // for invalid email addresses
+    @Test
+    fun `address with invalid ending character`() {
+        val addresses = parser.parse("user@domain.example/")
+
+        assertThat(addresses).isEmpty()
+    }
+
+    @Test
+    fun `address with invalid character in domain part`() {
+        val addresses = parser.parse("user@domain/example")
+
+        assertThat(addresses).isEmpty()
+    }
 }


### PR DESCRIPTION
Fixes #7112 

- Added a regular expression pattern to identify and invalidate email addresses that end with specific invalid characters.
- The validation logic was incorporated into the `isValidEmail` method, ensuring that any email address ending with characters such as `/`, `?`, `=`, `+`, `&`, `^`, `%`, `$`, `#`, `!`, `'`, and `-` is correctly flagged as invalid. (I checked and all the special characters that led to the repeating of this bug scenario were just these.)
- Improved error handling, and show an error when the focus is changed from the To, CC, and BCC fields; instead of showing the error after sending the email.

![image](https://github.com/user-attachments/assets/8df0dc77-f629-40a5-abef-53e2c671eb53)
