### PR TITLE
Add support for settings upgrader with access to all account settings

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -46,7 +46,7 @@ import static com.fsck.k9.preferences.upgrader.AccountSettingsUpgraderTo53.FOLDE
 
 class AccountSettingsDescriptions {
     static final Map<String, TreeMap<Integer, SettingsDescription<?>>> SETTINGS;
-    private static final Map<Integer, SettingsUpgrader> UPGRADERS;
+    static final Map<Integer, SettingsUpgrader> UPGRADERS;
 
     static {
         Map<String, TreeMap<Integer, SettingsDescription<?>>> s = new LinkedHashMap<>();
@@ -300,10 +300,6 @@ class AccountSettingsDescriptions {
 
     static Map<String, Object> validate(int version, Map<String, String> importedSettings, boolean useDefaultValues) {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
-    }
-
-    public static Map<String, Object> upgrade(int version, Map<String, Object> validatedSettings) {
-        return SettingsUpgradeHelper.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsUpgrader.kt
@@ -1,9 +1,10 @@
 package com.fsck.k9.preferences
 
-internal class AccountSettingsUpgrader {
-    private val identitySettingsUpgrader = IdentitySettingsUpgrader()
-    private val folderSettingsUpgrader = FolderSettingsUpgrader()
-    private val serverSettingsUpgrader = ServerSettingsUpgrader()
+internal class AccountSettingsUpgrader(
+    private val identitySettingsUpgrader: IdentitySettingsUpgrader,
+    private val folderSettingsUpgrader: FolderSettingsUpgrader,
+    private val serverSettingsUpgrader: ServerSettingsUpgrader,
+) {
 
     fun upgrade(contentVersion: Int, account: ValidatedSettings.Account): ValidatedSettings.Account {
         if (contentVersion == Settings.VERSION) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/CombinedSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/CombinedSettingsUpgrader.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.preferences
+
+fun interface CombinedSettingsUpgrader {
+    fun upgrade(account: ValidatedSettings.Account): ValidatedSettings.Account
+}

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/CombinedSettingsUpgraders.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/CombinedSettingsUpgraders.kt
@@ -1,0 +1,7 @@
+package com.fsck.k9.preferences
+
+internal typealias CombinedSettingsUpgraderFactory = () -> CombinedSettingsUpgrader
+
+internal object CombinedSettingsUpgraders {
+    val UPGRADERS = emptyMap<Int, CombinedSettingsUpgraderFactory>()
+}

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsDescriptions.java
@@ -16,7 +16,7 @@ import com.fsck.k9.preferences.Settings.V;
 
 class FolderSettingsDescriptions {
     static final Map<String, TreeMap<Integer, SettingsDescription<?>>> SETTINGS;
-    private static final Map<Integer, SettingsUpgrader> UPGRADERS;
+    static final Map<Integer, SettingsUpgrader> UPGRADERS;
 
     static {
         Map<String, TreeMap<Integer, SettingsDescription<?>>> s = new LinkedHashMap<>();
@@ -55,10 +55,6 @@ class FolderSettingsDescriptions {
 
     static Map<String, Object> validate(int version, Map<String, String> importedSettings, boolean useDefaultValues) {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
-    }
-
-    public static Map<String, Object> upgrade(int version, Map<String, Object> validatedSettings) {
-        return SettingsUpgradeHelper.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsUpgrader.kt
@@ -1,16 +1,16 @@
 package com.fsck.k9.preferences
 
 internal class FolderSettingsUpgrader(
-    private val latestVersion: Int = Settings.VERSION,
     private val settingsDescriptions: SettingsDescriptions = FolderSettingsDescriptions.SETTINGS,
     private val upgraders: Map<Int, SettingsUpgrader> = FolderSettingsDescriptions.UPGRADERS,
 ) {
-    fun upgrade(contentVersion: Int, folder: ValidatedSettings.Folder): ValidatedSettings.Folder {
-        if (contentVersion == latestVersion) {
+    fun upgrade(targetVersion: Int, contentVersion: Int, folder: ValidatedSettings.Folder): ValidatedSettings.Folder {
+        if (contentVersion == targetVersion) {
             return folder
         }
 
-        val upgradedSettings = SettingsUpgradeHelper.upgrade(
+        val upgradedSettings = SettingsUpgradeHelper.upgradeToVersion(
+            targetVersion,
             contentVersion,
             upgraders,
             settingsDescriptions,

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsUpgrader.kt
@@ -1,12 +1,21 @@
 package com.fsck.k9.preferences
 
-internal class FolderSettingsUpgrader {
+internal class FolderSettingsUpgrader(
+    private val latestVersion: Int = Settings.VERSION,
+    private val settingsDescriptions: SettingsDescriptions = FolderSettingsDescriptions.SETTINGS,
+    private val upgraders: Map<Int, SettingsUpgrader> = FolderSettingsDescriptions.UPGRADERS,
+) {
     fun upgrade(contentVersion: Int, folder: ValidatedSettings.Folder): ValidatedSettings.Folder {
-        if (contentVersion == Settings.VERSION) {
+        if (contentVersion == latestVersion) {
             return folder
         }
 
-        val upgradedSettings = FolderSettingsDescriptions.upgrade(contentVersion, folder.settings)
+        val upgradedSettings = SettingsUpgradeHelper.upgrade(
+            contentVersion,
+            upgraders,
+            settingsDescriptions,
+            folder.settings,
+        )
 
         return folder.copy(settings = upgradedSettings)
     }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
@@ -18,7 +18,7 @@ import com.fsck.k9.preferences.Settings.V;
 
 class IdentitySettingsDescriptions {
     static final Map<String, TreeMap<Integer, SettingsDescription<?>>> SETTINGS;
-    private static final Map<Integer, SettingsUpgrader> UPGRADERS;
+    static final Map<Integer, SettingsUpgrader> UPGRADERS;
 
     static {
         Map<String, TreeMap<Integer, SettingsDescription<?>>> s = new LinkedHashMap<>();
@@ -48,10 +48,6 @@ class IdentitySettingsDescriptions {
 
     static Map<String, Object> validate(int version, Map<String, String> importedSettings, boolean useDefaultValues) {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
-    }
-
-    public static Map<String, Object> upgrade(int version, Map<String, Object> validatedSettings) {
-        return SettingsUpgradeHelper.upgrade(version, UPGRADERS, SETTINGS, validatedSettings);
     }
 
     public static Map<String, String> convert(Map<String, Object> settings) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsUpgrader.kt
@@ -1,12 +1,21 @@
 package com.fsck.k9.preferences
 
-internal class IdentitySettingsUpgrader {
+internal class IdentitySettingsUpgrader(
+    private val latestVersion: Int = Settings.VERSION,
+    private val settingsDescriptions: SettingsDescriptions = IdentitySettingsDescriptions.SETTINGS,
+    private val upgraders: Map<Int, SettingsUpgrader> = IdentitySettingsDescriptions.UPGRADERS,
+) {
     fun upgrade(contentVersion: Int, identity: ValidatedSettings.Identity): ValidatedSettings.Identity {
-        if (contentVersion == Settings.VERSION) {
+        if (contentVersion == latestVersion) {
             return identity
         }
 
-        val upgradedSettings = IdentitySettingsDescriptions.upgrade(contentVersion, identity.settings)
+        val upgradedSettings = SettingsUpgradeHelper.upgrade(
+            contentVersion,
+            upgraders,
+            settingsDescriptions,
+            identity.settings,
+        )
 
         return identity.copy(settings = upgradedSettings)
     }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsUpgrader.kt
@@ -1,16 +1,20 @@
 package com.fsck.k9.preferences
 
 internal class IdentitySettingsUpgrader(
-    private val latestVersion: Int = Settings.VERSION,
     private val settingsDescriptions: SettingsDescriptions = IdentitySettingsDescriptions.SETTINGS,
     private val upgraders: Map<Int, SettingsUpgrader> = IdentitySettingsDescriptions.UPGRADERS,
 ) {
-    fun upgrade(contentVersion: Int, identity: ValidatedSettings.Identity): ValidatedSettings.Identity {
-        if (contentVersion == latestVersion) {
+    fun upgrade(
+        targetVersion: Int,
+        contentVersion: Int,
+        identity: ValidatedSettings.Identity,
+    ): ValidatedSettings.Identity {
+        if (contentVersion == targetVersion) {
             return identity
         }
 
-        val upgradedSettings = SettingsUpgradeHelper.upgrade(
+        val upgradedSettings = SettingsUpgradeHelper.upgradeToVersion(
+            targetVersion,
             contentVersion,
             upgraders,
             settingsDescriptions,

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
@@ -33,7 +33,19 @@ val preferencesModule = module {
     factory { GeneralSettingsWriter(preferences = get(), generalSettingsManager = get()) }
 
     factory { AccountSettingsValidator() }
-    factory { AccountSettingsUpgrader() }
+
+    factory { IdentitySettingsUpgrader() }
+    factory { FolderSettingsUpgrader() }
+    factory { ServerSettingsUpgrader() }
+
+    factory {
+        AccountSettingsUpgrader(
+            identitySettingsUpgrader = get(),
+            folderSettingsUpgrader = get(),
+            serverSettingsUpgrader = get(),
+        )
+    }
+
     factory {
         AccountSettingsWriter(
             preferences = get(),

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
@@ -11,90 +11,84 @@ import com.fsck.k9.preferences.upgrader.ServerSettingsUpgraderTo95
  * settings to the latest content version.
  */
 @Suppress("MagicNumber")
-internal class ServerSettingsDescriptions {
-    val settings: SettingsDescriptions by lazy {
-        mapOf(
-            HOST to versions(
-                1 to StringSetting(null),
-            ),
-            PORT to versions(
-                1 to IntegerRangeSetting(1, 65535, -1),
-            ),
-            CONNECTION_SECURITY to versions(
-                1 to StringEnumSetting(
-                    defaultValue = "SSL_TLS_REQUIRED",
-                    values = setOf(
-                        "NONE",
-                        "STARTTLS_OPTIONAL",
-                        "STARTTLS_REQUIRED",
-                        "SSL_TLS_OPTIONAL",
-                        "SSL_TLS_REQUIRED",
-                    ),
-                ),
-                92 to NoDefaultStringEnumSetting(
-                    values = setOf(
-                        "NONE",
-                        "STARTTLS_REQUIRED",
-                        "SSL_TLS_REQUIRED",
-                    ),
-                ),
-            ),
-            AUTHENTICATION_TYPE to versions(
-                1 to NoDefaultStringEnumSetting(
-                    values = setOf(
-                        "PLAIN",
-                        "CRAM_MD5",
-                        "EXTERNAL",
-                        "XOAUTH2",
-                        "AUTOMATIC",
-                        "LOGIN",
-                    ),
-                ),
-                94 to NoDefaultStringEnumSetting(
-                    values = setOf(
-                        "PLAIN",
-                        "CRAM_MD5",
-                        "EXTERNAL",
-                        "XOAUTH2",
-                    ),
-                ),
-                95 to NoDefaultStringEnumSetting(
-                    values = setOf(
-                        "PLAIN",
-                        "CRAM_MD5",
-                        "EXTERNAL",
-                        "XOAUTH2",
-                        "NONE",
-                    ),
-                ),
-            ),
-            USERNAME to versions(
-                1 to StringSetting(""),
-            ),
-            PASSWORD to versions(
-                1 to StringSetting(null),
-            ),
-            CLIENT_CERTIFICATE_ALIAS to versions(
-                1 to StringSetting(null),
-            ),
-        )
-    }
+internal object ServerSettingsDescriptions {
+    const val HOST = "host"
+    const val PORT = "port"
+    const val CONNECTION_SECURITY = "connectionSecurity"
+    const val AUTHENTICATION_TYPE = "authenticationType"
+    const val USERNAME = "username"
+    const val PASSWORD = "password"
+    const val CLIENT_CERTIFICATE_ALIAS = "clientCertificateAlias"
 
-    val upgraders: Map<Int, SettingsUpgrader> by lazy {
-        mapOf(
-            92 to ServerSettingsUpgraderTo92(),
-            94 to ServerSettingsUpgraderTo94(),
-            95 to ServerSettingsUpgraderTo95(),
-        )
-    }
+    val SETTINGS: SettingsDescriptions = mapOf(
+        HOST to versions(
+            1 to StringSetting(null),
+        ),
+        PORT to versions(
+            1 to IntegerRangeSetting(1, 65535, -1),
+        ),
+        CONNECTION_SECURITY to versions(
+            1 to StringEnumSetting(
+                defaultValue = "SSL_TLS_REQUIRED",
+                values = setOf(
+                    "NONE",
+                    "STARTTLS_OPTIONAL",
+                    "STARTTLS_REQUIRED",
+                    "SSL_TLS_OPTIONAL",
+                    "SSL_TLS_REQUIRED",
+                ),
+            ),
+            92 to NoDefaultStringEnumSetting(
+                values = setOf(
+                    "NONE",
+                    "STARTTLS_REQUIRED",
+                    "SSL_TLS_REQUIRED",
+                ),
+            ),
+        ),
+        AUTHENTICATION_TYPE to versions(
+            1 to NoDefaultStringEnumSetting(
+                values = setOf(
+                    "PLAIN",
+                    "CRAM_MD5",
+                    "EXTERNAL",
+                    "XOAUTH2",
+                    "AUTOMATIC",
+                    "LOGIN",
+                ),
+            ),
+            94 to NoDefaultStringEnumSetting(
+                values = setOf(
+                    "PLAIN",
+                    "CRAM_MD5",
+                    "EXTERNAL",
+                    "XOAUTH2",
+                ),
+            ),
+            95 to NoDefaultStringEnumSetting(
+                values = setOf(
+                    "PLAIN",
+                    "CRAM_MD5",
+                    "EXTERNAL",
+                    "XOAUTH2",
+                    "NONE",
+                ),
+            ),
+        ),
+        USERNAME to versions(
+            1 to StringSetting(""),
+        ),
+        PASSWORD to versions(
+            1 to StringSetting(null),
+        ),
+        CLIENT_CERTIFICATE_ALIAS to versions(
+            1 to StringSetting(null),
+        ),
+    )
 
-    companion object {
-        const val HOST = "host"
-        const val PORT = "port"
-        const val CONNECTION_SECURITY = "connectionSecurity"
-        const val AUTHENTICATION_TYPE = "authenticationType"
-        const val USERNAME = "username"
-        const val PASSWORD = "password"
-        const val CLIENT_CERTIFICATE_ALIAS = "clientCertificateAlias"
-    }
+    val UPGRADERS: Map<Int, SettingsUpgrader> = mapOf(
+        92 to ServerSettingsUpgraderTo92(),
+        94 to ServerSettingsUpgraderTo94(),
+        95 to ServerSettingsUpgraderTo95(),
+    )
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsDescriptions.kt
@@ -1,12 +1,10 @@
 package com.fsck.k9.preferences
 
 import com.fsck.k9.preferences.Settings.IntegerRangeSetting
-import com.fsck.k9.preferences.Settings.SettingsDescription
 import com.fsck.k9.preferences.Settings.StringSetting
 import com.fsck.k9.preferences.upgrader.ServerSettingsUpgraderTo92
 import com.fsck.k9.preferences.upgrader.ServerSettingsUpgraderTo94
 import com.fsck.k9.preferences.upgrader.ServerSettingsUpgraderTo95
-import java.util.TreeMap
 
 /**
  * Contains information to validate imported server settings with a given content version, and to upgrade those server
@@ -14,7 +12,7 @@ import java.util.TreeMap
  */
 @Suppress("MagicNumber")
 internal class ServerSettingsDescriptions {
-    val settings: Map<String, TreeMap<Int, SettingsDescription<*>?>> by lazy {
+    val settings: SettingsDescriptions by lazy {
         mapOf(
             HOST to versions(
                 1 to StringSetting(null),
@@ -99,8 +97,4 @@ internal class ServerSettingsDescriptions {
         const val PASSWORD = "password"
         const val CLIENT_CERTIFICATE_ALIAS = "clientCertificateAlias"
     }
-}
-
-private fun versions(vararg versions: Pair<Int, SettingsDescription<*>?>): TreeMap<Int, SettingsDescription<*>?> {
-    return TreeMap(versions.toMap())
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsUpgrader.kt
@@ -1,16 +1,16 @@
 package com.fsck.k9.preferences
 
 internal class ServerSettingsUpgrader(
-    private val latestVersion: Int = Settings.VERSION,
     private val settingsDescriptions: SettingsDescriptions = ServerSettingsDescriptions.SETTINGS,
     private val upgraders: Map<Int, SettingsUpgrader> = ServerSettingsDescriptions.UPGRADERS,
 ) {
-    fun upgrade(contentVersion: Int, server: ValidatedSettings.Server): ValidatedSettings.Server {
-        if (contentVersion == latestVersion) {
+    fun upgrade(targetVersion: Int, contentVersion: Int, server: ValidatedSettings.Server): ValidatedSettings.Server {
+        if (contentVersion == targetVersion) {
             return server
         }
 
-        val upgradedSettings = SettingsUpgradeHelper.upgrade(
+        val upgradedSettings = SettingsUpgradeHelper.upgradeToVersion(
+            targetVersion,
             contentVersion,
             upgraders,
             settingsDescriptions,

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsUpgrader.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsUpgrader.kt
@@ -1,17 +1,19 @@
 package com.fsck.k9.preferences
 
 internal class ServerSettingsUpgrader(
-    private val serverSettingsDescriptions: ServerSettingsDescriptions = ServerSettingsDescriptions(),
+    private val latestVersion: Int = Settings.VERSION,
+    private val settingsDescriptions: SettingsDescriptions = ServerSettingsDescriptions.SETTINGS,
+    private val upgraders: Map<Int, SettingsUpgrader> = ServerSettingsDescriptions.UPGRADERS,
 ) {
     fun upgrade(contentVersion: Int, server: ValidatedSettings.Server): ValidatedSettings.Server {
-        if (contentVersion == Settings.VERSION) {
+        if (contentVersion == latestVersion) {
             return server
         }
 
         val upgradedSettings = SettingsUpgradeHelper.upgrade(
             contentVersion,
-            serverSettingsDescriptions.upgraders,
-            serverSettingsDescriptions.settings,
+            upgraders,
+            settingsDescriptions,
             server.settings,
         )
 

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsValidator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsValidator.kt
@@ -1,22 +1,22 @@
 package com.fsck.k9.preferences
 
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.AUTHENTICATION_TYPE
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CLIENT_CERTIFICATE_ALIAS
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CONNECTION_SECURITY
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.HOST
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PASSWORD
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PORT
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.USERNAME
+import com.fsck.k9.preferences.ServerSettingsDescriptions.AUTHENTICATION_TYPE
+import com.fsck.k9.preferences.ServerSettingsDescriptions.CLIENT_CERTIFICATE_ALIAS
+import com.fsck.k9.preferences.ServerSettingsDescriptions.CONNECTION_SECURITY
+import com.fsck.k9.preferences.ServerSettingsDescriptions.HOST
+import com.fsck.k9.preferences.ServerSettingsDescriptions.PASSWORD
+import com.fsck.k9.preferences.ServerSettingsDescriptions.PORT
+import com.fsck.k9.preferences.ServerSettingsDescriptions.USERNAME
 import com.fsck.k9.preferences.ServerTypeConverter.toServerSettingsType
 import com.fsck.k9.preferences.Settings.InvalidSettingValueException
 
 internal class ServerSettingsValidator(
-    private val serverSettingsDescriptions: ServerSettingsDescriptions = ServerSettingsDescriptions(),
+    private val settingsDescriptions: SettingsDescriptions = ServerSettingsDescriptions.SETTINGS,
 ) {
     fun validate(contentVersion: Int, server: SettingsFile.Server): ValidatedSettings.Server {
         val settings = convertServerSettingsToMap(server)
 
-        val validatedSettings = Settings.validate(contentVersion, serverSettingsDescriptions.settings, settings, true)
+        val validatedSettings = Settings.validate(contentVersion, settingsDescriptions, settings, true)
 
         if (validatedSettings[AUTHENTICATION_TYPE] !is String) {
             throw InvalidSettingValueException("Missing '$AUTHENTICATION_TYPE' value")

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsWriter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/ServerSettingsWriter.kt
@@ -4,13 +4,13 @@ import com.fsck.k9.ServerSettingsSerializer
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.mail.ServerSettings
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.AUTHENTICATION_TYPE
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CLIENT_CERTIFICATE_ALIAS
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CONNECTION_SECURITY
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.HOST
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PASSWORD
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PORT
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.USERNAME
+import com.fsck.k9.preferences.ServerSettingsDescriptions.AUTHENTICATION_TYPE
+import com.fsck.k9.preferences.ServerSettingsDescriptions.CLIENT_CERTIFICATE_ALIAS
+import com.fsck.k9.preferences.ServerSettingsDescriptions.CONNECTION_SECURITY
+import com.fsck.k9.preferences.ServerSettingsDescriptions.HOST
+import com.fsck.k9.preferences.ServerSettingsDescriptions.PASSWORD
+import com.fsck.k9.preferences.ServerSettingsDescriptions.PORT
+import com.fsck.k9.preferences.ServerSettingsDescriptions.USERNAME
 
 internal class ServerSettingsWriter(
     private val serverSettingsSerializer: ServerSettingsSerializer,

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/SettingDescriptionsHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/SettingDescriptionsHelper.kt
@@ -1,0 +1,11 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.preferences.Settings.SettingsDescription
+import java.util.TreeMap
+
+internal typealias SettingDescriptionVersions = TreeMap<Int, SettingsDescription<*>?>
+internal typealias SettingsDescriptions = Map<String, SettingDescriptionVersions>
+
+internal fun versions(vararg pairs: Pair<Int, SettingsDescription<*>?>): SettingDescriptionVersions {
+    return pairs.toMap(TreeMap<Int, SettingsDescription<*>?>())
+}

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -1,10 +1,10 @@
 package com.fsck.k9.preferences
 
 import com.fsck.k9.helper.mapCollectionToSet
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.AUTHENTICATION_TYPE
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.HOST
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PASSWORD
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.USERNAME
+import com.fsck.k9.preferences.ServerSettingsDescriptions.AUTHENTICATION_TYPE
+import com.fsck.k9.preferences.ServerSettingsDescriptions.HOST
+import com.fsck.k9.preferences.ServerSettingsDescriptions.PASSWORD
+import com.fsck.k9.preferences.ServerSettingsDescriptions.USERNAME
 import com.fsck.k9.preferences.Settings.InvalidSettingValueException
 import java.io.InputStream
 import timber.log.Timber

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsUpgradeHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsUpgradeHelper.kt
@@ -2,7 +2,6 @@ package com.fsck.k9.preferences
 
 import com.fsck.k9.K9
 import com.fsck.k9.preferences.Settings.SettingsDescription
-import java.util.TreeMap
 import timber.log.Timber
 
 internal object SettingsUpgradeHelper {
@@ -24,7 +23,7 @@ internal object SettingsUpgradeHelper {
     fun upgrade(
         version: Int,
         upgraders: Map<Int, SettingsUpgrader>,
-        settingsDescriptions: Map<String, TreeMap<Int, SettingsDescription<*>?>>,
+        settingsDescriptions: SettingsDescriptions,
         settings: Map<String, Any?>,
     ): Map<String, Any?> {
         return upgradeToVersion(Settings.VERSION, version, upgraders, settingsDescriptions, settings)
@@ -34,7 +33,7 @@ internal object SettingsUpgradeHelper {
         targetVersion: Int,
         version: Int,
         upgraders: Map<Int, SettingsUpgrader>,
-        settingsDescriptions: Map<String, TreeMap<Int, SettingsDescription<*>?>>,
+        settingsDescriptions: SettingsDescriptions,
         settings: Map<String, Any?>,
     ): Map<String, Any?> {
         val upgradedSettings = settings.toMutableMap()
@@ -49,7 +48,7 @@ internal object SettingsUpgradeHelper {
     }
 
     private fun upgradeSettingsGeneric(
-        settingsDescriptions: Map<String, TreeMap<Int, SettingsDescription<*>?>>,
+        settingsDescriptions: SettingsDescriptions,
         mutableSettings: MutableMap<String, Any?>,
         toVersion: Int,
     ) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsUpgradeHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsUpgradeHelper.kt
@@ -27,9 +27,19 @@ internal object SettingsUpgradeHelper {
         settingsDescriptions: Map<String, TreeMap<Int, SettingsDescription<*>?>>,
         settings: Map<String, Any?>,
     ): Map<String, Any?> {
+        return upgradeToVersion(Settings.VERSION, version, upgraders, settingsDescriptions, settings)
+    }
+
+    fun upgradeToVersion(
+        targetVersion: Int,
+        version: Int,
+        upgraders: Map<Int, SettingsUpgrader>,
+        settingsDescriptions: Map<String, TreeMap<Int, SettingsDescription<*>?>>,
+        settings: Map<String, Any?>,
+    ): Map<String, Any?> {
         val upgradedSettings = settings.toMutableMap()
 
-        for (toVersion in version + 1..Settings.VERSION) {
+        for (toVersion in version + 1..targetVersion) {
             upgraders[toVersion]?.upgrade(upgradedSettings)
 
             upgradeSettingsGeneric(settingsDescriptions, upgradedSettings, toVersion)

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo92.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CONNECTION_SECURITY
+import com.fsck.k9.preferences.ServerSettingsDescriptions.CONNECTION_SECURITY
 import com.fsck.k9.preferences.SettingsUpgrader
 
 class ServerSettingsUpgraderTo92 : SettingsUpgrader {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo94.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.preferences.upgrader
 
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.AUTHENTICATION_TYPE
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.CONNECTION_SECURITY
+import com.fsck.k9.preferences.ServerSettingsDescriptions.AUTHENTICATION_TYPE
+import com.fsck.k9.preferences.ServerSettingsDescriptions.CONNECTION_SECURITY
 import com.fsck.k9.preferences.SettingsUpgrader
 
 /**

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo95.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/ServerSettingsUpgraderTo95.kt
@@ -1,8 +1,8 @@
 package com.fsck.k9.preferences.upgrader
 
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.AUTHENTICATION_TYPE
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.PASSWORD
-import com.fsck.k9.preferences.ServerSettingsDescriptions.Companion.USERNAME
+import com.fsck.k9.preferences.ServerSettingsDescriptions.AUTHENTICATION_TYPE
+import com.fsck.k9.preferences.ServerSettingsDescriptions.PASSWORD
+import com.fsck.k9.preferences.ServerSettingsDescriptions.USERNAME
 import com.fsck.k9.preferences.SettingsUpgrader
 
 /**

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/AccountSettingsUpgraderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/AccountSettingsUpgraderTest.kt
@@ -1,0 +1,125 @@
+package com.fsck.k9.preferences
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import com.fsck.k9.preferences.Settings.BooleanSetting
+import com.fsck.k9.preferences.Settings.StringSetting
+import kotlin.test.Test
+
+class AccountSettingsUpgraderTest {
+    @Suppress("LongMethod")
+    @Test
+    fun `with combined settings upgrader`() {
+        val accountSettingsDescriptions = mapOf(
+            "notificationFolderMode" to versions(
+                1 to StringSetting("FIRST_CLASS"),
+                2 to null,
+            ),
+            "additional" to versions(
+                3 to StringSetting("new"),
+            ),
+        )
+        val folderSettingsUpgrader = FolderSettingsUpgrader(
+            settingsDescriptions = mapOf(
+                "notificationClass" to versions(
+                    1 to StringSetting("NO_CLASS"),
+                    2 to null,
+                ),
+                "notificationEnabled" to versions(
+                    2 to BooleanSetting(false),
+                ),
+            ),
+            upgraders = emptyMap(),
+        )
+        val combinedUpgraders = mapOf(
+            2 to {
+                CombinedSettingsUpgrader { account ->
+                    val notificationFolderMode = account.settings["notificationFolderMode"]
+                    account.copy(
+                        folders = account.folders.map { folder ->
+                            folder.copy(
+                                settings = folder.settings.toMutableMap().apply {
+                                    this["notificationEnabled"] = this["notificationClass"] == notificationFolderMode
+                                },
+                            )
+                        },
+                    )
+                }
+            },
+        )
+        val accountSettingsUpgrader = AccountSettingsUpgrader(
+            identitySettingsUpgrader = irrelevantIdentitySettingsUpgrader(),
+            folderSettingsUpgrader = folderSettingsUpgrader,
+            serverSettingsUpgrader = irrelevantServerSettingsUpgrader(),
+            latestVersion = 3,
+            settingsDescriptions = accountSettingsDescriptions,
+            upgraders = emptyMap(),
+            combinedUpgraders = combinedUpgraders,
+        )
+        val account = ValidatedSettings.Account(
+            uuid = "irrelevant",
+            name = "irrelevant",
+            incoming = irrelevantServer(),
+            outgoing = irrelevantServer(),
+            settings = mapOf(
+                "notificationFolderMode" to "SECOND_CLASS",
+            ),
+            identities = emptyList(),
+            folders = listOf(
+                ValidatedSettings.Folder(
+                    name = "folderOne",
+                    settings = mapOf(
+                        "notificationClass" to "FIRST_CLASS",
+                    ),
+                ),
+                ValidatedSettings.Folder(
+                    name = "folderTwo",
+                    settings = mapOf(
+                        "notificationClass" to "SECOND_CLASS",
+                    ),
+                ),
+            ),
+        )
+
+        val result = accountSettingsUpgrader.upgrade(contentVersion = 1, account)
+
+        assertThat(result).all {
+            prop(ValidatedSettings.Account::settings).isEqualTo(mapOf("additional" to "new"))
+            prop(ValidatedSettings.Account::folders).containsExactlyInAnyOrder(
+                ValidatedSettings.Folder(
+                    name = "folderOne",
+                    settings = mapOf(
+                        "notificationEnabled" to false,
+                    ),
+                ),
+                ValidatedSettings.Folder(
+                    name = "folderTwo",
+                    settings = mapOf(
+                        "notificationEnabled" to true,
+                    ),
+                ),
+            )
+        }
+    }
+
+    private fun irrelevantIdentitySettingsUpgrader(): IdentitySettingsUpgrader {
+        return IdentitySettingsUpgrader(
+            settingsDescriptions = emptyMap(),
+            upgraders = emptyMap(),
+        )
+    }
+
+    private fun irrelevantServerSettingsUpgrader(): ServerSettingsUpgrader {
+        return ServerSettingsUpgrader(
+            settingsDescriptions = emptyMap(),
+            upgraders = emptyMap(),
+        )
+    }
+
+    private fun irrelevantServer(): ValidatedSettings.Server {
+        return ValidatedSettings.Server(type = "irrelevant", settings = emptyMap(), extras = emptyMap())
+    }
+}

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/ServerSettingsUpgraderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/ServerSettingsUpgraderTest.kt
@@ -23,7 +23,7 @@ class ServerSettingsUpgraderTest {
             extras = emptyMap(),
         )
 
-        val upgradedServer = upgrader.upgrade(contentVersion = 1, server)
+        val upgradedServer = upgrader.upgrade(targetVersion = 92, contentVersion = 1, server)
 
         assertThat(upgradedServer).isEqualTo(
             server.copy(

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsUpgradeHelperTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsUpgradeHelperTest.kt
@@ -8,9 +8,7 @@ import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.fail
 import com.fsck.k9.preferences.Settings.BooleanSetting
-import com.fsck.k9.preferences.Settings.SettingsDescription
 import com.fsck.k9.preferences.Settings.StringSetting
-import java.util.TreeMap
 import kotlin.test.Test
 
 class SettingsUpgradeHelperTest {

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsUpgradeHelperTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsUpgradeHelperTest.kt
@@ -245,10 +245,4 @@ class SettingsUpgradeHelperTest {
             ),
         )
     }
-
-    private fun versions(
-        vararg pairs: Pair<Int, SettingsDescription<*>?>,
-    ): TreeMap<Int, SettingsDescription<*>?> {
-        return pairs.toMap(TreeMap<Int, SettingsDescription<*>?>())
-    }
 }

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsUpgradeHelperTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsUpgradeHelperTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
+import assertk.fail
 import com.fsck.k9.preferences.Settings.BooleanSetting
 import com.fsck.k9.preferences.Settings.SettingsDescription
 import com.fsck.k9.preferences.Settings.StringSetting
@@ -166,6 +167,83 @@ class SettingsUpgradeHelperTest {
             )
         }.isInstanceOf<AssertionError>()
             .hasMessage("First version of a setting must be non-null!")
+    }
+
+    @Test
+    fun `upgradeToVersion() to intermediate version`() {
+        val version = 1
+        val upgraders = emptyMap<Int, SettingsUpgrader>()
+        val settingsDescriptions = mapOf(
+            "one" to versions(
+                1 to BooleanSetting(true),
+            ),
+            "two" to versions(
+                2 to StringSetting("default"),
+            ),
+            "three" to versions(
+                3 to BooleanSetting(false),
+            ),
+        )
+        val settings = mapOf<String, Any>(
+            "one" to false,
+        )
+
+        val result = SettingsUpgradeHelper.upgradeToVersion(
+            targetVersion = 2,
+            version,
+            upgraders,
+            settingsDescriptions,
+            settings,
+        )
+
+        assertThat(result).isEqualTo(
+            mapOf(
+                "one" to false,
+                "two" to "default",
+            ),
+        )
+    }
+
+    @Test
+    fun `upgradeToVersion() with custom upgrader`() {
+        val version = 1
+        val upgraders = mapOf(
+            2 to SettingsUpgrader { settings ->
+                settings["two"] = "custom"
+            },
+            3 to SettingsUpgrader {
+                fail("SettingsUpgrader for version 3 should not be invoked")
+            },
+        )
+        val settingsDescriptions = mapOf(
+            "one" to versions(
+                1 to BooleanSetting(true),
+            ),
+            "two" to versions(
+                2 to StringSetting("default"),
+            ),
+            "three" to versions(
+                3 to BooleanSetting(false),
+            ),
+        )
+        val settings = mapOf<String, Any>(
+            "one" to false,
+        )
+
+        val result = SettingsUpgradeHelper.upgradeToVersion(
+            targetVersion = 2,
+            version,
+            upgraders,
+            settingsDescriptions,
+            settings,
+        )
+
+        assertThat(result).isEqualTo(
+            mapOf(
+                "one" to false,
+                "two" to "custom",
+            ),
+        )
     }
 
     private fun versions(


### PR DESCRIPTION
This allows an upgrader access to all settings of an account (account settings, server settings, folder settings, identity settings).

Part of #2669

Depends on #8095