### PR TITLE
Enables Encrypted Backups

### DIFF
--- a/app-common/src/main/AndroidManifest.xml
+++ b/app-common/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
     >
 
     <application
-        android:allowBackup="false"
+        android:allowBackup="true"
+        android:fullBackupContent="@xml/backup"
         android:hasFragileUserData="false"
         android:networkSecurityConfig="@xml/network_security_config"
         android:usesCleartextTraffic="true"

--- a/app-common/src/main/res/xml/backup.xml
+++ b/app-common/src/main/res/xml/backup.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="sharedpref" path="." requireFlags="clientSideEncryption" />
+    <include domain="database" path="." requireFlags="clientSideEncryption" />
+    <include domain="file" path="." requireFlags="clientSideEncryption" />
+</full-backup-content>


### PR DESCRIPTION
Fixes https://github.com/thunderbird/thunderbird-android/issues/3857

As discussed it is only enabled in the situation where client side encryption is enabled so the credentials are protected (https://github.com/thunderbird/thunderbird-android/pull/3846#issuecomment-450231455)

I don't think it's necessary to implement BackupAgent as the manifest assertions should be sufficient?