### PR TITLE
Add issues permissions for handling needinfo requests

### DIFF
--- a/.github/workflows/needinfo-remove.yml
+++ b/.github/workflows/needinfo-remove.yml
@@ -12,6 +12,9 @@ jobs:
     if: |
       github.event.comment.author_association != 'OWNER' &&
       github.event.comment.author_association != 'COLLABORATOR'
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Remove needinfo label
         uses: octokit/request-action@v2.x

--- a/.github/workflows/needinfo-stale.yml
+++ b/.github/workflows/needinfo-stale.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Close old issues with the needinfo tag
         uses: dwieeb/needs-reply@v2


### PR DESCRIPTION
I see the needinfo job is failing due to missing permissions. I've not needed any permissions for this action before, but possibly they are locked down a bit due to recent releng work. This adds the issues permission. It is a stab in the dark, I don't know if it will work, but it is the area of all octokit API client calls that occurs in the action.

https://github.com/thunderbird/thunderbird-android/actions/runs/11004526905/job/30665933452