### PR TITLE
Move theme to `:core:ui:theme:api` module

### DIFF
--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -4,9 +4,9 @@ import app.k9mail.auth.K9OAuthConfigurationFactory
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
+import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.dev.developmentModuleAdditions
-import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import app.k9mail.featureflag.K9FeatureFlagFactory
 import app.k9mail.provider.K9AppNameProvider

--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -4,11 +4,11 @@ import app.k9mail.auth.K9OAuthConfigurationFactory
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
+import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.dev.developmentModuleAdditions
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import app.k9mail.featureflag.K9FeatureFlagFactory
-import app.k9mail.legacy.ui.theme.ThemeProvider
 import app.k9mail.provider.K9AppNameProvider
 import app.k9mail.provider.K9FeatureThemeProvider
 import app.k9mail.widget.appWidgetModule

--- a/app-k9mail/src/main/kotlin/app/k9mail/provider/K9FeatureThemeProvider.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/provider/K9FeatureThemeProvider.kt
@@ -2,9 +2,9 @@ package app.k9mail.provider
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.theme2.k9mail.K9MailTheme2
-import app.k9mail.feature.launcher.FeatureLauncherExternalContract
+import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 
-class K9FeatureThemeProvider : FeatureLauncherExternalContract.FeatureThemeProvider {
+class K9FeatureThemeProvider : FeatureThemeProvider {
     @Composable
     override fun WithTheme(content: @Composable () -> Unit) {
         K9MailTheme2 {

--- a/app-k9mail/src/main/kotlin/com/fsck/k9/provider/K9ThemeProvider.kt
+++ b/app-k9mail/src/main/kotlin/com/fsck/k9/provider/K9ThemeProvider.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.provider
 
-import app.k9mail.legacy.ui.theme.ThemeProvider
+import app.k9mail.core.ui.theme.api.ThemeProvider
 import com.fsck.k9.R
 
 class K9ThemeProvider : ThemeProvider {

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -3,8 +3,8 @@ package net.thunderbird.android
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
+import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
-import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import com.fsck.k9.AppConfig
 import com.fsck.k9.activity.MessageCompose

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -3,9 +3,9 @@ package net.thunderbird.android
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
+import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
-import app.k9mail.legacy.ui.theme.ThemeProvider
 import com.fsck.k9.AppConfig
 import com.fsck.k9.activity.MessageCompose
 import net.thunderbird.android.auth.TbOAuthConfigurationFactory

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbFeatureThemeProvider.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbFeatureThemeProvider.kt
@@ -2,9 +2,9 @@ package net.thunderbird.android.provider
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.theme2.thunderbird.ThunderbirdTheme2
-import app.k9mail.feature.launcher.FeatureLauncherExternalContract
+import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 
-class TbFeatureThemeProvider : FeatureLauncherExternalContract.FeatureThemeProvider {
+class TbFeatureThemeProvider : FeatureThemeProvider {
     @Composable
     override fun WithTheme(content: @Composable () -> Unit) {
         ThunderbirdTheme2 {

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbThemeProvider.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbThemeProvider.kt
@@ -1,6 +1,6 @@
 package net.thunderbird.android.provider
 
-import app.k9mail.legacy.ui.theme.ThemeProvider
+import app.k9mail.core.ui.theme.api.ThemeProvider
 import net.thunderbird.android.R
 
 class TbThemeProvider : ThemeProvider {

--- a/core/ui/theme/README.md
+++ b/core/ui/theme/README.md
@@ -1,0 +1,3 @@
+## Theme
+
+The app theme is provided by the `ThemeProvider` found in the `api` module and should be implemented in the app modules with the required app themes from the `core:compose` and `core:legacy` modules.

--- a/core/ui/theme/api/build.gradle.kts
+++ b/core/ui/theme/api/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id(ThunderbirdPlugins.Library.android)
+    id(ThunderbirdPlugins.Library.androidCompose)
 }
 
 android {

--- a/core/ui/theme/api/build.gradle.kts
+++ b/core/ui/theme/api/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id(ThunderbirdPlugins.Library.android)
+}
+
+android {
+    namespace = "app.k9mail.core.ui.theme.api"
+}

--- a/core/ui/theme/api/src/main/kotlin/app/k9mail/core/ui/theme/api/FeatureThemeProvider.kt
+++ b/core/ui/theme/api/src/main/kotlin/app/k9mail/core/ui/theme/api/FeatureThemeProvider.kt
@@ -1,0 +1,13 @@
+package app.k9mail.core.ui.theme.api
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Provides the compose theme for a feature.
+ */
+fun interface FeatureThemeProvider {
+    @Composable
+    fun WithTheme(
+        content: @Composable () -> Unit,
+    )
+}

--- a/core/ui/theme/api/src/main/kotlin/app/k9mail/core/ui/theme/api/Theme.kt
+++ b/core/ui/theme/api/src/main/kotlin/app/k9mail/core/ui/theme/api/Theme.kt
@@ -1,0 +1,6 @@
+package app.k9mail.core.ui.theme.api
+
+enum class Theme {
+    LIGHT,
+    DARK,
+}

--- a/core/ui/theme/api/src/main/kotlin/app/k9mail/core/ui/theme/api/ThemeManager.kt
+++ b/core/ui/theme/api/src/main/kotlin/app/k9mail/core/ui/theme/api/ThemeManager.kt
@@ -1,0 +1,25 @@
+package app.k9mail.core.ui.theme.api
+
+import androidx.annotation.StyleRes
+
+interface ThemeManager {
+
+    val appTheme: Theme
+    val messageViewTheme: Theme
+    val messageComposeTheme: Theme
+
+    @get:StyleRes
+    val appThemeResourceId: Int
+
+    @get:StyleRes
+    val messageViewThemeResourceId: Int
+
+    @get:StyleRes
+    val messageComposeThemeResourceId: Int
+
+    @get:StyleRes
+    val dialogThemeResourceId: Int
+
+    @get:StyleRes
+    val translucentDialogThemeResourceId: Int
+}

--- a/core/ui/theme/api/src/main/kotlin/app/k9mail/core/ui/theme/api/ThemeProvider.kt
+++ b/core/ui/theme/api/src/main/kotlin/app/k9mail/core/ui/theme/api/ThemeProvider.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.ui.theme
+package app.k9mail.core.ui.theme.api
 
 import androidx.annotation.StyleRes
 

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherExternalContract.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherExternalContract.kt
@@ -1,21 +1,9 @@
 package app.k9mail.feature.launcher
 
-import androidx.compose.runtime.Composable
-
 /**
  * Contract defining the external functionality of the feature launcher to be provided by the host application.
  */
 interface FeatureLauncherExternalContract {
-
-    /**
-     * Provides the theme for the feature.
-     */
-    fun interface FeatureThemeProvider {
-        @Composable
-        fun WithTheme(
-            content: @Composable () -> Unit,
-        )
-    }
 
     fun interface AccountSetupFinishedLauncher {
         fun launch(accountUuid: String?)

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/ui/FeatureLauncherApp.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/ui/FeatureLauncherApp.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
 import app.k9mail.core.ui.compose.common.activity.LocalActivity
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
-import app.k9mail.feature.launcher.FeatureLauncherExternalContract.FeatureThemeProvider
+import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.feature.launcher.navigation.FeatureLauncherNavHost
 import org.koin.compose.koinInject
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -13,6 +13,7 @@ import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.theme.api.Theme
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.folder.DisplayFolder
 import app.k9mail.legacy.folder.Folder
@@ -26,7 +27,6 @@ import app.k9mail.legacy.ui.folder.FolderIconProvider
 import app.k9mail.legacy.ui.folder.FolderList
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import app.k9mail.legacy.ui.folder.FoldersViewModel
-import app.k9mail.legacy.ui.theme.Theme
 import app.k9mail.legacy.ui.theme.ThemeManager
 import com.fsck.k9.K9
 import com.fsck.k9.ui.base.livedata.observeNotNull

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/helper/HtmlSettingsProvider.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/helper/HtmlSettingsProvider.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.ui.helper
 
-import app.k9mail.legacy.ui.theme.Theme
+import app.k9mail.core.ui.theme.api.Theme
 import app.k9mail.legacy.ui.theme.ThemeManager
 import com.fsck.k9.K9
 import com.fsck.k9.message.html.HtmlSettings

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -23,11 +23,11 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResultListener
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.theme.api.Theme
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.preferences.GeneralSettingsManager
-import app.k9mail.legacy.ui.theme.Theme
 import app.k9mail.legacy.ui.theme.ThemeManager
 import com.fsck.k9.K9
 import com.fsck.k9.activity.MessageCompose

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/WebViewConfigProvider.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/WebViewConfigProvider.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.view
 
-import app.k9mail.legacy.ui.theme.Theme
+import app.k9mail.core.ui.theme.api.Theme
 import app.k9mail.legacy.ui.theme.ThemeManager
 import com.fsck.k9.K9
 

--- a/legacy/ui/theme/build.gradle.kts
+++ b/legacy/ui/theme/build.gradle.kts
@@ -7,6 +7,8 @@ android {
 }
 
 dependencies {
+    api(projects.core.ui.theme.api)
+
     implementation(projects.core.ui.legacy.designsystem)
 
     implementation(projects.legacy.preferences)

--- a/legacy/ui/theme/src/main/java/app/k9mail/legacy/ui/theme/ThemeManager.kt
+++ b/legacy/ui/theme/src/main/java/app/k9mail/legacy/ui/theme/ThemeManager.kt
@@ -5,8 +5,9 @@ import android.content.res.Configuration
 import android.os.Build
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatDelegate
-import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.core.ui.theme.api.Theme
+import app.k9mail.core.ui.theme.api.ThemeManager
+import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.legacy.preferences.AppTheme
 import app.k9mail.legacy.preferences.GeneralSettings
 import app.k9mail.legacy.preferences.GeneralSettingsManager
@@ -24,12 +25,12 @@ class ThemeManager(
     private val themeProvider: ThemeProvider,
     private val generalSettingsManager: GeneralSettingsManager,
     private val appCoroutineScope: CoroutineScope,
-) {
+) : ThemeManager {
 
     private val generalSettings: GeneralSettings
         get() = generalSettingsManager.getSettings()
 
-    val appTheme: Theme
+    override val appTheme: Theme
         get() = when (generalSettings.appTheme) {
             AppTheme.LIGHT -> Theme.LIGHT
             AppTheme.DARK -> Theme.DARK
@@ -40,28 +41,28 @@ class ThemeManager(
             }
         }
 
-    val messageViewTheme: Theme
+    override val messageViewTheme: Theme
         get() = resolveTheme(generalSettings.messageViewTheme)
 
-    val messageComposeTheme: Theme
+    override val messageComposeTheme: Theme
         get() = resolveTheme(generalSettings.messageComposeTheme)
 
     @get:StyleRes
-    val appThemeResourceId: Int = themeProvider.appThemeResourceId
+    override val appThemeResourceId: Int = themeProvider.appThemeResourceId
 
     @get:StyleRes
-    val messageViewThemeResourceId: Int
+    override val messageViewThemeResourceId: Int
         get() = getSubThemeResourceId(generalSettings.messageViewTheme)
 
     @get:StyleRes
-    val messageComposeThemeResourceId: Int
+    override val messageComposeThemeResourceId: Int
         get() = getSubThemeResourceId(generalSettings.messageComposeTheme)
 
     @get:StyleRes
-    val dialogThemeResourceId: Int = themeProvider.dialogThemeResourceId
+    override val dialogThemeResourceId: Int = themeProvider.dialogThemeResourceId
 
     @get:StyleRes
-    val translucentDialogThemeResourceId: Int = themeProvider.translucentDialogThemeResourceId
+    override val translucentDialogThemeResourceId: Int = themeProvider.translucentDialogThemeResourceId
 
     fun init() {
         generalSettingsManager.getSettingsFlow()
@@ -116,4 +117,3 @@ class ThemeManager(
         }
     }
 }
-

--- a/legacy/ui/theme/src/main/java/app/k9mail/legacy/ui/theme/ThemeManager.kt
+++ b/legacy/ui/theme/src/main/java/app/k9mail/legacy/ui/theme/ThemeManager.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatDelegate
 import app.k9mail.core.ui.theme.api.ThemeProvider
+import app.k9mail.core.ui.theme.api.Theme
 import app.k9mail.legacy.preferences.AppTheme
 import app.k9mail.legacy.preferences.GeneralSettings
 import app.k9mail.legacy.preferences.GeneralSettingsManager
@@ -116,7 +117,3 @@ class ThemeManager(
     }
 }
 
-enum class Theme {
-    LIGHT,
-    DARK,
-}

--- a/legacy/ui/theme/src/main/java/app/k9mail/legacy/ui/theme/ThemeManager.kt
+++ b/legacy/ui/theme/src/main/java/app/k9mail/legacy/ui/theme/ThemeManager.kt
@@ -5,6 +5,7 @@ import android.content.res.Configuration
 import android.os.Build
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatDelegate
+import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.legacy.preferences.AppTheme
 import app.k9mail.legacy.preferences.GeneralSettings
 import app.k9mail.legacy.preferences.GeneralSettingsManager

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -88,6 +88,7 @@ include(
     ":core:ui:legacy:theme2:common",
     ":core:ui:legacy:theme2:k9mail",
     ":core:ui:legacy:theme2:thunderbird",
+    ":core:ui:theme:api",
 )
 
 include(


### PR DESCRIPTION
As part of #8104, this moves parts of the legacy theme handling to the `:core:ui:theme:api` module to allow use of the theme within the new drawer.

The theme implementation needs more effort to apply similar rules to the compose theme, but that's out of scope of this pull-request: #8116
