### PR TITLE
Change Thunderbird for Android package id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ gen/
 out/
 
 # Generated files
+*.aab
 *.apk
 *.ap_
 *.class

--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -106,7 +106,7 @@ android {
     }
 
     signingConfigs {
-        createSigningConfig(project, SigningType.K9_RELEASE)
+        createSigningConfig(project, SigningType.K9_RELEASE, isUpload = false)
     }
 
     buildTypes {

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -128,8 +128,14 @@ android {
 
         release {
             signingConfig = signingConfigs.findByName("release")
+
             isMinifyEnabled = true
             isShrinkResources = true
+
+            proguardFiles(
+                getDefaultProguardFile("proguard-android.txt"),
+                "proguard-rules.pro",
+            )
         }
 
         create("daily") {

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -106,18 +106,9 @@ android {
     }
 
     signingConfigs {
-        if (project.hasProperty("thunderbird.keyAlias") &&
-            project.hasProperty("thunderbird.keyPassword") &&
-            project.hasProperty("thunderbird.storeFile") &&
-            project.hasProperty("thunderbird.storePassword")
-        ) {
-            create("release") {
-                keyAlias = project.property("thunderbird.keyAlias") as String
-                keyPassword = project.property("thunderbird.keyPassword") as String
-                storeFile = file(project.property("thunderbird.storeFile") as String)
-                storePassword = project.property("thunderbird.storePassword") as String
-            }
-        }
+        createSigningConfig(project, SigningType.TB_RELEASE)
+        createSigningConfig(project, SigningType.TB_BETA)
+        createSigningConfig(project, SigningType.TB_DAILY)
     }
 
     buildTypes {
@@ -129,7 +120,7 @@ android {
         }
 
         release {
-            signingConfig = signingConfigs.findByName("release")
+            signingConfig = signingConfigs.getByType(SigningType.TB_RELEASE)
 
             isMinifyEnabled = true
             isShrinkResources = true
@@ -140,20 +131,24 @@ android {
             )
         }
 
-        create("daily") {
+        create("beta") {
             initWith(getByName("release"))
 
-            applicationIdSuffix = ".daily"
-            versionNameSuffix = "a1"
+            signingConfig = signingConfigs.getByType(SigningType.TB_BETA)
+
+            applicationIdSuffix = ".beta"
+            versionNameSuffix = "b1"
 
             matchingFallbacks += listOf("release")
         }
 
-        create("beta") {
+        create("daily") {
             initWith(getByName("release"))
 
-            applicationIdSuffix = ".beta"
-            versionNameSuffix = "b1"
+            signingConfig = signingConfigs.getByType(SigningType.TB_DAILY)
+
+            applicationIdSuffix = ".daily"
+            versionNameSuffix = "a1"
 
             matchingFallbacks += listOf("release")
         }

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -43,7 +43,7 @@ android {
         testApplicationId = "net.thunderbird.placeholder.tests"
 
         versionCode = 1
-        versionName = "0.1-SNAPSHOT"
+        versionName = "0.1"
 
         // Keep in sync with the resource string array "supported_languages"
         resourceConfigurations.addAll(
@@ -123,6 +123,8 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix = ".debug"
+            versionNameSuffix = "-SNAPSHOT"
+
             isMinifyEnabled = false
         }
 
@@ -140,13 +142,19 @@ android {
 
         create("daily") {
             initWith(getByName("release"))
+
             applicationIdSuffix = ".daily"
+            versionNameSuffix = "a1"
+
             matchingFallbacks += listOf("release")
         }
 
         create("beta") {
             initWith(getByName("release"))
+
             applicationIdSuffix = ".beta"
+            versionNameSuffix = "b1"
+
             matchingFallbacks += listOf("release")
         }
     }

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -39,8 +39,8 @@ android {
     namespace = "net.thunderbird.android"
 
     defaultConfig {
-        applicationId = "net.thunderbird.placeholder"
-        testApplicationId = "net.thunderbird.placeholder.tests"
+        applicationId = "net.thunderbird.android"
+        testApplicationId = "net.thunderbird.android.tests"
 
         versionCode = 1
         versionName = "0.1"

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -42,7 +42,7 @@ android {
         applicationId = "net.thunderbird.android"
         testApplicationId = "net.thunderbird.android.tests"
 
-        versionCode = 1
+        versionCode = 2
         versionName = "0.1"
 
         // Keep in sync with the resource string array "supported_languages"
@@ -117,6 +117,8 @@ android {
             versionNameSuffix = "-SNAPSHOT"
 
             isMinifyEnabled = false
+            isShrinkResources = false
+            isDebuggable = true
         }
 
         release {
@@ -124,6 +126,7 @@ android {
 
             isMinifyEnabled = true
             isShrinkResources = true
+            isDebuggable = false
 
             proguardFiles(
                 getDefaultProguardFile("proguard-android.txt"),
@@ -132,25 +135,39 @@ android {
         }
 
         create("beta") {
-            initWith(getByName("release"))
-
             signingConfig = signingConfigs.getByType(SigningType.TB_BETA)
 
             applicationIdSuffix = ".beta"
             versionNameSuffix = "b1"
 
+            isMinifyEnabled = true
+            isShrinkResources = true
+            isDebuggable = false
+
             matchingFallbacks += listOf("release")
+
+            proguardFiles(
+                getDefaultProguardFile("proguard-android.txt"),
+                "proguard-rules.pro",
+            )
         }
 
         create("daily") {
-            initWith(getByName("release"))
-
             signingConfig = signingConfigs.getByType(SigningType.TB_DAILY)
 
             applicationIdSuffix = ".daily"
             versionNameSuffix = "a1"
 
+            isMinifyEnabled = true
+            isShrinkResources = true
+            isDebuggable = false
+
             matchingFallbacks += listOf("release")
+
+            proguardFiles(
+                getDefaultProguardFile("proguard-android.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 

--- a/build-plugin/src/main/kotlin/SigningType.kt
+++ b/build-plugin/src/main/kotlin/SigningType.kt
@@ -4,4 +4,7 @@ enum class SigningType(
     val id: String = "$app.$type",
 ) {
     K9_RELEASE(app = "k9", type = "release"),
+    TB_RELEASE(app = "tb", type = "release"),
+    TB_BETA(app = "tb", type = "beta"),
+    TB_DAILY(app = "tb", type = "daily"),
 }


### PR DESCRIPTION
Change the Thunderbird for Android package id to `net.thunderbird.android` and add signing configuration for `daily`, `beta` and `release`. The app is setup to use an upload key instead of a signing key for the apk and app bundle.

The `RELEASING.md` needs to be updated to reflect the differences between both app versions: #8027

Fixes #8019
