### PR TITLE
Add drawer folder list - part 4

### DIFF
--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
@@ -29,6 +29,7 @@ fun DrawerContentWithAccountPreview() {
             state = DrawerContract.State(
                 accounts = persistentListOf(DISPLAY_ACCOUNT),
                 currentAccount = DISPLAY_ACCOUNT,
+                folders = persistentListOf(),
             ),
             onEvent = {},
         )

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
@@ -13,7 +13,7 @@ internal fun DrawerContentPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(),
-                currentAccount = null,
+                selectedAccount = null,
                 folders = persistentListOf(),
             ),
             onEvent = {},
@@ -28,7 +28,7 @@ fun DrawerContentWithAccountPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(DISPLAY_ACCOUNT),
-                currentAccount = DISPLAY_ACCOUNT,
+                selectedAccount = DISPLAY_ACCOUNT,
                 folders = persistentListOf(),
             ),
             onEvent = {},

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
@@ -3,9 +3,9 @@ package app.k9mail.feature.navigation.drawer.ui
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
-import app.k9mail.legacy.ui.folder.DisplayFolder
 
 internal object FakeData {
 
@@ -45,7 +45,8 @@ internal object FakeData {
         isLocalOnly = false,
     )
 
-    val DISPLAY_FOLDER = DisplayFolder(
+    val DISPLAY_FOLDER = DisplayAccountFolder(
+        accountUuid = ACCOUNT_UUID,
         folder = FOLDER,
         isInTopGroup = false,
         unreadMessageCount = 14,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
@@ -15,6 +15,7 @@ import org.koin.core.component.inject
 
 class FolderDrawer(
     override val parent: AppCompatActivity,
+    private val openAccount: (account: Account) -> Unit,
     private val openFolder: (folderId: Long) -> Unit,
     createDrawerListener: () -> DrawerLayout.DrawerListener,
 ) : NavigationDrawer, KoinComponent {
@@ -35,6 +36,7 @@ class FolderDrawer(
         drawerView.setContent {
             themeProvider.WithTheme {
                 DrawerView(
+                    openAccount = openAccount,
                     openFolder = openFolder,
                     closeDrawer = { close() },
                 )

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
@@ -15,6 +15,8 @@ import org.koin.core.component.inject
 
 class FolderDrawer(
     override val parent: AppCompatActivity,
+    private val openFolder: (folderId: Long) -> Unit,
+    createDrawerListener: () -> DrawerLayout.DrawerListener,
 ) : NavigationDrawer, KoinComponent {
 
     private val themeProvider: FeatureThemeProvider by inject()
@@ -28,10 +30,14 @@ class FolderDrawer(
         sliderView.visibility = View.GONE
         drawerView.visibility = View.VISIBLE
         swipeRefreshLayout.isEnabled = false
+        drawer.addDrawerListener(createDrawerListener())
 
         drawerView.setContent {
             themeProvider.WithTheme {
-                DrawerView()
+                DrawerView(
+                    openFolder = openFolder,
+                    closeDrawer = { close() },
+                )
             }
         }
     }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerExternalContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerExternalContract.kt
@@ -1,0 +1,10 @@
+package app.k9mail.feature.navigation.drawer
+
+import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
+
+interface NavigationDrawerExternalContract {
+
+    fun interface DrawerConfigLoader {
+        fun loadDrawerConfig(): DrawerConfig
+    }
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -4,6 +4,7 @@ import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDisplayAccounts
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDisplayFoldersForAccount
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDrawerConfig
+import app.k9mail.feature.navigation.drawer.domain.usecase.SyncMail
 import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
 import app.k9mail.feature.navigation.drawer.legacy.FoldersViewModel
 import app.k9mail.feature.navigation.drawer.ui.DrawerViewModel
@@ -35,6 +36,12 @@ val navigationDrawerModule: Module = module {
         )
     }
 
+    single<UseCase.SyncMail> {
+        SyncMail(
+            messagingController = get(),
+        )
+    }
+
     viewModel {
         AccountsViewModel(
             getDisplayAccounts = get(),
@@ -58,6 +65,7 @@ val navigationDrawerModule: Module = module {
             getDrawerConfig = get(),
             getDisplayAccounts = get(),
             getDisplayFoldersForAccount = get(),
+            syncMail = get(),
         )
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.navigation.drawer
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDisplayAccounts
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDisplayFoldersForAccount
+import app.k9mail.feature.navigation.drawer.domain.usecase.GetDrawerConfig
 import app.k9mail.feature.navigation.drawer.legacy.AccountsViewModel
 import app.k9mail.feature.navigation.drawer.legacy.FoldersViewModel
 import app.k9mail.feature.navigation.drawer.ui.DrawerViewModel
@@ -13,6 +14,12 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 val navigationDrawerModule: Module = module {
+
+    single<UseCase.GetDrawerConfig> {
+        GetDrawerConfig(
+            configProver = get(),
+        )
+    }
 
     single<UseCase.GetDisplayAccounts> {
         GetDisplayAccounts(
@@ -48,6 +55,7 @@ val navigationDrawerModule: Module = module {
 
     viewModel {
         DrawerViewModel(
+            getDrawerConfig = get(),
             getDisplayAccounts = get(),
             getDisplayFoldersForAccount = get(),
         )

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -1,12 +1,17 @@
 package app.k9mail.feature.navigation.drawer.domain
 
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
+import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import kotlinx.coroutines.flow.Flow
 
 interface DomainContract {
 
     interface UseCase {
+        fun interface GetDrawerConfig {
+            operator fun invoke(): Flow<DrawerConfig>
+        }
+
         fun interface GetDisplayAccounts {
             operator fun invoke(): Flow<List<DisplayAccount>>
         }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.navigation.drawer.domain
 
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
+import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import kotlinx.coroutines.flow.Flow
 
@@ -18,6 +19,15 @@ interface DomainContract {
 
         fun interface GetDisplayFoldersForAccount {
             operator fun invoke(accountUuid: String): Flow<List<DisplayFolder>>
+        }
+
+        /**
+         * Synchronize mail for the given account.
+         *
+         * Account can be null to synchronize unified inbox or account list.
+         */
+        fun interface SyncMail {
+            operator fun invoke(account: Account?): Flow<Result<Unit>>
         }
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -1,9 +1,9 @@
 package app.k9mail.feature.navigation.drawer.domain
 
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.ui.folder.DisplayFolder
 import kotlinx.coroutines.flow.Flow
 
 interface DomainContract {
@@ -18,7 +18,7 @@ interface DomainContract {
         }
 
         fun interface GetDisplayFoldersForAccount {
-            operator fun invoke(accountUuid: String): Flow<List<DisplayFolder>>
+            operator fun invoke(accountUuid: String): Flow<List<DisplayAccountFolder>>
         }
 
         /**

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
@@ -1,0 +1,11 @@
+package app.k9mail.feature.navigation.drawer.domain.entity
+
+import app.k9mail.core.mail.folder.api.Folder
+
+data class DisplayAccountFolder(
+    val accountUuid: String,
+    val folder: Folder,
+    val isInTopGroup: Boolean,
+    val unreadMessageCount: Int,
+    val starredMessageCount: Int,
+)

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DrawerConfig.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DrawerConfig.kt
@@ -1,0 +1,6 @@
+package app.k9mail.feature.navigation.drawer.domain.entity
+
+data class DrawerConfig(
+    val showUnifiedInbox: Boolean,
+    val showStarredCount: Boolean,
+)

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
@@ -1,14 +1,25 @@
 package app.k9mail.feature.navigation.drawer.domain.usecase
 
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
-import app.k9mail.legacy.ui.folder.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class GetDisplayFoldersForAccount(
     private val repository: DisplayFolderRepository,
 ) : UseCase.GetDisplayFoldersForAccount {
-    override fun invoke(accountUuid: String): Flow<List<DisplayFolder>> {
-        return repository.getDisplayFoldersFlow(accountUuid)
+    override fun invoke(accountUuid: String): Flow<List<DisplayAccountFolder>> {
+        return repository.getDisplayFoldersFlow(accountUuid).map { displayFolders ->
+            displayFolders.map { displayFolder ->
+                DisplayAccountFolder(
+                    accountUuid = accountUuid,
+                    folder = displayFolder.folder,
+                    isInTopGroup = displayFolder.isInTopGroup,
+                    unreadMessageCount = displayFolder.unreadMessageCount,
+                    starredMessageCount = displayFolder.starredMessageCount,
+                )
+            }
+        }
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfig.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfig.kt
@@ -1,0 +1,17 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfigLoader
+import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
+import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class GetDrawerConfig(
+    private val configProver: DrawerConfigLoader,
+) : UseCase.GetDrawerConfig {
+    override operator fun invoke(): Flow<DrawerConfig> {
+        return flow {
+            emit(configProver.loadDrawerConfig())
+        }
+    }
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfig.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfig.kt
@@ -10,6 +10,7 @@ class GetDrawerConfig(
     private val configProver: DrawerConfigLoader,
 ) : UseCase.GetDrawerConfig {
     override operator fun invoke(): Flow<DrawerConfig> {
+        // TODO This needs to be updated when the config changes
         return flow {
             emit(configProver.loadDrawerConfig())
         }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncMail.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncMail.kt
@@ -1,0 +1,37 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import android.content.Context
+import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
+import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
+import app.k9mail.legacy.message.controller.SimpleMessagingListener
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
+
+class SyncMail(
+    private val messagingController: MessagingControllerMailChecker,
+    private val coroutineContext: CoroutineContext = Dispatchers.IO,
+) : UseCase.SyncMail {
+    override fun invoke(account: Account?): Flow<Result<Unit>> = callbackFlow {
+        val listener = object : SimpleMessagingListener() {
+            override fun checkMailFinished(context: Context?, account: Account?) {
+                trySend(Result.success(Unit))
+                close()
+            }
+        }
+
+        messagingController.checkMail(
+            account = account,
+            ignoreLastCheckedTime = true,
+            useManualWakeLock = true,
+            notify = true,
+            listener = listener,
+        )
+
+        awaitClose()
+    }.flowOn(coroutineContext)
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -34,7 +34,7 @@ fun DrawerContent(
                 ),
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {
-            state.currentAccount?.let {
+            state.selectedAccount?.let {
                 AccountView(
                     displayName = it.account.displayName,
                     emailAddress = it.account.email,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -46,8 +46,10 @@ fun DrawerContent(
             }
             FolderList(
                 folders = state.folders,
-                selectedFolder = state.folders.firstOrNull(), // TODO Use selected folder from state
-                onFolderClick = { },
+                selectedFolder = state.selectedFolder,
+                onFolderClick = { folder ->
+                    onEvent(Event.OnFolderClick(folder))
+                },
                 showStarredCount = state.showStarredCount,
             )
         }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -50,7 +50,7 @@ fun DrawerContent(
                 onFolderClick = { folder ->
                     onEvent(Event.OnFolderClick(folder))
                 },
-                showStarredCount = state.showStarredCount,
+                showStarredCount = state.config.showStarredCount,
             )
         }
     }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -3,9 +3,9 @@ package app.k9mail.feature.navigation.drawer.ui
 import androidx.compose.runtime.Stable
 import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.ui.folder.DisplayFolder
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -20,16 +20,16 @@ interface DrawerContract {
             showStarredCount = false,
         ),
         val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
-        val currentAccount: DisplayAccount? = null,
-        val folders: ImmutableList<DisplayFolder> = persistentListOf(),
-        val selectedFolder: DisplayFolder? = null,
+        val selectedAccount: DisplayAccount? = null,
+        val folders: ImmutableList<DisplayAccountFolder> = persistentListOf(),
+        val selectedFolder: DisplayAccountFolder? = null,
         val isLoading: Boolean = false,
     )
 
     sealed interface Event {
         data class OnAccountClick(val account: DisplayAccount) : Event
         data class OnAccountViewClick(val account: DisplayAccount) : Event
-        data class OnFolderClick(val folder: DisplayFolder) : Event
+        data class OnFolderClick(val folder: DisplayAccountFolder) : Event
         data object OnRefresh : Event
     }
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -13,18 +13,23 @@ interface DrawerContract {
 
     @Stable
     data class State(
-        val currentAccount: DisplayAccount? = null,
         val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
+        val currentAccount: DisplayAccount? = null,
         val folders: ImmutableList<DisplayFolder> = persistentListOf(),
+        val selectedFolder: DisplayFolder? = null,
         val showStarredCount: Boolean = false,
         val isLoading: Boolean = false,
     )
 
     sealed interface Event {
-        data object OnRefresh : Event
         data class OnAccountClick(val account: DisplayAccount) : Event
         data class OnAccountViewClick(val account: DisplayAccount) : Event
+        data class OnFolderClick(val folder: DisplayFolder) : Event
+        data object OnRefresh : Event
     }
 
-    sealed interface Effect
+    sealed interface Effect {
+        data class OpenFolder(val folderId: Long) : Effect
+        data object CloseDrawer : Effect
+    }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.navigation.drawer.ui
 import androidx.compose.runtime.Stable
 import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
+import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import kotlinx.collections.immutable.ImmutableList
@@ -14,11 +15,14 @@ interface DrawerContract {
 
     @Stable
     data class State(
+        val config: DrawerConfig = DrawerConfig(
+            showUnifiedInbox = false,
+            showStarredCount = false,
+        ),
         val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
         val currentAccount: DisplayAccount? = null,
         val folders: ImmutableList<DisplayFolder> = persistentListOf(),
         val selectedFolder: DisplayFolder? = null,
-        val showStarredCount: Boolean = false,
         val isLoading: Boolean = false,
     )
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.navigation.drawer.ui
 import androidx.compose.runtime.Stable
 import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
+import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -29,6 +30,7 @@ interface DrawerContract {
     }
 
     sealed interface Effect {
+        data class OpenAccount(val account: Account) : Effect
         data class OpenFolder(val folderId: Long) : Effect
         data object CloseDrawer : Effect
     }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
@@ -3,15 +3,23 @@ package app.k9mail.feature.navigation.drawer.ui
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.molecule.PullToRefreshBox
+import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.ViewModel
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun DrawerView(
+    openFolder: (folderId: Long) -> Unit,
+    closeDrawer: () -> Unit,
     viewModel: ViewModel = koinViewModel<DrawerViewModel>(),
 ) {
-    val (state, dispatch) = viewModel.observe { }
+    val (state, dispatch) = viewModel.observe { effect ->
+        when (effect) {
+            is Effect.OpenFolder -> openFolder(effect.folderId)
+            Effect.CloseDrawer -> closeDrawer()
+        }
+    }
 
     PullToRefreshBox(
         isRefreshing = state.value.isLoading,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
@@ -6,16 +6,19 @@ import app.k9mail.core.ui.compose.designsystem.molecule.PullToRefreshBox
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.ViewModel
+import app.k9mail.legacy.account.Account
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun DrawerView(
+    openAccount: (account: Account) -> Unit,
     openFolder: (folderId: Long) -> Unit,
     closeDrawer: () -> Unit,
     viewModel: ViewModel = koinViewModel<DrawerViewModel>(),
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
         when (effect) {
+            is Effect.OpenAccount -> openAccount(effect.account)
             is Effect.OpenFolder -> openFolder(effect.folderId)
             Effect.CloseDrawer -> closeDrawer()
         }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -95,6 +95,8 @@ class DrawerViewModel(
                 )
             }
         }
+
+        emitEffect(Effect.OpenAccount(account.account))
     }
 
     private fun ImmutableList<DisplayAccount>.nextOrFirst(account: DisplayAccount): DisplayAccount? {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
+import app.k9mail.feature.navigation.drawer.domain.usecase.GetDrawerConfig
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
@@ -21,6 +22,7 @@ import kotlinx.coroutines.launch
 
 @Suppress("MagicNumber")
 class DrawerViewModel(
+    private val getDrawerConfig: UseCase.GetDrawerConfig,
     private val getDisplayAccounts: UseCase.GetDisplayAccounts,
     private val getDisplayFoldersForAccount: UseCase.GetDisplayFoldersForAccount,
     initialState: State = State(),
@@ -30,6 +32,14 @@ class DrawerViewModel(
     ViewModel {
 
     init {
+        viewModelScope.launch {
+            getDrawerConfig().collectLatest { config ->
+                updateState {
+                    it.copy(config = config)
+                }
+            }
+        }
+
         viewModelScope.launch {
             loadAccounts()
         }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.viewModelScope
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
-import app.k9mail.feature.navigation.drawer.domain.usecase.GetDrawerConfig
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
@@ -25,6 +24,7 @@ class DrawerViewModel(
     private val getDrawerConfig: UseCase.GetDrawerConfig,
     private val getDisplayAccounts: UseCase.GetDisplayAccounts,
     private val getDisplayFoldersForAccount: UseCase.GetDisplayFoldersForAccount,
+    private val syncMail: UseCase.SyncMail,
     initialState: State = State(),
 ) : BaseViewModel<State, Event, Effect>(
     initialState = initialState,
@@ -138,8 +138,9 @@ class DrawerViewModel(
                 it.copy(isLoading = true)
             }
 
-            // TODO: replace with actual data loading
-            delay(500)
+            syncMail(state.value.currentAccount?.account).collect {
+                // nothing to do
+            }
 
             updateState {
                 it.copy(isLoading = false)

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -5,14 +5,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.k9mail.legacy.ui.folder.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun FolderList(
-    folders: ImmutableList<DisplayFolder>,
-    selectedFolder: DisplayFolder?,
-    onFolderClick: (DisplayFolder) -> Unit,
+    folders: ImmutableList<DisplayAccountFolder>,
+    selectedFolder: DisplayAccountFolder?,
+    onFolderClick: (DisplayAccountFolder) -> Unit,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -7,14 +7,14 @@ import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItem
-import app.k9mail.legacy.ui.folder.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 
 @Composable
 fun FolderListItem(
-    displayFolder: DisplayFolder,
+    displayFolder: DisplayAccountFolder,
     selected: Boolean,
     showStarredCount: Boolean,
-    onClick: (DisplayFolder) -> Unit,
+    onClick: (DisplayAccountFolder) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     NavigationDrawerItem(

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfigTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfigTest.kt
@@ -1,0 +1,32 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+class GetDrawerConfigTest {
+
+    @Test
+    fun `should get drawer config`() = runTest {
+        val drawerConfig = DrawerConfig(
+            showUnifiedInbox = true,
+            showStarredCount = true,
+        )
+
+        val testSubject = GetDrawerConfig(
+            configProver = { drawerConfig },
+        )
+
+        val result = testSubject().first()
+
+        assertThat(result).isEqualTo(
+            DrawerConfig(
+                showUnifiedInbox = true,
+                showStarredCount = true,
+            ),
+        )
+    }
+}

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncMailTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncMailTest.kt
@@ -1,0 +1,43 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
+import app.k9mail.legacy.message.controller.MessagingListener
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class SyncMailTest {
+
+    @Test
+    fun `should sync mail`() = runTest {
+        val listenerExecutor: (MessagingListener?) -> Unit = { listener ->
+            listener?.checkMailFinished(null, null)
+        }
+        val testSubject = SyncMail(
+            messagingController = FakeMessagingControllerMailChecker(
+                listenerExecutor = listenerExecutor,
+            ),
+        )
+
+        val result = testSubject(null).first()
+
+        assertThat(result.isSuccess).isEqualTo(true)
+    }
+
+    private class FakeMessagingControllerMailChecker(
+        private val listenerExecutor: (MessagingListener?) -> Unit = {},
+    ) : MessagingControllerMailChecker {
+        override fun checkMail(
+            account: Account?,
+            ignoreLastCheckedTime: Boolean,
+            useManualWakeLock: Boolean,
+            notify: Boolean,
+            listener: MessagingListener?,
+        ) {
+            listenerExecutor(listener)
+        }
+    }
+}

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -20,7 +20,7 @@ class DrawerStateTest {
                     showStarredCount = false,
                 ),
                 accounts = persistentListOf(),
-                currentAccount = null,
+                selectedAccount = null,
                 folders = persistentListOf(),
                 selectedFolder = null,
                 isLoading = false,

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -1,0 +1,26 @@
+package app.k9mail.feature.navigation.drawer.ui
+
+import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.Test
+
+class DrawerStateTest {
+
+    @Test
+    fun `should set default values`() {
+        val state = State()
+
+        assertThat(state).isEqualTo(
+            State(
+                accounts = persistentListOf(),
+                currentAccount = null,
+                folders = persistentListOf(),
+                selectedFolder = null,
+                showStarredCount = false,
+                isLoading = false,
+            ),
+        )
+    }
+}

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.navigation.drawer.ui
 
+import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -14,11 +15,14 @@ class DrawerStateTest {
 
         assertThat(state).isEqualTo(
             State(
+                config = DrawerConfig(
+                    showUnifiedInbox = false,
+                    showStarredCount = false,
+                ),
                 accounts = persistentListOf(),
                 currentAccount = null,
                 folders = persistentListOf(),
                 selectedFolder = null,
-                showStarredCount = false,
                 isLoading = false,
             ),
         )

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
@@ -18,27 +18,36 @@ class DrawerViewKtTest : ComposeTest() {
     fun `should delegate effects`() = runTest {
         val initialState = State()
         val viewModel = FakeDrawerViewModel(initialState)
+        var openAccountCounter = 0
         var openFolderCounter = 0
         var closeDrawerCounter = 0
 
         setContentWithTheme {
             DrawerView(
+                openAccount = { openAccountCounter++ },
                 openFolder = { openFolderCounter++ },
                 closeDrawer = { closeDrawerCounter++ },
                 viewModel = viewModel,
             )
         }
 
+        assertThat(openAccountCounter).isEqualTo(0)
         assertThat(openFolderCounter).isEqualTo(0)
         assertThat(closeDrawerCounter).isEqualTo(0)
 
+        viewModel.effect(Effect.OpenAccount(FakeData.ACCOUNT))
+
+        assertThat(openAccountCounter).isEqualTo(1)
+
         viewModel.effect(Effect.OpenFolder(1))
 
+        assertThat(openAccountCounter).isEqualTo(1)
         assertThat(openFolderCounter).isEqualTo(1)
         assertThat(closeDrawerCounter).isEqualTo(0)
 
         viewModel.effect(Effect.CloseDrawer)
 
+        assertThat(openAccountCounter).isEqualTo(1)
         assertThat(openFolderCounter).isEqualTo(1)
         assertThat(closeDrawerCounter).isEqualTo(1)
     }
@@ -52,6 +61,7 @@ class DrawerViewKtTest : ComposeTest() {
 
         setContentWithTheme {
             DrawerView(
+                openAccount = {},
                 openFolder = {},
                 closeDrawer = {},
                 viewModel = viewModel,

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
@@ -5,11 +5,43 @@ import androidx.compose.ui.test.printToString
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.onNodeWithTag
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
 class DrawerViewKtTest : ComposeTest() {
+
+    @Test
+    fun `should delegate effects`() = runTest {
+        val initialState = State()
+        val viewModel = FakeDrawerViewModel(initialState)
+        var openFolderCounter = 0
+        var closeDrawerCounter = 0
+
+        setContentWithTheme {
+            DrawerView(
+                openFolder = { openFolderCounter++ },
+                closeDrawer = { closeDrawerCounter++ },
+                viewModel = viewModel,
+            )
+        }
+
+        assertThat(openFolderCounter).isEqualTo(0)
+        assertThat(closeDrawerCounter).isEqualTo(0)
+
+        viewModel.effect(Effect.OpenFolder(1))
+
+        assertThat(openFolderCounter).isEqualTo(1)
+        assertThat(closeDrawerCounter).isEqualTo(0)
+
+        viewModel.effect(Effect.CloseDrawer)
+
+        assertThat(openFolderCounter).isEqualTo(1)
+        assertThat(closeDrawerCounter).isEqualTo(1)
+    }
 
     @Test
     fun `pull refresh should listen to view model state`() = runTest {
@@ -20,6 +52,8 @@ class DrawerViewKtTest : ComposeTest() {
 
         setContentWithTheme {
             DrawerView(
+                openFolder = {},
+                closeDrawer = {},
                 viewModel = viewModel,
             )
         }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -5,7 +5,6 @@ import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.compose.testing.MainDispatcherRule
 import app.k9mail.core.ui.compose.testing.mvi.assertThatAndEffectTurbineConsumed
 import app.k9mail.core.ui.compose.testing.mvi.eventStateTest
-import app.k9mail.core.ui.compose.testing.mvi.turbines
 import app.k9mail.core.ui.compose.testing.mvi.turbinesWithInitialStateCheck
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
@@ -105,6 +104,13 @@ class DrawerViewModelTest {
         val testSubject = createTestSubject(
             displayAccountsFlow = getDisplayAccountsFlow,
         )
+        val turbines = turbinesWithInitialStateCheck(
+            testSubject,
+            State(
+                accounts = displayAccounts.toImmutableList(),
+                currentAccount = displayAccounts.first(),
+            ),
+        )
 
         advanceUntilIdle()
 
@@ -112,7 +118,11 @@ class DrawerViewModelTest {
 
         advanceUntilIdle()
 
-        assertThat(testSubject.state.value.currentAccount).isEqualTo(displayAccounts[1])
+        assertThat(turbines.awaitStateItem().currentAccount).isEqualTo(displayAccounts[1])
+
+        turbines.assertThatAndEffectTurbineConsumed {
+            isEqualTo(Effect.OpenAccount(displayAccounts[1].account))
+        }
     }
 
     @Test

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -20,6 +20,7 @@ import kotlin.test.Test
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
@@ -56,7 +57,12 @@ class DrawerViewModelTest {
 
     @Test
     fun `should change loading state when OnRefresh event is received`() = runTest {
-        val testSubject = createTestSubject()
+        val testSubject = createTestSubject(
+            syncMailFlow = flow {
+                delay(25)
+                emit(Result.success(Unit))
+            },
+        )
 
         eventStateTest(
             viewModel = testSubject,
@@ -227,6 +233,7 @@ class DrawerViewModelTest {
         drawerConfigFlow: Flow<DrawerConfig> = flow { emit(createDrawerConfig()) },
         displayAccountsFlow: Flow<List<DisplayAccount>> = flow { emit(emptyList()) },
         displayFoldersMap: Map<String, List<DisplayFolder>> = emptyMap(),
+        syncMailFlow: Flow<Result<Unit>> = flow { emit(Result.success(Unit)) },
     ): DrawerViewModel {
         return DrawerViewModel(
             getDrawerConfig = { drawerConfigFlow },
@@ -234,6 +241,7 @@ class DrawerViewModelTest {
             getDisplayFoldersForAccount = { accountUuid ->
                 flow { emit(displayFoldersMap[accountUuid] ?: emptyList()) }
             },
+            syncMail = { syncMailFlow },
         )
     }
 

--- a/legacy/common/build.gradle.kts
+++ b/legacy/common/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     implementation(projects.feature.account.setup)
     implementation(projects.feature.account.edit)
+    implementation(projects.feature.navigation.drawer)
     implementation(projects.feature.settings.import)
 
     implementation(projects.feature.widget.unread)

--- a/legacy/common/src/main/java/com/fsck/k9/feature/FeatureModule.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/feature/FeatureModule.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.feature
 
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
@@ -9,5 +10,9 @@ val featureModule = module {
         AccountSetupFinishedLauncher(
             context = androidContext(),
         )
+    }
+
+    single<NavigationDrawerExternalContract.DrawerConfigLoader> {
+        NavigationDrawerConfigLoader()
     }
 }

--- a/legacy/common/src/main/java/com/fsck/k9/feature/NavigationDrawerConfigLoader.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/feature/NavigationDrawerConfigLoader.kt
@@ -1,0 +1,14 @@
+package com.fsck.k9.feature
+
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfigLoader
+import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
+import com.fsck.k9.K9
+
+class NavigationDrawerConfigLoader : DrawerConfigLoader {
+    override fun loadDrawerConfig(): DrawerConfig {
+        return DrawerConfig(
+            showUnifiedInbox = K9.isShowUnifiedInbox,
+            showStarredCount = K9.isShowStarredCount,
+        )
+    }
+}

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -608,6 +608,7 @@ open class MessageList :
     private fun initializeFolderDrawer() {
         navigationDrawer = FolderDrawer(
             parent = this,
+            openAccount = { account -> openRealAccount(account) },
             openFolder = { folderId -> openFolder(folderId) },
             createDrawerListener = { createDrawerListener() },
         )
@@ -632,7 +633,7 @@ open class MessageList :
         }
     }
 
-    fun openFolder(folderId: Long) {
+    private fun openFolder(folderId: Long) {
         if (displayMode == DisplayMode.SPLIT_VIEW) {
             removeMessageViewContainerFragment()
             showMessageViewPlaceHolder()

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -608,6 +608,8 @@ open class MessageList :
     private fun initializeFolderDrawer() {
         navigationDrawer = FolderDrawer(
             parent = this,
+            openFolder = { folderId -> openFolder(folderId) },
+            createDrawerListener = { createDrawerListener() },
         )
     }
 


### PR DESCRIPTION
Fourth part of the drawer folder list implementation #8118. This adds account and folder selection, mail sync and integration of settings for starred message count. The aim is to get the folder drawer in a working state and optimize it once all features have been implemented.

Solves #8118