### PR TITLE
Add setting for app telemetry

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(projects.feature.widget.messageList)
     implementation(projects.feature.widget.shortcut)
     implementation(projects.feature.widget.unread)
+    implementation(projects.feature.telemetry.api)
 
     implementation(libs.androidx.work.runtime)
 

--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -7,10 +7,12 @@ import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.dev.developmentModuleAdditions
+import app.k9mail.feature.telemetry.api.TelemetryManager
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import app.k9mail.featureflag.K9FeatureFlagFactory
 import app.k9mail.provider.K9AppNameProvider
 import app.k9mail.provider.K9FeatureThemeProvider
+import app.k9mail.telemetry.K9TelemetryManager
 import app.k9mail.widget.appWidgetModule
 import com.fsck.k9.AppConfig
 import com.fsck.k9.BuildConfig
@@ -33,6 +35,7 @@ val appModule = module {
     single<ThemeProvider> { K9ThemeProvider() }
     single<FeatureThemeProvider> { K9FeatureThemeProvider() }
     single<FeatureFlagFactory> { K9FeatureFlagFactory() }
+    single<TelemetryManager> { K9TelemetryManager() }
 
     developmentModuleAdditions()
 }

--- a/app-k9mail/src/main/kotlin/app/k9mail/telemetry/K9TelemetryManager.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/telemetry/K9TelemetryManager.kt
@@ -1,0 +1,7 @@
+package app.k9mail.telemetry
+
+import app.k9mail.feature.telemetry.api.TelemetryManager
+
+class K9TelemetryManager : TelemetryManager {
+    override fun isTelemetryFeatureIncluded(): Boolean = false
+}

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(projects.feature.widget.messageList)
     implementation(projects.feature.widget.shortcut)
     implementation(projects.feature.widget.unread)
+    implementation(projects.feature.telemetry.glean)
 
     implementation(libs.androidx.work.runtime)
 

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -5,6 +5,8 @@ import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
+import app.k9mail.feature.telemetry.api.TelemetryManager
+import app.k9mail.feature.telemetry.glean.GleanTelemetryManager
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import com.fsck.k9.AppConfig
 import com.fsck.k9.activity.MessageCompose
@@ -32,6 +34,7 @@ val appModule = module {
     single<ThemeProvider> { TbThemeProvider() }
     single<FeatureThemeProvider> { TbFeatureThemeProvider() }
     single<FeatureFlagFactory> { TbFeatureFlagFactory() }
+    single<TelemetryManager> { GleanTelemetryManager() }
 
     developmentModuleAdditions()
 }

--- a/core/ui/legacy/designsystem/src/main/res/drawable/ic_analytics.xml
+++ b/core/ui/legacy/designsystem/src/main/res/drawable/ic_analytics.xml
@@ -1,0 +1,35 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    >
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5C21,3.9 20.1,3 19,3zM19,19H5V5h14V19z"
+        />
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,12h2v5h-2z"
+        />
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15,7h2v10h-2z"
+        />
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,14h2v3h-2z"
+        />
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,10h2v2h-2z"
+        />
+
+</vector>

--- a/feature/telemetry/api/build.gradle.kts
+++ b/feature/telemetry/api/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id(ThunderbirdPlugins.Library.jvm)
+}

--- a/feature/telemetry/api/src/main/kotlin/app/k9mail/feature/telemetry/api/TelemetryManager.kt
+++ b/feature/telemetry/api/src/main/kotlin/app/k9mail/feature/telemetry/api/TelemetryManager.kt
@@ -1,0 +1,8 @@
+package app.k9mail.feature.telemetry.api
+
+interface TelemetryManager {
+    /**
+     * Returns `true` if the app has a telemetry feature included.
+     */
+    fun isTelemetryFeatureIncluded(): Boolean
+}

--- a/feature/telemetry/glean/build.gradle.kts
+++ b/feature/telemetry/glean/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id(ThunderbirdPlugins.Library.android)
+}
+
+android {
+    namespace = "app.k9mail.feature.telemetry.glean"
+    resourcePrefix = "telemetry_glean_"
+}
+
+dependencies {
+    api(projects.feature.telemetry.api)
+}

