### PR TITLE
Add basic feature setup for funding and Google Play billing support

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(projects.feature.widget.shortcut)
     implementation(projects.feature.widget.unread)
     implementation(projects.feature.telemetry.noop)
+    implementation(projects.feature.funding.noop)
 
     implementation(libs.androidx.work.runtime)
 

--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -7,6 +7,7 @@ import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.dev.developmentModuleAdditions
+import app.k9mail.feature.funding.featureFundingModule
 import app.k9mail.feature.telemetry.telemetryModule
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import app.k9mail.featureflag.K9FeatureFlagFactory
@@ -26,6 +27,7 @@ import org.koin.dsl.module
 val appModule = module {
     includes(appWidgetModule)
     includes(telemetryModule)
+    includes(featureFundingModule)
 
     single(named("ClientInfoAppName")) { BuildConfig.CLIENT_INFO_APP_NAME }
     single(named("ClientInfoAppVersion")) { BuildConfig.VERSION_NAME }

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -198,6 +198,11 @@ dependencies {
     debugImplementation(projects.backend.demo)
     debugImplementation(projects.feature.autodiscovery.demo)
 
+    debugImplementation(projects.feature.funding.noop)
+    add("dailyImplementation", projects.feature.funding.googleplay)
+    add("betaImplementation", projects.feature.funding.noop)
+    releaseImplementation(projects.feature.funding.noop)
+
     testImplementation(libs.robolectric)
 
     // Required for DependencyInjectionTest to be able to resolve OpenPgpApiManager

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -5,6 +5,7 @@ import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
+import app.k9mail.feature.funding.featureFundingModule
 import app.k9mail.feature.telemetry.telemetryModule
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import com.fsck.k9.AppConfig
@@ -25,6 +26,7 @@ import org.koin.dsl.module
 val appModule = module {
     includes(appWidgetModule)
     includes(telemetryModule)
+    includes(featureFundingModule)
 
     single(named("ClientInfoAppName")) { BuildConfig.CLIENT_INFO_APP_NAME }
     single(named("ClientInfoAppVersion")) { BuildConfig.VERSION_NAME }

--- a/feature/funding/api/build.gradle.kts
+++ b/feature/funding/api/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id(ThunderbirdPlugins.Library.jvm)
+    alias(libs.plugins.android.lint)
+}

--- a/feature/funding/api/src/main/kotlin/app/k9mail/feature/funding/api/FundingManager.kt
+++ b/feature/funding/api/src/main/kotlin/app/k9mail/feature/funding/api/FundingManager.kt
@@ -1,0 +1,9 @@
+package app.k9mail.feature.funding.api
+
+interface FundingManager {
+
+    /**
+     * Returns `true` if the app has a funding feature included.
+     */
+    fun isFundingFeatureIncluded(): Boolean
+}

--- a/feature/funding/googleplay/build.gradle.kts
+++ b/feature/funding/googleplay/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "app.k9mail.feature.funding.googleplay"
+    resourcePrefix = "funding_googleplay_"
+}
+
+dependencies {
+    api(projects.feature.funding.api)
+
+    implementation(libs.android.billing)
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -1,0 +1,9 @@
+package app.k9mail.feature.funding
+
+import app.k9mail.feature.funding.api.FundingManager
+import app.k9mail.feature.funding.googleplay.GooglePlayFundingManager
+import org.koin.dsl.module
+
+val featureFundingModule = module {
+    single<FundingManager> { GooglePlayFundingManager() }
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/GooglePlayFundingManager.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/GooglePlayFundingManager.kt
@@ -1,0 +1,9 @@
+package app.k9mail.feature.funding.googleplay
+
+import app.k9mail.feature.funding.api.FundingManager
+
+class GooglePlayFundingManager : FundingManager {
+    override fun isFundingFeatureIncluded(): Boolean {
+        return true
+    }
+}

--- a/feature/funding/noop/build.gradle.kts
+++ b/feature/funding/noop/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id(ThunderbirdPlugins.Library.jvm)
+    alias(libs.plugins.android.lint)
+}
+
+dependencies {
+    api(projects.feature.funding.api)
+}

--- a/feature/funding/noop/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/noop/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -1,0 +1,9 @@
+package app.k9mail.feature.funding
+
+import app.k9mail.feature.funding.api.FundingManager
+import app.k9mail.feature.funding.noop.NoOpFundingManager
+import org.koin.dsl.module
+
+val featureFundingModule = module {
+    single<FundingManager> { NoOpFundingManager() }
+}

--- a/feature/funding/noop/src/main/kotlin/app/k9mail/feature/funding/noop/NoOpFundingManager.kt
+++ b/feature/funding/noop/src/main/kotlin/app/k9mail/feature/funding/noop/NoOpFundingManager.kt
@@ -1,0 +1,9 @@
+package app.k9mail.feature.funding.noop
+
+import app.k9mail.feature.funding.api.FundingManager
+
+class NoOpFundingManager : FundingManager {
+    override fun isFundingFeatureIncluded(): Boolean {
+        return false
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@
 # 4. Run the app and check for any issues.
 
 [versions]
+androidBilling = "7.0.0"
 androidDesugar = "2.1.2"
 androidMaterial = "1.12.0"
 # AGP and tools should be updated together
@@ -112,6 +113,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "kotlinKsp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }
 
 [libraries]
+android-billing = { module = "com.android.billingclient:billing", version.ref = "androidBilling" }
 android-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "androidDesugar" }
 android-material = { module = "com.google.android.material:material", version.ref = "androidMaterial" }
 android-tools-common = { module = "com.android.tools:common", version.ref = "androidTools" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -84,6 +84,12 @@ include(
 )
 
 include(
+    ":feature:funding:api",
+    ":feature:funding:googleplay",
+    ":feature:funding:noop",
+)
+
+include(
     ":core:common",
     ":core:featureflags",
     ":core:testing",


### PR DESCRIPTION
This sets up a feature for funding support and adds no-op and googleplay support. Implementation is only an on-off flag and the Google Play billing library dependency enabled for Thunderbird Daily.

Resolves  #8152
