### PR TITLE
Refactor `Settings.upgrade()`

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -303,8 +303,8 @@ public class AccountSettingsDescriptions {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
 
-    public static void upgrade(int version, Map<String, Object> validatedSettings) {
-        Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
+    public static Map<String, Object> upgrade(int version, Map<String, Object> validatedSettings) {
+        return Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -303,8 +303,8 @@ public class AccountSettingsDescriptions {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
 
-    public static Set<String> upgrade(int version, Map<String, Object> validatedSettings) {
-        return Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
+    public static void upgrade(int version, Map<String, Object> validatedSettings) {
+        Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
@@ -6,13 +6,12 @@ internal class AccountSettingsUpgrader {
     private val serverSettingsUpgrader = ServerSettingsUpgrader()
 
     fun upgrade(contentVersion: Int, account: ValidatedSettings.Account): ValidatedSettings.Account {
-        val validatedSettings = account.settings.toMutableMap()
-        if (contentVersion != Settings.VERSION) {
-            AccountSettingsDescriptions.upgrade(contentVersion, validatedSettings)
+        if (contentVersion == Settings.VERSION) {
+            return account
         }
 
         return account.copy(
-            settings = validatedSettings.toMap(),
+            settings = AccountSettingsDescriptions.upgrade(contentVersion, account.settings),
             incoming = serverSettingsUpgrader.upgrade(contentVersion, account.incoming),
             outgoing = serverSettingsUpgrader.upgrade(contentVersion, account.outgoing),
             identities = upgradeIdentities(contentVersion, account.identities),

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsDescriptions.java
@@ -58,8 +58,8 @@ class FolderSettingsDescriptions {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
 
-    public static void upgrade(int version, Map<String, Object> validatedSettings) {
-        Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
+    public static Map<String, Object> upgrade(int version, Map<String, Object> validatedSettings) {
+        return Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsDescriptions.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import com.fsck.k9.mail.FolderClass;
@@ -59,8 +58,8 @@ class FolderSettingsDescriptions {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
 
-    public static Set<String> upgrade(int version, Map<String, Object> validatedSettings) {
-        return Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
+    public static void upgrade(int version, Map<String, Object> validatedSettings) {
+        Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsUpgrader.kt
@@ -2,11 +2,12 @@ package com.fsck.k9.preferences
 
 internal class FolderSettingsUpgrader {
     fun upgrade(contentVersion: Int, folder: ValidatedSettings.Folder): ValidatedSettings.Folder {
-        val settings = folder.settings.toMutableMap()
-        if (contentVersion != Settings.VERSION) {
-            FolderSettingsDescriptions.upgrade(contentVersion, settings)
+        if (contentVersion == Settings.VERSION) {
+            return folder
         }
 
-        return folder.copy(settings = settings.toMap())
+        val upgradedSettings = FolderSettingsDescriptions.upgrade(contentVersion, folder.settings)
+
+        return folder.copy(settings = upgradedSettings)
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -316,8 +316,8 @@ public class GeneralSettingsDescriptions {
         return Settings.validate(version, SETTINGS, importedSettings, false);
     }
 
-    public static void upgrade(int version, Map<String, Object> validatedSettings) {
-        Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
+    public static Map<String, Object> upgrade(int version, Map<String, Object> validatedSettings) {
+        return Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import android.content.Context;
@@ -317,8 +316,8 @@ public class GeneralSettingsDescriptions {
         return Settings.validate(version, SETTINGS, importedSettings, false);
     }
 
-    public static Set<String> upgrade(int version, Map<String, Object> validatedSettings) {
-        return Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
+    public static void upgrade(int version, Map<String, Object> validatedSettings) {
+        Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsUpgrader.kt
@@ -2,11 +2,10 @@ package com.fsck.k9.preferences
 
 internal class GeneralSettingsUpgrader {
     fun upgrade(contentVersion: Int, internalSettings: InternalSettingsMap): InternalSettingsMap {
-        val settings = internalSettings.toMutableMap()
-        if (contentVersion != Settings.VERSION) {
-            GeneralSettingsDescriptions.upgrade(contentVersion, settings)
+        if (contentVersion == Settings.VERSION) {
+            return internalSettings
         }
 
-        return settings.toMap()
+        return GeneralSettingsDescriptions.upgrade(contentVersion, internalSettings)
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import com.fsck.k9.CoreResourceProvider;
@@ -52,8 +51,8 @@ class IdentitySettingsDescriptions {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
 
-    public static Set<String> upgrade(int version, Map<String, Object> validatedSettings) {
-        return Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
+    public static void upgrade(int version, Map<String, Object> validatedSettings) {
+        Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
@@ -51,8 +51,8 @@ class IdentitySettingsDescriptions {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
 
-    public static void upgrade(int version, Map<String, Object> validatedSettings) {
-        Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
+    public static Map<String, Object> upgrade(int version, Map<String, Object> validatedSettings) {
+        return Settings.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsUpgrader.kt
@@ -2,13 +2,12 @@ package com.fsck.k9.preferences
 
 internal class IdentitySettingsUpgrader {
     fun upgrade(contentVersion: Int, identity: ValidatedSettings.Identity): ValidatedSettings.Identity {
-        val settings = identity.settings.toMutableMap()
-
-        // Upgrade identity settings to current content version
-        if (contentVersion != Settings.VERSION) {
-            IdentitySettingsDescriptions.upgrade(contentVersion, settings)
+        if (contentVersion == Settings.VERSION) {
+            return identity
         }
 
-        return identity.copy(settings = settings.toMap())
+        val upgradedSettings = IdentitySettingsDescriptions.upgrade(contentVersion, identity.settings)
+
+        return identity.copy(settings = upgradedSettings)
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsUpgrader.kt
@@ -8,15 +8,13 @@ internal class ServerSettingsUpgrader(
             return server
         }
 
-        val settings = server.settings.toMutableMap()
-
-        Settings.upgrade(
+        val upgradedSettings = Settings.upgrade(
             contentVersion,
             serverSettingsDescriptions.upgraders,
             serverSettingsDescriptions.settings,
-            settings,
+            server.settings,
         )
 
-        return server.copy(settings = settings.toMap())
+        return server.copy(settings = upgradedSettings)
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -355,11 +355,8 @@ public class Settings {
          * @param settings
          *         The settings to upgrade.  This map is modified and contains the upgraded
          *         settings when this method returns.
-         *
-         * @return A set of setting names that were removed during the upgrade process or
-         *         {@code null} if none were removed.
          */
-        Set<String> upgrade(Map<String, Object> settings);
+        void upgrade(Map<String, Object> settings);
     }
 
 

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo53.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo53.java
@@ -2,7 +2,6 @@ package com.fsck.k9.preferences.upgrader;
 
 
 import java.util.Map;
-import java.util.Set;
 
 import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 
@@ -14,15 +13,13 @@ public class AccountSettingsUpgraderTo53 implements SettingsUpgrader {
     public static final String FOLDER_NONE = "-NONE-";
 
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         upgradeFolderEntry(settings, "archiveFolderName");
         upgradeFolderEntry(settings, "autoExpandFolderName");
         upgradeFolderEntry(settings, "draftsFolderName");
         upgradeFolderEntry(settings, "sentFolderName");
         upgradeFolderEntry(settings, "spamFolderName");
         upgradeFolderEntry(settings, "trashFolderName");
-
-        return null;
     }
 
     private void upgradeFolderEntry(Map<String, Object> settings, String key) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo54.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo54.java
@@ -2,7 +2,6 @@ package com.fsck.k9.preferences.upgrader;
 
 
 import java.util.Map;
-import java.util.Set;
 
 import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 
@@ -14,13 +13,11 @@ public class AccountSettingsUpgraderTo54 implements SettingsUpgrader {
     private static final String FOLDER_SELECTION_MANUAL = "MANUAL";
 
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         settings.put("archiveFolderSelection", FOLDER_SELECTION_MANUAL);
         settings.put("draftsFolderSelection", FOLDER_SELECTION_MANUAL);
         settings.put("sentFolderSelection", FOLDER_SELECTION_MANUAL);
         settings.put("spamFolderSelection", FOLDER_SELECTION_MANUAL);
         settings.put("trashFolderSelection", FOLDER_SELECTION_MANUAL);
-
-        return null;
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo74.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo74.java
@@ -2,7 +2,6 @@ package com.fsck.k9.preferences.upgrader;
 
 
 import java.util.Map;
-import java.util.Set;
 
 import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 
@@ -12,12 +11,10 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader;
  */
 public class AccountSettingsUpgraderTo74 implements SettingsUpgrader {
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         Integer idleRefreshMinutes = (Integer) settings.get("idleRefreshMinutes");
         if (idleRefreshMinutes == 1) {
             settings.put("idleRefreshMinutes", 2);
         }
-
-        return null;
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo80.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo80.java
@@ -2,13 +2,11 @@ package com.fsck.k9.preferences.upgrader;
 
 
 import java.util.Map;
-import java.util.Set;
 
-import app.k9mail.legacy.notification.NotificationLight;
 import app.k9mail.legacy.di.DI;
+import app.k9mail.legacy.notification.NotificationLight;
 import com.fsck.k9.notification.NotificationLightDecoder;
 import com.fsck.k9.preferences.Settings.SettingsUpgrader;
-import kotlin.collections.SetsKt;
 
 
 /**
@@ -18,7 +16,7 @@ public class AccountSettingsUpgraderTo80 implements SettingsUpgrader {
     private final NotificationLightDecoder notificationLightDecoder = DI.get(NotificationLightDecoder.class);
 
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         Boolean isLedEnabled = (Boolean) settings.get("led");
         Integer ledColor = (Integer) settings.get("ledColor");
         Integer chipColor = (Integer) settings.get("chipColor");
@@ -28,7 +26,5 @@ public class AccountSettingsUpgraderTo80 implements SettingsUpgrader {
             NotificationLight light = notificationLightDecoder.decode(isLedEnabled, ledColor, accountColor);
             settings.put("notificationLight", light.name());
         }
-
-        return SetsKt.setOf("led", "ledColor");
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo81.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo81.java
@@ -2,10 +2,8 @@ package com.fsck.k9.preferences.upgrader;
 
 
 import java.util.Map;
-import java.util.Set;
 
 import com.fsck.k9.preferences.Settings.SettingsUpgrader;
-import kotlin.collections.SetsKt;
 
 
 /**
@@ -13,7 +11,7 @@ import kotlin.collections.SetsKt;
  */
 public class AccountSettingsUpgraderTo81 implements SettingsUpgrader {
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         Boolean useCompressionWifi = (Boolean) settings.get("useCompression.WIFI");
         Boolean useCompressionMobile = (Boolean) settings.get("useCompression.MOBILE");
         Boolean useCompressionOther = (Boolean) settings.get("useCompression.OTHER");
@@ -21,7 +19,5 @@ public class AccountSettingsUpgraderTo81 implements SettingsUpgrader {
         boolean useCompression = useCompressionWifi != null && useCompressionMobile != null &&
             useCompressionOther != null && useCompressionWifi && useCompressionMobile && useCompressionOther;
         settings.put("useCompression", useCompression);
-
-        return SetsKt.setOf("useCompression.WIFI", "useCompression.MOBILE", "useCompression.OTHER");
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo91.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/AccountSettingsUpgraderTo91.kt
@@ -6,9 +6,7 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader
  * Rewrite `sendClientId` to `sendClientInfo`
  */
 class AccountSettingsUpgraderTo91 : SettingsUpgrader {
-    override fun upgrade(settings: MutableMap<String, Any?>): Set<String> {
+    override fun upgrade(settings: MutableMap<String, Any?>) {
         settings["sendClientInfo"] = settings["sendClientId"]
-
-        return setOf("sendClientId")
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo24.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo24.java
@@ -2,7 +2,6 @@ package com.fsck.k9.preferences.upgrader;
 
 
 import java.util.Map;
-import java.util.Set;
 
 import app.k9mail.legacy.preferences.AppTheme;
 import app.k9mail.legacy.preferences.SubTheme;
@@ -16,14 +15,12 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 public class GeneralSettingsUpgraderTo24 implements SettingsUpgrader {
 
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         SubTheme messageViewTheme = (SubTheme) settings.get("messageViewTheme");
         AppTheme theme = (AppTheme) settings.get("theme");
         if ((theme == AppTheme.LIGHT && messageViewTheme == SubTheme.LIGHT) ||
             (theme == AppTheme.DARK && messageViewTheme == SubTheme.DARK)) {
             settings.put("messageViewTheme", SubTheme.USE_GLOBAL);
         }
-
-        return null;
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo31.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo31.java
@@ -1,10 +1,7 @@
 package com.fsck.k9.preferences.upgrader;
 
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 
@@ -15,14 +12,12 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 public class GeneralSettingsUpgraderTo31 implements SettingsUpgrader {
 
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         int oldSize = (Integer) settings.get("fontSizeMessageViewContent");
 
         int newSize = convertFromOldSize(oldSize);
 
         settings.put("fontSizeMessageViewContentPercent", newSize);
-
-        return new HashSet<>(Collections.singletonList("fontSizeMessageViewContent"));
     }
 
     public static int convertFromOldSize(int oldSize) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo58.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo58.java
@@ -2,7 +2,6 @@ package com.fsck.k9.preferences.upgrader;
 
 
 import java.util.Map;
-import java.util.Set;
 
 import app.k9mail.legacy.preferences.AppTheme;
 import com.fsck.k9.preferences.Settings.SettingsUpgrader;
@@ -14,12 +13,10 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 public class GeneralSettingsUpgraderTo58 implements SettingsUpgrader {
 
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         AppTheme theme = (AppTheme) settings.get("theme");
         if (theme == AppTheme.LIGHT) {
             settings.put("theme", AppTheme.FOLLOW_SYSTEM);
         }
-
-        return null;
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo69.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo69.java
@@ -1,10 +1,7 @@
 package com.fsck.k9.preferences.upgrader;
 
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 
@@ -15,11 +12,9 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 public class GeneralSettingsUpgraderTo69 implements SettingsUpgrader {
 
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         Boolean hideSpecialAccounts = (Boolean) settings.get("hideSpecialAccounts");
         boolean showUnifiedInbox = hideSpecialAccounts == null || !hideSpecialAccounts;
         settings.put("showUnifiedInbox", showUnifiedInbox);
-
-        return new HashSet<>(Collections.singleton("hideSpecialAccounts"));
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo79.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo79.java
@@ -2,7 +2,6 @@ package com.fsck.k9.preferences.upgrader;
 
 
 import java.util.Map;
-import java.util.Set;
 
 import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 
@@ -17,13 +16,11 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 public class GeneralSettingsUpgraderTo79 implements SettingsUpgrader {
 
     @Override
-    public Set<String> upgrade(Map<String, Object> settings) {
+    public void upgrade(Map<String, Object> settings) {
         final Integer registeredNameColorValue = (Integer) settings.get("registeredNameColor");
 
         if (registeredNameColorValue != null && registeredNameColorValue == 0xFF00008F) {
             settings.put("registeredNameColor", 0xFF1093F5);
         }
-
-        return null;
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo89.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo89.kt
@@ -6,7 +6,7 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader
  * Combine `messageViewReturnToList` and `messageViewShowNext` into `messageViewPostDeleteAction`.
  */
 class GeneralSettingsUpgraderTo89 : SettingsUpgrader {
-    override fun upgrade(settings: MutableMap<String, Any>): Set<String> {
+    override fun upgrade(settings: MutableMap<String, Any>) {
         val messageViewReturnToList = settings["messageViewReturnToList"] as? Boolean
         val messageViewShowNext = settings["messageViewShowNext"] as? Boolean
 
@@ -17,7 +17,5 @@ class GeneralSettingsUpgraderTo89 : SettingsUpgrader {
         } else {
             settings["messageViewPostDeleteAction"] = "ShowPreviousMessage"
         }
-
-        return setOf("messageViewReturnToList", "messageViewShowNext")
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92.kt
@@ -4,7 +4,7 @@ import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CONNECTION_S
 import com.fsck.k9.preferences.Settings.SettingsUpgrader
 
 class ServerSettingsUpgraderTo92 : SettingsUpgrader {
-    override fun upgrade(settings: MutableMap<String, Any?>): Set<String> {
+    override fun upgrade(settings: MutableMap<String, Any?>) {
         val oldConnectionSecurity = settings[CONNECTION_SECURITY] as? String
 
         settings[CONNECTION_SECURITY] = when (oldConnectionSecurity) {
@@ -15,7 +15,5 @@ class ServerSettingsUpgraderTo92 : SettingsUpgrader {
             "SSL_TLS_REQUIRED" -> "SSL_TLS_REQUIRED"
             else -> "SSL_TLS_REQUIRED"
         }
-
-        return emptySet()
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94.kt
@@ -11,7 +11,7 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader
  * Replaces the authentication value "LOGIN" with "PLAIN".
  */
 class ServerSettingsUpgraderTo94 : SettingsUpgrader {
-    override fun upgrade(settings: MutableMap<String, Any?>): Set<String> {
+    override fun upgrade(settings: MutableMap<String, Any?>) {
         val connectionSecurity = settings[CONNECTION_SECURITY] as? String
         val isSecure = connectionSecurity == "STARTTLS_REQUIRED" || connectionSecurity == "SSL_TLS_REQUIRED"
         val authenticationType = settings[AUTHENTICATION_TYPE] as? String
@@ -21,7 +21,5 @@ class ServerSettingsUpgraderTo94 : SettingsUpgrader {
             "LOGIN" -> "PLAIN"
             else -> authenticationType
         }
-
-        return emptySet()
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo95.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo95.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader
  * Updates server settings to use an authentication type value of "NONE" when appropriate.
  */
 class ServerSettingsUpgraderTo95 : SettingsUpgrader {
-    override fun upgrade(settings: MutableMap<String, Any?>): Set<String> {
+    override fun upgrade(settings: MutableMap<String, Any?>) {
         val username = settings[USERNAME] as? String
 
         if (username.isNullOrEmpty()) {
@@ -17,7 +17,5 @@ class ServerSettingsUpgraderTo95 : SettingsUpgrader {
             settings[USERNAME] = ""
             settings[PASSWORD] = null
         }
-
-        return emptySet()
     }
 }

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsTest.kt
@@ -104,7 +104,6 @@ class SettingsTest {
         val upgraders = mapOf(
             Settings.VERSION to SettingsUpgrader {
                 upgraderCalled = true
-                emptySet()
             },
         )
         val settings = mapOf(

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsTest.kt
@@ -18,7 +18,7 @@ class SettingsTest {
     fun `upgrade() with new setting being added`() {
         val version = 1
         val upgraders = emptyMap<Int, SettingsUpgrader>()
-        val settings = mapOf(
+        val settingsDescriptions = mapOf(
             "one" to versions(
                 1 to BooleanSetting(true),
             ),
@@ -26,13 +26,13 @@ class SettingsTest {
                 2 to StringSetting("default"),
             ),
         )
-        val validatedSettings = mutableMapOf<String, Any>(
+        val settings = mapOf<String, Any>(
             "one" to false,
         )
 
-        Settings.upgrade(version, upgraders, settings, validatedSettings)
+        val result = Settings.upgrade(version, upgraders, settingsDescriptions, settings)
 
-        assertThat(validatedSettings).isEqualTo(
+        assertThat(result).isEqualTo(
             mapOf(
                 "one" to false,
                 "two" to "default",
@@ -44,7 +44,7 @@ class SettingsTest {
     fun `upgrade() with setting being removed`() {
         val version = 1
         val upgraders = emptyMap<Int, SettingsUpgrader>()
-        val settings = mapOf(
+        val settingsDescriptions = mapOf(
             "one" to versions(
                 1 to BooleanSetting(true),
                 2 to null,
@@ -53,13 +53,13 @@ class SettingsTest {
                 2 to StringSetting("default"),
             ),
         )
-        val validatedSettings = mutableMapOf<String, Any>(
+        val settings = mapOf<String, Any>(
             "one" to false,
         )
 
-        Settings.upgrade(version, upgraders, settings, validatedSettings)
+        val result = Settings.upgrade(version, upgraders, settingsDescriptions, settings)
 
-        assertThat(validatedSettings).isEqualTo(
+        assertThat(result).isEqualTo(
             mapOf(
                 "two" to "default",
             ),
@@ -75,7 +75,7 @@ class SettingsTest {
                 setOf("one")
             },
         )
-        val settings = mapOf(
+        val settingsDescriptions = mapOf(
             "one" to versions(
                 1 to BooleanSetting(true),
                 2 to null,
@@ -84,13 +84,13 @@ class SettingsTest {
                 2 to BooleanSetting(true),
             ),
         )
-        val validatedSettings = mutableMapOf<String, Any>(
+        val settings = mutableMapOf<String, Any>(
             "one" to false,
         )
 
-        Settings.upgrade(version, upgraders, settings, validatedSettings)
+        val result = Settings.upgrade(version, upgraders, settingsDescriptions, settings)
 
-        assertThat(validatedSettings).isEqualTo(
+        assertThat(result).isEqualTo(
             mapOf(
                 "two" to false,
             ),
@@ -106,18 +106,18 @@ class SettingsTest {
                 upgraderCalled = true
             },
         )
-        val settings = mapOf(
+        val settingsDescriptions = mapOf(
             "setting" to versions(
                 1 to BooleanSetting(true),
             ),
         )
-        val validatedSettings = mutableMapOf<String, Any>(
+        val settings = mapOf<String, Any>(
             "setting" to false,
         )
 
-        Settings.upgrade(version, upgraders, settings, validatedSettings)
+        val result = Settings.upgrade(version, upgraders, settingsDescriptions, settings)
 
-        assertThat(validatedSettings).isEqualTo(
+        assertThat(result).isEqualTo(
             mapOf(
                 "setting" to false,
             ),
@@ -129,17 +129,17 @@ class SettingsTest {
     fun `upgrade() with first version of setting being null should throw`() {
         val version = 1
         val upgraders = emptyMap<Int, SettingsUpgrader>()
-        val settings = mapOf(
+        val settingsDescriptions = mapOf(
             "setting" to versions(
                 2 to null,
             ),
         )
-        val validatedSettings = mutableMapOf<String, Any>(
+        val settings = mapOf<String, Any>(
             "settings" to "1",
         )
 
         assertFailure {
-            Settings.upgrade(version, upgraders, settings, validatedSettings)
+            Settings.upgrade(version, upgraders, settingsDescriptions, settings)
         }.isInstanceOf<AssertionError>()
             .hasMessage("First version of a setting must be non-null!")
     }

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsTest.kt
@@ -1,0 +1,153 @@
+package com.fsck.k9.preferences
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import com.fsck.k9.preferences.Settings.BooleanSetting
+import com.fsck.k9.preferences.Settings.SettingsDescription
+import com.fsck.k9.preferences.Settings.SettingsUpgrader
+import com.fsck.k9.preferences.Settings.StringSetting
+import java.util.TreeMap
+import kotlin.test.Test
+
+class SettingsTest {
+    @Test
+    fun `upgrade() with new setting being added`() {
+        val version = 1
+        val upgraders = emptyMap<Int, SettingsUpgrader>()
+        val settings = mapOf(
+            "one" to versions(
+                1 to BooleanSetting(true),
+            ),
+            "two" to versions(
+                2 to StringSetting("default"),
+            ),
+        )
+        val validatedSettings = mutableMapOf<String, Any>(
+            "one" to false,
+        )
+
+        Settings.upgrade(version, upgraders, settings, validatedSettings)
+
+        assertThat(validatedSettings).isEqualTo(
+            mapOf(
+                "one" to false,
+                "two" to "default",
+            ),
+        )
+    }
+
+    @Test
+    fun `upgrade() with setting being removed`() {
+        val version = 1
+        val upgraders = emptyMap<Int, SettingsUpgrader>()
+        val settings = mapOf(
+            "one" to versions(
+                1 to BooleanSetting(true),
+                2 to null,
+            ),
+            "two" to versions(
+                2 to StringSetting("default"),
+            ),
+        )
+        val validatedSettings = mutableMapOf<String, Any>(
+            "one" to false,
+        )
+
+        Settings.upgrade(version, upgraders, settings, validatedSettings)
+
+        assertThat(validatedSettings).isEqualTo(
+            mapOf(
+                "two" to "default",
+            ),
+        )
+    }
+
+    @Test
+    fun `upgrade() with custom upgrader renaming a setting`() {
+        val version = 1
+        val upgraders = mapOf(
+            2 to SettingsUpgrader { settings ->
+                settings["two"] = settings["one"]
+                setOf("one")
+            },
+        )
+        val settings = mapOf(
+            "one" to versions(
+                1 to BooleanSetting(true),
+                2 to null,
+            ),
+            "two" to versions(
+                2 to BooleanSetting(true),
+            ),
+        )
+        val validatedSettings = mutableMapOf<String, Any>(
+            "one" to false,
+        )
+
+        Settings.upgrade(version, upgraders, settings, validatedSettings)
+
+        assertThat(validatedSettings).isEqualTo(
+            mapOf(
+                "two" to false,
+            ),
+        )
+    }
+
+    @Test
+    fun `upgrade() with settings already at latest version`() {
+        var upgraderCalled = false
+        val version = Settings.VERSION
+        val upgraders = mapOf(
+            Settings.VERSION to SettingsUpgrader {
+                upgraderCalled = true
+                emptySet()
+            },
+        )
+        val settings = mapOf(
+            "setting" to versions(
+                1 to BooleanSetting(true),
+            ),
+        )
+        val validatedSettings = mutableMapOf<String, Any>(
+            "setting" to false,
+        )
+
+        Settings.upgrade(version, upgraders, settings, validatedSettings)
+
+        assertThat(validatedSettings).isEqualTo(
+            mapOf(
+                "setting" to false,
+            ),
+        )
+        assertThat(upgraderCalled).isFalse()
+    }
+
+    @Test
+    fun `upgrade() with first version of setting being null should throw`() {
+        val version = 1
+        val upgraders = emptyMap<Int, SettingsUpgrader>()
+        val settings = mapOf(
+            "setting" to versions(
+                2 to null,
+            ),
+        )
+        val validatedSettings = mutableMapOf<String, Any>(
+            "settings" to "1",
+        )
+
+        assertFailure {
+            Settings.upgrade(version, upgraders, settings, validatedSettings)
+        }.isInstanceOf<AssertionError>()
+            .hasMessage("First version of a setting must be non-null!")
+    }
+
+    private fun versions(
+        vararg pairs: Pair<Int, SettingsDescription<*>?>,
+    ): TreeMap<Int, SettingsDescription<*>?> {
+        return pairs.toMap(TreeMap<Int, SettingsDescription<*>?>())
+    }
+}

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92Test.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
 import assertk.assertThat
-import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
@@ -12,9 +11,8 @@ class ServerSettingsUpgraderTo92Test {
     fun `STARTTLS_OPTIONAL should be rewritten to STARTTLS_REQUIRED`() {
         val mutableSettings = mutableMapOf<String, Any?>("connectionSecurity" to "STARTTLS_OPTIONAL")
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(mapOf<String, Any?>("connectionSecurity" to "STARTTLS_REQUIRED"))
     }
 
@@ -22,9 +20,8 @@ class ServerSettingsUpgraderTo92Test {
     fun `SSL_TLS_OPTIONAL should be rewritten to SSL_TLS_REQUIRED`() {
         val mutableSettings = mutableMapOf<String, Any?>("connectionSecurity" to "SSL_TLS_OPTIONAL")
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(mapOf<String, Any?>("connectionSecurity" to "SSL_TLS_REQUIRED"))
     }
 
@@ -33,9 +30,8 @@ class ServerSettingsUpgraderTo92Test {
         val settings = mapOf<String, Any?>("connectionSecurity" to "NONE")
         val mutableSettings = settings.toMutableMap()
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(settings)
     }
 
@@ -44,9 +40,8 @@ class ServerSettingsUpgraderTo92Test {
         val settings = mapOf<String, Any?>("connectionSecurity" to "STARTTLS_REQUIRED")
         val mutableSettings = settings.toMutableMap()
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(settings)
     }
 
@@ -55,9 +50,8 @@ class ServerSettingsUpgraderTo92Test {
         val settings = mapOf<String, Any?>("connectionSecurity" to "SSL_TLS_REQUIRED")
         val mutableSettings = settings.toMutableMap()
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(settings)
     }
 
@@ -65,9 +59,8 @@ class ServerSettingsUpgraderTo92Test {
     fun `Unsupported values should be changed to SSL_TLS_REQUIRED`() {
         val mutableSettings = mutableMapOf<String, Any?>("connectionSecurity" to "unsupported")
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(mapOf<String, Any?>("connectionSecurity" to "SSL_TLS_REQUIRED"))
     }
 }

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94Test.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
 import assertk.assertThat
-import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
@@ -15,9 +14,8 @@ class ServerSettingsUpgraderTo94Test {
             "connectionSecurity" to "STARTTLS_REQUIRED",
         )
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(
             mapOf<String, Any?>(
                 "authenticationType" to "PLAIN",
@@ -33,9 +31,8 @@ class ServerSettingsUpgraderTo94Test {
             "connectionSecurity" to "SSL_TLS_REQUIRED",
         )
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(
             mapOf<String, Any?>(
                 "authenticationType" to "PLAIN",
@@ -51,9 +48,8 @@ class ServerSettingsUpgraderTo94Test {
             "connectionSecurity" to "NONE",
         )
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(
             mapOf<String, Any?>(
                 "authenticationType" to "CRAM_MD5",
@@ -69,9 +65,8 @@ class ServerSettingsUpgraderTo94Test {
             "connectionSecurity" to "SSL_TLS_REQUIRED",
         )
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(
             mapOf<String, Any?>(
                 "authenticationType" to "PLAIN",
@@ -88,9 +83,8 @@ class ServerSettingsUpgraderTo94Test {
         )
         val mutableSettings = settings.toMutableMap()
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(settings)
     }
 
@@ -102,9 +96,8 @@ class ServerSettingsUpgraderTo94Test {
         )
         val mutableSettings = settings.toMutableMap()
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(settings)
     }
 
@@ -116,9 +109,8 @@ class ServerSettingsUpgraderTo94Test {
         )
         val mutableSettings = settings.toMutableMap()
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(settings)
     }
 }

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo95Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo95Test.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
 import assertk.assertThat
-import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
@@ -16,9 +15,8 @@ class ServerSettingsUpgraderTo95Test {
             "password" to "",
         )
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(
             mapOf<String, Any?>(
                 "authenticationType" to "NONE",
@@ -37,9 +35,8 @@ class ServerSettingsUpgraderTo95Test {
         )
         val mutableSettings = settings.toMutableMap()
 
-        val result = upgrader.upgrade(mutableSettings)
+        upgrader.upgrade(mutableSettings)
 
-        assertThat(result).isEmpty()
         assertThat(mutableSettings).isEqualTo(settings)
     }
 }


### PR DESCRIPTION
This is a first step of refactoring settings import to be able to have upgrade code that can access both account settings and folder settings. We'll need this to be able to import old settings files after we've removed folder classes (see #2669).

This is an internal refactoring that doesn't change the observable behavior of `SettingsImporter`.