### PR TITLE
Added logic to show seen messages and messages in sent items

### DIFF
--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -107,6 +107,14 @@ class Account(
 
     @get:Synchronized
     @set:Synchronized
+    var isShowSentMessages = false
+
+    @get:Synchronized
+    @set:Synchronized
+    var isShowSeenMessages = true
+
+    @get:Synchronized
+    @set:Synchronized
     var legacyInboxFolder: String? = null
 
     @get:Synchronized

--- a/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -51,8 +51,10 @@ class K9NotificationStrategy(
                     return false
                 }
                 account.sentFolderId -> {
-                    Timber.v("No notification: Message is in Sent folder")
-                    return false
+                    if (!account.isShowSentMessages) {
+                        Timber.v("No notification: Message is in Sent folder")
+                        return false
+                    }
                 }
             }
         }
@@ -72,7 +74,7 @@ class K9NotificationStrategy(
             return false
         }
 
-        if (message.isSet(Flag.SEEN)) {
+        if (!account.isShowSeenMessages && message.isSet(Flag.SEEN)) {
             Timber.v("No notification: Message is marked as read")
             return false
         }

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -68,6 +68,8 @@ class AccountPreferenceSerializer(
             isNotifySelfNewMail = storage.getBoolean("$accountUuid.notifySelfNewMail", true)
             isNotifyContactsMailOnly = storage.getBoolean("$accountUuid.notifyContactsMailOnly", false)
             isIgnoreChatMessages = storage.getBoolean("$accountUuid.ignoreChatMessages", false)
+            isShowSentMessages = storage.getBoolean("$accountUuid.showSentMessages", false)
+            isShowSeenMessages = storage.getBoolean("$accountUuid.showSeenMessages", false)
             isNotifySync = storage.getBoolean("$accountUuid.notifyMailCheck", false)
             messagesNotificationChannelVersion = storage.getInt("$accountUuid.messagesNotificationChannelVersion", 0)
             deletePolicy = DeletePolicy.fromInt(storage.getInt("$accountUuid.deletePolicy", DeletePolicy.NEVER.setting))
@@ -289,6 +291,8 @@ class AccountPreferenceSerializer(
             editor.putBoolean("$accountUuid.notifySelfNewMail", isNotifySelfNewMail)
             editor.putBoolean("$accountUuid.notifyContactsMailOnly", isNotifyContactsMailOnly)
             editor.putBoolean("$accountUuid.ignoreChatMessages", isIgnoreChatMessages)
+            editor.putBoolean("$accountUuid.showSentMessages", isShowSeenMessages)
+            editor.putBoolean("$accountUuid.showSeenMessages", isShowSentMessages)
             editor.putBoolean("$accountUuid.notifyMailCheck", isNotifySync)
             editor.putInt("$accountUuid.messagesNotificationChannelVersion", messagesNotificationChannelVersion)
             editor.putInt("$accountUuid.deletePolicy", deletePolicy.setting)
@@ -408,6 +412,8 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.notifyNewMail")
         editor.remove("$accountUuid.notifySelfNewMail")
         editor.remove("$accountUuid.ignoreChatMessages")
+        editor.remove("$accountUuid.showSentMessages")
+        editor.remove("$accountUuid.showSeenMessages")
         editor.remove("$accountUuid.messagesNotificationChannelVersion")
         editor.remove("$accountUuid.deletePolicy")
         editor.remove("$accountUuid.draftsFolderName")
@@ -581,6 +587,8 @@ class AccountPreferenceSerializer(
             isNotifySelfNewMail = true
             isNotifyContactsMailOnly = false
             isIgnoreChatMessages = false
+            isShowSentMessages = false
+            isShowSeenMessages = false
             messagesNotificationChannelVersion = 0
             folderDisplayMode = FolderMode.NOT_SECOND_CLASS
             folderSyncMode = FolderMode.FIRST_CLASS

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -267,7 +267,13 @@ class AccountSettingsDescriptions {
                 new V(54, new EnumSetting<>(SpecialFolderSelection.class, SpecialFolderSelection.AUTOMATIC))
         ));
         s.put("ignoreChatMessages", Settings.versions(
-                new V(76, new BooleanSetting(false))
+            new V(76, new BooleanSetting(false))
+        ));
+        s.put("showSentMessages", Settings.versions(
+            new V(96, new BooleanSetting(false))
+        ));
+        s.put("showSeenMessages", Settings.versions(
+            new V(96, new BooleanSetting(false))
         ));
         s.put("notificationLight", Settings.versions(
                 new V(80, new EnumSetting<>(NotificationLight.class, NotificationLight.Disabled))

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -33,7 +33,7 @@ class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 95;
+    public static final int VERSION = 96;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription<?>>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -43,6 +43,8 @@ class AccountSettingsDataStore(
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual
             "upload_sent_messages" -> account.isUploadSentMessages
             "ignore_chat_messages" -> account.isIgnoreChatMessages
+            "show_sent_messages" -> account.isShowSentMessages
+            "show_seen_messages" -> account.isShowSeenMessages
             "subscribed_folders_only" -> account.isSubscribedFoldersOnly
             else -> defValue
         }
@@ -68,6 +70,8 @@ class AccountSettingsDataStore(
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual = value
             "upload_sent_messages" -> account.isUploadSentMessages = value
             "ignore_chat_messages" -> account.isIgnoreChatMessages = value
+            "show_sent_messages" -> account.isShowSentMessages = value
+            "show_seen_messages" -> account.isShowSeenMessages = value
             "subscribed_folders_only" -> updateSubscribedFoldersOnly(value)
             else -> return
         }

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -398,6 +398,10 @@
     <string name="account_notify_contacts_mail_only_summary">Show notifications only for messages from known contacts</string>
     <string name="account_settings_ignore_chat_messages_label">Ignore chat messages</string>
     <string name="account_settings_ignore_chat_messages_summary">Don\'t show notifications for messages belonging to an email chat</string>
+    <string name="account_settings_show_seen_messages_label">Show seen messages</string>
+    <string name="account_settings_show_seen_messages_summary">Show notifications for messages already read on the server side</string>
+    <string name="account_settings_show_sent_messages_label">Show sent messages</string>
+    <string name="account_settings_show_sent_messages_summary">Show notifications for messages in the Sent folder (if also configured in "Notifications folders")</string>
     <string name="account_settings_mark_message_as_read_on_view_label">Mark as read when opened</string>
     <string name="account_settings_mark_message_as_read_on_view_summary">Mark a message as read when it is opened for viewing</string>
     <string name="account_settings_mark_message_as_read_on_delete_label">Mark as read when deleted</string>

--- a/legacy/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/account_settings.xml
@@ -367,6 +367,22 @@
             android:title="@string/account_settings_ignore_chat_messages_label"
             />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:dependency="account_notify"
+            android:key="show_sent_messages"
+            android:summary="@string/account_settings_show_sent_messages_summary"
+            android:title="@string/account_settings_show_sent_messages_label"
+            />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:dependency="account_notify"
+            android:key="show_seen_messages"
+            android:summary="@string/account_settings_show_seen_messages_summary"
+            android:title="@string/account_settings_show_seen_messages_label"
+            />
+
         <com.fsck.k9.ui.settings.account.NotificationSoundPreference
             android:defaultValue="content://settings/system/notification_sound"
             android:dependency="account_notify"


### PR DESCRIPTION
Hey team!

This is something I did mostly for myself but I'm opening a PR in case it's something you're interested in. It adds these to account settings:
![image](https://github.com/user-attachments/assets/52947642-dc4d-4799-b11c-3a52d3e8c837)

It fixes two minor annoyances with using a shared email address:
 - If someone else reads things before I see them then I don't get notified (K9 clears the notification)
 - I can get notified of things another person sends from the email address

It mainly amounts to changes to `K9NotificationStrategy` and the supporting code to expose the settings. 

Might need further chipping away at things like translations and unit tests - happy to help as I can (I won't be much use at translations though unfortunately).