### PR TITLE
Fix drawer package visibility

### DIFF
--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerExternalContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerExternalContract.kt
@@ -1,8 +1,11 @@
 package app.k9mail.feature.navigation.drawer
 
-import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
-
 interface NavigationDrawerExternalContract {
+
+    data class DrawerConfig(
+        val showUnifiedFolders: Boolean,
+        val showStarredCount: Boolean,
+    )
 
     fun interface DrawerConfigLoader {
         fun loadDrawerConfig(): DrawerConfig

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -6,7 +6,7 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.legacy.account.Account
 import kotlinx.coroutines.flow.Flow
 
-interface DomainContract {
+internal interface DomainContract {
 
     interface UseCase {
         fun interface GetDrawerConfig {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -1,8 +1,8 @@
 package app.k9mail.feature.navigation.drawer.domain
 
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
-import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.legacy.account.Account
 import kotlinx.coroutines.flow.Flow
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccount.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.navigation.drawer.domain.entity
 
 import app.k9mail.legacy.account.Account
 
-data class DisplayAccount(
+internal data class DisplayAccount(
     val account: Account,
     val unreadMessageCount: Int,
     val starredMessageCount: Int,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.navigation.drawer.domain.entity
 
 import app.k9mail.core.mail.folder.api.Folder
 
-data class DisplayAccountFolder(
+internal data class DisplayAccountFolder(
     val accountUuid: String,
     val folder: Folder,
     val isInTopGroup: Boolean,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayFolder.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.domain.entity
 
-interface DisplayFolder {
+internal interface DisplayFolder {
     val id: String
     val unreadMessageCount: Int
     val starredMessageCount: Int

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolder.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.domain.entity
 
-data class DisplayUnifiedFolder(
+internal data class DisplayUnifiedFolder(
     override val id: String,
     val unifiedType: DisplayUnifiedFolderType,
     override val unreadMessageCount: Int,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolderType.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolderType.kt
@@ -1,5 +1,5 @@
 package app.k9mail.feature.navigation.drawer.domain.entity
 
-enum class DisplayUnifiedFolderType {
+internal enum class DisplayUnifiedFolderType {
     INBOX,
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DrawerConfig.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DrawerConfig.kt
@@ -1,6 +1,0 @@
-package app.k9mail.feature.navigation.drawer.domain.entity
-
-data class DrawerConfig(
-    val showUnifiedFolders: Boolean,
-    val showStarredCount: Boolean,
-)

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayAccounts.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayAccounts.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 
-class GetDisplayAccounts(
+internal class GetDisplayAccounts(
     private val accountManager: AccountManager,
     private val messageCountsProvider: MessageCountsProvider,
     private val messageListRepository: MessageListRepository,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
@@ -13,7 +13,7 @@ import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class GetDisplayFoldersForAccount(
+internal class GetDisplayFoldersForAccount(
     private val repository: DisplayFolderRepository,
     private val messageCountsProvider: MessageCountsProvider,
 ) : UseCase.GetDisplayFoldersForAccount {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfig.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfig.kt
@@ -1,8 +1,8 @@
 package app.k9mail.feature.navigation.drawer.domain.usecase
 
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfigLoader
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
-import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfig.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfig.kt
@@ -6,7 +6,7 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class GetDrawerConfig(
+internal class GetDrawerConfig(
     private val configProver: DrawerConfigLoader,
 ) : UseCase.GetDrawerConfig {
     override operator fun invoke(): Flow<DrawerConfig> {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncMail.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncMail.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 
-class SyncMail(
+internal class SyncMail(
     private val messagingController: MessagingControllerMailChecker,
     private val coroutineContext: CoroutineContext = Dispatchers.IO,
 ) : UseCase.SyncMail {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/AccountsViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/AccountsViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.asLiveData
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 
-class AccountsViewModel(
+internal class AccountsViewModel(
     getDisplayAccounts: UseCase.GetDisplayAccounts,
 ) : ViewModel() {
     val displayAccountsLiveData: LiveData<List<DisplayAccount>> = getDisplayAccounts().asLiveData()

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/DisplayUnifiedInbox.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/DisplayUnifiedInbox.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.legacy
 
-data class DisplayUnifiedInbox(
+internal data class DisplayUnifiedInbox(
     val unreadMessageCount: Int,
     val starredMessageCount: Int,
 )

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FolderList.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.navigation.drawer.legacy
 
 import app.k9mail.legacy.ui.folder.DisplayFolder
 
-data class FolderList(
+internal data class FolderList(
     val unifiedInbox: DisplayUnifiedInbox?,
     val accountId: Int,
     val folders: List<DisplayFolder>,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/legacy/FoldersViewModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class FoldersViewModel(
+internal class FoldersViewModel(
     private val folderRepository: DisplayFolderRepository,
     private val messageCountsProvider: MessageCountsProvider,
     private val isShowUnifiedInbox: () -> Boolean,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -17,7 +17,7 @@ import app.k9mail.feature.navigation.drawer.ui.folder.FolderList
 import app.k9mail.feature.navigation.drawer.ui.setting.SettingList
 
 @Composable
-fun DrawerContent(
+internal fun DrawerContent(
     state: State,
     onEvent: (Event) -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -2,9 +2,9 @@ package app.k9mail.feature.navigation.drawer.ui
 
 import androidx.compose.runtime.Stable
 import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
-import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.legacy.account.Account
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -9,7 +9,7 @@ import app.k9mail.legacy.account.Account
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-interface DrawerContract {
+internal interface DrawerContract {
 
     interface ViewModel : UnidirectionalViewModel<State, Event, Effect>
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
@@ -10,7 +10,7 @@ import app.k9mail.legacy.account.Account
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
-fun DrawerView(
+internal fun DrawerView(
     openAccount: (account: Account) -> Unit,
     openFolder: (folderId: Long) -> Unit,
     openUnifiedFolder: () -> Unit,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 @Suppress("MagicNumber")
-class DrawerViewModel(
+internal class DrawerViewModel(
     private val getDrawerConfig: UseCase.GetDrawerConfig,
     private val getDisplayAccounts: UseCase.GetDisplayAccounts,
     private val getDisplayFoldersForAccount: UseCase.GetDisplayFoldersForAccount,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
@@ -16,7 +16,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 
 @Composable
-fun AccountAvatar(
+internal fun AccountAvatar(
     account: DisplayAccount,
     onClick: (DisplayAccount) -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountIndicator.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountIndicator.kt
@@ -8,7 +8,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
 
 @Composable
-fun AccountIndicator(
+internal fun AccountIndicator(
     accountColor: Int,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountList.kt
@@ -17,7 +17,7 @@ import app.k9mail.feature.navigation.drawer.ui.setting.SettingItem
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
-fun AccountList(
+internal fun AccountList(
     accounts: ImmutableList<DisplayAccount>,
     selectedAccount: DisplayAccount?,
     onAccountClick: (DisplayAccount) -> Unit,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListItem.kt
@@ -10,7 +10,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 
 @Composable
-fun AccountListItem(
+internal fun AccountListItem(
     account: DisplayAccount,
     onClick: (DisplayAccount) -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
@@ -23,7 +23,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 
 @Composable
-fun AccountView(
+internal fun AccountView(
     account: DisplayAccount,
     onClick: () -> Unit,
     showAvatar: Boolean,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -17,7 +17,7 @@ import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
-fun FolderList(
+internal fun FolderList(
     folders: ImmutableList<DisplayFolder>,
     selectedFolder: DisplayFolder?,
     onFolderClick: (DisplayFolder) -> Unit,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -16,7 +16,7 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderTy
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 
 @Composable
-fun FolderListItem(
+internal fun FolderListItem(
     displayFolder: DisplayFolder,
     selected: Boolean,
     onClick: (DisplayFolder) -> Unit,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemBadge.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemBadge.kt
@@ -13,7 +13,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.R
 
 @Composable
-fun FolderListItemBadge(
+internal fun FolderListItemBadge(
     unreadCount: Int,
     starredCount: Int,
     showStarredCount: Boolean,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingList.kt
@@ -11,7 +11,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.R
 
 @Composable
-fun SettingList(
+internal fun SettingList(
     onAccountSelectorClick: () -> Unit,
     onManageFoldersClick: () -> Unit,
     showAccountSelector: Boolean,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/setting/SettingListItem.kt
@@ -7,7 +7,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
 import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItem
 
 @Composable
-fun SettingListItem(
+internal fun SettingListItem(
     label: String,
     onClick: () -> Unit,
     imageVector: ImageVector,

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfigTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfigTest.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.domain.usecase
 
-import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.ui
 
-import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -7,12 +7,12 @@ import app.k9mail.core.ui.compose.testing.mvi.assertThatAndEffectTurbineConsumed
 import app.k9mail.core.ui.compose.testing.mvi.assertThatAndStateTurbineConsumed
 import app.k9mail.core.ui.compose.testing.mvi.eventStateTest
 import app.k9mail.core.ui.compose.testing.mvi.turbinesWithInitialStateCheck
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
-import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State

--- a/legacy/common/src/main/java/com/fsck/k9/feature/NavigationDrawerConfigLoader.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/feature/NavigationDrawerConfigLoader.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.feature
 
+import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfigLoader
-import app.k9mail.feature.navigation.drawer.domain.entity.DrawerConfig
 import com.fsck.k9.K9
 
 class NavigationDrawerConfigLoader : DrawerConfigLoader {


### PR DESCRIPTION
This ensures that the drawer module only exposes api relevant classes as `public`, the rest is changed to `internal` package visibility.
