### PR TITLE
Add drawer unified folder support

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.filled.Outbox
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material.icons.outlined.AllInbox
 import androidx.compose.material.icons.outlined.Archive
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.ChevronLeft
@@ -49,6 +50,9 @@ object Icons {
     object Outlined {
         val AccountCircle: ImageVector
             get() = MaterialIcons.Outlined.AccountCircle
+
+        val AllInbox: ImageVector
+            get() = MaterialIcons.Outlined.AllInbox
 
         val Archive: ImageVector
             get() = MaterialIcons.Outlined.Archive

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.navigation.drawer.ui.FakeData.DISPLAY_ACCOUNT
+import app.k9mail.feature.navigation.drawer.ui.FakeData.DISPLAY_FOLDER
+import app.k9mail.feature.navigation.drawer.ui.FakeData.UNIFIED_FOLDER
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
@@ -23,13 +25,54 @@ internal fun DrawerContentPreview() {
 
 @Composable
 @Preview(showBackground = true)
-fun DrawerContentWithAccountPreview() {
+internal fun DrawerContentWithAccountPreview() {
     PreviewWithTheme {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(DISPLAY_ACCOUNT),
                 selectedAccount = DISPLAY_ACCOUNT,
                 folders = persistentListOf(),
+            ),
+            onEvent = {},
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun DrawerContentWithFoldersPreview() {
+    PreviewWithTheme {
+        DrawerContent(
+            state = DrawerContract.State(
+                accounts = persistentListOf(
+                    DISPLAY_ACCOUNT,
+                ),
+                selectedAccount = null,
+                folders = persistentListOf(
+                    UNIFIED_FOLDER,
+                    DISPLAY_FOLDER,
+                ),
+            ),
+            onEvent = {},
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun DrawerContentWithSelectedFolderPreview() {
+    PreviewWithTheme {
+        DrawerContent(
+            state = DrawerContract.State(
+                accounts = persistentListOf(
+                    DISPLAY_ACCOUNT,
+                ),
+                selectedAccount = DISPLAY_ACCOUNT,
+                folders = persistentListOf(
+                    UNIFIED_FOLDER,
+                    DISPLAY_FOLDER,
+                ),
+                selectedFolder = DISPLAY_FOLDER,
             ),
             onEvent = {},
         )

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
@@ -4,6 +4,8 @@ import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
 
@@ -51,5 +53,12 @@ internal object FakeData {
         isInTopGroup = false,
         unreadMessageCount = 14,
         starredMessageCount = 5,
+    )
+
+    val UNIFIED_FOLDER = DisplayUnifiedFolder(
+        id = "unified_inbox",
+        unifiedType = DisplayUnifiedFolderType.INBOX,
+        unreadMessageCount = 123,
+        starredMessageCount = 567,
     )
 }

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatarPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatarPreview.kt
@@ -7,7 +7,7 @@ import app.k9mail.feature.navigation.drawer.ui.FakeData.DISPLAY_ACCOUNT
 
 @Composable
 @Preview(showBackground = true)
-fun AccountAvatarPreview() {
+internal fun AccountAvatarPreview() {
     PreviewWithThemes {
         AccountAvatar(
             account = DISPLAY_ACCOUNT,

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListItemPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListItemPreview.kt
@@ -7,7 +7,7 @@ import app.k9mail.feature.navigation.drawer.ui.FakeData.DISPLAY_ACCOUNT
 
 @Composable
 @Preview(showBackground = true)
-fun AccountListItemPreview() {
+internal fun AccountListItemPreview() {
     PreviewWithThemes {
         AccountListItem(
             account = DISPLAY_ACCOUNT,

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListPreview.kt
@@ -8,7 +8,7 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 @Preview(showBackground = true)
-fun AccountListPreview() {
+internal fun AccountListPreview() {
     PreviewWithTheme {
         AccountList(
             accounts = persistentListOf(
@@ -23,7 +23,7 @@ fun AccountListPreview() {
 
 @Composable
 @Preview(showBackground = true)
-fun AccountListWithSelectedPreview() {
+internal fun AccountListWithSelectedPreview() {
     PreviewWithTheme {
         AccountList(
             accounts = persistentListOf(

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemPreview.kt
@@ -1,11 +1,13 @@
 package app.k9mail.feature.navigation.drawer.ui.folder
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
 import app.k9mail.feature.navigation.drawer.ui.FakeData.DISPLAY_FOLDER
 import app.k9mail.feature.navigation.drawer.ui.FakeData.UNIFIED_FOLDER
+import app.k9mail.legacy.ui.folder.FolderNameFormatter
 
 @Composable
 @Preview(showBackground = true)
@@ -16,6 +18,7 @@ internal fun FolderListItemPreview() {
             selected = false,
             showStarredCount = false,
             onClick = {},
+            folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
         )
     }
 }
@@ -29,6 +32,7 @@ internal fun FolderListItemSelectedPreview() {
             selected = true,
             showStarredCount = false,
             onClick = {},
+            folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
         )
     }
 }
@@ -42,6 +46,7 @@ internal fun FolderListItemWithStarredPreview() {
             selected = false,
             showStarredCount = true,
             onClick = {},
+            folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
         )
     }
 }
@@ -55,6 +60,7 @@ internal fun FolderListItemWithStarredSelectedPreview() {
             selected = true,
             showStarredCount = true,
             onClick = {},
+            folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
         )
     }
 }
@@ -72,6 +78,7 @@ internal fun FolderListItemWithInboxFolderPreview() {
             selected = false,
             showStarredCount = true,
             onClick = {},
+            folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
         )
     }
 }
@@ -85,6 +92,7 @@ internal fun FolderListItemWithUnifiedFolderPreview() {
             selected = false,
             showStarredCount = false,
             onClick = {},
+            folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
         )
     }
 }

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemPreview.kt
@@ -5,10 +5,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
 import app.k9mail.feature.navigation.drawer.ui.FakeData.DISPLAY_FOLDER
+import app.k9mail.feature.navigation.drawer.ui.FakeData.UNIFIED_FOLDER
 
 @Composable
 @Preview(showBackground = true)
-fun FolderListItemPreview() {
+internal fun FolderListItemPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = DISPLAY_FOLDER,
@@ -21,7 +22,7 @@ fun FolderListItemPreview() {
 
 @Composable
 @Preview(showBackground = true)
-fun FolderListItemSelectedPreview() {
+internal fun FolderListItemSelectedPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = DISPLAY_FOLDER,
@@ -34,7 +35,7 @@ fun FolderListItemSelectedPreview() {
 
 @Composable
 @Preview(showBackground = true)
-fun FolderListItemWithStarredPreview() {
+internal fun FolderListItemWithStarredPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = DISPLAY_FOLDER,
@@ -47,7 +48,7 @@ fun FolderListItemWithStarredPreview() {
 
 @Composable
 @Preview(showBackground = true)
-fun FolderListItemWithStarredSelectedPreview() {
+internal fun FolderListItemWithStarredSelectedPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = DISPLAY_FOLDER,
@@ -60,7 +61,7 @@ fun FolderListItemWithStarredSelectedPreview() {
 
 @Composable
 @Preview(showBackground = true)
-fun FolderListItemWithInboxFolderPreview() {
+internal fun FolderListItemWithInboxFolderPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = DISPLAY_FOLDER.copy(
@@ -70,6 +71,19 @@ fun FolderListItemWithInboxFolderPreview() {
             ),
             selected = false,
             showStarredCount = true,
+            onClick = {},
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun FolderListItemWithUnifiedFolderPreview() {
+    PreviewWithThemes {
+        FolderListItem(
+            displayFolder = UNIFIED_FOLDER,
+            selected = false,
+            showStarredCount = false,
             onClick = {},
         )
     }

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListPreview.kt
@@ -1,0 +1,54 @@
+package app.k9mail.feature.navigation.drawer.ui.folder
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.navigation.drawer.ui.FakeData.DISPLAY_FOLDER
+import app.k9mail.feature.navigation.drawer.ui.FakeData.UNIFIED_FOLDER
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+@Preview(showBackground = true)
+internal fun FolderListPreview() {
+    PreviewWithTheme {
+        FolderList(
+            folders = persistentListOf(
+                DISPLAY_FOLDER,
+            ),
+            selectedFolder = null,
+            onFolderClick = {},
+            showStarredCount = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun FolderListPreviewSelected() {
+    PreviewWithTheme {
+        FolderList(
+            folders = persistentListOf(
+                DISPLAY_FOLDER,
+            ),
+            selectedFolder = DISPLAY_FOLDER,
+            onFolderClick = {},
+            showStarredCount = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun FolderListWithUnifiedFolderPreview() {
+    PreviewWithTheme {
+        FolderList(
+            folders = persistentListOf(
+                UNIFIED_FOLDER,
+                DISPLAY_FOLDER,
+            ),
+            selectedFolder = DISPLAY_FOLDER,
+            onFolderClick = {},
+            showStarredCount = false,
+        )
+    }
+}

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingItemPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingItemPreview.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
 
 @Composable
 @Preview(showBackground = true)
-fun SettingItemPreview() {
+internal fun SettingItemPreview() {
     PreviewWithThemes {
         SettingItem(
             label = "Setting",

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListItemPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListItemPreview.kt
@@ -7,7 +7,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 
 @Composable
 @Preview(showBackground = true)
-fun SettingListItemPreview() {
+internal fun SettingListItemPreview() {
     PreviewWithThemes {
         SettingListItem(
             label = "Settings",

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListPreview.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 
 @Composable
 @Preview(showBackground = true)
-fun SettingListPreview() {
+internal fun SettingListPreview() {
     PreviewWithTheme {
         SettingList(
             onAccountSelectorClick = {},
@@ -18,7 +18,7 @@ fun SettingListPreview() {
 
 @Composable
 @Preview(showBackground = true)
-fun SettingListShowAccountSelectorPreview() {
+internal fun SettingListShowAccountSelectorPreview() {
     PreviewWithTheme {
         SettingList(
             onAccountSelectorClick = {},

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
@@ -17,6 +17,7 @@ class FolderDrawer(
     override val parent: AppCompatActivity,
     private val openAccount: (account: Account) -> Unit,
     private val openFolder: (folderId: Long) -> Unit,
+    private val openUnifiedFolder: () -> Unit,
     private val openManageFolders: () -> Unit,
     private val openSettings: () -> Unit,
     createDrawerListener: () -> DrawerLayout.DrawerListener,
@@ -40,6 +41,7 @@ class FolderDrawer(
                 DrawerView(
                     openAccount = openAccount,
                     openFolder = openFolder,
+                    openUnifiedFolder = openUnifiedFolder,
                     openManageFolders = openManageFolders,
                     openSettings = openSettings,
                     closeDrawer = { close() },

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -33,6 +33,7 @@ val navigationDrawerModule: Module = module {
     single<UseCase.GetDisplayFoldersForAccount> {
         GetDisplayFoldersForAccount(
             repository = get(),
+            messageCountsProvider = get(),
         )
     }
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -1,7 +1,7 @@
 package app.k9mail.feature.navigation.drawer.domain
 
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
-import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.legacy.account.Account
 import kotlinx.coroutines.flow.Flow
@@ -18,7 +18,7 @@ interface DomainContract {
         }
 
         fun interface GetDisplayFoldersForAccount {
-            operator fun invoke(accountUuid: String): Flow<List<DisplayAccountFolder>>
+            operator fun invoke(accountUuid: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>>
         }
 
         /**

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
@@ -6,6 +6,8 @@ data class DisplayAccountFolder(
     val accountUuid: String,
     val folder: Folder,
     val isInTopGroup: Boolean,
-    val unreadMessageCount: Int,
-    val starredMessageCount: Int,
-)
+    override val unreadMessageCount: Int,
+    override val starredMessageCount: Int,
+) : DisplayFolder {
+    override val id: String = accountUuid + folder.id
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayFolder.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.navigation.drawer.domain.entity
+
+interface DisplayFolder {
+    val id: String
+    val unreadMessageCount: Int
+    val starredMessageCount: Int
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolder.kt
@@ -1,0 +1,8 @@
+package app.k9mail.feature.navigation.drawer.domain.entity
+
+data class DisplayUnifiedFolder(
+    override val id: String,
+    val unifiedType: DisplayUnifiedFolderType,
+    override val unreadMessageCount: Int,
+    override val starredMessageCount: Int,
+) : DisplayFolder

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolderType.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolderType.kt
@@ -1,0 +1,5 @@
+package app.k9mail.feature.navigation.drawer.domain.entity
+
+enum class DisplayUnifiedFolderType {
+    INBOX,
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DrawerConfig.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DrawerConfig.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.domain.entity
 
 data class DrawerConfig(
-    val showUnifiedInbox: Boolean,
+    val showUnifiedFolders: Boolean,
     val showStarredCount: Boolean,
 )

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
@@ -2,14 +2,22 @@ package app.k9mail.feature.navigation.drawer.domain.usecase
 
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
+import app.k9mail.legacy.message.controller.MessageCountsProvider
+import app.k9mail.legacy.search.LocalSearch
+import app.k9mail.legacy.search.api.SearchAttribute
+import app.k9mail.legacy.search.api.SearchField
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class GetDisplayFoldersForAccount(
     private val repository: DisplayFolderRepository,
+    private val messageCountsProvider: MessageCountsProvider,
 ) : UseCase.GetDisplayFoldersForAccount {
-    override fun invoke(accountUuid: String): Flow<List<DisplayAccountFolder>> {
+    override fun invoke(accountUuid: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>> {
         return repository.getDisplayFoldersFlow(accountUuid).map { displayFolders ->
             displayFolders.map { displayFolder ->
                 DisplayAccountFolder(
@@ -20,6 +28,41 @@ class GetDisplayFoldersForAccount(
                     starredMessageCount = displayFolder.starredMessageCount,
                 )
             }
+        }.map { displayFolders ->
+            if (includeUnifiedFolders) {
+                createDisplayUnifiedFolders() + displayFolders
+            } else {
+                displayFolders
+            }
         }
+    }
+
+    private fun createDisplayUnifiedFolders(): List<DisplayUnifiedFolder> {
+        return listOf(
+            createUnifiedInboxFolder(),
+        )
+    }
+
+    private fun createUnifiedInboxFolder(): DisplayUnifiedFolder {
+        val search = getUnifiedInboxSearch()
+        val messageCounts = messageCountsProvider.getMessageCounts(search)
+
+        return DisplayUnifiedFolder(
+            id = UNIFIED_INBOX_ID,
+            unifiedType = DisplayUnifiedFolderType.INBOX,
+            unreadMessageCount = messageCounts.unread,
+            starredMessageCount = messageCounts.starred,
+        )
+    }
+
+    private fun getUnifiedInboxSearch(): LocalSearch {
+        return LocalSearch().apply {
+            id = UNIFIED_INBOX_ID
+            and(SearchField.INTEGRATE, "1", SearchAttribute.EQUALS)
+        }
+    }
+
+    companion object {
+        private const val UNIFIED_INBOX_ID = "unified_inbox"
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -16,7 +16,7 @@ interface DrawerContract {
     @Stable
     data class State(
         val config: DrawerConfig = DrawerConfig(
-            showUnifiedInbox = false,
+            showUnifiedFolders = false,
             showStarredCount = false,
         ),
         val accounts: ImmutableList<DisplayAccount> = persistentListOf(),

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.navigation.drawer.ui
 import androidx.compose.runtime.Stable
 import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
-import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.legacy.account.Account
 import kotlinx.collections.immutable.ImmutableList
@@ -21,8 +21,8 @@ interface DrawerContract {
         ),
         val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
         val selectedAccount: DisplayAccount? = null,
-        val folders: ImmutableList<DisplayAccountFolder> = persistentListOf(),
-        val selectedFolder: DisplayAccountFolder? = null,
+        val folders: ImmutableList<DisplayFolder> = persistentListOf(),
+        val selectedFolder: DisplayFolder? = null,
         val showAccountSelector: Boolean = false,
         val isLoading: Boolean = false,
     )
@@ -30,7 +30,7 @@ interface DrawerContract {
     sealed interface Event {
         data class OnAccountClick(val account: DisplayAccount) : Event
         data class OnAccountViewClick(val account: DisplayAccount) : Event
-        data class OnFolderClick(val folder: DisplayAccountFolder) : Event
+        data class OnFolderClick(val folder: DisplayFolder) : Event
         data object OnAccountSelectorClick : Event
         data object OnManageFoldersClick : Event
         data object OnSettingsClick : Event
@@ -40,6 +40,7 @@ interface DrawerContract {
     sealed interface Effect {
         data class OpenAccount(val account: Account) : Effect
         data class OpenFolder(val folderId: Long) : Effect
+        data object OpenUnifiedFolder : Effect
         data object OpenManageFolders : Effect
         data object OpenSettings : Effect
         data object CloseDrawer : Effect

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
@@ -13,6 +13,7 @@ import org.koin.androidx.compose.koinViewModel
 fun DrawerView(
     openAccount: (account: Account) -> Unit,
     openFolder: (folderId: Long) -> Unit,
+    openUnifiedFolder: () -> Unit,
     openManageFolders: () -> Unit,
     openSettings: () -> Unit,
     closeDrawer: () -> Unit,
@@ -22,6 +23,7 @@ fun DrawerView(
         when (effect) {
             is Effect.OpenAccount -> openAccount(effect.account)
             is Effect.OpenFolder -> openFolder(effect.folderId)
+            Effect.OpenUnifiedFolder -> openUnifiedFolder()
             is Effect.OpenManageFolders -> openManageFolders()
             is Effect.OpenSettings -> openSettings()
             Effect.CloseDrawer -> closeDrawer()

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -2,12 +2,15 @@ package app.k9mail.feature.navigation.drawer.ui.folder
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -33,6 +36,16 @@ fun FolderList(
                 showStarredCount = showStarredCount,
                 onClick = onFolderClick,
             )
+            if (folder is DisplayUnifiedFolder) {
+                DividerHorizontal(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            vertical = MainTheme.spacings.default,
+                            horizontal = MainTheme.spacings.triple,
+                        ),
+                )
+            }
         }
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -7,14 +7,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.theme2.MainTheme
-import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun FolderList(
-    folders: ImmutableList<DisplayAccountFolder>,
-    selectedFolder: DisplayAccountFolder?,
-    onFolderClick: (DisplayAccountFolder) -> Unit,
+    folders: ImmutableList<DisplayFolder>,
+    selectedFolder: DisplayFolder?,
+    onFolderClick: (DisplayFolder) -> Unit,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -23,7 +23,10 @@ fun FolderList(
             .fillMaxWidth(),
         contentPadding = PaddingValues(vertical = MainTheme.spacings.default),
     ) {
-        items(folders) { folder ->
+        items(
+            items = folders,
+            key = { it.id },
+        ) { folder ->
             FolderListItem(
                 displayFolder = folder,
                 selected = folder == selectedFolder,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -21,6 +24,9 @@ fun FolderList(
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val resources = LocalContext.current.resources
+    val folderNameFormatter = remember { FolderNameFormatter(resources) }
+
     LazyColumn(
         modifier = modifier
             .fillMaxWidth(),
@@ -35,6 +41,7 @@ fun FolderList(
                 selected = folder == selectedFolder,
                 showStarredCount = showStarredCount,
                 onClick = onFolderClick,
+                folderNameFormatter = folderNameFormatter,
             )
             if (folder is DisplayUnifiedFolder) {
                 DividerHorizontal(

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -8,23 +8,24 @@ import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItem
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 
 @Composable
 fun FolderListItem(
-    displayFolder: DisplayAccountFolder,
+    displayFolder: DisplayFolder,
     selected: Boolean,
-    onClick: (DisplayAccountFolder) -> Unit,
+    onClick: (DisplayFolder) -> Unit,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {
     NavigationDrawerItem(
-        label = displayFolder.folder.name,
+        label = mapFolderName(displayFolder),
         selected = selected,
         onClick = { onClick(displayFolder) },
         modifier = modifier,
         icon = {
             Icon(
-                imageVector = mapFolderIcon(displayFolder.folder.type),
+                imageVector = mapFolderIcon(displayFolder),
             )
         },
         badge = {
@@ -37,7 +38,21 @@ fun FolderListItem(
     )
 }
 
-private fun mapFolderIcon(type: FolderType): ImageVector {
+private fun mapFolderName(folder: DisplayFolder): String {
+    return when (folder) {
+        is DisplayAccountFolder -> folder.folder.name
+        else -> "Unknown folder" // TODO: Add more names for other folder types
+    }
+}
+
+private fun mapFolderIcon(folder: DisplayFolder): ImageVector {
+    return when (folder) {
+        is DisplayAccountFolder -> mapAccountFolderIcon(folder.folder.type)
+        else -> Icons.Outlined.Folder // TODO: Add more icons for other folder types
+    }
+}
+
+private fun mapAccountFolderIcon(type: FolderType): ImageVector {
     return when (type) {
         FolderType.INBOX -> Icons.Outlined.Inbox
         FolderType.OUTBOX -> Icons.Outlined.Outbox

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -3,12 +3,16 @@ package app.k9mail.feature.navigation.drawer.ui.folder
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItem
+import app.k9mail.feature.navigation.drawer.R
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
 
 @Composable
 fun FolderListItem(
@@ -38,22 +42,32 @@ fun FolderListItem(
     )
 }
 
+@Composable
 private fun mapFolderName(folder: DisplayFolder): String {
     return when (folder) {
         is DisplayAccountFolder -> folder.folder.name
-        else -> "Unknown folder" // TODO: Add more names for other folder types
+        is DisplayUnifiedFolder -> mapUnifiedFolderName(folder)
+        else -> throw IllegalArgumentException("Unknown display folder type: $folder")
+    }
+}
+
+@Composable
+private fun mapUnifiedFolderName(folder: DisplayUnifiedFolder): String {
+    return when (folder.unifiedType) {
+        DisplayUnifiedFolderType.INBOX -> stringResource(R.string.navigation_drawer_unified_inbox_title)
     }
 }
 
 private fun mapFolderIcon(folder: DisplayFolder): ImageVector {
     return when (folder) {
-        is DisplayAccountFolder -> mapAccountFolderIcon(folder.folder.type)
-        else -> Icons.Outlined.Folder // TODO: Add more icons for other folder types
+        is DisplayAccountFolder -> mapDisplayAccountFolderIcon(folder)
+        is DisplayUnifiedFolder -> mapDisplayUnifiedFolderIcon(folder)
+        else -> throw IllegalArgumentException("Unknown display folder type: $folder")
     }
 }
 
-private fun mapAccountFolderIcon(type: FolderType): ImageVector {
-    return when (type) {
+private fun mapDisplayAccountFolderIcon(folder: DisplayAccountFolder): ImageVector {
+    return when (folder.folder.type) {
         FolderType.INBOX -> Icons.Outlined.Inbox
         FolderType.OUTBOX -> Icons.Outlined.Outbox
         FolderType.SENT -> Icons.Outlined.Send
@@ -62,5 +76,11 @@ private fun mapAccountFolderIcon(type: FolderType): ImageVector {
         FolderType.ARCHIVE -> Icons.Outlined.Archive
         FolderType.SPAM -> Icons.Outlined.Report
         FolderType.REGULAR -> Icons.Outlined.Folder
+    }
+}
+
+private fun mapDisplayUnifiedFolderIcon(folder: DisplayUnifiedFolder): ImageVector {
+    when (folder.unifiedType) {
+        DisplayUnifiedFolderType.INBOX -> return Icons.Outlined.AllInbox
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -13,6 +13,7 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
+import app.k9mail.legacy.ui.folder.FolderNameFormatter
 
 @Composable
 fun FolderListItem(
@@ -20,10 +21,11 @@ fun FolderListItem(
     selected: Boolean,
     onClick: (DisplayFolder) -> Unit,
     showStarredCount: Boolean,
+    folderNameFormatter: FolderNameFormatter,
     modifier: Modifier = Modifier,
 ) {
     NavigationDrawerItem(
-        label = mapFolderName(displayFolder),
+        label = mapFolderName(displayFolder, folderNameFormatter),
         selected = selected,
         onClick = { onClick(displayFolder) },
         modifier = modifier,
@@ -43,11 +45,14 @@ fun FolderListItem(
 }
 
 @Composable
-private fun mapFolderName(folder: DisplayFolder): String {
-    return when (folder) {
-        is DisplayAccountFolder -> folder.folder.name
-        is DisplayUnifiedFolder -> mapUnifiedFolderName(folder)
-        else -> throw IllegalArgumentException("Unknown display folder type: $folder")
+private fun mapFolderName(
+    displayFolder: DisplayFolder,
+    folderNameFormatter: FolderNameFormatter,
+): String {
+    return when (displayFolder) {
+        is DisplayAccountFolder -> folderNameFormatter.displayName(displayFolder.folder)
+        is DisplayUnifiedFolder -> mapUnifiedFolderName(displayFolder)
+        else -> throw IllegalArgumentException("Unknown display folder: $displayFolder")
     }
 }
 

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfigTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfigTest.kt
@@ -12,7 +12,7 @@ class GetDrawerConfigTest {
     @Test
     fun `should get drawer config`() = runTest {
         val drawerConfig = DrawerConfig(
-            showUnifiedInbox = true,
+            showUnifiedFolders = true,
             showStarredCount = true,
         )
 
@@ -24,7 +24,7 @@ class GetDrawerConfigTest {
 
         assertThat(result).isEqualTo(
             DrawerConfig(
-                showUnifiedInbox = true,
+                showUnifiedFolders = true,
                 showStarredCount = true,
             ),
         )

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -16,7 +16,7 @@ class DrawerStateTest {
         assertThat(state).isEqualTo(
             State(
                 config = DrawerConfig(
-                    showUnifiedInbox = false,
+                    showUnifiedFolders = false,
                     showStarredCount = false,
                 ),
                 accounts = persistentListOf(),

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
@@ -18,68 +18,42 @@ class DrawerViewKtTest : ComposeTest() {
     fun `should delegate effects`() = runTest {
         val initialState = State()
         val viewModel = FakeDrawerViewModel(initialState)
-        var openAccountCounter = 0
-        var openFolderCounter = 0
-        var openManageFoldersCounter = 0
-        var openSettingsCounter = 0
-        var closeDrawerCounter = 0
+        val counter = Counter()
+        val verifyCounter = Counter()
 
         setContentWithTheme {
             DrawerView(
-                openAccount = { openAccountCounter++ },
-                openFolder = { openFolderCounter++ },
-                openManageFolders = { openManageFoldersCounter++ },
-                openSettings = { openSettingsCounter++ },
-                closeDrawer = { closeDrawerCounter++ },
+                openAccount = { counter.openAccountCount++ },
+                openFolder = { counter.openFolderCount++ },
+                openUnifiedFolder = { counter.openUnifiedFolderCount++ },
+                openManageFolders = { counter.openManageFoldersCount++ },
+                openSettings = { counter.openSettingsCount++ },
+                closeDrawer = { counter.closeDrawerCount++ },
                 viewModel = viewModel,
             )
         }
 
-        assertThat(openAccountCounter).isEqualTo(0)
-        assertThat(openFolderCounter).isEqualTo(0)
-        assertThat(openManageFoldersCounter).isEqualTo(0)
-        assertThat(openSettingsCounter).isEqualTo(0)
-        assertThat(closeDrawerCounter).isEqualTo(0)
+        assertThat(counter).isEqualTo(verifyCounter)
 
         viewModel.effect(Effect.OpenAccount(FakeData.ACCOUNT))
 
-        assertThat(openAccountCounter).isEqualTo(1)
-        assertThat(openFolderCounter).isEqualTo(0)
-        assertThat(openManageFoldersCounter).isEqualTo(0)
-        assertThat(openSettingsCounter).isEqualTo(0)
-        assertThat(closeDrawerCounter).isEqualTo(0)
+        verifyCounter.openAccountCount++
+        assertThat(counter).isEqualTo(verifyCounter)
 
+        verifyCounter.openFolderCount++
         viewModel.effect(Effect.OpenFolder(1))
 
-        assertThat(openAccountCounter).isEqualTo(1)
-        assertThat(openFolderCounter).isEqualTo(1)
-        assertThat(openManageFoldersCounter).isEqualTo(0)
-        assertThat(openSettingsCounter).isEqualTo(0)
-        assertThat(closeDrawerCounter).isEqualTo(0)
+        verifyCounter.openUnifiedFolderCount++
+        viewModel.effect(Effect.OpenUnifiedFolder)
 
+        verifyCounter.openManageFoldersCount++
         viewModel.effect(Effect.OpenManageFolders)
 
-        assertThat(openAccountCounter).isEqualTo(1)
-        assertThat(openFolderCounter).isEqualTo(1)
-        assertThat(openManageFoldersCounter).isEqualTo(1)
-        assertThat(openSettingsCounter).isEqualTo(0)
-        assertThat(closeDrawerCounter).isEqualTo(0)
-
+        verifyCounter.openSettingsCount++
         viewModel.effect(Effect.OpenSettings)
 
-        assertThat(openAccountCounter).isEqualTo(1)
-        assertThat(openFolderCounter).isEqualTo(1)
-        assertThat(openManageFoldersCounter).isEqualTo(1)
-        assertThat(openSettingsCounter).isEqualTo(1)
-        assertThat(closeDrawerCounter).isEqualTo(0)
-
+        verifyCounter.closeDrawerCount++
         viewModel.effect(Effect.CloseDrawer)
-
-        assertThat(openAccountCounter).isEqualTo(1)
-        assertThat(openFolderCounter).isEqualTo(1)
-        assertThat(openManageFoldersCounter).isEqualTo(1)
-        assertThat(openSettingsCounter).isEqualTo(1)
-        assertThat(closeDrawerCounter).isEqualTo(1)
     }
 
     @Test
@@ -93,6 +67,7 @@ class DrawerViewKtTest : ComposeTest() {
             DrawerView(
                 openAccount = {},
                 openFolder = {},
+                openUnifiedFolder = {},
                 openManageFolders = {},
                 openSettings = {},
                 closeDrawer = {},
@@ -120,4 +95,14 @@ class DrawerViewKtTest : ComposeTest() {
             .printToString()
             .contains("ProgressBarRangeInfo(current=0.0, range=0.0..1.0, steps=0)")
     }
+
+    @Suppress("DataClassShouldBeImmutable")
+    private data class Counter(
+        var openAccountCount: Int = 0,
+        var openFolderCount: Int = 0,
+        var openUnifiedFolderCount: Int = 0,
+        var openManageFoldersCount: Int = 0,
+        var openSettingsCount: Int = 0,
+        var closeDrawerCount: Int = 0,
+    )
 }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -295,7 +295,7 @@ class DrawerViewModelTest {
         showStarredCount: Boolean = false,
     ): DrawerConfig {
         return DrawerConfig(
-            showUnifiedInbox = showUnifiedInbox,
+            showUnifiedFolders = showUnifiedInbox,
             showStarredCount = showStarredCount,
         )
     }

--- a/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -7,6 +7,7 @@ import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.message.controller.MessageCounts
 import app.k9mail.legacy.message.controller.MessageCountsProvider
+import app.k9mail.legacy.search.LocalSearch
 import app.k9mail.legacy.search.SearchAccount
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import assertk.assertThat
@@ -134,6 +135,10 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
 
         override fun getMessageCounts(searchAccount: SearchAccount): MessageCounts {
             return MessageCounts(unread = SEARCH_ACCOUNT_UNREAD_COUNT, starred = 0)
+        }
+
+        override fun getMessageCounts(search: LocalSearch): MessageCounts {
+            throw UnsupportedOperationException()
         }
 
         override fun getUnreadMessageCount(account: Account, folderId: Long): Int {

--- a/legacy/common/src/main/java/com/fsck/k9/feature/NavigationDrawerConfigLoader.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/feature/NavigationDrawerConfigLoader.kt
@@ -7,7 +7,7 @@ import com.fsck.k9.K9
 class NavigationDrawerConfigLoader : DrawerConfigLoader {
     override fun loadDrawerConfig(): DrawerConfig {
         return DrawerConfig(
-            showUnifiedInbox = K9.isShowUnifiedInbox,
+            showUnifiedFolders = K9.isShowUnifiedInbox,
             showStarredCount = K9.isShowStarredCount,
         )
     }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/DefaultMessageCountsProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/DefaultMessageCountsProvider.kt
@@ -27,7 +27,10 @@ internal class DefaultMessageCountsProvider(
     }
 
     override fun getMessageCounts(searchAccount: SearchAccount): MessageCounts {
-        val search = searchAccount.relatedSearch
+        return getMessageCounts(searchAccount.relatedSearch)
+    }
+
+    override fun getMessageCounts(search: LocalSearch): MessageCounts {
         val accounts = search.getAccounts(accountManager)
 
         var unreadCount = 0

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessageCountsProvider.kt
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessageCountsProvider.kt
@@ -1,11 +1,13 @@
 package app.k9mail.legacy.message.controller
 
 import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.search.LocalSearch
 import app.k9mail.legacy.search.SearchAccount
 
 interface MessageCountsProvider {
     fun getMessageCounts(account: Account): MessageCounts
     fun getMessageCounts(searchAccount: SearchAccount): MessageCounts
+    fun getMessageCounts(search: LocalSearch): MessageCounts
     fun getUnreadMessageCount(account: Account, folderId: Long): Int
 }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -610,6 +610,7 @@ open class MessageList :
             parent = this,
             openAccount = { account -> openRealAccount(account) },
             openFolder = { folderId -> openFolder(folderId) },
+            openUnifiedFolder = { openUnifiedInbox() },
             openManageFolders = { launchManageFoldersScreen() },
             openSettings = { SettingsActivity.launch(this) },
             createDrawerListener = { createDrawerListener() },


### PR DESCRIPTION
Added the unified folder support for the drawer. The default selection has not been implemented as it requires state information from the MessageList properly propagated: #8142

![drawer with unified folder support](https://github.com/user-attachments/assets/94502a0b-45d9-4a78-8e83-aa908531289c)

Depends on #8151

Resolves #8121 
