### PR TITLE
Change QR code validation/mapping

### DIFF
--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/domain/entity/AccountData.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/domain/entity/AccountData.kt
@@ -45,61 +45,26 @@ internal data class AccountData(
         val displayName: String,
     )
 
-    @Suppress("MagicNumber")
-    enum class IncomingServerProtocol(val intValue: Int) {
-        Imap(0),
-        Pop3(1),
-        ;
-
-        companion object {
-            fun fromInt(value: Int): IncomingServerProtocol {
-                return requireNotNull(entries.find { it.intValue == value }) { "Unsupported value: $value" }
-            }
-        }
+    enum class IncomingServerProtocol {
+        Imap,
+        Pop3,
     }
 
-    @Suppress("MagicNumber")
-    enum class OutgoingServerProtocol(val intValue: Int) {
-        Smtp(0),
-        ;
-
-        companion object {
-            fun fromInt(value: Int): OutgoingServerProtocol {
-                return requireNotNull(entries.find { it.intValue == value }) { "Unsupported value: $value" }
-            }
-        }
+    enum class OutgoingServerProtocol {
+        Smtp,
     }
 
-    @Suppress("MagicNumber")
-    enum class ConnectionSecurity(val intValue: Int) {
-        Plain(0),
-        TryStartTls(1),
-        AlwaysStartTls(2),
-        Tls(3),
-        ;
-
-        companion object {
-            fun fromInt(value: Int): ConnectionSecurity {
-                return requireNotNull(entries.find { it.intValue == value }) { "Unsupported value: $value" }
-            }
-        }
+    enum class ConnectionSecurity {
+        Plain,
+        AlwaysStartTls,
+        Tls,
     }
 
-    @Suppress("MagicNumber")
-    enum class AuthenticationType(val intValue: Int) {
-        None(0),
-        PasswordCleartext(1),
-        PasswordEncrypted(2),
-        Gssapi(3),
-        Ntlm(4),
-        TlsCertificate(5),
-        OAuth2(6),
-        ;
-
-        companion object {
-            fun fromInt(value: Int): AuthenticationType {
-                return requireNotNull(entries.find { it.intValue == value }) { "Unsupported value: $value" }
-            }
-        }
+    enum class AuthenticationType {
+        None,
+        PasswordCleartext,
+        PasswordEncrypted,
+        TlsCertificate,
+        OAuth2,
     }
 }

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/payload/IntValueMapper.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/payload/IntValueMapper.kt
@@ -1,0 +1,47 @@
+@file:Suppress("MagicNumber")
+
+package app.k9mail.feature.migration.qrcode.payload
+
+import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.AuthenticationType
+import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.ConnectionSecurity
+import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.IncomingServerProtocol
+import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.OutgoingServerProtocol
+
+internal fun Int.toIncomingServerProtocol(): IncomingServerProtocol {
+    return when (this) {
+        0 -> IncomingServerProtocol.Imap
+        1 -> IncomingServerProtocol.Pop3
+        else -> throw IllegalArgumentException("Unsupported value: $this")
+    }
+}
+
+internal fun Int.toOutgoingServerProtocol(): OutgoingServerProtocol {
+    return when (this) {
+        0 -> OutgoingServerProtocol.Smtp
+        else -> throw IllegalArgumentException("Unsupported value: $this")
+    }
+}
+
+internal fun Int.toConnectionSecurity(): ConnectionSecurity {
+    return when (this) {
+        0 -> ConnectionSecurity.Plain
+        1 -> ConnectionSecurity.AlwaysStartTls // TryStartTls, but we treat it like AlwaysStartTls
+        2 -> ConnectionSecurity.AlwaysStartTls
+        3 -> ConnectionSecurity.Tls
+        else -> throw IllegalArgumentException("Unsupported value: $this")
+    }
+}
+
+@Suppress("ThrowsCount")
+internal fun Int.toAuthenticationType(): AuthenticationType {
+    return when (this) {
+        0 -> AuthenticationType.None
+        1 -> AuthenticationType.PasswordCleartext
+        2 -> AuthenticationType.PasswordEncrypted
+        3 -> throw IllegalArgumentException("Unsupported authentication method: Gssapi")
+        4 -> throw IllegalArgumentException("Unsupported authentication method: Ntlm")
+        5 -> AuthenticationType.TlsCertificate
+        6 -> AuthenticationType.OAuth2
+        else -> throw IllegalArgumentException("Unsupported value: $this")
+    }
+}

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadMapper.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadMapper.kt
@@ -49,11 +49,11 @@ internal class QrCodePayloadMapper(
 
     private fun mapIncomingServer(incomingServer: QrCodeData.IncomingServer): AccountData.IncomingServer {
         return AccountData.IncomingServer(
-            protocol = AccountData.IncomingServerProtocol.fromInt(incomingServer.protocol),
+            protocol = incomingServer.protocol.toIncomingServerProtocol(),
             hostname = incomingServer.hostname.toHostname(),
             port = incomingServer.port.toPort(),
-            connectionSecurity = AccountData.ConnectionSecurity.fromInt(incomingServer.connectionSecurity),
-            authenticationType = AccountData.AuthenticationType.fromInt(incomingServer.authenticationType),
+            connectionSecurity = incomingServer.connectionSecurity.toConnectionSecurity(),
+            authenticationType = incomingServer.authenticationType.toAuthenticationType(),
             username = incomingServer.username,
             password = incomingServer.password,
         )
@@ -72,11 +72,11 @@ internal class QrCodePayloadMapper(
 
     private fun mapOutgoingServer(outgoingServer: QrCodeData.OutgoingServer): AccountData.OutgoingServer {
         return AccountData.OutgoingServer(
-            protocol = AccountData.OutgoingServerProtocol.fromInt(outgoingServer.protocol),
+            protocol = outgoingServer.protocol.toOutgoingServerProtocol(),
             hostname = outgoingServer.hostname.toHostname(),
             port = outgoingServer.port.toPort(),
-            connectionSecurity = AccountData.ConnectionSecurity.fromInt(outgoingServer.connectionSecurity),
-            authenticationType = AccountData.AuthenticationType.fromInt(outgoingServer.authenticationType),
+            connectionSecurity = outgoingServer.connectionSecurity.toConnectionSecurity(),
+            authenticationType = outgoingServer.authenticationType.toAuthenticationType(),
             username = outgoingServer.username,
             password = outgoingServer.password,
         )

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadValidator.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadValidator.kt
@@ -4,7 +4,6 @@ import app.k9mail.core.common.mail.EmailAddressParserException
 import app.k9mail.core.common.mail.toUserEmailAddress
 import app.k9mail.core.common.net.toHostname
 import app.k9mail.core.common.net.toPort
-import app.k9mail.feature.migration.qrcode.domain.entity.AccountData
 import timber.log.Timber
 
 @Suppress("TooManyFunctions")
@@ -86,11 +85,11 @@ internal class QrCodePayloadValidator {
     }
 
     private fun validateIncomingServerProtocol(protocol: Int) {
-        AccountData.IncomingServerProtocol.fromInt(protocol)
+        protocol.toIncomingServerProtocol()
     }
 
     private fun validateOutgoingServerProtocol(protocol: Int) {
-        AccountData.OutgoingServerProtocol.fromInt(protocol)
+        protocol.toOutgoingServerProtocol()
     }
 
     private fun validateHostname(hostname: String) {
@@ -102,11 +101,11 @@ internal class QrCodePayloadValidator {
     }
 
     private fun validateConnectionSecurity(value: Int) {
-        AccountData.ConnectionSecurity.fromInt(value)
+        value.toConnectionSecurity()
     }
 
     private fun validateAuthenticationType(value: Int) {
-        AccountData.AuthenticationType.fromInt(value)
+        value.toAuthenticationType()
     }
 
     private fun validateUsername(username: String) {

--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadMapperTest.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadMapperTest.kt
@@ -4,6 +4,7 @@ import app.k9mail.core.common.mail.toUserEmailAddress
 import app.k9mail.core.common.net.toHostname
 import app.k9mail.core.common.net.toPort
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData
+import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.ConnectionSecurity
 import assertk.assertThat
 import assertk.assertions.first
 import assertk.assertions.isEqualTo
@@ -47,6 +48,21 @@ class QrCodePayloadMapperTest {
         assertThat(result).isNotNull()
             .prop(AccountData::accounts).first()
             .prop(AccountData.Account::accountName).isEqualTo("user@domain.example")
+    }
+
+    @Test
+    fun `TryStartTls should be mapped to AlwaysStartTls`() {
+        val input = INPUT.updateIncomingServer { server ->
+            server.copy(connectionSecurity = 1)
+        }
+
+        val result = mapper.toAccountData(input)
+
+        assertThat(result).isNotNull()
+            .prop(AccountData::accounts).first()
+            .prop(AccountData.Account::incomingServer)
+            .prop(AccountData.IncomingServer::connectionSecurity)
+            .isEqualTo(ConnectionSecurity.AlwaysStartTls)
     }
 
     companion object {
@@ -99,7 +115,7 @@ class QrCodePayloadMapperTest {
                         protocol = AccountData.IncomingServerProtocol.Imap,
                         hostname = "imap.domain.example".toHostname(),
                         port = 993.toPort(),
-                        connectionSecurity = AccountData.ConnectionSecurity.Tls,
+                        connectionSecurity = ConnectionSecurity.Tls,
                         authenticationType = AccountData.AuthenticationType.PasswordCleartext,
                         username = "user@domain.example",
                         password = "password",
@@ -110,7 +126,7 @@ class QrCodePayloadMapperTest {
                                 protocol = AccountData.OutgoingServerProtocol.Smtp,
                                 hostname = "smtp.domain.example".toHostname(),
                                 port = 465.toPort(),
-                                connectionSecurity = AccountData.ConnectionSecurity.Tls,
+                                connectionSecurity = ConnectionSecurity.Tls,
                                 authenticationType = AccountData.AuthenticationType.PasswordCleartext,
                                 username = "user@domain.example",
                                 password = "password",

--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadValidatorTest.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadValidatorTest.kt
@@ -152,6 +152,28 @@ class QrCodePayloadValidatorTest {
     }
 
     @Test
+    fun `unsupported incoming server authentication type Gssapi`() {
+        val input = INPUT.updateIncomingServer { server ->
+            server.copy(authenticationType = 3)
+        }
+
+        val result = validator.isValid(input)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `unsupported incoming server authentication type Ntlm`() {
+        val input = INPUT.updateIncomingServer { server ->
+            server.copy(authenticationType = 4)
+        }
+
+        val result = validator.isValid(input)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
     fun `invalid incoming server username`() {
         val input = INPUT.updateIncomingServer { server ->
             server.copy(username = "contains\nline break")
@@ -221,6 +243,28 @@ class QrCodePayloadValidatorTest {
     fun `invalid outgoing server authentication type`() {
         val input = INPUT.updateOutgoingServer { server ->
             server.copy(authenticationType = 100)
+        }
+
+        val result = validator.isValid(input)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `unsupported outgoing server authentication type Gssapi`() {
+        val input = INPUT.updateOutgoingServer { server ->
+            server.copy(authenticationType = 3)
+        }
+
+        val result = validator.isValid(input)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `unsupported outgoing server authentication type Ntlm`() {
+        val input = INPUT.updateOutgoingServer { server ->
+            server.copy(authenticationType = 4)
         }
 
         val result = validator.isValid(input)


### PR DESCRIPTION
- Change QR code validation to only allow values we actually support.
- Change mapping so the connection security value `TryStartTls` is mapped to `AlwaysStartTls`.