### PR TITLE
Fix a11y warnings in accounts and settings

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/Checkbox.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/Checkbox.kt
@@ -7,7 +7,7 @@ import androidx.compose.material3.Checkbox as Material3Checkbox
 @Composable
 fun Checkbox(
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
+    onCheckedChange: ((Boolean) -> Unit)?,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/CheckboxInput.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/molecule/input/CheckboxInput.kt
@@ -1,13 +1,14 @@
 package app.k9mail.core.ui.compose.designsystem.molecule.input
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import app.k9mail.core.ui.compose.designsystem.atom.Checkbox
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
 import app.k9mail.core.ui.compose.theme2.MainTheme
@@ -29,13 +30,17 @@ fun CheckboxInput(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { onCheckedChange(!checked) },
+                .toggleable(
+                    value = checked,
+                    role = Role.Checkbox,
+                    onValueChange = { onCheckedChange(!checked) },
+                ),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
         ) {
             Checkbox(
                 checked = checked,
-                onCheckedChange = onCheckedChange,
+                onCheckedChange = null,
             )
             TextBodyLarge(text = text)
         }

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportScreen.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportScreen.kt
@@ -31,6 +31,7 @@ fun SettingsImportScreen(
                     ButtonIcon(
                         onClick = onBack,
                         imageVector = Icons.Outlined.ArrowBack,
+                        contentDescription = stringResource(androidx.appcompat.R.string.abc_action_bar_up_description),
                     )
                 },
             )


### PR DESCRIPTION
I believe this fixes the a11y warnings in the play console. I suspect there may be an easier way to merge checkbox and text field, simply using mergeDescendants on its own didn't do it though.