### PR TITLE
Remove "Move/copy destination folders" setting

### DIFF
--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetConfigurationFragment.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetConfigurationFragment.kt
@@ -59,7 +59,6 @@ class UnreadWidgetConfigurationFragment : PreferenceFragmentCompat() {
                 context = requireContext(),
                 action = ChooseFolderActivity.Action.CHOOSE,
                 accountUuid = selectedAccountUuid!!,
-                showDisplayableOnly = true,
             )
             startActivityForResult(intent, REQUEST_CHOOSE_FOLDER)
             false

--- a/legacy/core/src/main/java/com/fsck/k9/Account.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/Account.kt
@@ -186,10 +186,6 @@ class Account(override val uuid: String) : BaseAccount {
 
     @get:Synchronized
     @set:Synchronized
-    var folderTargetMode = FolderMode.NOT_SECOND_CLASS
-
-    @get:Synchronized
-    @set:Synchronized
     var accountNumber = 0
 
     @get:Synchronized

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -178,9 +178,6 @@ class AccountPreferenceSerializer(
 
             folderPushMode = getEnumStringPref<FolderMode>(storage, "$accountUuid.folderPushMode", FolderMode.NONE)
 
-            folderTargetMode =
-                getEnumStringPref<FolderMode>(storage, "$accountUuid.folderTargetMode", FolderMode.NOT_SECOND_CLASS)
-
             searchableFolders = getEnumStringPref<Searchable>(storage, "$accountUuid.searchableFolders", Searchable.ALL)
 
             isSignatureBeforeQuotedText = storage.getBoolean("$accountUuid.signatureBeforeQuotedText", false)
@@ -319,7 +316,6 @@ class AccountPreferenceSerializer(
             editor.putString("$accountUuid.folderDisplayMode", folderDisplayMode.name)
             editor.putString("$accountUuid.folderSyncMode", folderSyncMode.name)
             editor.putString("$accountUuid.folderPushMode", folderPushMode.name)
-            editor.putString("$accountUuid.folderTargetMode", folderTargetMode.name)
             editor.putBoolean("$accountUuid.signatureBeforeQuotedText", isSignatureBeforeQuotedText)
             editor.putString("$accountUuid.expungePolicy", expungePolicy.name)
             editor.putBoolean("$accountUuid.syncRemoteDeletions", isSyncRemoteDeletions)
@@ -432,7 +428,6 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.folderDisplayMode")
         editor.remove("$accountUuid.folderSyncMode")
         editor.remove("$accountUuid.folderPushMode")
-        editor.remove("$accountUuid.folderTargetMode")
         editor.remove("$accountUuid.signatureBeforeQuotedText")
         editor.remove("$accountUuid.expungePolicy")
         editor.remove("$accountUuid.syncRemoteDeletions")
@@ -589,7 +584,6 @@ class AccountPreferenceSerializer(
             folderDisplayMode = FolderMode.NOT_SECOND_CLASS
             folderSyncMode = FolderMode.FIRST_CLASS
             folderPushMode = FolderMode.NONE
-            folderTargetMode = FolderMode.NOT_SECOND_CLASS
             sortType = DEFAULT_SORT_TYPE
             setSortAscending(DEFAULT_SORT_TYPE, DEFAULT_SORT_ASCENDING)
             showPictures = ShowPictures.NEVER

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -107,9 +107,6 @@ public class AccountSettingsDescriptions {
         s.put("folderSyncMode", Settings.versions(
                 new V(1, new EnumSetting<>(FolderMode.class, FolderMode.FIRST_CLASS))
         ));
-        s.put("folderTargetMode", Settings.versions(
-                new V(1, new EnumSetting<>(FolderMode.class, FolderMode.NOT_SECOND_CLASS))
-        ));
         s.put("idleRefreshMinutes", Settings.versions(
                 new V(1, new IntegerArraySetting(24, new int[] { 1, 2, 3, 6, 12, 24, 36, 48, 60 })),
                 new V(74, new IntegerResourceSetting(24, R.array.idle_refresh_period_values))

--- a/legacy/core/src/main/res/values/arrays_account_settings_values.xml
+++ b/legacy/core/src/main/res/values/arrays_account_settings_values.xml
@@ -143,13 +143,6 @@
         <item>NONE</item>
     </string-array>
 
-    <string-array name="folder_target_mode_values" translatable="false">
-        <item>ALL</item>
-        <item>FIRST_CLASS</item>
-        <item>FIRST_AND_SECOND_CLASS</item>
-        <item>NOT_SECOND_CLASS</item>
-    </string-array>
-
     <string-array name="delete_policy_values" translatable="false">
         <item>NEVER</item>
         <item>ON_DELETE</item>

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -41,7 +41,6 @@ class ChooseFolderActivity : K9Activity() {
     private var currentFolderId: Long? = null
     private var scrollToFolderId: Long? = null
     private var messageReference: String? = null
-    private var showDisplayableOnly = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -79,7 +78,6 @@ class ChooseFolderActivity : K9Activity() {
 
         messageReference = intent.getStringExtra(EXTRA_MESSAGE_REFERENCE)
         currentFolderId = intent.getLongExtraOrNull(EXTRA_CURRENT_FOLDER_ID)
-        showDisplayableOnly = intent.getBooleanExtra(EXTRA_SHOW_DISPLAYABLE_ONLY, false)
 
         scrollToFolderId = if (savedInstanceState != null) {
             savedInstanceState.getLongOrNull(STATE_SCROLL_TO_FOLDER_ID)
@@ -91,7 +89,7 @@ class ChooseFolderActivity : K9Activity() {
     }
 
     private fun getInitialDisplayMode(): FolderMode {
-        return if (showDisplayableOnly) account.folderDisplayMode else account.folderTargetMode
+        return account.folderDisplayMode
     }
 
     private fun initializeActionBar() {
@@ -246,7 +244,6 @@ class ChooseFolderActivity : K9Activity() {
         private const val EXTRA_CURRENT_FOLDER_ID = "currentFolderId"
         private const val EXTRA_SCROLL_TO_FOLDER_ID = "scrollToFolderId"
         private const val EXTRA_MESSAGE_REFERENCE = "messageReference"
-        private const val EXTRA_SHOW_DISPLAYABLE_ONLY = "showDisplayableOnly"
         const val RESULT_SELECTED_FOLDER_ID = "selectedFolderId"
         const val RESULT_FOLDER_DISPLAY_NAME = "folderDisplayName"
         const val RESULT_MESSAGE_REFERENCE = "messageReference"
@@ -258,7 +255,6 @@ class ChooseFolderActivity : K9Activity() {
             accountUuid: String,
             currentFolderId: Long? = null,
             scrollToFolderId: Long? = null,
-            showDisplayableOnly: Boolean = false,
             messageReference: MessageReference? = null,
         ): Intent {
             return Intent(context, ChooseFolderActivity::class.java).apply {
@@ -266,7 +262,6 @@ class ChooseFolderActivity : K9Activity() {
                 putExtra(EXTRA_ACCOUNT, accountUuid)
                 currentFolderId?.let { putExtra(EXTRA_CURRENT_FOLDER_ID, currentFolderId) }
                 scrollToFolderId?.let { putExtra(EXTRA_SCROLL_TO_FOLDER_ID, scrollToFolderId) }
-                putExtra(EXTRA_SHOW_DISPLAYABLE_ONLY, showDisplayableOnly)
                 messageReference?.let { putExtra(EXTRA_MESSAGE_REFERENCE, it.toIdentityString()) }
             }
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -1099,7 +1099,6 @@ class MessageListFragment :
             accountUuid = accountUuid,
             currentFolderId = sourceFolderId,
             scrollToFolderId = lastSelectedFolderId,
-            showDisplayableOnly = false,
             messageReference = null,
         )
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -556,7 +556,6 @@ class MessageViewFragment :
             accountUuid = account.uuid,
             currentFolderId = messageReference.folderId,
             scrollToFolderId = account.lastSelectedFolderId,
-            showDisplayableOnly = false,
             messageReference = messageReference,
         )
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -128,7 +128,6 @@ class AccountSettingsDataStore(
                 loadSpecialFolder(account.autoExpandFolderId, SpecialFolderSelection.MANUAL)
             }
             "folder_display_mode" -> account.folderDisplayMode.name
-            "folder_target_mode" -> account.folderTargetMode.name
             "searchable_folders" -> account.searchableFolders.name
             "archive_folder" -> loadSpecialFolder(account.archiveFolderId, account.archiveFolderSelection)
             "drafts_folder" -> loadSpecialFolder(account.draftsFolderId, account.draftsFolderSelection)
@@ -173,7 +172,6 @@ class AccountSettingsDataStore(
             "account_quote_prefix" -> account.quotePrefix = value
             "account_setup_auto_expand_folder" -> account.autoExpandFolderId = extractFolderId(value)
             "folder_display_mode" -> account.folderDisplayMode = Account.FolderMode.valueOf(value)
-            "folder_target_mode" -> account.folderTargetMode = Account.FolderMode.valueOf(value)
             "searchable_folders" -> account.searchableFolders = Account.Searchable.valueOf(value)
             "archive_folder" -> saveSpecialFolderSelection(value, account::setArchiveFolderId)
             "drafts_folder" -> saveSpecialFolderSelection(value, account::setDraftsFolderId)

--- a/legacy/ui/legacy/src/main/res/values/arrays_account_settings_strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/arrays_account_settings_strings.xml
@@ -114,13 +114,6 @@
         <item>@string/account_settings_folder_notify_new_mail_mode_none</item>
     </string-array>
 
-    <string-array name="folder_target_mode_entries">
-        <item>@string/account_settings_folder_target_mode_all</item>
-        <item>@string/account_settings_folder_target_mode_first_class</item>
-        <item>@string/account_settings_folder_target_mode_first_and_second_class</item>
-        <item>@string/account_settings_folder_target_mode_not_second_class</item>
-    </string-array>
-
     <string-array name="delete_policy_entries">
         <item>@string/account_setup_incoming_delete_policy_never_label</item>
         <item>@string/account_setup_incoming_delete_policy_delete_label</item>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -520,12 +520,6 @@
     <string name="account_settings_folder_push_mode_not_second_class">All except 2nd Class folders</string>
     <string name="account_settings_folder_push_mode_none">None</string>
 
-    <string name="account_settings_folder_target_mode_label">Move/copy destination folders</string>
-    <string name="account_settings_folder_target_mode_all">All</string>
-    <string name="account_settings_folder_target_mode_first_class">Only 1st Class folders</string>
-    <string name="account_settings_folder_target_mode_first_and_second_class">1st and 2nd Class folders</string>
-    <string name="account_settings_folder_target_mode_not_second_class">All except 2nd Class folders</string>
-
     <string name="account_settings_sync_remote_deletetions_label">Sync server deletions</string>
     <string name="account_settings_sync_remote_deletetions_summary">Remove messages when deleted on server</string>
 

--- a/legacy/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/account_settings.xml
@@ -289,15 +289,6 @@
             />
 
         <ListPreference
-            android:dialogTitle="@string/account_settings_folder_target_mode_label"
-            android:entries="@array/folder_target_mode_entries"
-            android:entryValues="@array/folder_target_mode_values"
-            android:key="folder_target_mode"
-            app:useSimpleSummaryProvider="true"
-            android:title="@string/account_settings_folder_target_mode_label"
-            />
-
-        <ListPreference
             android:dialogTitle="@string/account_settings_searchable_label"
             android:entries="@array/searchable_entries"
             android:entryValues="@array/searchable_values"


### PR DESCRIPTION
When moving a message, all visible folders (i.e. folders matching the "Folders to display" class) are now displayed to select from.

Part of #2669