### PR TITLE
Add navigation drawer feature flag

### DIFF
--- a/app-k9mail/src/main/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
@@ -2,9 +2,12 @@ package app.k9mail.featureflag
 
 import app.k9mail.core.featureflag.FeatureFlag
 import app.k9mail.core.featureflag.FeatureFlagFactory
+import app.k9mail.core.featureflag.FeatureFlagKey
 
 class K9FeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
-        return emptyList()
+        return listOf(
+            FeatureFlag(FeatureFlagKey("material3_navigation_drawer"), false),
+        )
     }
 }

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -2,9 +2,12 @@ package net.thunderbird.android.featureflag
 
 import app.k9mail.core.featureflag.FeatureFlag
 import app.k9mail.core.featureflag.FeatureFlagFactory
+import app.k9mail.core.featureflag.FeatureFlagKey
 
 class TbFeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
-        return emptyList()
+        return listOf(
+            FeatureFlag(FeatureFlagKey("material3_navigation_drawer"), false),
+        )
     }
 }

--- a/core/featureflags/src/main/kotlin/app/k9mail/core/featureflag/FeatureFlagResult.kt
+++ b/core/featureflags/src/main/kotlin/app/k9mail/core/featureflag/FeatureFlagResult.kt
@@ -1,9 +1,9 @@
 package app.k9mail.core.featureflag
 
 sealed interface FeatureFlagResult {
-    object Enabled : FeatureFlagResult
-    object Disabled : FeatureFlagResult
-    object Unavailable : FeatureFlagResult
+    data object Enabled : FeatureFlagResult
+    data object Disabled : FeatureFlagResult
+    data object Unavailable : FeatureFlagResult
 
     fun onEnabled(action: () -> Unit): FeatureFlagResult {
         if (this is Enabled) {
@@ -23,6 +23,14 @@ sealed interface FeatureFlagResult {
 
     fun onUnavailable(action: () -> Unit): FeatureFlagResult {
         if (this is Unavailable) {
+            action()
+        }
+
+        return this
+    }
+
+    fun onDisabledOrUnavailable(action: () -> Unit): FeatureFlagResult {
+        if (this is Disabled || this is Unavailable) {
             action()
         }
 

--- a/core/featureflags/src/test/kotlin/app/k9mail/core/featureflags/FeatureFlagResultTest.kt
+++ b/core/featureflags/src/test/kotlin/app/k9mail/core/featureflags/FeatureFlagResultTest.kt
@@ -11,50 +11,112 @@ class FeatureFlagResultTest {
     fun `should only call onEnabled when enabled`() {
         val testSubject = FeatureFlagResult.Enabled
 
-        var result = ""
+        var resultEnabled = ""
+        var resultDisabled = ""
+        var resultUnavailable = ""
 
         testSubject.onEnabled {
-            result = "enabled"
+            resultEnabled = "enabled"
         }.onDisabled {
-            result = "disabled"
+            resultDisabled = "disabled"
         }.onUnavailable {
-            result = "unavailable"
+            resultUnavailable = "unavailable"
         }
 
-        assertThat(result).isEqualTo("enabled")
+        assertThat(resultEnabled).isEqualTo("enabled")
+        assertThat(resultDisabled).isEqualTo("")
+        assertThat(resultUnavailable).isEqualTo("")
     }
 
     @Test
     fun `should only call onDisabled when disabled`() {
         val testSubject = FeatureFlagResult.Disabled
 
-        var result = ""
+        var resultEnabled = ""
+        var resultDisabled = ""
+        var resultUnavailable = ""
 
         testSubject.onEnabled {
-            result = "enabled"
+            resultEnabled = "enabled"
         }.onDisabled {
-            result = "disabled"
+            resultDisabled = "disabled"
         }.onUnavailable {
-            result = "unavailable"
+            resultUnavailable = "unavailable"
         }
 
-        assertThat(result).isEqualTo("disabled")
+        assertThat(resultEnabled).isEqualTo("")
+        assertThat(resultDisabled).isEqualTo("disabled")
+        assertThat(resultUnavailable).isEqualTo("")
     }
 
     @Test
     fun `should only call onUnavailable when unavailable`() {
         val testSubject = FeatureFlagResult.Unavailable
 
-        var result = ""
+        var resultEnabled = ""
+        var resultDisabled = ""
+        var resultUnavailable = ""
 
         testSubject.onEnabled {
-            result = "enabled"
+            resultEnabled = "enabled"
         }.onDisabled {
-            result = "disabled"
+            resultDisabled = "disabled"
         }.onUnavailable {
-            result = "unavailable"
+            resultUnavailable = "unavailable"
         }
 
-        assertThat(result).isEqualTo("unavailable")
+        assertThat(resultEnabled).isEqualTo("")
+        assertThat(resultDisabled).isEqualTo("")
+        assertThat(resultUnavailable).isEqualTo("unavailable")
+    }
+
+    @Test
+    fun `should call onDisabledOrUnavailable when disabled`() {
+        val testSubject = FeatureFlagResult.Disabled
+
+        var resultEnabled = ""
+        var resultDisabled = ""
+        var resultUnavailable = ""
+        var resultDisabledOrUnavailable = ""
+
+        testSubject.onEnabled {
+            resultEnabled = "enabled"
+        }.onDisabled {
+            resultDisabled = "disabled"
+        }.onUnavailable {
+            resultUnavailable = "unavailable"
+        }.onDisabledOrUnavailable {
+            resultDisabledOrUnavailable = "disabled or unavailable"
+        }
+
+        assertThat(resultEnabled).isEqualTo("")
+        assertThat(resultDisabled).isEqualTo("disabled")
+        assertThat(resultUnavailable).isEqualTo("")
+        assertThat(resultDisabledOrUnavailable).isEqualTo("disabled or unavailable")
+    }
+
+    @Test
+    fun `should call onDisabledOrUnavailable when unavailable`() {
+        val testSubject = FeatureFlagResult.Unavailable
+
+        var resultEnabled = ""
+        var resultDisabled = ""
+        var resultUnavailable = ""
+        var resultDisabledOrUnavailable = ""
+
+        testSubject.onEnabled {
+            resultEnabled = "enabled"
+        }.onDisabled {
+            resultDisabled = "disabled"
+        }.onUnavailable {
+            resultUnavailable = "unavailable"
+        }.onDisabledOrUnavailable {
+            resultDisabledOrUnavailable = "disabled or unavailable"
+        }
+
+        assertThat(resultEnabled).isEqualTo("")
+        assertThat(resultDisabled).isEqualTo("")
+        assertThat(resultUnavailable).isEqualTo("unavailable")
+        assertThat(resultDisabledOrUnavailable).isEqualTo("disabled or unavailable")
     }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -25,6 +25,8 @@ import androidx.fragment.app.commitNow
 import app.k9mail.core.android.common.compat.BundleCompat
 import app.k9mail.core.android.common.contact.CachingRepository
 import app.k9mail.core.android.common.contact.ContactRepository
+import app.k9mail.core.featureflag.FeatureFlagKey
+import app.k9mail.core.featureflag.FeatureFlagProvider
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.feature.launcher.FeatureLauncherActivity
 import app.k9mail.feature.navigation.drawer.LegacyDrawer
@@ -93,6 +95,7 @@ open class MessageList :
     private val messagingController: MessagingController by inject()
     private val contactRepository: ContactRepository by inject()
     private val coreResourceProvider: CoreResourceProvider by inject()
+    private val featureFlagProvider: FeatureFlagProvider by inject()
 
     private lateinit var actionBar: ActionBar
     private var searchView: SearchView? = null
@@ -579,6 +582,16 @@ open class MessageList :
             return
         }
 
+        featureFlagProvider.provide(FeatureFlagKey("material3_navigation_drawer"))
+            .onEnabled {
+                TODO()
+            }
+            .onDisabledOrUnavailable {
+                initializeLegacyDrawer(savedInstanceState)
+            }
+    }
+
+    private fun initializeLegacyDrawer(savedInstanceState: Bundle?) {
         navigationDrawer = LegacyDrawer(
             parent = this,
             savedInstanceState = savedInstanceState,


### PR DESCRIPTION
A feature flag was added to toggle between new and old drawer implementation.

The feature flag implementation has been enhanced to include a `onDisabledOrUnavailable` to cover both cases in one call.