### PR TITLE
Add folder drawer state

### DIFF
--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
@@ -72,7 +72,28 @@ internal fun DrawerContentWithSelectedFolderPreview() {
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,
                 ),
-                selectedFolder = DISPLAY_FOLDER,
+                selectedFolderId = DISPLAY_FOLDER.id,
+            ),
+            onEvent = {},
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun DrawerContentWithSelectedUnifiedFolderPreview() {
+    PreviewWithTheme {
+        DrawerContent(
+            state = DrawerContract.State(
+                accounts = persistentListOf(
+                    DISPLAY_ACCOUNT,
+                ),
+                selectedAccountUuid = DISPLAY_ACCOUNT.uuid,
+                folders = persistentListOf(
+                    UNIFIED_FOLDER,
+                    DISPLAY_FOLDER,
+                ),
+                selectedFolderId = UNIFIED_FOLDER.id,
             ),
             onEvent = {},
         )

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
@@ -15,7 +15,7 @@ internal fun DrawerContentPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(),
-                selectedAccount = null,
+                selectedAccountUuid = null,
                 folders = persistentListOf(),
             ),
             onEvent = {},
@@ -30,7 +30,7 @@ internal fun DrawerContentWithAccountPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(DISPLAY_ACCOUNT),
-                selectedAccount = DISPLAY_ACCOUNT,
+                selectedAccountUuid = DISPLAY_ACCOUNT.uuid,
                 folders = persistentListOf(),
             ),
             onEvent = {},
