### PR TITLE
Remove `EarlyInit` interface that is no longer necessary

### DIFF
--- a/config/detekt/detekt-baseline-legacy-core.xml
+++ b/config/detekt/detekt-baseline-legacy-core.xml
@@ -96,7 +96,7 @@
     <ID>TooGenericExceptionCaught:SettingsExporter.kt$SettingsExporter$e: Exception</ID>
     <ID>TooManyFunctions:CoreResourceProvider.kt$CoreResourceProvider</ID>
     <ID>TooManyFunctions:HttpUriParser.kt$HttpUriParser : UriParser</ID>
-    <ID>TooManyFunctions:K9.kt$K9 : EarlyInit</ID>
+    <ID>TooManyFunctions:K9.kt$K9 : KoinComponent</ID>
     <ID>TooManyFunctions:K9BackendFolder.kt$K9BackendFolder : BackendFolder</ID>
     <ID>TooManyFunctions:MessageListCache.kt$MessageListCache</ID>
     <ID>TooManyFunctions:NotificationActionCreator.kt$NotificationActionCreator</ID>

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/BaseUnreadWidgetProvider.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/BaseUnreadWidgetProvider.kt
@@ -8,12 +8,12 @@ import android.content.Intent
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.app.PendingIntentCompat
-import app.k9mail.legacy.di.EarlyInit
-import app.k9mail.legacy.di.inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import timber.log.Timber
 
 /**
@@ -46,7 +46,7 @@ import timber.log.Timber
  *            qualified class name that can't ever be changed. Otherwise widgets created with older versions of the app
  *            will stop working.
  */
-abstract class BaseUnreadWidgetProvider : AppWidgetProvider(), EarlyInit {
+abstract class BaseUnreadWidgetProvider : AppWidgetProvider(), KoinComponent {
     private val repository: UnreadWidgetRepository by inject()
     private val widgetScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 

--- a/legacy/core/src/main/java/com/fsck/k9/Core.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/Core.kt
@@ -3,17 +3,17 @@ package com.fsck.k9
 import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
-import app.k9mail.legacy.di.EarlyInit
-import app.k9mail.legacy.di.inject
 import com.fsck.k9.job.K9JobManager
 import com.fsck.k9.mail.internet.BinaryTempFileBody
 import com.fsck.k9.notification.NotificationController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 
-object Core : EarlyInit {
+object Core : KoinComponent {
     private val context: Context by inject()
     private val appConfig: AppConfig by inject()
     private val jobManager: K9JobManager by inject()

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -6,8 +6,6 @@ import app.k9mail.feature.telemetry.api.TelemetryManager
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.SortType
 import app.k9mail.legacy.di.DI
-import app.k9mail.legacy.di.EarlyInit
-import app.k9mail.legacy.di.inject
 import com.fsck.k9.core.BuildConfig
 import com.fsck.k9.mail.K9MailLib
 import com.fsck.k9.mailstore.LocalStore
@@ -15,11 +13,13 @@ import com.fsck.k9.preferences.RealGeneralSettingsManager
 import com.fsck.k9.preferences.Storage
 import com.fsck.k9.preferences.StorageEditor
 import kotlinx.datetime.Clock
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
 // TODO "Use GeneralSettingsManager and GeneralSettings instead"
-object K9 : EarlyInit {
+object K9 : KoinComponent {
     private val generalSettingsManager: RealGeneralSettingsManager by inject()
     private val telemetryManager: TelemetryManager by inject()
 

--- a/legacy/di/src/main/kotlin/app/k9mail/legacy/di/DI.kt
+++ b/legacy/di/src/main/kotlin/app/k9mail/legacy/di/DI.kt
@@ -5,9 +5,6 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
-import org.koin.core.parameter.ParametersDefinition
-import org.koin.core.qualifier.Qualifier
-import org.koin.java.KoinJavaComponent.getKoin
 import org.koin.java.KoinJavaComponent.get as koinGet
 
 object DI {
@@ -36,11 +33,3 @@ object DI {
         return koinGet(T::class.java)
     }
 }
-
-interface EarlyInit
-
-// Copied from ComponentCallbacks.inject()
-inline fun <reified T : Any> EarlyInit.inject(
-    qualifier: Qualifier? = null,
-    noinline parameters: ParametersDefinition? = null,
-) = lazy { getKoin().get<T>(qualifier, parameters) }


### PR DESCRIPTION
The `EarlyInit` functionality was introduced when `KoinComponent.inject()` was resolving dependencies eagerly, leading to problems with classes that were loaded before Koin was initialized. Nowadays, `KoinComponent.inject()` lazily loads dependencies. So the `EarlyInit` mechanism is no longer necessary.