### PR TITLE
Add drawer folder list - Part 2

### DIFF
--- a/core/mail/folder/api/build.gradle.kts
+++ b/core/mail/folder/api/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id(ThunderbirdPlugins.Library.jvm)
+    alias(libs.plugins.android.lint)
+}
+
+dependencies {
+    implementation(projects.mail.common)
+
+    testImplementation(projects.core.testing)
+}

--- a/core/mail/folder/api/src/main/kotlin/app/k9mail/core/mail/folder/api/Folder.kt
+++ b/core/mail/folder/api/src/main/kotlin/app/k9mail/core/mail/folder/api/Folder.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.folder
+package app.k9mail.core.mail.folder.api
 
 data class Folder(
     val id: Long,

--- a/core/mail/folder/api/src/main/kotlin/app/k9mail/core/mail/folder/api/FolderDetails.kt
+++ b/core/mail/folder/api/src/main/kotlin/app/k9mail/core/mail/folder/api/FolderDetails.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.folder
+package app.k9mail.core.mail.folder.api
 
 import com.fsck.k9.mail.FolderClass
 

--- a/core/mail/folder/api/src/main/kotlin/app/k9mail/core/mail/folder/api/FolderType.kt
+++ b/core/mail/folder/api/src/main/kotlin/app/k9mail/core/mail/folder/api/FolderType.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.folder
+package app.k9mail.core.mail.folder.api
 
 enum class FolderType {
     REGULAR,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -22,10 +22,10 @@ import app.k9mail.feature.navigation.drawer.legacy.DisplayUnifiedInbox
 import app.k9mail.feature.navigation.drawer.legacy.FolderList
 import app.k9mail.feature.navigation.drawer.legacy.FoldersViewModel
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.DisplayFolder
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import app.k9mail.legacy.ui.account.AccountImageLoader
+import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.FolderIconProvider
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import app.k9mail.legacy.ui.theme.ThemeManager

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -17,6 +17,7 @@ import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.theme.api.Theme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
+import app.k9mail.feature.navigation.drawer.legacy.FoldersViewModel
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.folder.DisplayFolder
 import app.k9mail.legacy.folder.Folder
@@ -27,7 +28,6 @@ import app.k9mail.legacy.ui.folder.DisplayUnifiedInbox
 import app.k9mail.legacy.ui.folder.FolderIconProvider
 import app.k9mail.legacy.ui.folder.FolderList
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
-import app.k9mail.legacy.ui.folder.FoldersViewModel
 import app.k9mail.legacy.ui.theme.ThemeManager
 import com.fsck.k9.K9
 import com.fsck.k9.ui.base.livedata.observeNotNull

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -15,13 +15,13 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.theme.api.Theme
+import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.folder.DisplayFolder
 import app.k9mail.legacy.folder.Folder
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import app.k9mail.legacy.ui.account.AccountImageLoader
-import app.k9mail.legacy.ui.account.AccountsViewModel
 import app.k9mail.legacy.ui.account.DisplayAccount
 import app.k9mail.legacy.ui.folder.DisplayUnifiedInbox
 import app.k9mail.legacy.ui.folder.FolderIconProvider

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -13,6 +13,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.theme.api.Theme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
@@ -20,7 +21,6 @@ import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
 import app.k9mail.feature.navigation.drawer.legacy.FoldersViewModel
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.folder.DisplayFolder
-import app.k9mail.legacy.folder.Folder
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import app.k9mail.legacy.ui.account.AccountImageLoader

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -15,6 +15,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.theme.api.Theme
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.folder.DisplayFolder
@@ -22,7 +23,6 @@ import app.k9mail.legacy.folder.Folder
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import app.k9mail.legacy.ui.account.AccountImageLoader
-import app.k9mail.legacy.ui.account.DisplayAccount
 import app.k9mail.legacy.ui.folder.DisplayUnifiedInbox
 import app.k9mail.legacy.ui.folder.FolderIconProvider
 import app.k9mail.legacy.ui.folder.FolderList

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -18,15 +18,15 @@ import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.theme.api.Theme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
+import app.k9mail.feature.navigation.drawer.legacy.DisplayUnifiedInbox
+import app.k9mail.feature.navigation.drawer.legacy.FolderList
 import app.k9mail.feature.navigation.drawer.legacy.FoldersViewModel
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.folder.DisplayFolder
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import app.k9mail.legacy.ui.account.AccountImageLoader
-import app.k9mail.legacy.ui.folder.DisplayUnifiedInbox
 import app.k9mail.legacy.ui.folder.FolderIconProvider
-import app.k9mail.legacy.ui.folder.FolderList
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import app.k9mail.legacy.ui.theme.ThemeManager
 import com.fsck.k9.K9

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -1,5 +1,7 @@
 package app.k9mail.feature.navigation.drawer
 
+import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
+import app.k9mail.feature.navigation.drawer.domain.usecase.GetDisplayAccounts
 import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
 import app.k9mail.feature.navigation.drawer.legacy.FoldersViewModel
 import app.k9mail.feature.navigation.drawer.ui.DrawerViewModel
@@ -11,13 +13,17 @@ import org.koin.dsl.module
 
 val navigationDrawerModule: Module = module {
 
-    viewModel { DrawerViewModel() }
-
-    viewModel {
-        AccountsViewModel(
+    single<UseCase.GetDisplayAccounts> {
+        GetDisplayAccounts(
             accountManager = get(),
             messageCountsProvider = get(),
             messageListRepository = get(),
+        )
+    }
+
+    viewModel {
+        AccountsViewModel(
+            getDisplayAccounts = get(),
         )
     }
 
@@ -32,4 +38,6 @@ val navigationDrawerModule: Module = module {
             getUnifiedInboxDetail = { coreResourceProvider.searchUnifiedInboxDetail() },
         )
     }
+
+    viewModel { DrawerViewModel() }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.navigation.drawer
 
+import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
 import app.k9mail.feature.navigation.drawer.ui.DrawerViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
@@ -8,4 +9,12 @@ import org.koin.dsl.module
 val navigationDrawerModule: Module = module {
 
     viewModel { DrawerViewModel() }
+
+    viewModel {
+        AccountsViewModel(
+            accountManager = get(),
+            messageCountsProvider = get(),
+            messageListRepository = get(),
+        )
+    }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -1,7 +1,10 @@
 package app.k9mail.feature.navigation.drawer
 
 import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
+import app.k9mail.feature.navigation.drawer.legacy.FoldersViewModel
 import app.k9mail.feature.navigation.drawer.ui.DrawerViewModel
+import com.fsck.k9.CoreResourceProvider
+import com.fsck.k9.K9
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -15,6 +18,18 @@ val navigationDrawerModule: Module = module {
             accountManager = get(),
             messageCountsProvider = get(),
             messageListRepository = get(),
+        )
+    }
+
+    viewModel {
+        val coreResourceProvider = get<CoreResourceProvider>()
+
+        FoldersViewModel(
+            folderRepository = get(),
+            messageCountsProvider = get(),
+            isShowUnifiedInbox = { K9.isShowUnifiedInbox },
+            getUnifiedInboxTitle = { coreResourceProvider.searchUnifiedInboxTitle() },
+            getUnifiedInboxDetail = { coreResourceProvider.searchUnifiedInboxDetail() },
         )
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -1,0 +1,13 @@
+package app.k9mail.feature.navigation.drawer.domain
+
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
+import kotlinx.coroutines.flow.Flow
+
+interface DomainContract {
+
+    interface UseCase {
+        fun interface GetDisplayAccounts {
+            fun execute(): Flow<List<DisplayAccount>>
+        }
+    }
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccount.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.ui.account
+package app.k9mail.feature.navigation.drawer.domain.entity
 
 import app.k9mail.legacy.account.Account
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayAccounts.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayAccounts.kt
@@ -1,0 +1,65 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
+import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.mailstore.MessageListChangedListener
+import app.k9mail.legacy.mailstore.MessageListRepository
+import app.k9mail.legacy.message.controller.MessageCounts
+import app.k9mail.legacy.message.controller.MessageCountsProvider
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
+
+class GetDisplayAccounts(
+    private val accountManager: AccountManager,
+    private val messageCountsProvider: MessageCountsProvider,
+    private val messageListRepository: MessageListRepository,
+    private val coroutineContext: CoroutineContext = Dispatchers.IO,
+) : UseCase.GetDisplayAccounts {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun execute(): Flow<List<DisplayAccount>> {
+        return accountManager.getAccountsFlow()
+            .flatMapLatest { accounts ->
+                val messageCountsFlows: List<Flow<MessageCounts>> = accounts.map { account ->
+                    getMessageCountsFlow(account)
+                }
+
+                combine(messageCountsFlows) { messageCountsList ->
+                    messageCountsList.mapIndexed { index, messageCounts ->
+                        DisplayAccount(
+                            account = accounts[index],
+                            unreadMessageCount = messageCounts.unread,
+                            starredMessageCount = messageCounts.starred,
+                        )
+                    }
+                }
+            }
+    }
+
+    private fun getMessageCountsFlow(account: Account): Flow<MessageCounts> {
+        return callbackFlow {
+            send(messageCountsProvider.getMessageCounts(account))
+
+            val listener = MessageListChangedListener {
+                launch {
+                    send(messageCountsProvider.getMessageCounts(account))
+                }
+            }
+            messageListRepository.addListener(account.uuid, listener)
+
+            awaitClose {
+                messageListRepository.removeListener(listener)
+            }
+        }.flowOn(coroutineContext)
+    }
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/AccountsViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/AccountsViewModel.kt
@@ -3,13 +3,13 @@ package app.k9mail.feature.navigation.drawer.legacy
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.mailstore.MessageListChangedListener
 import app.k9mail.legacy.mailstore.MessageListRepository
 import app.k9mail.legacy.message.controller.MessageCounts
 import app.k9mail.legacy.message.controller.MessageCountsProvider
-import app.k9mail.legacy.ui.account.DisplayAccount
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/AccountsViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/AccountsViewModel.kt
@@ -3,62 +3,11 @@ package app.k9mail.feature.navigation.drawer.legacy
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
-import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.AccountManager
-import app.k9mail.legacy.mailstore.MessageListChangedListener
-import app.k9mail.legacy.mailstore.MessageListRepository
-import app.k9mail.legacy.message.controller.MessageCounts
-import app.k9mail.legacy.message.controller.MessageCountsProvider
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class AccountsViewModel(
-    accountManager: AccountManager,
-    private val messageCountsProvider: MessageCountsProvider,
-    private val messageListRepository: MessageListRepository,
+    getDisplayAccounts: UseCase.GetDisplayAccounts,
 ) : ViewModel() {
-    private val displayAccountFlow: Flow<List<DisplayAccount>> = accountManager.getAccountsFlow()
-        .flatMapLatest { accounts ->
-            val messageCountsFlows: List<Flow<MessageCounts>> = accounts.map { account ->
-                getMessageCountsFlow(account)
-            }
-
-            combine(messageCountsFlows) { messageCountsList ->
-                messageCountsList.mapIndexed { index, messageCounts ->
-                    DisplayAccount(
-                        account = accounts[index],
-                        unreadMessageCount = messageCounts.unread,
-                        starredMessageCount = messageCounts.starred,
-                    )
-                }
-            }
-        }
-
-    private fun getMessageCountsFlow(account: Account): Flow<MessageCounts> {
-        return callbackFlow {
-            send(messageCountsProvider.getMessageCounts(account))
-
-            val listener = MessageListChangedListener {
-                launch {
-                    send(messageCountsProvider.getMessageCounts(account))
-                }
-            }
-            messageListRepository.addListener(account.uuid, listener)
-
-            awaitClose {
-                messageListRepository.removeListener(listener)
-            }
-        }.flowOn(Dispatchers.IO)
-    }
-
-    val displayAccountsLiveData: LiveData<List<DisplayAccount>> = displayAccountFlow.asLiveData()
+    val displayAccountsLiveData: LiveData<List<DisplayAccount>> = getDisplayAccounts.execute().asLiveData()
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/AccountsViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/AccountsViewModel.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.ui.account
+package app.k9mail.feature.navigation.drawer.legacy
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
@@ -9,6 +9,7 @@ import app.k9mail.legacy.mailstore.MessageListChangedListener
 import app.k9mail.legacy.mailstore.MessageListRepository
 import app.k9mail.legacy.message.controller.MessageCounts
 import app.k9mail.legacy.message.controller.MessageCountsProvider
+import app.k9mail.legacy.ui.account.DisplayAccount
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/DisplayUnifiedInbox.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/DisplayUnifiedInbox.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.ui.folder
+package app.k9mail.feature.navigation.drawer.legacy
 
 data class DisplayUnifiedInbox(
     val unreadMessageCount: Int,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FolderList.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.legacy
 
-import app.k9mail.legacy.folder.DisplayFolder
+import app.k9mail.legacy.ui.folder.DisplayFolder
 
 data class FolderList(
     val unifiedInbox: DisplayUnifiedInbox?,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FolderList.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.ui.folder
+package app.k9mail.feature.navigation.drawer.legacy
 
 import app.k9mail.legacy.folder.DisplayFolder
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.mailstore.FolderRepository
+import app.k9mail.legacy.mailstore.DisplayFolderRepository
 import app.k9mail.legacy.message.controller.MessageCountsProvider
 import app.k9mail.legacy.search.SearchAccount
+import app.k9mail.legacy.ui.folder.DisplayUnifiedInbox
+import app.k9mail.legacy.ui.folder.FolderList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,7 +22,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FoldersViewModel(
-    private val folderRepository: FolderRepository,
+    private val folderRepository: DisplayFolderRepository,
     private val messageCountsProvider: MessageCountsProvider,
     private val isShowUnifiedInbox: () -> Boolean,
     private val getUnifiedInboxTitle: () -> String,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
@@ -8,8 +8,6 @@ import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.message.controller.MessageCountsProvider
 import app.k9mail.legacy.search.SearchAccount
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
-import app.k9mail.legacy.ui.folder.DisplayUnifiedInbox
-import app.k9mail.legacy.ui.folder.FolderList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.ui.folder
+package app.k9mail.feature.navigation.drawer.legacy
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.mailstore.DisplayFolderRepository
 import app.k9mail.legacy.message.controller.MessageCountsProvider
 import app.k9mail.legacy.search.SearchAccount
+import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import app.k9mail.legacy.ui.folder.DisplayUnifiedInbox
 import app.k9mail.legacy.ui.folder.FolderList
 import kotlinx.coroutines.CoroutineDispatcher

--- a/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -1,9 +1,9 @@
 package app.k9mail.feature.widget.unread
 
 import android.content.Context
+import app.k9mail.core.mail.folder.api.Folder
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.Folder
-import app.k9mail.legacy.folder.FolderType
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.message.controller.MessageCounts
 import app.k9mail.legacy.message.controller.MessageCountsProvider

--- a/legacy/core/build.gradle.kts
+++ b/legacy/core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(projects.backend.api)
     api(projects.library.htmlCleaner)
     api(projects.core.android.common)
+    api(projects.core.mail.folder.api)
 
     api(projects.legacy.account)
     api(projects.legacy.di)

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9.mailstore
 
-import app.k9mail.legacy.mailstore.DisplayFolderRepository
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.mailstore.MessageListRepository
 import app.k9mail.legacy.mailstore.MessageStoreManager
@@ -12,12 +11,6 @@ import org.koin.dsl.module
 val mailStoreModule = module {
     single {
         FolderRepository(
-            messageStoreManager = get(),
-            accountManager = get(),
-        )
-    }
-    single {
-        DisplayFolderRepository(
             messageStoreManager = get(),
             accountManager = get(),
         )

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.mailstore
 
+import app.k9mail.legacy.mailstore.DisplayFolderRepository
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.mailstore.MessageListRepository
 import app.k9mail.legacy.mailstore.MessageStoreManager
@@ -9,7 +10,18 @@ import com.fsck.k9.message.extractors.MessagePreviewCreator
 import org.koin.dsl.module
 
 val mailStoreModule = module {
-    single { FolderRepository(messageStoreManager = get(), accountManager = get()) }
+    single {
+        FolderRepository(
+            messageStoreManager = get(),
+            accountManager = get(),
+        )
+    }
+    single {
+        DisplayFolderRepository(
+            messageStoreManager = get(),
+            accountManager = get(),
+        )
+    }
     single { MessageViewInfoExtractorFactory(get(), get(), get()) }
     single { StorageManager.getInstance(get()) }
     single { SpecialFolderSelectionStrategy() }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderSelectionStrategy.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderSelectionStrategy.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.mailstore
 
-import app.k9mail.legacy.folder.FolderType
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.folder.RemoteFolder
 
 /**

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
@@ -1,9 +1,9 @@
 package com.fsck.k9.mailstore
 
 import app.k9mail.core.common.mail.Protocols
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.SpecialFolderSelection
-import app.k9mail.legacy.folder.FolderType
 import app.k9mail.legacy.folder.RemoteFolder
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.Preferences

--- a/legacy/folder/build.gradle.kts
+++ b/legacy/folder/build.gradle.kts
@@ -8,4 +8,6 @@ android {
 
 dependencies {
     implementation(projects.mail.common)
+
+    implementation(projects.core.mail.folder.api)
 }

--- a/legacy/folder/src/main/kotlin/app/k9mail/legacy/folder/DisplayFolder.kt
+++ b/legacy/folder/src/main/kotlin/app/k9mail/legacy/folder/DisplayFolder.kt
@@ -1,5 +1,7 @@
 package app.k9mail.legacy.folder
 
+import app.k9mail.core.mail.folder.api.Folder
+
 data class DisplayFolder(
     val folder: Folder,
     val isInTopGroup: Boolean,

--- a/legacy/folder/src/main/kotlin/app/k9mail/legacy/folder/RemoteFolder.kt
+++ b/legacy/folder/src/main/kotlin/app/k9mail/legacy/folder/RemoteFolder.kt
@@ -1,5 +1,7 @@
 package app.k9mail.legacy.folder
 
+import app.k9mail.core.mail.folder.api.FolderType
+
 data class RemoteFolder(
     val id: Long,
     val serverId: String,

--- a/legacy/mailstore/build.gradle.kts
+++ b/legacy/mailstore/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
     implementation(projects.legacy.search)
 
     implementation(projects.mail.common)
+    implementation(projects.core.mail.folder.api)
 }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/DisplayFolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/DisplayFolderRepository.kt
@@ -1,0 +1,103 @@
+package app.k9mail.legacy.mailstore
+
+import app.k9mail.core.mail.folder.api.Folder
+import app.k9mail.core.mail.folder.api.FolderType
+import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.di.DI
+import app.k9mail.legacy.folder.DisplayFolder
+import app.k9mail.legacy.mailstore.FolderTypeMapper.folderTypeOf
+import app.k9mail.legacy.message.controller.MessagingControllerRegistry
+import app.k9mail.legacy.message.controller.SimpleMessagingListener
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+
+class DisplayFolderRepository(
+    private val messageStoreManager: MessageStoreManager,
+    private val accountManager: AccountManager,
+    private val coroutineContext: CoroutineContext = Dispatchers.IO,
+) {
+    private val sortForDisplay =
+        compareByDescending<DisplayFolder> { it.folder.type == FolderType.INBOX }
+            .thenByDescending { it.folder.type == FolderType.OUTBOX }
+            .thenByDescending { it.folder.type != FolderType.REGULAR }
+            .thenByDescending { it.isInTopGroup }
+            .thenBy(String.CASE_INSENSITIVE_ORDER) { it.folder.name }
+
+    private fun getDisplayFolders(account: Account, displayMode: FolderMode?): List<DisplayFolder> {
+        val messageStore = messageStoreManager.getMessageStore(account.uuid)
+        return messageStore.getDisplayFolders(
+            displayMode = displayMode ?: account.folderDisplayMode,
+            outboxFolderId = account.outboxFolderId,
+        ) { folder ->
+            DisplayFolder(
+                folder = Folder(
+                    id = folder.id,
+                    name = folder.name,
+                    type = folderTypeOf(account, folder.id),
+                    isLocalOnly = folder.isLocalOnly,
+                ),
+                isInTopGroup = folder.isInTopGroup,
+                unreadMessageCount = folder.unreadMessageCount,
+                starredMessageCount = folder.starredMessageCount,
+            )
+        }.sortedWith(sortForDisplay)
+    }
+
+    fun getDisplayFoldersFlow(account: Account, displayMode: FolderMode): Flow<List<DisplayFolder>> {
+        val messagingController = DI.get<MessagingControllerRegistry>()
+        val messageStore = messageStoreManager.getMessageStore(account.uuid)
+
+        return callbackFlow {
+            send(getDisplayFolders(account, displayMode))
+
+            val folderStatusChangedListener = object : SimpleMessagingListener() {
+                override fun folderStatusChanged(statusChangedAccount: Account, folderId: Long) {
+                    if (statusChangedAccount.uuid == account.uuid) {
+                        trySendBlocking(getDisplayFolders(account, displayMode))
+                    }
+                }
+            }
+            messagingController.addListener(folderStatusChangedListener)
+
+            val folderSettingsChangedListener = FolderSettingsChangedListener {
+                trySendBlocking(getDisplayFolders(account, displayMode))
+            }
+            messageStore.addFolderSettingsChangedListener(folderSettingsChangedListener)
+
+            awaitClose {
+                messagingController.removeListener(folderStatusChangedListener)
+                messageStore.removeFolderSettingsChangedListener(folderSettingsChangedListener)
+            }
+        }.buffer(capacity = Channel.CONFLATED)
+            .distinctUntilChanged()
+            .flowOn(coroutineContext)
+    }
+
+    fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>> {
+        return accountManager.getAccountFlow(accountUuid)
+            .map { latestAccount ->
+                AccountContainer(latestAccount, latestAccount.folderDisplayMode)
+            }
+            .distinctUntilChanged()
+            .flatMapLatest { (account, folderDisplayMode) ->
+                getDisplayFoldersFlow(account, folderDisplayMode)
+            }
+    }
+}
+
+private data class AccountContainer(
+    val account: Account,
+    val folderDisplayMode: FolderMode,
+)

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
@@ -1,13 +1,13 @@
 package app.k9mail.legacy.mailstore
 
+import app.k9mail.core.mail.folder.api.Folder
+import app.k9mail.core.mail.folder.api.FolderDetails
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.di.DI
 import app.k9mail.legacy.folder.DisplayFolder
-import app.k9mail.legacy.folder.Folder
-import app.k9mail.legacy.folder.FolderDetails
-import app.k9mail.legacy.folder.FolderType
 import app.k9mail.legacy.folder.RemoteFolder
 import app.k9mail.legacy.message.controller.MessagingControllerRegistry
 import app.k9mail.legacy.message.controller.SimpleMessagingListener

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
@@ -91,8 +91,8 @@ class FolderRepository(
             .flowOn(ioDispatcher)
     }
 
-    fun getDisplayFoldersFlow(account: Account): Flow<List<DisplayFolder>> {
-        return accountManager.getAccountFlow(account.uuid)
+    fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>> {
+        return accountManager.getAccountFlow(accountUuid)
             .map { latestAccount ->
                 AccountContainer(latestAccount, latestAccount.folderDisplayMode)
             }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
@@ -2,15 +2,12 @@ package app.k9mail.legacy.mailstore
 
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderDetails
-import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.account.AccountManager
-import app.k9mail.legacy.di.DI
-import app.k9mail.legacy.folder.DisplayFolder
 import app.k9mail.legacy.folder.RemoteFolder
-import app.k9mail.legacy.message.controller.MessagingControllerRegistry
-import app.k9mail.legacy.message.controller.SimpleMessagingListener
+import app.k9mail.legacy.mailstore.FolderTypeMapper.folderTypeOf
+import app.k9mail.legacy.mailstore.RemoteFolderTypeMapper.toFolderType
 import com.fsck.k9.mail.FolderClass
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -25,7 +22,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import com.fsck.k9.mail.FolderType as RemoteFolderType
 
 @Suppress("TooManyFunctions")
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -34,74 +30,6 @@ class FolderRepository(
     private val accountManager: AccountManager,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
-    private val sortForDisplay =
-        compareByDescending<DisplayFolder> { it.folder.type == FolderType.INBOX }
-            .thenByDescending { it.folder.type == FolderType.OUTBOX }
-            .thenByDescending { it.folder.type != FolderType.REGULAR }
-            .thenByDescending { it.isInTopGroup }
-            .thenBy(String.CASE_INSENSITIVE_ORDER) { it.folder.name }
-
-    fun getDisplayFolders(account: Account, displayMode: FolderMode?): List<DisplayFolder> {
-        val messageStore = messageStoreManager.getMessageStore(account)
-        return messageStore.getDisplayFolders(
-            displayMode = displayMode ?: account.folderDisplayMode,
-            outboxFolderId = account.outboxFolderId,
-        ) { folder ->
-            DisplayFolder(
-                folder = Folder(
-                    id = folder.id,
-                    name = folder.name,
-                    type = folderTypeOf(account, folder.id),
-                    isLocalOnly = folder.isLocalOnly,
-                ),
-                isInTopGroup = folder.isInTopGroup,
-                unreadMessageCount = folder.unreadMessageCount,
-                starredMessageCount = folder.starredMessageCount,
-            )
-        }.sortedWith(sortForDisplay)
-    }
-
-    fun getDisplayFoldersFlow(account: Account, displayMode: FolderMode): Flow<List<DisplayFolder>> {
-        val messagingController = DI.get<MessagingControllerRegistry>()
-        val messageStore = messageStoreManager.getMessageStore(account)
-
-        return callbackFlow {
-            send(getDisplayFolders(account, displayMode))
-
-            val folderStatusChangedListener = object : SimpleMessagingListener() {
-                override fun folderStatusChanged(statusChangedAccount: Account, folderId: Long) {
-                    if (statusChangedAccount.uuid == account.uuid) {
-                        trySendBlocking(getDisplayFolders(account, displayMode))
-                    }
-                }
-            }
-            messagingController.addListener(folderStatusChangedListener)
-
-            val folderSettingsChangedListener = FolderSettingsChangedListener {
-                trySendBlocking(getDisplayFolders(account, displayMode))
-            }
-            messageStore.addFolderSettingsChangedListener(folderSettingsChangedListener)
-
-            awaitClose {
-                messagingController.removeListener(folderStatusChangedListener)
-                messageStore.removeFolderSettingsChangedListener(folderSettingsChangedListener)
-            }
-        }.buffer(capacity = Channel.CONFLATED)
-            .distinctUntilChanged()
-            .flowOn(ioDispatcher)
-    }
-
-    fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>> {
-        return accountManager.getAccountFlow(accountUuid)
-            .map { latestAccount ->
-                AccountContainer(latestAccount, latestAccount.folderDisplayMode)
-            }
-            .distinctUntilChanged()
-            .flatMapLatest { (account, folderDisplayMode) ->
-                getDisplayFoldersFlow(account, folderDisplayMode)
-            }
-    }
-
     fun getFolder(account: Account, folderId: Long): Folder? {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolder(folderId) { folder ->
@@ -259,28 +187,6 @@ class FolderRepository(
         messageStore.setNotificationsEnabled(folderId, enable)
     }
 
-    private fun folderTypeOf(account: Account, folderId: Long) = when (folderId) {
-        account.inboxFolderId -> FolderType.INBOX
-        account.outboxFolderId -> FolderType.OUTBOX
-        account.sentFolderId -> FolderType.SENT
-        account.trashFolderId -> FolderType.TRASH
-        account.draftsFolderId -> FolderType.DRAFTS
-        account.archiveFolderId -> FolderType.ARCHIVE
-        account.spamFolderId -> FolderType.SPAM
-        else -> FolderType.REGULAR
-    }
-
-    private fun RemoteFolderType.toFolderType(): FolderType = when (this) {
-        RemoteFolderType.REGULAR -> FolderType.REGULAR
-        RemoteFolderType.INBOX -> FolderType.INBOX
-        RemoteFolderType.OUTBOX -> FolderType.REGULAR // We currently don't support remote Outbox folders
-        RemoteFolderType.DRAFTS -> FolderType.DRAFTS
-        RemoteFolderType.SENT -> FolderType.SENT
-        RemoteFolderType.TRASH -> FolderType.TRASH
-        RemoteFolderType.SPAM -> FolderType.SPAM
-        RemoteFolderType.ARCHIVE -> FolderType.ARCHIVE
-    }
-
     private fun Account.getFolderPushModeFlow(): Flow<FolderMode> {
         return accountManager.getAccountFlow(uuid).map { it.folderPushMode }
     }
@@ -291,11 +197,6 @@ class FolderRepository(
     private val RemoteFolderDetails.effectiveSyncClass: FolderClass
         get() = if (syncClass == FolderClass.INHERITED) displayClass else syncClass
 }
-
-private data class AccountContainer(
-    val account: Account,
-    val folderDisplayMode: FolderMode,
-)
 
 data class RemoteFolderDetails(
     val folder: RemoteFolder,

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderTypeMapper.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderTypeMapper.kt
@@ -1,0 +1,18 @@
+package app.k9mail.legacy.mailstore
+
+import app.k9mail.core.mail.folder.api.FolderType
+import app.k9mail.legacy.account.Account
+
+object FolderTypeMapper {
+
+    fun folderTypeOf(account: Account, folderId: Long) = when (folderId) {
+        account.inboxFolderId -> FolderType.INBOX
+        account.outboxFolderId -> FolderType.OUTBOX
+        account.sentFolderId -> FolderType.SENT
+        account.trashFolderId -> FolderType.TRASH
+        account.draftsFolderId -> FolderType.DRAFTS
+        account.archiveFolderId -> FolderType.ARCHIVE
+        account.spamFolderId -> FolderType.SPAM
+        else -> FolderType.REGULAR
+    }
+}

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/ListenableMessageStore.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/ListenableMessageStore.kt
@@ -1,6 +1,6 @@
 package app.k9mail.legacy.mailstore
 
-import app.k9mail.legacy.folder.FolderDetails
+import app.k9mail.core.mail.folder.api.FolderDetails
 import com.fsck.k9.mail.FolderClass
 import java.util.concurrent.CopyOnWriteArraySet
 

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStore.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStore.kt
@@ -1,7 +1,7 @@
 package app.k9mail.legacy.mailstore
 
+import app.k9mail.core.mail.folder.api.FolderDetails
 import app.k9mail.legacy.account.Account.FolderMode
-import app.k9mail.legacy.folder.FolderDetails
 import app.k9mail.legacy.search.ConditionsTreeNode
 import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.FolderClass

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/RemoteFolderTypeMapper.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/RemoteFolderTypeMapper.kt
@@ -1,0 +1,18 @@
+package app.k9mail.legacy.mailstore
+
+import app.k9mail.core.mail.folder.api.FolderType
+import com.fsck.k9.mail.FolderType as RemoteFolderType
+
+object RemoteFolderTypeMapper {
+
+    fun RemoteFolderType.toFolderType(): FolderType = when (this) {
+        RemoteFolderType.REGULAR -> FolderType.REGULAR
+        RemoteFolderType.INBOX -> FolderType.INBOX
+        RemoteFolderType.OUTBOX -> FolderType.REGULAR // We currently don't support remote Outbox folders
+        RemoteFolderType.DRAFTS -> FolderType.DRAFTS
+        RemoteFolderType.SENT -> FolderType.SENT
+        RemoteFolderType.TRASH -> FolderType.TRASH
+        RemoteFolderType.SPAM -> FolderType.SPAM
+        RemoteFolderType.ARCHIVE -> FolderType.ARCHIVE
+    }
+}

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.storage.messages
 
+import app.k9mail.core.mail.folder.api.FolderDetails
 import app.k9mail.legacy.account.Account.FolderMode
-import app.k9mail.legacy.folder.FolderDetails
 import app.k9mail.legacy.mailstore.CreateFolderInfo
 import app.k9mail.legacy.mailstore.FolderMapper
 import app.k9mail.legacy.mailstore.MessageMapper

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/UpdateFolderOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/UpdateFolderOperations.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.storage.messages
 
 import android.content.ContentValues
-import app.k9mail.legacy.folder.FolderDetails
+import app.k9mail.core.mail.folder.api.FolderDetails
 import app.k9mail.legacy.mailstore.MoreMessages
 import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.mail.FolderType

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/UpdateFolderOperationsTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/UpdateFolderOperationsTest.kt
@@ -1,8 +1,8 @@
 package com.fsck.k9.storage.messages
 
-import app.k9mail.legacy.folder.Folder
-import app.k9mail.legacy.folder.FolderDetails
-import app.k9mail.legacy.folder.FolderType
+import app.k9mail.core.mail.folder.api.Folder
+import app.k9mail.core.mail.folder.api.FolderDetails
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.mailstore.MoreMessages
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/legacy/ui/folder/build.gradle.kts
+++ b/legacy/ui/folder/build.gradle.kts
@@ -9,6 +9,8 @@ android {
 dependencies {
     implementation(projects.core.ui.legacy.designsystem)
 
+    implementation(projects.core.mail.folder.api)
+
     implementation(projects.legacy.account)
     implementation(projects.legacy.folder)
     implementation(projects.legacy.mailstore)

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolder.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolder.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.folder
+package app.k9mail.legacy.ui.folder
 
 import app.k9mail.core.mail.folder.api.Folder
 

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
@@ -5,7 +5,6 @@ import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.account.AccountManager
-import app.k9mail.legacy.folder.DisplayFolder
 import app.k9mail.legacy.mailstore.FolderSettingsChangedListener
 import app.k9mail.legacy.mailstore.FolderTypeMapper
 import app.k9mail.legacy.mailstore.MessageStoreManager

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/FolderIconProvider.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/FolderIconProvider.kt
@@ -1,7 +1,7 @@
 package app.k9mail.legacy.ui.folder
 
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
-import app.k9mail.legacy.folder.FolderType
 
 class FolderIconProvider {
     fun getFolderIcon(type: FolderType): Int = when (type) {

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/FolderNameFormatter.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/FolderNameFormatter.kt
@@ -1,8 +1,8 @@
 package app.k9mail.legacy.ui.folder
 
 import android.content.res.Resources
-import app.k9mail.legacy.folder.Folder
-import app.k9mail.legacy.folder.FolderType
+import app.k9mail.core.mail.folder.api.Folder
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.folder.RemoteFolder
 
 class FolderNameFormatter(private val resources: Resources) {

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/FoldersViewModel.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/FoldersViewModel.kt
@@ -33,7 +33,7 @@ class FoldersViewModel(
             if (account == null) {
                 flowOf(0 to emptyList())
             } else {
-                folderRepository.getDisplayFoldersFlow(account)
+                folderRepository.getDisplayFoldersFlow(account.uuid)
                     .map { displayFolders ->
                         account.accountNumber to displayFolders
                     }

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/KoinModule.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/KoinModule.kt
@@ -1,0 +1,13 @@
+package app.k9mail.legacy.ui.folder
+
+import org.koin.dsl.module
+
+val uiFolderModule = module {
+    single {
+        DisplayFolderRepository(
+            accountManager = get(),
+            messagingController = get(),
+            messageStoreManager = get(),
+        )
+    }
+}

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/UiKoinModules.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/UiKoinModules.kt
@@ -2,6 +2,7 @@ package com.fsck.k9
 
 import app.k9mail.feature.account.oauth.featureAccountOAuthModule
 import app.k9mail.feature.launcher.di.featureLauncherModule
+import app.k9mail.legacy.ui.folder.uiFolderModule
 import com.fsck.k9.account.accountModule
 import com.fsck.k9.activity.activityModule
 import com.fsck.k9.contacts.contactsModule
@@ -26,6 +27,7 @@ val uiModules = listOf(
     uiBaseModule,
     activityModule,
     uiModule,
+    uiFolderModule,
     settingsUiModule,
     endToEndUiModule,
     foldersUiModule,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/FolderInfoHolder.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/FolderInfoHolder.kt
@@ -1,8 +1,8 @@
 package com.fsck.k9.activity
 
+import app.k9mail.core.mail.folder.api.Folder
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.Folder
-import app.k9mail.legacy.folder.FolderType
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import com.fsck.k9.mailstore.LocalFolder
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/account/KoinModule.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/account/KoinModule.kt
@@ -2,14 +2,9 @@ package com.fsck.k9.ui.account
 
 import app.k9mail.legacy.ui.account.AccountFallbackImageProvider
 import app.k9mail.legacy.ui.account.AccountImageLoader
-import app.k9mail.legacy.ui.account.AccountsViewModel
-import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val accountUiModule = module {
-    viewModel {
-        AccountsViewModel(accountManager = get(), messageCountsProvider = get(), messageListRepository = get())
-    }
     factory { AccountImageLoader(accountFallbackImageProvider = get()) }
     factory { AccountFallbackImageProvider(context = get()) }
     factory { AccountImageModelLoaderFactory(contactPhotoLoader = get(), accountFallbackImageProvider = get()) }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -8,11 +8,11 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.widget.SearchView
 import androidx.recyclerview.widget.RecyclerView
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.folder.DisplayFolder
-import app.k9mail.legacy.folder.FolderType
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.ui.folder.FolderIconProvider
 import app.k9mail.legacy.ui.folder.FolderNameFormatter

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -12,8 +12,8 @@ import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.FolderMode
-import app.k9mail.legacy.folder.DisplayFolder
 import app.k9mail.legacy.message.controller.MessageReference
+import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.FolderIconProvider
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import com.fsck.k9.Preferences

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
@@ -7,14 +7,16 @@ import androidx.lifecycle.viewModelScope
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.folder.DisplayFolder
-import app.k9mail.legacy.mailstore.FolderRepository
+import app.k9mail.legacy.mailstore.DisplayFolderRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class ChooseFolderViewModel(private val folderRepository: FolderRepository) : ViewModel() {
+class ChooseFolderViewModel(
+    private val folderRepository: DisplayFolderRepository,
+) : ViewModel() {
     private val inputFlow = MutableSharedFlow<DisplayMode>(replay = 1)
     private val foldersFlow = inputFlow
         .flatMapLatest { (account, displayMode) ->

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.folder.DisplayFolder
-import app.k9mail.legacy.mailstore.DisplayFolderRepository
+import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flatMapLatest

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.FolderMode
-import app.k9mail.legacy.folder.DisplayFolder
+import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/folders/KoinModule.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/folders/KoinModule.kt
@@ -2,24 +2,9 @@ package com.fsck.k9.ui.folders
 
 import app.k9mail.legacy.ui.folder.FolderIconProvider
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
-import app.k9mail.legacy.ui.folder.FoldersViewModel
-import com.fsck.k9.CoreResourceProvider
-import com.fsck.k9.K9
-import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val foldersUiModule = module {
     factory { FolderNameFormatter(resources = get()) }
-    viewModel {
-        val coreResourceProvider = get<CoreResourceProvider>()
-
-        FoldersViewModel(
-            folderRepository = get(),
-            messageCountsProvider = get(),
-            isShowUnifiedInbox = { K9.isShowUnifiedInbox },
-            getUnifiedInboxTitle = { coreResourceProvider.searchUnifiedInboxTitle() },
-            getUnifiedInboxDetail = { coreResourceProvider.searchUnifiedInboxDetail() },
-        )
-    }
     factory { FolderIconProvider() }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsDataStore.kt
@@ -1,8 +1,8 @@
 package com.fsck.k9.ui.managefolders
 
 import androidx.preference.PreferenceDataStore
+import app.k9mail.core.mail.folder.api.FolderDetails
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.FolderDetails
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.mail.FolderClass
 import kotlinx.coroutines.CoroutineScope

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
+import app.k9mail.core.mail.folder.api.Folder
+import app.k9mail.core.mail.folder.api.FolderDetails
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.Folder
-import app.k9mail.legacy.folder.FolderDetails
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
@@ -13,7 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.DisplayFolder
+import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.FolderIconProvider
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import com.fsck.k9.Preferences

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.folder.DisplayFolder
-import app.k9mail.legacy.mailstore.FolderRepository
+import app.k9mail.legacy.mailstore.DisplayFolderRepository
 
-class ManageFoldersViewModel(private val folderRepository: FolderRepository) : ViewModel() {
+class ManageFoldersViewModel(
+    private val folderRepository: DisplayFolderRepository,
+) : ViewModel() {
     fun getFolders(account: Account): LiveData<List<DisplayFolder>> {
         return folderRepository.getDisplayFoldersFlow(account.uuid).asLiveData()
     }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.DisplayFolder
+import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 
 class ManageFoldersViewModel(

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
@@ -9,6 +9,6 @@ import app.k9mail.legacy.mailstore.FolderRepository
 
 class ManageFoldersViewModel(private val folderRepository: FolderRepository) : ViewModel() {
     fun getFolders(account: Account): LiveData<List<DisplayFolder>> {
-        return folderRepository.getDisplayFoldersFlow(account).asLiveData()
+        return folderRepository.getDisplayFoldersFlow(account.uuid).asLiveData()
     }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.folder.DisplayFolder
-import app.k9mail.legacy.mailstore.DisplayFolderRepository
+import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 
 class ManageFoldersViewModel(
     private val folderRepository: DisplayFolderRepository,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsUi.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsUi.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.ui.messagedetails
 
 import android.net.Uri
-import app.k9mail.legacy.folder.FolderType
+import app.k9mail.core.mail.folder.api.FolderType
 import com.fsck.k9.mail.Address
 import com.fsck.k9.view.MessageCryptoDisplayStatus
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsViewModel.kt
@@ -9,9 +9,9 @@ import app.k9mail.core.android.common.contact.CachingRepository
 import app.k9mail.core.android.common.contact.ContactPermissionResolver
 import app.k9mail.core.android.common.contact.ContactRepository
 import app.k9mail.core.common.mail.toEmailAddressOrNull
+import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
-import app.k9mail.legacy.folder.Folder
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.ui.folder.FolderNameFormatter

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -14,9 +14,9 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreference
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.feature.launcher.FeatureLauncherActivity
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.FolderType
 import app.k9mail.legacy.folder.RemoteFolder
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.activity.ManageIdentities

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
-import app.k9mail.legacy.folder.FolderType
 import app.k9mail.legacy.folder.RemoteFolder
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.mailstore.SpecialFolderSelectionStrategy

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -96,6 +96,10 @@ include(
 )
 
 include(
+    ":core:mail:folder:api",
+)
+
+include(
     ":legacy:account",
     ":legacy:common",
     ":legacy:core",


### PR DESCRIPTION
Second part of the drawer folder list implementation #8118. The direct dependencies, like `AccountsViewModel` and `FoldersViewModel`, have been moved to the feature module. The UI related functionality has been separated from the `FolderRepository` and moved into `DisplayFolderRepository`, to clarify responsibilities. Related data models have been moved out of legacy to where they are actually used.

This introduces a new `:core:mail:folder:api` module for folder specific declarations.