--- a/feature/telemetry/glean/src/main/kotlin/app/k9mail/feature/telemetry/glean/GleanTelemetryManager.kt
+++ b/feature/telemetry/glean/src/main/kotlin/app/k9mail/feature/telemetry/glean/GleanTelemetryManager.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.telemetry.glean
+
+import app.k9mail.feature.telemetry.api.TelemetryManager
+
+class GleanTelemetryManager : TelemetryManager {
+    override fun isTelemetryFeatureIncluded(): Boolean = true
+}

--- a/legacy/core/build.gradle.kts
+++ b/legacy/core/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     api(projects.legacy.search)
 
     implementation(projects.plugins.openpgpApiLib.openpgpApi)
+    implementation(projects.feature.telemetry.api)
 
     api(libs.androidx.annotation)
 

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -2,6 +2,7 @@ package com.fsck.k9
 
 import android.content.Context
 import android.content.SharedPreferences
+import app.k9mail.feature.telemetry.api.TelemetryManager
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.SortType
 import app.k9mail.legacy.di.DI
@@ -20,6 +21,7 @@ import timber.log.Timber.DebugTree
 // TODO "Use GeneralSettingsManager and GeneralSettings instead"
 object K9 : EarlyInit {
     private val generalSettingsManager: RealGeneralSettingsManager by inject()
+    private val telemetryManager: TelemetryManager by inject()
 
     /**
      * If this is `true`, various development settings will be enabled.
@@ -267,6 +269,11 @@ object K9 : EarlyInit {
     @JvmStatic
     var swipeLeftAction: SwipeAction = SwipeAction.ToggleRead
 
+    // TODO: This is a feature-specific setting that doesn't need to be available to apps that don't include the
+    //  feature. Extract `Storage` and `StorageEditor` to a separate module so feature modules can retrieve and store
+    //  their own settings.
+    var isTelemetryEnabled = false
+
     val isQuietTime: Boolean
         get() {
             if (!isQuietTimeEnabled) {
@@ -384,6 +391,10 @@ object K9 : EarlyInit {
 
         swipeRightAction = storage.getEnum("swipeRightAction", SwipeAction.ToggleSelection)
         swipeLeftAction = storage.getEnum("swipeLeftAction", SwipeAction.ToggleRead)
+
+        if (telemetryManager.isTelemetryFeatureIncluded()) {
+            isTelemetryEnabled = storage.getBoolean("enableTelemetry", true)
+        }
     }
 
     internal fun save(editor: StorageEditor) {
@@ -447,6 +458,10 @@ object K9 : EarlyInit {
 
         editor.putEnum("swipeRightAction", swipeRightAction)
         editor.putEnum("swipeLeftAction", swipeLeftAction)
+
+        if (telemetryManager.isTelemetryFeatureIncluded()) {
+            editor.putBoolean("enableTelemetry", isTelemetryEnabled)
+        }
 
         fontSizes.save(editor)
     }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -9,6 +9,7 @@ import java.util.TreeMap;
 
 import android.content.Context;
 
+import app.k9mail.feature.telemetry.api.TelemetryManager;
 import app.k9mail.legacy.account.Account;
 import app.k9mail.legacy.account.Account.SortType;
 import app.k9mail.legacy.di.DI;
@@ -47,6 +48,8 @@ import static com.fsck.k9.K9.LockScreenNotificationVisibility;
 class GeneralSettingsDescriptions {
     static final Map<String, TreeMap<Integer, SettingsDescription<?>>> SETTINGS;
     private static final Map<Integer, SettingsUpgrader> UPGRADERS;
+
+    private static final TelemetryManager telemetryManager = DI.get(TelemetryManager.class);
 
     static {
         Map<String, TreeMap<Integer, SettingsDescription<?>>> s = new LinkedHashMap<>();
@@ -297,6 +300,13 @@ class GeneralSettingsDescriptions {
             new V(90,
                 new EnumSetting<>(PostMarkAsUnreadNavigation.class, PostMarkAsUnreadNavigation.ReturnToMessageList))
         ));
+
+        // TODO: Add a way to properly support feature-specific settings.
+        if (telemetryManager.isTelemetryFeatureIncluded()) {
+            s.put("enableTelemetry", Settings.versions(
+                new V(97, new BooleanSetting(true))
+            ));
+        }
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -33,7 +33,7 @@ class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 96;
+    public static final int VERSION = 97;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription<?>>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/legacy/core/src/test/java/com/fsck/k9/TestApp.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/TestApp.kt
@@ -2,6 +2,7 @@ package com.fsck.k9
 
 import android.app.Application
 import androidx.work.WorkManager
+import app.k9mail.feature.telemetry.api.TelemetryManager
 import app.k9mail.legacy.di.DI
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.controller.ControllerExtension
@@ -43,4 +44,9 @@ val testModule = module {
     single { mock<NotificationStrategy>() }
     single(named("controllerExtensions")) { emptyList<ControllerExtension>() }
     single { mock<WorkManager>() }
+    single<TelemetryManager> {
+        object : TelemetryManager {
+            override fun isTelemetryFeatureIncluded(): Boolean = true
+        }
+    }
 }

--- a/legacy/storage/build.gradle.kts
+++ b/legacy/storage/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
     testImplementation(projects.mail.testing)
     testImplementation(projects.legacy.testing)
+    testImplementation(projects.feature.telemetry.api)
     testImplementation(libs.robolectric)
     testImplementation(libs.commons.io)
 }

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/TestApp.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/TestApp.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.storage
 
 import android.app.Application
+import app.k9mail.feature.telemetry.api.TelemetryManager
 import app.k9mail.legacy.di.DI
 import com.fsck.k9.AppConfig
 import com.fsck.k9.Core
@@ -32,4 +33,9 @@ val testModule = module {
     single { mock<EncryptionExtractor>() }
     single<StoragePersister> { K9StoragePersister(get()) }
     single { mock<BackendManager>() }
+    single<TelemetryManager> {
+        object : TelemetryManager {
+            override fun isTelemetryFeatureIncluded(): Boolean = true
+        }
+    }
 }

--- a/legacy/ui/legacy/build.gradle.kts
+++ b/legacy/ui/legacy/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     // TODO: Remove AccountOauth dependency
     implementation(projects.feature.account.oauth)
     implementation(projects.feature.settings.import)
+    implementation(projects.feature.telemetry.api)
 
     compileOnly(projects.mail.protocols.imap)
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -45,6 +45,7 @@ class GeneralSettingsDataStore(
             "debug_logging" -> K9.isDebugLoggingEnabled
             "sensitive_logging" -> K9.isSensitiveDebugLoggingEnabled
             "volume_navigation" -> K9.isUseVolumeKeysForNavigation
+            "enable_telemetry" -> K9.isTelemetryEnabled
             else -> defValue
         }
     }
@@ -74,6 +75,7 @@ class GeneralSettingsDataStore(
             "debug_logging" -> K9.isDebugLoggingEnabled = value
             "sensitive_logging" -> K9.isSensitiveDebugLoggingEnabled = value
             "volume_navigation" -> K9.isUseVolumeKeysForNavigation = value
+            "enable_telemetry" -> K9.isTelemetryEnabled = value
             else -> return
         }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
@@ -7,9 +7,12 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import androidx.activity.result.contract.ActivityResultContracts.CreateDocument
 import androidx.preference.ListPreference
+import androidx.preference.Preference
+import app.k9mail.feature.telemetry.api.TelemetryManager
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.extensions.withArguments
 import com.fsck.k9.ui.observe
+import com.fsck.k9.ui.settings.remove
 import com.google.android.material.snackbar.Snackbar
 import com.takisoft.preferencex.PreferenceFragmentCompat
 import org.koin.android.ext.android.inject
@@ -19,6 +22,7 @@ import com.fsck.k9.core.R as CoreR
 class GeneralSettingsFragment : PreferenceFragmentCompat() {
     private val viewModel: GeneralSettingsViewModel by viewModel()
     private val dataStore: GeneralSettingsDataStore by inject()
+    private val telemetryManager: TelemetryManager by inject()
 
     private var rootKey: String? = null
     private var currentUiState: GeneralSettingsUiState? = null
@@ -37,6 +41,7 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
         setPreferencesFromResource(R.xml.general_settings, rootKey)
 
         initializeTheme()
+        initializeDataCollection()
 
         viewModel.uiState.observe(this) { uiState ->
             updateUiState(uiState)
@@ -80,6 +85,12 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
         }
     }
 
+    private fun initializeDataCollection() {
+        if (!telemetryManager.isTelemetryFeatureIncluded()) {
+            findPreference<Preference>(PREFERENCE_DATA_COLLECTION)?.remove()
+        }
+    }
+
     private fun updateUiState(uiState: GeneralSettingsUiState) {
         val oldUiState = currentUiState
         currentUiState = uiState
@@ -119,6 +130,7 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
     companion object {
         private const val PREFERENCE_THEME = "theme"
         private const val PREFERENCE_SCREEN_DEBUGGING = "debug_preferences"
+        private const val PREFERENCE_DATA_COLLECTION = "data_collection"
 
         fun create(rootKey: String? = null) = GeneralSettingsFragment().withArguments(ARG_PREFERENCE_ROOT to rootKey)
     }

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -1114,4 +1114,11 @@ You can keep this message and use it as a backup for your secret key. If you wan
 
     <!-- For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers. -->
     <string name="message_list_content_description_unread_prefix">unread, %s</string>
+
+    <!-- Name of the "data collection" section in the general settings screen -->
+    <string name="settings_ui_data_collection">Data collection</string>
+    <!-- Title of the "Usage and technical data" setting used in the "data collection" section of the general settings screen -->
+    <string name="settings_ui_telemetry_title">Usage and technical data</string>
+    <!-- Description of the "Usage and technical data" setting used in the "data collection" section of the general settings screen -->
+    <string name="settings_ui_telemetry_description">Shares performance, usage, hardware and customization data about this app with Mozilla to help us make Thunderbird better</string>
 </resources>

--- a/legacy/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/general_settings.xml
@@ -515,6 +515,21 @@
     </PreferenceScreen>
 
     <PreferenceScreen
+        android:icon="@drawable/ic_analytics"
+        android:key="data_collection"
+        android:title="@string/settings_ui_data_collection"
+        search:ignore="true"
+        >
+
+        <SwitchPreference
+            android:key="enable_telemetry"
+            android:summary="@string/settings_ui_telemetry_description"
+            android:title="@string/settings_ui_telemetry_title"
+            />
+
+    </PreferenceScreen>
+
+    <PreferenceScreen
         android:icon="@drawable/ic_bug_report"
         android:key="debug_preferences"
         android:title="@string/debug_preferences"

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/TestApp.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/TestApp.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9
 
 import android.app.Application
+import app.k9mail.feature.telemetry.api.TelemetryManager
 import app.k9mail.legacy.di.DI
 import com.fsck.k9.preferences.InMemoryStoragePersister
 import com.fsck.k9.preferences.StoragePersister
@@ -26,4 +27,9 @@ val testModule = module {
     single { AppConfig(emptyList()) }
     single<CoreResourceProvider> { TestCoreResourceProvider() }
     single<StoragePersister> { InMemoryStoragePersister() }
+    single<TelemetryManager> {
+        object : TelemetryManager {
+            override fun isTelemetryFeatureIncluded(): Boolean = true
+        }
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -76,6 +76,11 @@ include(
 )
 
 include(
+    ":feature:telemetry:api",
+    ":feature:telemetry:glean",
+)
+
+include(
     ":core:common",
     ":core:featureflags",
     ":core:testing",


### PR DESCRIPTION
Adds a setting to disable app telemetry. 

Telemetry will only be included in Thunderbird. So this new setting is only visible in Thunderbird.

|General settings|Data collection category|
|-|-|
|![image](https://github.com/user-attachments/assets/791b7f75-6a08-4be0-9ded-8e8399478883)|![image](https://github.com/user-attachments/assets/d6542159-4047-4c79-ad4e-4f5e4078d253)|

Closes #8089