### PR TITLE
Move feature flags to app modules

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation(projects.legacy.core)
     implementation(projects.legacy.ui.legacy)
 
+    implementation(projects.core.featureflags)
+
     implementation(projects.feature.widget.messageList)
     implementation(projects.feature.widget.shortcut)
     implementation(projects.feature.widget.unread)

--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -3,9 +3,11 @@ package app.k9mail
 import app.k9mail.auth.K9OAuthConfigurationFactory
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.dev.developmentModuleAdditions
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
+import app.k9mail.featureflag.K9FeatureFlagFactory
 import app.k9mail.provider.K9AppNameProvider
 import app.k9mail.provider.K9FeatureThemeProvider
 import app.k9mail.widget.appWidgetModule
@@ -27,6 +29,7 @@ val appModule = module {
     single<OAuthConfigurationFactory> { K9OAuthConfigurationFactory() }
     single<AppNameProvider> { K9AppNameProvider(androidContext()) }
     single<FeatureThemeProvider> { K9FeatureThemeProvider() }
+    single<FeatureFlagFactory> { K9FeatureFlagFactory() }
 
     developmentModuleAdditions()
 }

--- a/app-k9mail/src/main/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
@@ -1,9 +1,9 @@
-package com.fsck.k9.featureflag
+package app.k9mail.featureflag
 
 import app.k9mail.core.featureflag.FeatureFlag
 import app.k9mail.core.featureflag.FeatureFlagFactory
 
-class InMemoryFeatureFlagFactory : FeatureFlagFactory {
+class K9FeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return emptyList()
     }

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation(projects.legacy.core)
     implementation(projects.legacy.ui.legacy)
 
+    implementation(projects.core.featureflags)
+
     implementation(projects.feature.widget.messageList)
     implementation(projects.feature.widget.shortcut)
     implementation(projects.feature.widget.unread)

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -2,12 +2,14 @@ package net.thunderbird.android
 
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import com.fsck.k9.AppConfig
 import com.fsck.k9.activity.MessageCompose
 import net.thunderbird.android.auth.TbOAuthConfigurationFactory
 import net.thunderbird.android.dev.developmentModuleAdditions
+import net.thunderbird.android.featureflag.TbFeatureFlagFactory
 import net.thunderbird.android.provider.TbAppNameProvider
 import net.thunderbird.android.provider.TbFeatureThemeProvider
 import net.thunderbird.android.widget.appWidgetModule
@@ -26,6 +28,7 @@ val appModule = module {
     single<OAuthConfigurationFactory> { TbOAuthConfigurationFactory() }
     single<AppNameProvider> { TbAppNameProvider(androidContext()) }
     single<FeatureThemeProvider> { TbFeatureThemeProvider() }
+    single<FeatureFlagFactory> { TbFeatureFlagFactory() }
 
     developmentModuleAdditions()
 }

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -1,0 +1,10 @@
+package net.thunderbird.android.featureflag
+
+import app.k9mail.core.featureflag.FeatureFlag
+import app.k9mail.core.featureflag.FeatureFlagFactory
+
+class TbFeatureFlagFactory : FeatureFlagFactory {
+    override fun createFeatureCatalog(): List<FeatureFlag> {
+        return emptyList()
+    }
+}

--- a/legacy/common/src/main/java/com/fsck/k9/CommonKoinModule.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/CommonKoinModule.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9
 
-import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.featureflag.FeatureFlagProvider
 import app.k9mail.core.featureflag.InMemoryFeatureFlagProvider
 import app.k9mail.feature.widget.message.list.messageListWidgetModule
@@ -12,7 +11,6 @@ import com.fsck.k9.controller.ControllerExtension
 import com.fsck.k9.crypto.EncryptionExtractor
 import com.fsck.k9.crypto.openpgp.OpenPgpEncryptionExtractor
 import com.fsck.k9.feature.featureModule
-import com.fsck.k9.featureflag.InMemoryFeatureFlagFactory
 import com.fsck.k9.notification.notificationModule
 import com.fsck.k9.preferences.K9StoragePersister
 import com.fsck.k9.preferences.StoragePersister
@@ -32,7 +30,6 @@ val commonAppModule = module {
     single(named("controllerExtensions")) { emptyList<ControllerExtension>() }
     single<EncryptionExtractor> { OpenPgpEncryptionExtractor.newInstance() }
     single<StoragePersister> { K9StoragePersister(get()) }
-    single<FeatureFlagFactory> { InMemoryFeatureFlagFactory() }
     single<FeatureFlagProvider> {
         InMemoryFeatureFlagProvider(
             featureFlagFactory = get(),


### PR DESCRIPTION
The feature flags are moved to the app modules to allow individual configuration per app.
