### PR TITLE
Remove default signature

### DIFF
--- a/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/FakeCoreResourceProvider.kt
+++ b/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/FakeCoreResourceProvider.kt
@@ -8,10 +8,6 @@ class FakeCoreResourceProvider : CoreResourceProvider {
 
     override fun searchUnifiedInboxDetail(): String = "All messages in unified folders"
 
-    override fun defaultSignature(): String {
-        throw UnsupportedOperationException("not implemented")
-    }
-
     override fun defaultIdentityDescription(): String {
         throw UnsupportedOperationException("not implemented")
     }

--- a/legacy/common/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.resources
 
 import android.content.Context
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.notification.PushNotificationState
@@ -9,9 +8,7 @@ import com.fsck.k9.ui.R
 
 class K9CoreResourceProvider(
     private val context: Context,
-    private val appNameProvider: AppNameProvider,
 ) : CoreResourceProvider {
-    override fun defaultSignature(): String = context.getString(R.string.default_signature, appNameProvider.appName)
     override fun defaultIdentityDescription(): String = context.getString(R.string.default_identity_description)
 
     override fun contactDisplayNamePrefix(): String = context.getString(R.string.message_to_label)

--- a/legacy/common/src/main/java/com/fsck/k9/resources/KoinModule.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/resources/KoinModule.kt
@@ -8,7 +8,6 @@ val resourcesModule = module {
     single<CoreResourceProvider> {
         K9CoreResourceProvider(
             context = get(),
-            appNameProvider = get(),
         )
     }
     single<AutocryptStringProvider> {

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -626,7 +626,7 @@ class AccountPreferenceSerializer(
 
             val identity = Identity(
                 signatureUse = false,
-                signature = resourceProvider.defaultSignature(),
+                signature = null,
                 description = resourceProvider.defaultIdentityDescription(),
             )
             identities.add(identity)

--- a/legacy/core/src/main/java/com/fsck/k9/CoreResourceProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/CoreResourceProvider.kt
@@ -3,7 +3,6 @@ package com.fsck.k9
 import com.fsck.k9.notification.PushNotificationState
 
 interface CoreResourceProvider {
-    fun defaultSignature(): String
     fun defaultIdentityDescription(): String
 
     fun contactDisplayNamePrefix(): String

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/IdentitySettingsDescriptions.java
@@ -13,6 +13,7 @@ import com.fsck.k9.EmailAddressValidator;
 import com.fsck.k9.preferences.Settings.BooleanSetting;
 import com.fsck.k9.preferences.Settings.InvalidSettingValueException;
 import com.fsck.k9.preferences.Settings.SettingsDescription;
+import com.fsck.k9.preferences.Settings.StringSetting;
 import com.fsck.k9.preferences.Settings.V;
 
 
@@ -29,7 +30,7 @@ class IdentitySettingsDescriptions {
          */
 
         s.put("signature", Settings.versions(
-                new V(1, new SignatureSetting())
+                new V(1, new StringSetting(null))
         ));
         s.put("signatureUse", Settings.versions(
                 new V(1, new BooleanSetting(true)),
@@ -56,29 +57,6 @@ class IdentitySettingsDescriptions {
 
     static boolean isEmailAddressValid(String email) {
         return new EmailAddressValidator().isValidAddressOnly(email);
-    }
-
-    private static class SignatureSetting extends SettingsDescription<String> {
-        private final CoreResourceProvider resourceProvider = DI.get(CoreResourceProvider.class);
-
-        SignatureSetting() {
-            super(null);
-        }
-
-        @Override
-        public String getDefaultValue() {
-            return resourceProvider.defaultSignature();
-        }
-
-        @Override
-        public String fromString(String value) throws InvalidSettingValueException {
-            return value;
-        }
-
-        @Override
-        public String toString(String value) {
-            return value;
-        }
     }
 
     private static class OptionalEmailAddressSetting extends SettingsDescription<String> {

--- a/legacy/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
@@ -3,8 +3,6 @@ package com.fsck.k9
 import com.fsck.k9.notification.PushNotificationState
 
 class TestCoreResourceProvider : CoreResourceProvider {
-    override fun defaultSignature() = "\n--\nbrevity!"
-
     override fun defaultIdentityDescription() = "initial identity"
 
     override fun contactDisplayNamePrefix() = "To:"

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -23,11 +23,6 @@
     <!-- Button text of the "snack bar" that is displayed when the app was updated. -->
     <string name="changelog_snackbar_button_text">View</string>
 
-
-    <!-- Default signature -->
-    <string name="default_signature">-- \nSent from my Android device with <xliff:g id="app_name">%s</xliff:g>. Please excuse my brevity.</string>
-
-
     <!-- General strings that include the app name -->
     <string name="account_delete_dlg_instructions_fmt">The account \"<xliff:g id="account">%s</xliff:g>\" will be removed from <xliff:g id="app_name">%s</xliff:g>.</string>
 

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
@@ -3,8 +3,6 @@ package com.fsck.k9
 import com.fsck.k9.notification.PushNotificationState
 
 class TestCoreResourceProvider : CoreResourceProvider {
-    override fun defaultSignature() = throw UnsupportedOperationException("not implemented")
-
     override fun defaultIdentityDescription() = throw UnsupportedOperationException("not implemented")
 
     override fun contactDisplayNamePrefix() = throw UnsupportedOperationException("not implemented")


### PR DESCRIPTION
Since we're asking the user to provide a signature during account setup (and defaulting to an empty one), the default signature isn't really used anymore.

This does change the behavior when importing a settings file without a signature key present. Instead of using the old default signature, now an empty signature will be used. I think this behavior change is acceptable.