### PR TITLE
Change K9-Mail signing to new setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ out/
 *.jks
 *.keystore
 
+# Signing files
+.signing/
+*.signing.properties
+
 # IDEA/Android Studio ignores
 *iml
 .idea/*

--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -106,23 +106,12 @@ android {
     }
 
     signingConfigs {
-        if (project.hasProperty("k9mail.keyAlias") &&
-            project.hasProperty("k9mail.keyPassword") &&
-            project.hasProperty("k9mail.storeFile") &&
-            project.hasProperty("k9mail.storePassword")
-        ) {
-            create("release") {
-                keyAlias = project.property("k9mail.keyAlias") as String
-                keyPassword = project.property("k9mail.keyPassword") as String
-                storeFile = file(project.property("k9mail.storeFile") as String)
-                storePassword = project.property("k9mail.storePassword") as String
-            }
-        }
+        createSigningConfig(project, SigningType.K9_RELEASE)
     }
 
     buildTypes {
         release {
-            signingConfig = signingConfigs.findByName("release")
+            signingConfig = signingConfigs.getByType(SigningType.K9_RELEASE)
 
             isMinifyEnabled = true
             proguardFiles(

--- a/build-plugin/src/main/kotlin/SigningExtensions.kt
+++ b/build-plugin/src/main/kotlin/SigningExtensions.kt
@@ -1,0 +1,78 @@
+import com.android.build.api.dsl.ApkSigningConfig
+import java.io.FileInputStream
+import java.util.Properties
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+
+private const val SIGNING_FOLDER = ".signing"
+private const val SIGNING_FILE_ENDING = ".signing.properties"
+
+private const val PROPERTY_STORE_FILE = "storeFile"
+private const val PROPERTY_STORE_PASSWORD = "storePassword"
+private const val PROPERTY_KEY_ALIAS = "keyAlias"
+private const val PROPERTY_KEY_PASSWORD = "keyPassword"
+
+/**
+ * Creates an [ApkSigningConfig] for the given signing type.
+ *
+ * The signing properties are read from a file in the `.signing` folder in the project root directory.
+ * File names are expected to be in the format `$app.$type.signing.properties`.
+ *
+ * The file should contain the following properties:
+ * - `$app.$type.storeFile`
+ * - `$app.$type.storePassword`
+ * - `$app.$type.keyAlias`
+ * - `$app.$type.keyPassword`
+ *
+ * @param project the project to create the signing config for
+ * @param signingType the signing type to create the signing config for
+ */
+fun NamedDomainObjectContainer<out ApkSigningConfig>.createSigningConfig(project: Project, signingType: SigningType) {
+    val properties = project.readSigningProperties(signingType)
+
+    if (properties.hasSigningConfig(signingType)) {
+        create(signingType.type) {
+            storeFile = project.file(properties.getSigningProperty(signingType, PROPERTY_STORE_FILE))
+            storePassword = properties.getSigningProperty(signingType, PROPERTY_STORE_PASSWORD)
+            keyAlias = properties.getSigningProperty(signingType, PROPERTY_KEY_ALIAS)
+            keyPassword = properties.getSigningProperty(signingType, PROPERTY_KEY_PASSWORD)
+        }
+    }
+}
+
+/**
+ * Returns the [ApkSigningConfig] for the given signing type.
+ *
+ * @param signingType the signing type to get the signing config for
+ */
+fun NamedDomainObjectContainer<out ApkSigningConfig>.getByType(signingType: SigningType): ApkSigningConfig? {
+    return findByName(signingType.type)
+}
+
+private fun Project.readSigningProperties(signingType: SigningType) = Properties().apply {
+    val signingPropertiesFile = rootProject.file("$SIGNING_FOLDER/${signingType.id}$SIGNING_FILE_ENDING")
+    if (signingPropertiesFile.exists()) {
+        FileInputStream(signingPropertiesFile).use { inputStream ->
+            load(inputStream)
+        }
+    } else {
+        println("Signing properties file not found: $signingPropertiesFile")
+    }
+}
+
+private fun Properties.hasSigningConfig(signingType: SigningType): Boolean {
+    return isNotEmpty() &&
+        containsKey(signingType, PROPERTY_STORE_FILE) &&
+        containsKey(signingType, PROPERTY_STORE_PASSWORD) &&
+        containsKey(signingType, PROPERTY_KEY_ALIAS) &&
+        containsKey(signingType, PROPERTY_KEY_PASSWORD)
+}
+
+private fun Properties.containsKey(signingType: SigningType, key: String): Boolean {
+    return containsKey("${signingType.id}.$key")
+}
+
+private fun Properties.getSigningProperty(signingType: SigningType, key: String): String {
+    return getProperty("${signingType.id}.$key")
+        ?: throw IllegalArgumentException("Missing property: ${signingType.type}.$key")
+}

--- a/build-plugin/src/main/kotlin/SigningType.kt
+++ b/build-plugin/src/main/kotlin/SigningType.kt
@@ -1,0 +1,7 @@
+enum class SigningType(
+    val app: String,
+    val type: String,
+    val id: String = "$app.$type",
+) {
+    K9_RELEASE(app = "k9", type = "release"),
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,14 +2,20 @@
 
 ## One-time setup
 
-1. Download `tb-android keystore` from 1Password and place it somewhere outside the root of the Git repository.
-2. Add the following to `~/.gradle/gradle.properties` (create the file if necessary)
-   ```
-   k9mail.storeFile=<path to keystore>
-   k9mail.storePassword=<password 'tb-android keystore' in 1Password>
-   k9mail.keyAlias=k9mail
-   k9mail.keyPassword=<password 'k9mail@tb-android' in 1Password>
-   ```
+1. Create a `.signing` folder in the root of the Git repository, if it doesn't exist yet.
+2. Download the `k9-release-signing.jks` and `k9.release.signing.properties` files from 1Password and place them in the `.signing` folder.
+
+Example `<app>.<realeaseType>.signing.properties` file:
+
+```
+<app>.<releaseType>.storeFile=<path to keystore '../.signing/k9mail.jks'>
+<app>.<releaseType>.storePassword=<storePassword>
+<app>.<releaseType>.keyAlias=<keyAlias>
+<app>.<releaseType>.keyPassword=<keyPassword>
+```
+
+- `<app>` is the short name of the app, e.g. `k9`
+- `<releaseType>` is the type of release, e.g. `release`
 
 ### One-time setup for F-Droid builds
 


### PR DESCRIPTION
This changes the signing configuration to allow easier addition of different signing configs for our different app variants. Keystores are now located in the `.signing` directory, accompanied by `signing.properties` files that provide the necessary keys. This avoids having to declare global properties for all the different variants.

This is the first iteration to change signing for K-9 Mail. Thunderbird for Android will follow shortly.