### PR TITLE
Add automation for needinfo requests

### DIFF
--- a/.github/workflows/needinfo-remove.yml
+++ b/.github/workflows/needinfo-remove.yml
@@ -1,0 +1,25 @@
+---
+name: Remove needinfo label
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.comment.author_association != 'OWNER' &&
+      github.event.comment.author_association != 'COLLABORATOR'
+    steps:
+      - name: Remove needinfo label
+        uses: octokit/request-action@v2.x
+        continue-on-error: true
+        with:
+          route: DELETE /repos/:repository/issues/:issue/labels/:label
+          repository: ${{ github.repository }}
+          issue: ${{ github.event.issue.number }}
+          label: "status: needs information"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/needinfo-stale.yml
+++ b/.github/workflows/needinfo-stale.yml
@@ -1,0 +1,23 @@
+---
+name: Close old issues with the needinfo label
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close old issues with the needinfo tag
+        uses: dwieeb/needs-reply@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-label: "status: needs information"
+          days-before-close: 30
+          close-message: >
+            Thank you for taking the time to report this issue. It looks like we haven't heard back
+            in a while, therefore we're closing this issue. If the problem persists in the latest
+            version please open a new issue and reference this one so we can follow up more
+            effectively.


### PR DESCRIPTION
I think it would be useful to have some automation to close stale issues if the reporter does not respond. Here is what I have been using personally.

Also tagging @madhens in case the wording needs to be adjusted.