@@ -47,7 +47,7 @@ internal fun DrawerContentWithFoldersPreview() {
                 accounts = persistentListOf(
                     DISPLAY_ACCOUNT,
                 ),
-                selectedAccount = null,
+                selectedAccountUuid = null,
                 folders = persistentListOf(
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,
@@ -67,7 +67,7 @@ internal fun DrawerContentWithSelectedFolderPreview() {
                 accounts = persistentListOf(
                     DISPLAY_ACCOUNT,
                 ),
-                selectedAccount = DISPLAY_ACCOUNT,
+                selectedAccountUuid = DISPLAY_ACCOUNT.uuid,
                 folders = persistentListOf(
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/LegacyDrawer.kt
@@ -437,7 +437,7 @@ class LegacyDrawer(
         }
     }
 
-    override fun selectFolder(folderId: Long) {
+    override fun selectFolder(accountUuid: String, folderId: Long) {
         deselect()
         openedFolderId = folderId
         for (drawerId in userFolderDrawerIds) {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawer.kt
@@ -7,11 +7,12 @@ interface NavigationDrawer {
     val parent: AppCompatActivity
     val isOpen: Boolean
 
+    // TODO: remove once LegacyDrawer is removed
     fun updateUserAccountsAndFolders(account: Account?)
 
     fun selectAccount(accountUuid: String)
 
-    fun selectFolder(folderId: Long)
+    fun selectFolder(accountUuid: String, folderId: Long)
 
     fun selectUnifiedInbox()
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -40,6 +40,7 @@ val navigationDrawerModule: Module = module {
 
     single<UseCase.SyncAccount> {
         SyncAccount(
+            accountManager = get(),
             messagingController = get(),
         )
     }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -3,7 +3,6 @@ package app.k9mail.feature.navigation.drawer.domain
 import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
-import app.k9mail.legacy.account.Account
 import kotlinx.coroutines.flow.Flow
 
 internal interface DomainContract {
@@ -22,10 +21,10 @@ internal interface DomainContract {
         }
 
         /**
-         * Synchronize the given account.
+         * Synchronize the given account uuid.
          */
         fun interface SyncAccount {
-            operator fun invoke(account: Account): Flow<Result<Unit>>
+            operator fun invoke(accountUuid: String): Flow<Result<Unit>>
         }
 
         /**

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccount.kt
@@ -6,4 +6,6 @@ internal data class DisplayAccount(
     val account: Account,
     val unreadMessageCount: Int,
     val starredMessageCount: Int,
-)
+) {
+    val uuid: String = account.uuid
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
@@ -9,5 +9,9 @@ internal data class DisplayAccountFolder(
     override val unreadMessageCount: Int,
     override val starredMessageCount: Int,
 ) : DisplayFolder {
-    override val id: String = "${accountUuid}_${folder.id}"
+    override val id: String = createDisplayAccountFolderId(accountUuid, folder.id)
+}
+
+fun createDisplayAccountFolderId(accountUuid: String, folderId: Long): String {
+    return "${accountUuid}_$folderId"
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
@@ -9,5 +9,5 @@ internal data class DisplayAccountFolder(
     override val unreadMessageCount: Int,
     override val starredMessageCount: Int,
 ) : DisplayFolder {
-    override val id: String = accountUuid + folder.id
+    override val id: String = "${accountUuid}_${folder.id}"
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolderType.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayUnifiedFolderType.kt
@@ -1,5 +1,12 @@
 package app.k9mail.feature.navigation.drawer.domain.entity
 
-internal enum class DisplayUnifiedFolderType {
-    INBOX,
+/**
+ * Represents a unified folder in the drawer.
+ *
+ * The id is unique for each unified folder type.
+ */
+internal enum class DisplayUnifiedFolderType(
+    val id: String,
+) {
+    INBOX("unified_inbox"),
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAccount.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.navigation.drawer.domain.usecase
 import android.content.Context
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import kotlin.coroutines.CoroutineContext
@@ -13,16 +14,19 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 
 internal class SyncAccount(
+    private val accountManager: AccountManager,
     private val messagingController: MessagingControllerMailChecker,
     private val coroutineContext: CoroutineContext = Dispatchers.IO,
 ) : UseCase.SyncAccount {
-    override fun invoke(account: Account): Flow<Result<Unit>> = callbackFlow {
+    override fun invoke(accountUuid: String): Flow<Result<Unit>> = callbackFlow {
         val listener = object : SimpleMessagingListener() {
             override fun checkMailFinished(context: Context?, account: Account?) {
                 trySend(Result.success(Unit))
                 close()
             }
         }
+
+        val account = accountManager.getAccount(accountUuid)
 
         messagingController.checkMail(
             account = account,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -57,7 +57,7 @@ internal fun DrawerContent(
                 ) {
                     FolderList(
                         folders = state.folders,
-                        selectedFolder = state.selectedFolder,
+                        selectedFolder = state.folders.firstOrNull { it.id == state.selectedFolderId },
                         onFolderClick = { folder ->
                             onEvent(Event.OnFolderClick(folder))
                         },

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -27,11 +27,12 @@ internal fun DrawerContent(
             .fillMaxSize()
             .testTag("DrawerContent"),
     ) {
+        val selectedAccount = state.accounts.firstOrNull { it.uuid == state.selectedAccountUuid }
         Column {
-            state.selectedAccount?.let {
+            selectedAccount?.let {
                 AccountView(
-                    account = it,
-                    onClick = { onEvent(Event.OnAccountViewClick(it)) },
+                    account = selectedAccount,
+                    onClick = { onEvent(Event.OnAccountViewClick(selectedAccount)) },
                     showAvatar = state.showAccountSelector,
                 )
 
@@ -43,7 +44,7 @@ internal fun DrawerContent(
                 ) {
                     AccountList(
                         accounts = state.accounts,
-                        selectedAccount = state.selectedAccount,
+                        selectedAccount = selectedAccount,
                         onAccountClick = { onEvent(Event.OnAccountClick(it)) },
                         onSyncAllAccountsClick = { onEvent(Event.OnSyncAllAccounts) },
                         onSettingsClick = { onEvent(Event.OnSettingsClick) },

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -22,7 +22,7 @@ internal interface DrawerContract {
         val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
         val selectedAccountUuid: String? = null,
         val folders: ImmutableList<DisplayFolder> = persistentListOf(),
-        val selectedFolder: DisplayFolder? = null,
+        val selectedFolderId: String? = null,
         val showAccountSelector: Boolean = false,
         val isLoading: Boolean = false,
     )

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -20,7 +20,7 @@ internal interface DrawerContract {
             showStarredCount = false,
         ),
         val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
-        val selectedAccount: DisplayAccount? = null,
+        val selectedAccountUuid: String? = null,
         val folders: ImmutableList<DisplayFolder> = persistentListOf(),
         val selectedFolder: DisplayFolder? = null,
         val showAccountSelector: Boolean = false,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -28,6 +28,8 @@ internal interface DrawerContract {
     )
 
     sealed interface Event {
+        data class SelectAccount(val accountUuid: String?) : Event
+        data class SelectFolder(val folderId: String?) : Event
         data class OnAccountClick(val account: DisplayAccount) : Event
         data class OnAccountViewClick(val account: DisplayAccount) : Event
         data class OnFolderClick(val folder: DisplayFolder) : Event

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
@@ -1,8 +1,10 @@
 package app.k9mail.feature.navigation.drawer.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.molecule.PullToRefreshBox
+import app.k9mail.feature.navigation.drawer.FolderDrawerState
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.ViewModel
@@ -11,6 +13,7 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 internal fun DrawerView(
+    drawerState: FolderDrawerState,
     openAccount: (account: Account) -> Unit,
     openFolder: (folderId: Long) -> Unit,
     openUnifiedFolder: () -> Unit,
@@ -28,6 +31,14 @@ internal fun DrawerView(
             is Effect.OpenSettings -> openSettings()
             Effect.CloseDrawer -> closeDrawer()
         }
+    }
+
+    LaunchedEffect(drawerState.selectedAccountUuid) {
+        dispatch(Event.SelectAccount(drawerState.selectedAccountUuid))
+    }
+
+    LaunchedEffect(drawerState.selectedFolderId) {
+        dispatch(Event.SelectFolder(drawerState.selectedFolderId))
     }
 
     PullToRefreshBox(

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -89,13 +89,13 @@ internal class DrawerViewModel(
 
     private fun updateFolders(displayFolders: List<DisplayFolder>) {
         val selectedFolder = displayFolders.find {
-            it.id == state.value.selectedFolder?.id
+            it.id == state.value.selectedFolderId
         } ?: displayFolders.firstOrNull()
 
         updateState {
             it.copy(
                 folders = displayFolders.toImmutableList(),
-                selectedFolder = selectedFolder,
+                selectedFolderId = selectedFolder?.id,
             )
         }
     }
@@ -145,7 +145,7 @@ internal class DrawerViewModel(
 
     private fun selectFolder(folder: DisplayFolder) {
         updateState {
-            it.copy(selectedFolder = folder)
+            it.copy(selectedFolderId = folder.id)
         }
 
         if (folder is DisplayAccountFolder) {

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeAccountManager.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeAccountManager.kt
@@ -1,0 +1,49 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.AccountRemovedListener
+import app.k9mail.legacy.account.AccountsChangeListener
+import kotlinx.coroutines.flow.Flow
+
+class FakeAccountManager(
+    val recordedParameters: MutableList<String> = mutableListOf(),
+    private val accounts: List<Account> = emptyList(),
+) : AccountManager {
+    override fun getAccounts(): List<Account> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAccountsFlow(): Flow<List<Account>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAccount(accountUuid: String): Account? {
+        recordedParameters.add(accountUuid)
+        return accounts.find { it.uuid == accountUuid }
+    }
+
+    override fun getAccountFlow(accountUuid: String): Flow<Account> {
+        TODO("Not yet implemented")
+    }
+
+    override fun addAccountRemovedListener(listener: AccountRemovedListener) {
+        TODO("Not yet implemented")
+    }
+
+    override fun moveAccount(account: Account, newPosition: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun addOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) {
+        TODO("Not yet implemented")
+    }
+
+    override fun removeOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) {
+        TODO("Not yet implemented")
+    }
+
+    override fun saveAccount(account: Account) {
+        TODO("Not yet implemented")
+    }
+}

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeAccountManager.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeAccountManager.kt
@@ -6,7 +6,7 @@ import app.k9mail.legacy.account.AccountRemovedListener
 import app.k9mail.legacy.account.AccountsChangeListener
 import kotlinx.coroutines.flow.Flow
 
-class FakeAccountManager(
+internal class FakeAccountManager(
     val recordedParameters: MutableList<String> = mutableListOf(),
     private val accounts: List<Account> = emptyList(),
 ) : AccountManager {

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeMessagingControllerMailChecker.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeMessagingControllerMailChecker.kt
@@ -5,6 +5,7 @@ import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.MessagingListener
 
 internal class FakeMessagingControllerMailChecker(
+    val recordedParameters: MutableList<CheckMailParameters> = mutableListOf(),
     private val listenerExecutor: (MessagingListener?) -> Unit = {},
 ) : MessagingControllerMailChecker {
     override fun checkMail(
@@ -14,6 +15,15 @@ internal class FakeMessagingControllerMailChecker(
         notify: Boolean,
         listener: MessagingListener?,
     ) {
+        recordedParameters.add(CheckMailParameters(account, ignoreLastCheckedTime, useManualWakeLock, notify))
+
         listenerExecutor(listener)
     }
 }
+
+internal data class CheckMailParameters(
+    val account: Account?,
+    val ignoreLastCheckedTime: Boolean,
+    val useManualWakeLock: Boolean,
+    val notify: Boolean,
+)

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfigTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDrawerConfigTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
-class GetDrawerConfigTest {
+internal class GetDrawerConfigTest {
 
     @Test
     fun `should get drawer config`() = runTest {

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAccountTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAccountTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.Test
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
-class SyncAccountTest {
+internal class SyncAccountTest {
 
     @Test
     fun `should sync mail with account`() = runTest {

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAccountTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAccountTest.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.navigation.drawer.domain.usecase
 
 import app.k9mail.feature.navigation.drawer.ui.FakeData
 import app.k9mail.legacy.message.controller.MessagingListener
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
 import kotlinx.coroutines.flow.first
@@ -14,14 +15,31 @@ class SyncAccountTest {
         val listenerExecutor: (MessagingListener?) -> Unit = { listener ->
             listener?.checkMailFinished(null, null)
         }
+        val account = FakeData.ACCOUNT
+        val accountManager = FakeAccountManager(
+            accounts = listOf(account),
+        )
+        val messagingController = FakeMessagingControllerMailChecker(
+            listenerExecutor = listenerExecutor,
+        )
         val testSubject = SyncAccount(
-            messagingController = FakeMessagingControllerMailChecker(
-                listenerExecutor = listenerExecutor,
-            ),
+            accountManager = accountManager,
+            messagingController = messagingController,
         )
 
-        val result = testSubject(FakeData.ACCOUNT).first()
+        val result = testSubject(account.uuid).first()
 
-        assertk.assertThat(result.isSuccess).isEqualTo(true)
+        assertThat(result.isSuccess).isEqualTo(true)
+        assertThat(accountManager.recordedParameters).isEqualTo(listOf(account.uuid))
+        assertThat(messagingController.recordedParameters).isEqualTo(
+            listOf(
+                CheckMailParameters(
+                    account = account,
+                    ignoreLastCheckedTime = true,
+                    useManualWakeLock = true,
+                    notify = true,
+                ),
+            ),
+        )
     }
 }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAllAccountsTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAllAccountsTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
-class SyncAllAccountsTest {
+internal class SyncAllAccountsTest {
 
     @Test
     fun `should sync mail`() = runTest {

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAllAccountsTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAllAccountsTest.kt
@@ -1,6 +1,7 @@
 package app.k9mail.feature.navigation.drawer.domain.usecase
 
 import app.k9mail.legacy.message.controller.MessagingListener
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
 import kotlinx.coroutines.flow.first
@@ -13,14 +14,25 @@ class SyncAllAccountsTest {
         val listenerExecutor: (MessagingListener?) -> Unit = { listener ->
             listener?.checkMailFinished(null, null)
         }
+        val messagingController = FakeMessagingControllerMailChecker(
+            listenerExecutor = listenerExecutor,
+        )
         val testSubject = SyncAllAccounts(
-            messagingController = FakeMessagingControllerMailChecker(
-                listenerExecutor = listenerExecutor,
-            ),
+            messagingController = messagingController,
         )
 
         val result = testSubject().first()
 
-        assertk.assertThat(result.isSuccess).isEqualTo(true)
+        assertThat(result.isSuccess).isEqualTo(true)
+        assertThat(messagingController.recordedParameters).isEqualTo(
+            listOf(
+                CheckMailParameters(
+                    account = null,
+                    ignoreLastCheckedTime = true,
+                    useManualWakeLock = true,
+                    notify = true,
+                ),
+            ),
+        )
     }
 }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -20,7 +20,7 @@ class DrawerStateTest {
                     showStarredCount = false,
                 ),
                 accounts = persistentListOf(),
-                selectedAccount = null,
+                selectedAccountUuid = null,
                 folders = persistentListOf(),
                 selectedFolder = null,
                 showAccountSelector = false,

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -7,7 +7,7 @@ import assertk.assertions.isEqualTo
 import kotlinx.collections.immutable.persistentListOf
 import org.junit.Test
 
-class DrawerStateTest {
+internal class DrawerStateTest {
 
     @Test
     fun `should set default values`() {

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -22,7 +22,7 @@ class DrawerStateTest {
                 accounts = persistentListOf(),
                 selectedAccountUuid = null,
                 folders = persistentListOf(),
-                selectedFolder = null,
+                selectedFolderId = null,
                 showAccountSelector = false,
                 isLoading = false,
             ),

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
@@ -2,17 +2,21 @@ package app.k9mail.feature.navigation.drawer.ui
 
 import androidx.compose.ui.test.onChildAt
 import androidx.compose.ui.test.printToString
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.onNodeWithTag
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import app.k9mail.feature.navigation.drawer.FolderDrawerState
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
+import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 
-class DrawerViewKtTest : ComposeTest() {
+internal class DrawerViewKtTest : ComposeTest() {
 
     @Test
     fun `should delegate effects`() = runTest {
@@ -23,6 +27,7 @@ class DrawerViewKtTest : ComposeTest() {
 
         setContentWithTheme {
             DrawerView(
+                drawerState = FolderDrawerState(),
                 openAccount = { counter.openAccountCount++ },
                 openFolder = { counter.openFolderCount++ },
                 openUnifiedFolder = { counter.openUnifiedFolderCount++ },
@@ -57,6 +62,45 @@ class DrawerViewKtTest : ComposeTest() {
     }
 
     @Test
+    fun `should register to drawer state and send events to view model`() = runTest {
+        val initialState = State()
+        val viewModel = FakeDrawerViewModel(initialState)
+        val initialDrawerState = FolderDrawerState()
+        val drawerStateFlow = MutableStateFlow(initialDrawerState)
+
+        setContentWithTheme {
+            val state = drawerStateFlow.collectAsStateWithLifecycle()
+
+            DrawerView(
+                drawerState = state.value,
+                openAccount = { },
+                openFolder = { },
+                openUnifiedFolder = { },
+                openManageFolders = { },
+                openSettings = { },
+                closeDrawer = { },
+                viewModel = viewModel,
+            )
+        }
+
+        drawerStateFlow.emit(initialDrawerState.copy(selectedAccountUuid = FakeData.ACCOUNT.uuid))
+
+        viewModel.events.contains(Event.SelectAccount(FakeData.ACCOUNT.uuid))
+
+        drawerStateFlow.emit(initialDrawerState.copy(selectedAccountUuid = null))
+
+        viewModel.events.contains(Event.SelectAccount(null))
+
+        drawerStateFlow.emit(initialDrawerState.copy(selectedFolderId = "1"))
+
+        viewModel.events.contains(Event.SelectFolder("1"))
+
+        drawerStateFlow.emit(initialDrawerState.copy(selectedFolderId = null))
+
+        viewModel.events.contains(Event.SelectFolder(null))
+    }
+
+    @Test
     fun `pull refresh should listen to view model state`() = runTest {
         val initialState = State(
             isLoading = false,
@@ -65,6 +109,7 @@ class DrawerViewKtTest : ComposeTest() {
 
         setContentWithTheme {
             DrawerView(
+                drawerState = FolderDrawerState(),
                 openAccount = {},
                 openFolder = {},
                 openUnifiedFolder = {},

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -320,7 +320,7 @@ class DrawerViewModelTest {
             accounts = displayAccounts.toImmutableList(),
             selectedAccountUuid = displayAccounts[0].uuid,
             folders = displayFoldersMap[displayAccounts[0].account.uuid]!!.toImmutableList(),
-            selectedFolder = displayFoldersMap[displayAccounts[0].account.uuid]!![0],
+            selectedFolderId = displayFoldersMap[displayAccounts[0].account.uuid]!![0].id,
         )
         val testSubject = createTestSubject(
             displayAccountsFlow = getDisplayAccountsFlow,
@@ -333,7 +333,7 @@ class DrawerViewModelTest {
         val displayFolders = displayFoldersMap[displayAccounts[0].account.uuid] ?: emptyList()
         testSubject.event(Event.OnFolderClick(displayFolders[1]))
 
-        assertThat(turbines.awaitStateItem().selectedFolder).isEqualTo(displayFolders[1])
+        assertThat(turbines.awaitStateItem().selectedFolderId).isEqualTo(displayFolders[1].id)
 
         assertThat(turbines.awaitEffectItem()).isEqualTo(Effect.OpenFolder(displayFolders[1].folder.id))
 
@@ -356,7 +356,7 @@ class DrawerViewModelTest {
                 accounts = displayAccounts.toImmutableList(),
                 selectedAccountUuid = displayAccounts[0].account.uuid,
                 folders = displayFoldersMap[displayAccounts[0].account.uuid]!!.toImmutableList(),
-                selectedFolder = displayFoldersMap[displayAccounts[0].account.uuid]!![0],
+                selectedFolderId = displayFoldersMap[displayAccounts[0].account.uuid]!![0].id,
             )
             val testSubject = createTestSubject(
                 displayAccountsFlow = getDisplayAccountsFlow,
@@ -369,7 +369,7 @@ class DrawerViewModelTest {
             val displayFolders = displayFoldersMap[displayAccounts[0].account.uuid] ?: emptyList()
             testSubject.event(Event.OnFolderClick(displayFolders[1]))
 
-            assertThat(turbines.awaitStateItem().selectedFolder).isEqualTo(displayFolders[1])
+            assertThat(turbines.awaitStateItem().selectedFolderId).isEqualTo(displayFolders[1].id)
 
             assertThat(turbines.awaitEffectItem()).isEqualTo(Effect.OpenUnifiedFolder)
 

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class DrawerViewModelTest {
+internal class DrawerViewModelTest {
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
@@ -235,7 +235,7 @@ class DrawerViewModelTest {
     }
 
     @Test
-    fun `should set selected account when OnAccountClick event is received`() = runTest {
+    fun `should send OpenAccount effect when OnAccountClick event is received`() = runTest {
         val displayAccounts = createDisplayAccountList(3)
         val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
         val testSubject = createTestSubject(
@@ -254,8 +254,6 @@ class DrawerViewModelTest {
         testSubject.event(Event.OnAccountClick(displayAccounts[1]))
 
         advanceUntilIdle()
-
-        assertThat(turbines.awaitStateItem().selectedAccountUuid).isEqualTo(displayAccounts[1].uuid)
 
         turbines.assertThatAndEffectTurbineConsumed {
             isEqualTo(Effect.OpenAccount(displayAccounts[1].account))
@@ -299,7 +297,7 @@ class DrawerViewModelTest {
 
         advanceUntilIdle()
 
-        testSubject.event(Event.OnAccountClick(displayAccounts[1]))
+        testSubject.event(Event.SelectAccount(displayAccounts[1].uuid))
 
         advanceUntilIdle()
 
@@ -309,7 +307,7 @@ class DrawerViewModelTest {
     }
 
     @Test
-    fun `should set selected folder and emit OpenFolder when OnFolderClick event is received`() = runTest {
+    fun `should emit OpenFolder effect when OnFolderClick event is received`() = runTest {
         val displayAccounts = createDisplayAccountList(3)
         val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
         val displayFoldersMap = mapOf(
@@ -333,8 +331,6 @@ class DrawerViewModelTest {
         val displayFolders = displayFoldersMap[displayAccounts[0].account.uuid] ?: emptyList()
         testSubject.event(Event.OnFolderClick(displayFolders[1]))
 
-        assertThat(turbines.awaitStateItem().selectedFolderId).isEqualTo(displayFolders[1].id)
-
         assertThat(turbines.awaitEffectItem()).isEqualTo(Effect.OpenFolder(displayFolders[1].folder.id))
 
         turbines.assertThatAndEffectTurbineConsumed {
@@ -343,7 +339,7 @@ class DrawerViewModelTest {
     }
 
     @Test
-    fun `should set selected folder emit OpenUnifiedFolder when OnFolderClick event for unified folder is received`() =
+    fun `should emit OpenUnifiedFolder when OnFolderClick event for unified folder is received`() =
         runTest {
             val displayAccounts = createDisplayAccountList(1)
             val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
@@ -368,8 +364,6 @@ class DrawerViewModelTest {
 
             val displayFolders = displayFoldersMap[displayAccounts[0].account.uuid] ?: emptyList()
             testSubject.event(Event.OnFolderClick(displayFolders[1]))
-
-            assertThat(turbines.awaitStateItem().selectedFolderId).isEqualTo(displayFolders[1].id)
 
             assertThat(turbines.awaitEffectItem()).isEqualTo(Effect.OpenUnifiedFolder)
 

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -64,7 +64,7 @@ class DrawerViewModelTest {
     fun `should change loading state when OnSyncAccount event is received`() = runTest {
         val initialState = State(
             accounts = listOf(DISPLAY_ACCOUNT).toImmutableList(),
-            selectedAccount = DISPLAY_ACCOUNT,
+            selectedAccountUuid = DISPLAY_ACCOUNT.uuid,
         )
         val testSubject = createTestSubject(
             initialState = initialState,
@@ -90,12 +90,13 @@ class DrawerViewModelTest {
 
     @Test
     fun `should skip loading when no account is selected and OnSyncAccount event is received`() = runTest {
-        val initialState = State(selectedAccount = null)
+        val initialState = State(selectedAccountUuid = null)
         var counter = 0
         val testSubject = createTestSubject(
             initialState = initialState,
             syncAccountFlow = flow {
                 delay(25)
+                counter++
                 emit(Result.success(Unit))
             },
         )
@@ -197,7 +198,7 @@ class DrawerViewModelTest {
 
         assertThat(testSubject.state.value.accounts.size).isEqualTo(displayAccounts.size)
         assertThat(testSubject.state.value.accounts).isEqualTo(displayAccounts)
-        assertThat(testSubject.state.value.selectedAccount).isEqualTo(displayAccounts.first())
+        assertThat(testSubject.state.value.selectedAccountUuid).isEqualTo(displayAccounts.first().uuid)
     }
 
     @Test
@@ -217,7 +218,7 @@ class DrawerViewModelTest {
 
         assertThat(testSubject.state.value.accounts.size).isEqualTo(newDisplayAccounts.size)
         assertThat(testSubject.state.value.accounts).isEqualTo(newDisplayAccounts)
-        assertThat(testSubject.state.value.selectedAccount).isEqualTo(newDisplayAccounts.first())
+        assertThat(testSubject.state.value.selectedAccountUuid).isEqualTo(newDisplayAccounts.first().uuid)
     }
 
     @Test
@@ -230,7 +231,7 @@ class DrawerViewModelTest {
         advanceUntilIdle()
 
         assertThat(testSubject.state.value.accounts.size).isEqualTo(0)
-        assertThat(testSubject.state.value.selectedAccount).isEqualTo(null)
+        assertThat(testSubject.state.value.selectedAccountUuid).isEqualTo(null)
     }
 
     @Test
@@ -244,7 +245,7 @@ class DrawerViewModelTest {
             testSubject,
             State(
                 accounts = displayAccounts.toImmutableList(),
-                selectedAccount = displayAccounts.first(),
+                selectedAccountUuid = displayAccounts.first().uuid,
             ),
         )
 
@@ -254,7 +255,7 @@ class DrawerViewModelTest {
 
         advanceUntilIdle()
 
-        assertThat(turbines.awaitStateItem().selectedAccount).isEqualTo(displayAccounts[1])
+        assertThat(turbines.awaitStateItem().selectedAccountUuid).isEqualTo(displayAccounts[1].uuid)
 
         turbines.assertThatAndEffectTurbineConsumed {
             isEqualTo(Effect.OpenAccount(displayAccounts[1].account))
@@ -266,7 +267,7 @@ class DrawerViewModelTest {
         val displayAccounts = createDisplayAccountList(3)
         val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
         val displayFoldersMap = mapOf(
-            displayAccounts[0].account.uuid to createDisplayFolderList(3),
+            displayAccounts[0].uuid to createDisplayFolderList(3),
         )
         val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
         val testSubject = createTestSubject(
@@ -276,7 +277,7 @@ class DrawerViewModelTest {
 
         advanceUntilIdle()
 
-        val displayFolders = displayFoldersMap[displayAccounts[0].account.uuid] ?: emptyList()
+        val displayFolders = displayFoldersMap[displayAccounts[0].uuid] ?: emptyList()
         assertThat(testSubject.state.value.folders.size).isEqualTo(displayFolders.size)
         assertThat(testSubject.state.value.folders).isEqualTo(displayFolders)
     }
@@ -286,9 +287,9 @@ class DrawerViewModelTest {
         val displayAccounts = createDisplayAccountList(3)
         val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
         val displayFoldersMap = mapOf(
-            displayAccounts[0].account.uuid to createDisplayFolderList(1),
-            displayAccounts[1].account.uuid to createDisplayFolderList(5),
-            displayAccounts[2].account.uuid to createDisplayFolderList(10),
+            displayAccounts[0].uuid to createDisplayFolderList(1),
+            displayAccounts[1].uuid to createDisplayFolderList(5),
+            displayAccounts[2].uuid to createDisplayFolderList(10),
         )
         val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
         val testSubject = createTestSubject(
@@ -317,7 +318,7 @@ class DrawerViewModelTest {
         val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
         val initialState = State(
             accounts = displayAccounts.toImmutableList(),
-            selectedAccount = displayAccounts[0],
+            selectedAccountUuid = displayAccounts[0].uuid,
             folders = displayFoldersMap[displayAccounts[0].account.uuid]!!.toImmutableList(),
             selectedFolder = displayFoldersMap[displayAccounts[0].account.uuid]!![0],
         )
@@ -353,7 +354,7 @@ class DrawerViewModelTest {
             val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
             val initialState = State(
                 accounts = displayAccounts.toImmutableList(),
-                selectedAccount = displayAccounts[0],
+                selectedAccountUuid = displayAccounts[0].account.uuid,
                 folders = displayFoldersMap[displayAccounts[0].account.uuid]!!.toImmutableList(),
                 selectedFolder = displayFoldersMap[displayAccounts[0].account.uuid]!![0],
             )

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeDrawerViewModel.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeDrawerViewModel.kt
@@ -6,6 +6,6 @@ import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.ViewModel
 
-class FakeDrawerViewModel(
+internal class FakeDrawerViewModel(
     initialState: State = State(),
 ) : BaseFakeViewModel<State, Event, Effect>(initialState), ViewModel

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1413,7 +1413,7 @@ open class MessageList :
         val drawer = navigationDrawer ?: return
         drawer.selectAccount(account!!.uuid)
         when {
-            singleFolderMode -> drawer.selectFolder(search!!.folderIds[0])
+            singleFolderMode -> drawer.selectFolder(search!!.accountUuids[0], search!!.folderIds[0])
             // Don't select any item in the drawer because the Unified Inbox is displayed, but not listed in the drawer
             search!!.id == SearchAccount.UNIFIED_INBOX && !K9.isShowUnifiedInbox -> drawer.deselect()
             search!!.id == SearchAccount.UNIFIED_INBOX -> drawer.selectUnifiedInbox()


### PR DESCRIPTION
The `FolderDrawerState` is introduced to help synchronizing account and folder selection between `FolderDrawer` and `MessageList`. Like with the legacy implementation the `MessageList` will control the the selection state. To support different lifecycles the `FolderDrawer` will only store the current account uuid and folder id and resolve the selection on the fly. This is not very quick, but avoids having to rewrite the `MessageList`.

Resolves #8142
