### PR TITLE
Add drawer bottom view

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
@@ -10,6 +10,8 @@ import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.Archive
 import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.ChevronLeft
+import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Drafts
 import androidx.compose.material.icons.outlined.ErrorOutline
@@ -21,10 +23,11 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Report
 import androidx.compose.material.icons.outlined.Security
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.ui.graphics.vector.ImageVector
 import app.k9mail.core.ui.compose.designsystem.atom.icon.filled.Dot
+import app.k9mail.core.ui.compose.designsystem.atom.icon.outlined.FolderManaged
 import androidx.compose.material.icons.Icons as MaterialIcons
 
 // We're using getters so not all icons are loaded into memory as soon as one of the nested objects is accessed.
@@ -56,6 +59,12 @@ object Icons {
         val Check: ImageVector
             get() = MaterialIcons.Outlined.Check
 
+        val ChevronLeft: ImageVector
+            get() = MaterialIcons.Outlined.ChevronLeft
+
+        val ChevronRight: ImageVector
+            get() = MaterialIcons.Outlined.ChevronRight
+
         val Delete: ImageVector
             get() = MaterialIcons.Outlined.Delete
 
@@ -80,6 +89,9 @@ object Icons {
         val Info: ImageVector
             get() = MaterialIcons.Outlined.Info
 
+        val FolderManaged: ImageVector
+            get() = MaterialIcons.Outlined.FolderManaged
+
         val Menu: ImageVector
             get() = MaterialIcons.Outlined.Menu
 
@@ -91,6 +103,9 @@ object Icons {
 
         val Send: ImageVector
             get() = MaterialIcons.AutoMirrored.Outlined.Send
+
+        val Settings: ImageVector
+            get() = MaterialIcons.Outlined.Settings
 
         val Report: ImageVector
             get() = MaterialIcons.Outlined.Report

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/outlined/FolderManaged.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/outlined/FolderManaged.kt
@@ -1,0 +1,134 @@
+package app.k9mail.core.ui.compose.designsystem.atom.icon.outlined
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+@Suppress("MagicNumber")
+val Icons.Outlined.FolderManaged: ImageVector
+    get() {
+        if (instance != null) {
+            return instance!!
+        }
+        instance = ImageVector.Builder(
+            name = "Outlined.FolderManaged",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 960f,
+            viewportHeight = 960f,
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black),
+                fillAlpha = 1.0f,
+                stroke = null,
+                strokeAlpha = 1.0f,
+                strokeLineWidth = 1.0f,
+                strokeLineCap = StrokeCap.Butt,
+                strokeLineJoin = StrokeJoin.Miter,
+                strokeLineMiter = 1.0f,
+                pathFillType = PathFillType.NonZero,
+            ) {
+                moveTo(680f, 880f)
+                lineTo(668f, 820f)
+                quadTo(656f, 815f, 645.5f, 809.5f)
+                quadTo(635f, 804f, 624f, 796f)
+                lineTo(566f, 814f)
+                lineTo(526f, 746f)
+                lineTo(572f, 706f)
+                quadTo(570f, 694f, 570f, 680f)
+                quadTo(570f, 666f, 572f, 654f)
+                lineTo(526f, 614f)
+                lineTo(566f, 546f)
+                lineTo(624f, 564f)
+                quadTo(635f, 556f, 645.5f, 550.5f)
+                quadTo(656f, 545f, 668f, 540f)
+                lineTo(680f, 480f)
+                lineTo(760f, 480f)
+                lineTo(772f, 540f)
+                quadTo(784f, 545f, 794.5f, 550.5f)
+                quadTo(805f, 556f, 816f, 564f)
+                lineTo(874f, 546f)
+                lineTo(914f, 614f)
+                lineTo(868f, 654f)
+                quadTo(870f, 666f, 870f, 680f)
+                quadTo(870f, 694f, 868f, 706f)
+                lineTo(914f, 746f)
+                lineTo(874f, 814f)
+                lineTo(816f, 796f)
+                quadTo(805f, 804f, 794.5f, 809.5f)
+                quadTo(784f, 815f, 772f, 820f)
+                lineTo(760f, 880f)
+                lineTo(680f, 880f)
+                close()
+                moveTo(720f, 760f)
+                quadTo(753f, 760f, 776.5f, 736.5f)
+                quadTo(800f, 713f, 800f, 680f)
+                quadTo(800f, 647f, 776.5f, 623.5f)
+                quadTo(753f, 600f, 720f, 600f)
+                quadTo(687f, 600f, 663.5f, 623.5f)
+                quadTo(640f, 647f, 640f, 680f)
+                quadTo(640f, 713f, 663.5f, 736.5f)
+                quadTo(687f, 760f, 720f, 760f)
+                close()
+                moveTo(160f, 720f)
+                lineTo(160f, 720f)
+                quadTo(160f, 720f, 160f, 720f)
+                quadTo(160f, 720f, 160f, 720f)
+                lineTo(160f, 240f)
+                quadTo(160f, 240f, 160f, 240f)
+                quadTo(160f, 240f, 160f, 240f)
+                lineTo(160f, 240f)
+                lineTo(160f, 320f)
+                lineTo(160f, 320f)
+                quadTo(160f, 320f, 160f, 320f)
+                quadTo(160f, 320f, 160f, 320f)
+                lineTo(160f, 412f)
+                quadTo(160f, 406f, 160f, 403f)
+                quadTo(160f, 400f, 160f, 400f)
+                quadTo(160f, 400f, 160f, 482.5f)
+                quadTo(160f, 565f, 160f, 679f)
+                quadTo(160f, 690f, 160f, 699.5f)
+                quadTo(160f, 709f, 160f, 720f)
+                close()
+                moveTo(160f, 800f)
+                quadTo(127f, 800f, 103.5f, 776.5f)
+                quadTo(80f, 753f, 80f, 720f)
+                lineTo(80f, 240f)
+                quadTo(80f, 207f, 103.5f, 183.5f)
+                quadTo(127f, 160f, 160f, 160f)
+                lineTo(400f, 160f)
+                lineTo(480f, 240f)
+                lineTo(800f, 240f)
+                quadTo(833f, 240f, 856.5f, 263.5f)
+                quadTo(880f, 287f, 880f, 320f)
+                lineTo(880f, 451f)
+                quadTo(862f, 438f, 842f, 428.5f)
+                quadTo(822f, 419f, 800f, 412f)
+                lineTo(800f, 320f)
+                quadTo(800f, 320f, 800f, 320f)
+                quadTo(800f, 320f, 800f, 320f)
+                lineTo(447f, 320f)
+                lineTo(367f, 240f)
+                lineTo(160f, 240f)
+                quadTo(160f, 240f, 160f, 240f)
+                quadTo(160f, 240f, 160f, 240f)
+                lineTo(160f, 720f)
+                quadTo(160f, 720f, 160f, 720f)
+                quadTo(160f, 720f, 160f, 720f)
+                lineTo(443f, 720f)
+                quadTo(446f, 741f, 452.5f, 761f)
+                quadTo(459f, 781f, 468f, 800f)
+                lineTo(160f, 800f)
+                close()
+            }
+        }.build()
+        return instance!!
+    }
+
+private var instance: ImageVector? = null

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListItemPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListItemPreview.kt
@@ -1,0 +1,18 @@
+package app.k9mail.feature.navigation.drawer.ui.setting
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+
+@Composable
+@Preview(showBackground = true)
+fun SettingListItemPreview() {
+    PreviewWithThemes {
+        SettingListItem(
+            label = "Settings",
+            onClick = {},
+            imageVector = Icons.Outlined.Settings,
+        )
+    }
+}

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListPreview.kt
@@ -1,0 +1,29 @@
+package app.k9mail.feature.navigation.drawer.ui.setting
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+
+@Composable
+@Preview(showBackground = true)
+fun SettingListPreview() {
+    PreviewWithTheme {
+        SettingList(
+            onAccountSelectorClick = {},
+            onManageFoldersClick = {},
+            showAccountSelector = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun SettingListShowAccountSelectorPreview() {
+    PreviewWithTheme {
+        SettingList(
+            onAccountSelectorClick = {},
+            onManageFoldersClick = {},
+            showAccountSelector = true,
+        )
+    }
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
@@ -17,6 +17,8 @@ class FolderDrawer(
     override val parent: AppCompatActivity,
     private val openAccount: (account: Account) -> Unit,
     private val openFolder: (folderId: Long) -> Unit,
+    private val openManageFolders: () -> Unit,
+    private val openSettings: () -> Unit,
     createDrawerListener: () -> DrawerLayout.DrawerListener,
 ) : NavigationDrawer, KoinComponent {
 
@@ -38,6 +40,8 @@ class FolderDrawer(
                 DrawerView(
                     openAccount = openAccount,
                     openFolder = openFolder,
+                    openManageFolders = openManageFolders,
+                    openSettings = openSettings,
                     closeDrawer = { close() },
                 )
             }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -290,7 +290,7 @@ class LegacyDrawer(
     private fun addFooterItems() {
         sliderView.addStickyFooterItem(
             PrimaryDrawerItem().apply {
-                nameRes = R.string.navigation_drawer_action_folders
+                nameRes = R.string.navigation_drawer_action_manage_folders
                 iconRes = Icons.Outlined.Folder
                 identifier = DRAWER_ID_FOLDERS
                 isSelectable = false

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -66,7 +66,7 @@ private const val EN_SPACE = "\u2000"
 @Suppress("MagicNumber", "TooManyFunctions", "LongParameterList")
 class LegacyDrawer(
     override val parent: AppCompatActivity,
-    private val openFolders: () -> Unit,
+    private val openManageFolders: () -> Unit,
     private val openUnifiedInbox: () -> Unit,
     private val openFolder: (folderId: Long) -> Unit,
     private val openAccount: (account: Account) -> Boolean,
@@ -352,7 +352,7 @@ class LegacyDrawer(
     private fun handleItemClickListener(drawerItem: IDrawerItem<*>) {
         when (drawerItem.identifier) {
             DRAWER_ID_PREFERENCES -> openSettings()
-            DRAWER_ID_FOLDERS -> openFolders()
+            DRAWER_ID_FOLDERS -> openManageFolders()
             DRAWER_ID_UNIFIED_INBOX -> openUnifiedInbox()
             else -> {
                 val folder = drawerItem.tag as Folder

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -1,19 +1,17 @@
 package app.k9mail.feature.navigation.drawer.ui
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
-import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
 import app.k9mail.feature.navigation.drawer.ui.account.AccountView
 import app.k9mail.feature.navigation.drawer.ui.folder.FolderList
+import app.k9mail.feature.navigation.drawer.ui.setting.SettingList
 
 @Composable
 fun DrawerContent(
@@ -28,11 +26,7 @@ fun DrawerContent(
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(
-                    vertical = MainTheme.spacings.oneHalf,
-                ),
-            verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
+                .fillMaxSize(),
         ) {
             state.selectedAccount?.let {
                 AccountView(
@@ -51,7 +45,16 @@ fun DrawerContent(
                     onEvent(Event.OnFolderClick(folder))
                 },
                 showStarredCount = state.config.showStarredCount,
+                modifier = Modifier.weight(1f),
             )
+            Column {
+                DividerHorizontal()
+                SettingList(
+                    onAccountSelectorClick = { onEvent(Event.OnAccountSelectorClick) },
+                    onManageFoldersClick = { onEvent(Event.OnManageFoldersClick) },
+                    showAccountSelector = state.showAccountSelector,
+                )
+            }
         }
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -23,6 +23,7 @@ interface DrawerContract {
         val selectedAccount: DisplayAccount? = null,
         val folders: ImmutableList<DisplayAccountFolder> = persistentListOf(),
         val selectedFolder: DisplayAccountFolder? = null,
+        val showAccountSelector: Boolean = false,
         val isLoading: Boolean = false,
     )
 
@@ -30,12 +31,17 @@ interface DrawerContract {
         data class OnAccountClick(val account: DisplayAccount) : Event
         data class OnAccountViewClick(val account: DisplayAccount) : Event
         data class OnFolderClick(val folder: DisplayAccountFolder) : Event
+        data object OnAccountSelectorClick : Event
+        data object OnManageFoldersClick : Event
+        data object OnSettingsClick : Event
         data object OnRefresh : Event
     }
 
     sealed interface Effect {
         data class OpenAccount(val account: Account) : Effect
         data class OpenFolder(val folderId: Long) : Effect
+        data object OpenManageFolders : Effect
+        data object OpenSettings : Effect
         data object CloseDrawer : Effect
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
@@ -13,6 +13,8 @@ import org.koin.androidx.compose.koinViewModel
 fun DrawerView(
     openAccount: (account: Account) -> Unit,
     openFolder: (folderId: Long) -> Unit,
+    openManageFolders: () -> Unit,
+    openSettings: () -> Unit,
     closeDrawer: () -> Unit,
     viewModel: ViewModel = koinViewModel<DrawerViewModel>(),
 ) {
@@ -20,6 +22,8 @@ fun DrawerView(
         when (effect) {
             is Effect.OpenAccount -> openAccount(effect.account)
             is Effect.OpenFolder -> openFolder(effect.folderId)
+            is Effect.OpenManageFolders -> openManageFolders()
+            is Effect.OpenSettings -> openSettings()
             Effect.CloseDrawer -> closeDrawer()
         }
     }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -101,6 +101,10 @@ class DrawerViewModel(
                     state.value.accounts.nextOrFirst(event.account)!!,
                 )
             }
+
+            Event.OnAccountSelectorClick -> updateState { it.copy(showAccountSelector = it.showAccountSelector.not()) }
+            Event.OnManageFoldersClick -> emitEffect(Effect.OpenManageFolders)
+            Event.OnSettingsClick -> emitEffect(Effect.OpenSettings)
         }
     }
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
@@ -30,10 +30,10 @@ fun AccountView(
             .height(intrinsicSize = IntrinsicSize.Max)
             .clickable(onClick = onClick)
             .padding(
-                top = MainTheme.spacings.default,
+                top = MainTheme.spacings.double,
                 start = MainTheme.spacings.double,
                 end = MainTheme.spacings.triple,
-                bottom = MainTheme.spacings.oneHalf,
+                bottom = MainTheme.spacings.double,
             ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -42,7 +42,7 @@ fun AccountView(
             modifier = Modifier
                 .fillMaxHeight()
                 .padding(
-                    end = MainTheme.spacings.default,
+                    end = MainTheme.spacings.oneHalf,
                 ),
         )
         Column(

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -1,10 +1,12 @@
 package app.k9mail.feature.navigation.drawer.ui.folder
 
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import kotlinx.collections.immutable.ImmutableList
 
@@ -18,7 +20,8 @@ fun FolderList(
 ) {
     LazyColumn(
         modifier = modifier
-            .fillMaxSize(),
+            .fillMaxWidth(),
+        contentPadding = PaddingValues(vertical = MainTheme.spacings.default),
     ) {
         items(folders) { folder ->
             FolderListItem(

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -13,15 +13,15 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 fun FolderListItem(
     displayFolder: DisplayAccountFolder,
     selected: Boolean,
-    showStarredCount: Boolean,
     onClick: (DisplayAccountFolder) -> Unit,
+    showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {
     NavigationDrawerItem(
         label = displayFolder.folder.name,
         selected = selected,
-        modifier = modifier,
         onClick = { onClick(displayFolder) },
+        modifier = modifier,
         icon = {
             Icon(
                 imageVector = mapFolderIcon(displayFolder.folder.type),

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingList.kt
@@ -1,0 +1,44 @@
+package app.k9mail.feature.navigation.drawer.ui.setting
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import app.k9mail.feature.navigation.drawer.R
+
+@Composable
+fun SettingList(
+    onAccountSelectorClick: () -> Unit,
+    onManageFoldersClick: () -> Unit,
+    showAccountSelector: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(vertical = MainTheme.spacings.default)
+            .fillMaxWidth(),
+    ) {
+        SettingListItem(
+            label = stringResource(R.string.navigation_drawer_action_manage_folders),
+            onClick = onManageFoldersClick,
+            imageVector = Icons.Outlined.FolderManaged,
+        )
+        SettingListItem(
+            label = if (showAccountSelector) {
+                stringResource(R.string.navigation_drawer_action_hide_accounts)
+            } else {
+                stringResource(R.string.navigation_drawer_action_show_accounts)
+            },
+            onClick = onAccountSelectorClick,
+            imageVector = if (showAccountSelector) {
+                Icons.Outlined.ChevronLeft
+            } else {
+                Icons.Outlined.ChevronRight
+            },
+        )
+    }
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListItem.kt
@@ -1,0 +1,27 @@
+package app.k9mail.feature.navigation.drawer.ui.setting
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
+import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItem
+
+@Composable
+fun SettingListItem(
+    label: String,
+    onClick: () -> Unit,
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    NavigationDrawerItem(
+        label = label,
+        onClick = onClick,
+        modifier = modifier,
+        selected = false,
+        icon = {
+            Icon(
+                imageVector = imageVector,
+            )
+        },
+    )
+}

--- a/feature/navigation/drawer/src/main/res/values-ar/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-ar/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">الإعدادات</string>
-    <string name="navigation_drawer_action_folders">إدارة المجلدات</string>
+    <string name="navigation_drawer_action_manage_folders">إدارة المجلدات</string>
     <string name="navigation_drawer_unified_inbox_title">البريد الوارد الموحَّد</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-be/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-be/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Налады</string>
-    <string name="navigation_drawer_action_folders">Кіраванне каталогамі</string>
+    <string name="navigation_drawer_action_manage_folders">Кіраванне каталогамі</string>
     <string name="navigation_drawer_unified_inbox_title">Усе атрыманыя</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-bg/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-bg/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Настройки</string>
-    <string name="navigation_drawer_action_folders">Управление на папки</string>
+    <string name="navigation_drawer_action_manage_folders">Управление на папки</string>
     <string name="navigation_drawer_unified_inbox_title">Обща входяща кутия</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-br/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-br/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Arventennoù</string>
-    <string name="navigation_drawer_action_folders">Merañ an teuliadoù</string>
+    <string name="navigation_drawer_action_manage_folders">Merañ an teuliadoù</string>
     <string name="navigation_drawer_unified_inbox_title">Boest degemer unanet</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-bs/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-bs/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Postavke</string>
-    <string name="navigation_drawer_action_folders">Upravljajte direktorijumima</string>
+    <string name="navigation_drawer_action_manage_folders">Upravljajte direktorijumima</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-ca/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-ca/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Configuració</string>
-    <string name="navigation_drawer_action_folders">Gestioneu les carpetes</string>
+    <string name="navigation_drawer_action_manage_folders">Gestioneu les carpetes</string>
     <string name="navigation_drawer_unified_inbox_title">Bústia d\'entrada unificada</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-co/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-co/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Parametri</string>
-    <string name="navigation_drawer_action_folders">Ghjestione di i cartulari</string>
+    <string name="navigation_drawer_action_manage_folders">Ghjestione di i cartulari</string>
     <string name="navigation_drawer_unified_inbox_title">Ricezzione cuncolta</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-cs/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-cs/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Nastavení</string>
-    <string name="navigation_drawer_action_folders">Správa složek</string>
+    <string name="navigation_drawer_action_manage_folders">Správa složek</string>
     <string name="navigation_drawer_unified_inbox_title">Integrovaná doručená pošta</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-cy/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-cy/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Gosodiadau</string>
-    <string name="navigation_drawer_action_folders">Rheoli ffolderi</string>
+    <string name="navigation_drawer_action_manage_folders">Rheoli ffolderi</string>
     <string name="navigation_drawer_unified_inbox_title">Mewnflwch Unedig</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-da/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-da/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Indstillinger</string>
-    <string name="navigation_drawer_action_folders">Håndtér mapper</string>
+    <string name="navigation_drawer_action_manage_folders">Håndtér mapper</string>
     <string name="navigation_drawer_unified_inbox_title">Fælles indbakke</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-de/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Einstellungen</string>
-    <string name="navigation_drawer_action_folders">Ordner verwalten</string>
+    <string name="navigation_drawer_action_manage_folders">Ordner verwalten</string>
     <string name="navigation_drawer_unified_inbox_title">Gemeinsamer Posteingang</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-el/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-el/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Ρυθμίσεις</string>
-    <string name="navigation_drawer_action_folders">Διαχείριση φακέλων</string>
+    <string name="navigation_drawer_action_manage_folders">Διαχείριση φακέλων</string>
     <string name="navigation_drawer_unified_inbox_title">Ενιαία Εισερχόμενα</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-en-rGB/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-en-rGB/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Settings</string>
-    <string name="navigation_drawer_action_folders">Manage folders</string>
+    <string name="navigation_drawer_action_manage_folders">Manage folders</string>
     <string name="navigation_drawer_unified_inbox_title">Unified Inbox</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-eo/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-eo/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Agordoj</string>
-    <string name="navigation_drawer_action_folders">Administri mesaĝujojn</string>
+    <string name="navigation_drawer_action_manage_folders">Administri mesaĝujojn</string>
     <string name="navigation_drawer_unified_inbox_title">Unuigita ricevujo</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-es/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-es/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Ajustes</string>
-    <string name="navigation_drawer_action_folders">Administrar carpetas</string>
+    <string name="navigation_drawer_action_manage_folders">Administrar carpetas</string>
     <string name="navigation_drawer_unified_inbox_title">Entrada unificada</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-et/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-et/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Sätted</string>
-    <string name="navigation_drawer_action_folders">Halda kaustu</string>
+    <string name="navigation_drawer_action_manage_folders">Halda kaustu</string>
     <string name="navigation_drawer_unified_inbox_title">Koondsisendkaust</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-eu/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-eu/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Ezarpenak</string>
-    <string name="navigation_drawer_action_folders">Kudeatu karpetak</string>
+    <string name="navigation_drawer_action_manage_folders">Kudeatu karpetak</string>
     <string name="navigation_drawer_unified_inbox_title">Sarrerako ontzi bateratua</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-fa/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-fa/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">تنظیمات</string>
-    <string name="navigation_drawer_action_folders">مدیریت پوشه‌ها</string>
+    <string name="navigation_drawer_action_manage_folders">مدیریت پوشه‌ها</string>
     <string name="navigation_drawer_unified_inbox_title">صندوق ورودی یکپارچه</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-fi/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-fi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Asetukset</string>
-    <string name="navigation_drawer_action_folders">Hallitse kansioita</string>
+    <string name="navigation_drawer_action_manage_folders">Hallitse kansioita</string>
     <string name="navigation_drawer_unified_inbox_title">Yhdistetty saapuneet</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-fr/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Paramètres</string>
-    <string name="navigation_drawer_action_folders">Gérer les dossiers</string>
+    <string name="navigation_drawer_action_manage_folders">Gérer les dossiers</string>
     <string name="navigation_drawer_unified_inbox_title">Boîte de réception unifiée</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-fy/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-fy/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Ynstellingen</string>
-    <string name="navigation_drawer_action_folders">Mappen beheare</string>
+    <string name="navigation_drawer_action_manage_folders">Mappen beheare</string>
     <string name="navigation_drawer_unified_inbox_title">Kombinearre Postfek YN</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-gd/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-gd/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Roghainnean</string>
-    <string name="navigation_drawer_action_folders">Stiùirich na pasganan</string>
+    <string name="navigation_drawer_action_manage_folders">Stiùirich na pasganan</string>
     <string name="navigation_drawer_unified_inbox_title">An t-oll-bhogsa</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-gl/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-gl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Configuración</string>
-    <string name="navigation_drawer_action_folders">Xestionar cartafoles</string>
+    <string name="navigation_drawer_action_manage_folders">Xestionar cartafoles</string>
     <string name="navigation_drawer_unified_inbox_title">Entrada unificada</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-hi/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-hi/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">सेटिंग</string>
-    <string name="navigation_drawer_action_folders">फोल्डर मैनेज करें</string>
+    <string name="navigation_drawer_action_manage_folders">फोल्डर मैनेज करें</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-hr/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-hr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Podešenja</string>
-    <string name="navigation_drawer_action_folders">Upravljanje mapama</string>
+    <string name="navigation_drawer_action_manage_folders">Upravljanje mapama</string>
     <string name="navigation_drawer_unified_inbox_title">Objedinjena Dolazna Pošta</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-hu/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-hu/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Beállítások</string>
-    <string name="navigation_drawer_action_folders">Mappák kezelése</string>
+    <string name="navigation_drawer_action_manage_folders">Mappák kezelése</string>
     <string name="navigation_drawer_unified_inbox_title">Egységes beérkezett üzenetek</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-in/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-in/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Pengaturan</string>
-    <string name="navigation_drawer_action_folders">Kelola folder</string>
+    <string name="navigation_drawer_action_manage_folders">Kelola folder</string>
     <string name="navigation_drawer_unified_inbox_title">Kotak Masuk Terpadu</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-is/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-is/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Stillingar</string>
-    <string name="navigation_drawer_action_folders">Sýsla með möppur</string>
+    <string name="navigation_drawer_action_manage_folders">Sýsla með möppur</string>
     <string name="navigation_drawer_unified_inbox_title">Sameinað innhólf</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-it/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-it/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Impostazioni</string>
-    <string name="navigation_drawer_action_folders">Gestione cartelle</string>
+    <string name="navigation_drawer_action_manage_folders">Gestione cartelle</string>
     <string name="navigation_drawer_unified_inbox_title">Posta combinata</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-iw/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-iw/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">הגדרות</string>
-    <string name="navigation_drawer_action_folders">נהל תיקיות</string>
+    <string name="navigation_drawer_action_manage_folders">נהל תיקיות</string>
     <string name="navigation_drawer_unified_inbox_title">תיבת דואר נכנס אחידה</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-ja/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-ja/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">設定</string>
-    <string name="navigation_drawer_action_folders">フォルダーを管理</string>
+    <string name="navigation_drawer_action_manage_folders">フォルダーを管理</string>
     <string name="navigation_drawer_unified_inbox_title">統合受信トレイ</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-ka/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-ka/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">პარამეტრები</string>
-    <string name="navigation_drawer_action_folders">საკეცების მართვა</string>
+    <string name="navigation_drawer_action_manage_folders">საკეცების მართვა</string>
     <string name="navigation_drawer_unified_inbox_title">გაერთიანებული შემავალი</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-ko/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-ko/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">설정</string>
-    <string name="navigation_drawer_action_folders">폴더 관리</string>
+    <string name="navigation_drawer_action_manage_folders">폴더 관리</string>
     <string name="navigation_drawer_unified_inbox_title">통합 편지함</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-lt/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-lt/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Nustatymai</string>
-    <string name="navigation_drawer_action_folders">Tvarkyti aplankus</string>
+    <string name="navigation_drawer_action_manage_folders">Tvarkyti aplankus</string>
     <string name="navigation_drawer_unified_inbox_title">Suvestiniai gautieji</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-lv/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-lv/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Iestatījumi</string>
-    <string name="navigation_drawer_action_folders">Pārvaldīt mapes</string>
+    <string name="navigation_drawer_action_manage_folders">Pārvaldīt mapes</string>
     <string name="navigation_drawer_unified_inbox_title">Apvienotā Iesūtne</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-ml/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-ml/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">സജ്ജീകരണങ്ങൾ</string>
-    <string name="navigation_drawer_action_folders">ഫോൾഡറുകൾ നിയന്ത്രിക്കുക</string>
+    <string name="navigation_drawer_action_manage_folders">ഫോൾഡറുകൾ നിയന്ത്രിക്കുക</string>
     <string name="navigation_drawer_unified_inbox_title">ഏകീകൃത ഇൻ‌ബോക്സ്</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-nb/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-nb/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Innstillinger</string>
-    <string name="navigation_drawer_action_folders">Behandle mapper</string>
+    <string name="navigation_drawer_action_manage_folders">Behandle mapper</string>
     <string name="navigation_drawer_unified_inbox_title">Samlet innboks</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-nl/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-nl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Instellingen</string>
-    <string name="navigation_drawer_action_folders">Mappen beheren</string>
+    <string name="navigation_drawer_action_manage_folders">Mappen beheren</string>
     <string name="navigation_drawer_unified_inbox_title">Samengevoegd Postvak IN</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-pl/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-pl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Ustawienia</string>
-    <string name="navigation_drawer_action_folders">Zarządzaj folderami</string>
+    <string name="navigation_drawer_action_manage_folders">Zarządzaj folderami</string>
     <string name="navigation_drawer_unified_inbox_title">Zintegrowana odbiorcza</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Configurações</string>
-    <string name="navigation_drawer_action_folders">Gerenciar pastas</string>
+    <string name="navigation_drawer_action_manage_folders">Gerenciar pastas</string>
     <string name="navigation_drawer_unified_inbox_title">Caixa de Entrada Unificada</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-pt-rPT/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-pt-rPT/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Configurações</string>
-    <string name="navigation_drawer_action_folders">Gerir pastas</string>
+    <string name="navigation_drawer_action_manage_folders">Gerir pastas</string>
     <string name="navigation_drawer_unified_inbox_title">Caixa de entrada unificada</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-ro/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-ro/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Opțiuni</string>
-    <string name="navigation_drawer_action_folders">Gestionează dosarele</string>
+    <string name="navigation_drawer_action_manage_folders">Gestionează dosarele</string>
     <string name="navigation_drawer_unified_inbox_title">Căsuță poștală unificată</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-ru/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-ru/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Настройки</string>
-    <string name="navigation_drawer_action_folders">Выбрать папки</string>
+    <string name="navigation_drawer_action_manage_folders">Выбрать папки</string>
     <string name="navigation_drawer_unified_inbox_title">Входящие</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-sk/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-sk/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Nastavenia</string>
-    <string name="navigation_drawer_action_folders">Spravovať priečinky</string>
+    <string name="navigation_drawer_action_manage_folders">Spravovať priečinky</string>
     <string name="navigation_drawer_unified_inbox_title">Jednotná schránka</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-sl/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-sl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Nastavitve</string>
-    <string name="navigation_drawer_action_folders">Upravljanje z mapami</string>
+    <string name="navigation_drawer_action_manage_folders">Upravljanje z mapami</string>
     <string name="navigation_drawer_unified_inbox_title">Skupna mapa prejetih sporočil</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-sq/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-sq/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Rregullime</string>
-    <string name="navigation_drawer_action_folders">Administroni dosje</string>
+    <string name="navigation_drawer_action_manage_folders">Administroni dosje</string>
     <string name="navigation_drawer_unified_inbox_title">Kuti Poste e Njësuar</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-sr/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-sr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Поставке</string>
-    <string name="navigation_drawer_action_folders">Управљај фасциклама</string>
+    <string name="navigation_drawer_action_manage_folders">Управљај фасциклама</string>
     <string name="navigation_drawer_unified_inbox_title">Обједињено сандуче</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-sv/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-sv/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Inställningar</string>
-    <string name="navigation_drawer_action_folders">Hantera mappar</string>
+    <string name="navigation_drawer_action_manage_folders">Hantera mappar</string>
     <string name="navigation_drawer_unified_inbox_title">Samlad inkorg</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-tr/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-tr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Ayarlar</string>
-    <string name="navigation_drawer_action_folders">Klasörleri yönet</string>
+    <string name="navigation_drawer_action_manage_folders">Klasörleri yönet</string>
     <string name="navigation_drawer_unified_inbox_title">Birleşik Gelen Kutusu</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-uk/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-uk/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Налаштування</string>
-    <string name="navigation_drawer_action_folders">Керування теками</string>
+    <string name="navigation_drawer_action_manage_folders">Керування теками</string>
     <string name="navigation_drawer_unified_inbox_title">Об\'єднані Вхідні</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-vi/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-vi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Thiết đặt</string>
-    <string name="navigation_drawer_action_folders">Quản lý thư mục</string>
+    <string name="navigation_drawer_action_manage_folders">Quản lý thư mục</string>
     <string name="navigation_drawer_unified_inbox_title">Hộp thư đồng nhất</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">设置</string>
-    <string name="navigation_drawer_action_folders">管理文件夹</string>
+    <string name="navigation_drawer_action_manage_folders">管理文件夹</string>
     <string name="navigation_drawer_unified_inbox_title">统一收件箱</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">設定</string>
-    <string name="navigation_drawer_action_folders">整理信件匣</string>
+    <string name="navigation_drawer_action_manage_folders">整理信件匣</string>
     <string name="navigation_drawer_unified_inbox_title">全域收件匣</string>
 </resources>

--- a/feature/navigation/drawer/src/main/res/values/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Settings</string>
-    <string name="navigation_drawer_action_folders">Manage folders</string>
+    <string name="navigation_drawer_action_manage_folders">Manage folders</string>
     <string name="navigation_drawer_action_show_accounts">Show accounts</string>
     <string name="navigation_drawer_action_hide_accounts">Hide accounts</string>
     <string name="navigation_drawer_unified_inbox_title">Unified Inbox</string>

--- a/feature/navigation/drawer/src/main/res/values/strings.xml
+++ b/feature/navigation/drawer/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_action_settings">Settings</string>
     <string name="navigation_drawer_action_folders">Manage folders</string>
+    <string name="navigation_drawer_action_show_accounts">Show accounts</string>
+    <string name="navigation_drawer_action_hide_accounts">Hide accounts</string>
     <string name="navigation_drawer_unified_inbox_title">Unified Inbox</string>
     <string name="navigation_drawer_folder_item_badge_count_greater_than_99">99+</string>
     <string name="navigation_drawer_folder_item_badge_count_greater_than_1_000">1k+</string>

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncMailTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncMailTest.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.navigation.drawer.domain.usecase
 
+import app.k9mail.feature.navigation.drawer.ui.FakeData
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.MessagingListener
@@ -23,6 +24,22 @@ class SyncMailTest {
         )
 
         val result = testSubject(null).first()
+
+        assertThat(result.isSuccess).isEqualTo(true)
+    }
+
+    @Test
+    fun `should sync mail with account`() = runTest {
+        val listenerExecutor: (MessagingListener?) -> Unit = { listener ->
+            listener?.checkMailFinished(null, null)
+        }
+        val testSubject = SyncMail(
+            messagingController = FakeMessagingControllerMailChecker(
+                listenerExecutor = listenerExecutor,
+            ),
+        )
+
+        val result = testSubject(FakeData.ACCOUNT).first()
 
         assertThat(result.isSuccess).isEqualTo(true)
     }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -23,6 +23,7 @@ class DrawerStateTest {
                 selectedAccount = null,
                 folders = persistentListOf(),
                 selectedFolder = null,
+                showAccountSelector = false,
                 isLoading = false,
             ),
         )

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
@@ -20,12 +20,16 @@ class DrawerViewKtTest : ComposeTest() {
         val viewModel = FakeDrawerViewModel(initialState)
         var openAccountCounter = 0
         var openFolderCounter = 0
+        var openManageFoldersCounter = 0
+        var openSettingsCounter = 0
         var closeDrawerCounter = 0
 
         setContentWithTheme {
             DrawerView(
                 openAccount = { openAccountCounter++ },
                 openFolder = { openFolderCounter++ },
+                openManageFolders = { openManageFoldersCounter++ },
+                openSettings = { openSettingsCounter++ },
                 closeDrawer = { closeDrawerCounter++ },
                 viewModel = viewModel,
             )
@@ -33,22 +37,48 @@ class DrawerViewKtTest : ComposeTest() {
 
         assertThat(openAccountCounter).isEqualTo(0)
         assertThat(openFolderCounter).isEqualTo(0)
+        assertThat(openManageFoldersCounter).isEqualTo(0)
+        assertThat(openSettingsCounter).isEqualTo(0)
         assertThat(closeDrawerCounter).isEqualTo(0)
 
         viewModel.effect(Effect.OpenAccount(FakeData.ACCOUNT))
 
         assertThat(openAccountCounter).isEqualTo(1)
+        assertThat(openFolderCounter).isEqualTo(0)
+        assertThat(openManageFoldersCounter).isEqualTo(0)
+        assertThat(openSettingsCounter).isEqualTo(0)
+        assertThat(closeDrawerCounter).isEqualTo(0)
 
         viewModel.effect(Effect.OpenFolder(1))
 
         assertThat(openAccountCounter).isEqualTo(1)
         assertThat(openFolderCounter).isEqualTo(1)
+        assertThat(openManageFoldersCounter).isEqualTo(0)
+        assertThat(openSettingsCounter).isEqualTo(0)
+        assertThat(closeDrawerCounter).isEqualTo(0)
+
+        viewModel.effect(Effect.OpenManageFolders)
+
+        assertThat(openAccountCounter).isEqualTo(1)
+        assertThat(openFolderCounter).isEqualTo(1)
+        assertThat(openManageFoldersCounter).isEqualTo(1)
+        assertThat(openSettingsCounter).isEqualTo(0)
+        assertThat(closeDrawerCounter).isEqualTo(0)
+
+        viewModel.effect(Effect.OpenSettings)
+
+        assertThat(openAccountCounter).isEqualTo(1)
+        assertThat(openFolderCounter).isEqualTo(1)
+        assertThat(openManageFoldersCounter).isEqualTo(1)
+        assertThat(openSettingsCounter).isEqualTo(1)
         assertThat(closeDrawerCounter).isEqualTo(0)
 
         viewModel.effect(Effect.CloseDrawer)
 
         assertThat(openAccountCounter).isEqualTo(1)
         assertThat(openFolderCounter).isEqualTo(1)
+        assertThat(openManageFoldersCounter).isEqualTo(1)
+        assertThat(openSettingsCounter).isEqualTo(1)
         assertThat(closeDrawerCounter).isEqualTo(1)
     }
 
@@ -63,6 +93,8 @@ class DrawerViewKtTest : ComposeTest() {
             DrawerView(
                 openAccount = {},
                 openFolder = {},
+                openManageFolders = {},
+                openSettings = {},
                 closeDrawer = {},
                 viewModel = viewModel,
             )

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -4,6 +4,7 @@ import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.compose.testing.MainDispatcherRule
 import app.k9mail.core.ui.compose.testing.mvi.assertThatAndEffectTurbineConsumed
+import app.k9mail.core.ui.compose.testing.mvi.assertThatAndStateTurbineConsumed
 import app.k9mail.core.ui.compose.testing.mvi.eventStateTest
 import app.k9mail.core.ui.compose.testing.mvi.turbinesWithInitialStateCheck
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
@@ -226,6 +227,46 @@ class DrawerViewModelTest {
 
         turbines.assertThatAndEffectTurbineConsumed {
             isEqualTo(Effect.CloseDrawer)
+        }
+    }
+
+    @Test
+    fun `should change state when OnAccountSelectorClick event is received`() = runTest {
+        val testSubject = createTestSubject()
+        val turbines = turbinesWithInitialStateCheck(testSubject, State())
+
+        testSubject.event(Event.OnAccountSelectorClick)
+
+        assertThat(turbines.awaitStateItem()).isEqualTo(State(showAccountSelector = true))
+
+        testSubject.event(Event.OnAccountSelectorClick)
+
+        turbines.assertThatAndStateTurbineConsumed {
+            isEqualTo(State(showAccountSelector = false))
+        }
+    }
+
+    @Test
+    fun `should emit OpenManageFolders effect when OnManageFoldersClick event is received`() = runTest {
+        val testSubject = createTestSubject()
+        val turbines = turbinesWithInitialStateCheck(testSubject, State())
+
+        testSubject.event(Event.OnManageFoldersClick)
+
+        turbines.assertThatAndEffectTurbineConsumed {
+            isEqualTo(Effect.OpenManageFolders)
+        }
+    }
+
+    @Test
+    fun `should emit OpenSettings effect when OnSettingsClick event is received`() = runTest {
+        val testSubject = createTestSubject()
+        val turbines = turbinesWithInitialStateCheck(testSubject, State())
+
+        testSubject.event(Event.OnSettingsClick)
+
+        turbines.assertThatAndEffectTurbineConsumed {
+            isEqualTo(Effect.OpenSettings)
         }
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -596,7 +596,7 @@ open class MessageList :
         navigationDrawer = LegacyDrawer(
             parent = this,
             savedInstanceState = savedInstanceState,
-            openFolders = { launchManageFoldersScreen() },
+            openManageFolders = { launchManageFoldersScreen() },
             openUnifiedInbox = { openUnifiedInbox() },
             openFolder = { folderId -> openFolder(folderId) },
             openAccount = { account -> openRealAccount(account) },
@@ -610,6 +610,8 @@ open class MessageList :
             parent = this,
             openAccount = { account -> openRealAccount(account) },
             openFolder = { folderId -> openFolder(folderId) },
+            openManageFolders = { launchManageFoldersScreen() },
+            openSettings = { SettingsActivity.launch(this) },
             createDrawerListener = { createDrawerListener() },
         )
     }


### PR DESCRIPTION
This adds the `SettingsView` as drawer bottom view to access folder management and show and hide the account selector, that will be added in a follow-up pull-request.

![Drawer with bottom view](https://github.com/user-attachments/assets/2a32860f-346e-4eb3-abf9-ad62fa9a7a43)

Tasks after review:

- Lock drawer module on weblate
- Check for updates to changed translations strings
- Update strings if needed
- Unlock drawer module on weblate

Resolves #8122 
