### PR TITLE
Fix incorrect mimetype inferrence

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/helper/MimeTypeUtil.java
+++ b/legacy/core/src/main/java/com/fsck/k9/helper/MimeTypeUtil.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class MimeTypeUtil {
     public static final String DEFAULT_ATTACHMENT_MIME_TYPE = "application/octet-stream";
+    public static final String PLAIN_TEXT_MIME_TYPE = "text/plain";
     public static final String K9_SETTINGS_MIME_TYPE = "application/x-k9settings";
 
     /*
@@ -19,7 +20,7 @@ public class MimeTypeUtil {
             //* Do not delete the next three lines
             { "", DEFAULT_ATTACHMENT_MIME_TYPE },
             { "k9s", K9_SETTINGS_MIME_TYPE },
-            { "txt", "text/plain" },
+            { "txt", PLAIN_TEXT_MIME_TYPE },
             //* Do not delete the previous three lines
             { "123", "application/vnd.lotus-1-2-3" },
             { "323", "text/h323" },
@@ -68,7 +69,7 @@ public class MimeTypeUtil {
             { "azf", "application/vnd.airzip.filesecure.azf" },
             { "azs", "application/vnd.airzip.filesecure.azs" },
             { "azw", "application/vnd.amazon.ebook" },
-            { "bas", "text/plain" },
+            { "bas", PLAIN_TEXT_MIME_TYPE },
             { "bat", "application/x-msdownload" },
             { "bcpio", "application/x-bcpio" },
             { "bdf", "application/x-font-bdf" },
@@ -123,7 +124,7 @@ public class MimeTypeUtil {
             { "cmx", "image/x-cmx" },
             { "cod", "application/vnd.rim.cod" },
             { "com", "application/x-msdownload" },
-            { "conf", "text/plain" },
+            { "conf", PLAIN_TEXT_MIME_TYPE },
             { "cpio", "application/x-cpio" },
             { "cpp", "text/x-c" },
             { "cpt", "application/mac-compactpro" },
@@ -136,7 +137,7 @@ public class MimeTypeUtil {
             { "css", "text/css" },
             { "cst", "application/x-director" },
             { "csv", "text/csv" },
-            { "c", "text/plain" },
+            { "c", PLAIN_TEXT_MIME_TYPE },
             { "cu", "application/cu-seeme" },
             { "curl", "text/vnd.curl" },
             { "cww", "application/prs.cww" },
@@ -150,12 +151,12 @@ public class MimeTypeUtil {
             { "dd2", "application/vnd.oma.dd2+xml" },
             { "ddd", "application/vnd.fujixerox.ddd" },
             { "deb", "application/x-debian-package" },
-            { "def", "text/plain" },
+            { "def", PLAIN_TEXT_MIME_TYPE },
             { "deploy", "application/octet-stream" },
             { "der", "application/x-x509-ca-cert" },
             { "dfac", "application/vnd.dreamfactory" },
             { "dic", "text/x-c" },
-            { "diff", "text/plain" },
+            { "diff", PLAIN_TEXT_MIME_TYPE },
             { "dir", "application/x-director" },
             { "dis", "application/vnd.mobius.dis" },
             { "dist", "application/octet-stream" },
@@ -284,7 +285,7 @@ public class MimeTypeUtil {
             { "hqx", "application/mac-binhex40" },
             { "hta", "application/hta" },
             { "htc", "text/x-component" },
-            { "h", "text/plain" },
+            { "h", PLAIN_TEXT_MIME_TYPE },
             { "htke", "application/vnd.kenameaapp" },
             { "html", "text/html" },
             { "htm", "text/html" },
@@ -309,7 +310,7 @@ public class MimeTypeUtil {
             { "imp", "application/vnd.accpac.simply.imp" },
             { "ims", "application/vnd.ms-ims" },
             { "ins", "application/x-internet-signup" },
-            { "in", "text/plain" },
+            { "in", PLAIN_TEXT_MIME_TYPE },
             { "ipk", "application/vnd.shana.informed.package" },
             { "irm", "application/vnd.ibm.rights-management" },
             { "irp", "application/vnd.irepository.package+xml" },
@@ -347,7 +348,7 @@ public class MimeTypeUtil {
             { "kon", "application/vnd.kde.kontour" },
             { "kpr", "application/vnd.kde.kpresenter" },
             { "kpt", "application/vnd.kde.kpresenter" },
-            { "ksh", "text/plain" },
+            { "ksh", PLAIN_TEXT_MIME_TYPE },
             { "ksp", "application/vnd.kde.kspread" },
             { "ktr", "application/vnd.kahootz" },
             { "ktz", "application/vnd.kahootz" },
@@ -361,8 +362,8 @@ public class MimeTypeUtil {
             { "link66", "application/vnd.route66.link66+xml" },
             { "list3820", "application/vnd.ibm.modcap" },
             { "listafp", "application/vnd.ibm.modcap" },
-            { "list", "text/plain" },
-            { "log", "text/plain" },
+            { "list", PLAIN_TEXT_MIME_TYPE },
+            { "log", PLAIN_TEXT_MIME_TYPE },
             { "lostxml", "application/lost+xml" },
             { "lrf", "application/octet-stream" },
             { "lrm", "application/vnd.ms-lrm" },
@@ -542,7 +543,7 @@ public class MimeTypeUtil {
             { "plc", "application/vnd.mobius.plc" },
             { "plf", "application/vnd.pocketlearn" },
             { "pls", "application/pls+xml" },
-            { "pl", "text/plain" },
+            { "pl", PLAIN_TEXT_MIME_TYPE },
             { "pma", "application/x-perfmon" },
             { "pmc", "application/x-perfmon" },
             { "pml", "application/x-perfmon" },
@@ -727,7 +728,7 @@ public class MimeTypeUtil {
             { "tex", "application/x-tex" },
             { "texi", "application/x-texinfo" },
             { "texinfo", "application/x-texinfo" },
-            { "text", "text/plain" },
+            { "text", PLAIN_TEXT_MIME_TYPE },
             { "tfm", "application/x-tex-tfm" },
             { "tgz", "application/x-gzip" },
             { "tiff", "image/tiff" },
@@ -746,7 +747,7 @@ public class MimeTypeUtil {
             { "twds", "application/vnd.simtech-mindmapper" },
             { "txd", "application/vnd.genomatix.tuxedo" },
             { "txf", "application/vnd.mobius.txf" },
-            { "txt", "text/plain" },
+            { "txt", PLAIN_TEXT_MIME_TYPE },
             { "u32", "application/x-authorware-bin" },
             { "udeb", "application/x-debian-package" },
             { "ufd", "application/vnd.ufdl" },
@@ -872,7 +873,8 @@ public class MimeTypeUtil {
     };
 
     public static boolean isDefaultMimeType(String mimeType) {
-        return isSameMimeType(mimeType, DEFAULT_ATTACHMENT_MIME_TYPE);
+        return isSameMimeType(mimeType, DEFAULT_ATTACHMENT_MIME_TYPE) ||
+            isSameMimeType(mimeType, PLAIN_TEXT_MIME_TYPE);
     }
 
     public static String getMimeTypeByExtension(String filename) {


### PR DESCRIPTION
An android app must set the mime type correctly before opening an attachment so it opens with the right app. 
However, in the current implementation, K-9 checks the received mimetype from the server, if it's different from the default `application/octet-stream`, it tries to infer it from file extension. But I was able to find in my inbox emails where pdf files are tagged by default `text/plain` from the sender, what makes thunderbird open them as text, and thus any app will fail to open the file. 
Issue #8045 also describes the same problem.

As a result, this commit makes K-9 also treat `text/plain` as a default mimetype too, so it forces it to try infer the type automatically from file extension, what fixes the issue

------

Closes #8045