### PR TITLE
Add funding dependencies

### DIFF
--- a/app-k9mail/dependencies/releaseRuntimeClasspath.txt
+++ b/app-k9mail/dependencies/releaseRuntimeClasspath.txt
@@ -196,9 +196,11 @@ org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1
 org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.6.1
 org.jetbrains.kotlinx:kotlinx-datetime:0.6.1
-org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3
 org.jetbrains:annotations:24.1.0
 org.jsoup:jsoup:1.17.2
 org.minidns:minidns-client:1.0.5

--- a/app-thunderbird/dependencies/fossBetaRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fossBetaRuntimeClasspath.txt
@@ -200,11 +200,11 @@ org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1
 org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.6.1
 org.jetbrains.kotlinx:kotlinx-datetime:0.6.1
-org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3
 org.jetbrains:annotations:24.1.0
 org.jsoup:jsoup:1.17.2
 org.minidns:minidns-client:1.0.5

--- a/app-thunderbird/dependencies/fossDailyRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fossDailyRuntimeClasspath.txt
@@ -200,11 +200,11 @@ org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1
 org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.6.1
 org.jetbrains.kotlinx:kotlinx-datetime:0.6.1
-org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3
 org.jetbrains:annotations:24.1.0
 org.jsoup:jsoup:1.17.2
 org.minidns:minidns-client:1.0.5

--- a/app-thunderbird/dependencies/fossReleaseRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fossReleaseRuntimeClasspath.txt
@@ -200,11 +200,11 @@ org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1
 org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.6.1
 org.jetbrains.kotlinx:kotlinx-datetime:0.6.1
-org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3
 org.jetbrains:annotations:24.1.0
 org.jsoup:jsoup:1.17.2
 org.minidns:minidns-client:1.0.5

--- a/app-thunderbird/dependencies/fullBetaRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fullBetaRuntimeClasspath.txt
@@ -134,6 +134,7 @@ co.touchlab:stately-concurrent-collections-jvm:2.0.6
 co.touchlab:stately-concurrent-collections:2.0.6
 co.touchlab:stately-strict-jvm:2.0.6
 co.touchlab:stately-strict:2.0.6
+com.android.billingclient:billing-ktx:7.0.0
 com.android.billingclient:billing:7.0.0
 com.beetstra.jutf7:jutf7:1.0.0
 com.github.ByteHamster:SearchPreference:v2.3.0

--- a/app-thunderbird/dependencies/fullBetaRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fullBetaRuntimeClasspath.txt
@@ -214,11 +214,11 @@ org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1
 org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.6.1
 org.jetbrains.kotlinx:kotlinx-datetime:0.6.1
-org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3
 org.jetbrains:annotations:24.1.0
 org.jsoup:jsoup:1.17.2
 org.minidns:minidns-client:1.0.5

--- a/app-thunderbird/dependencies/fullDailyRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fullDailyRuntimeClasspath.txt
@@ -134,6 +134,7 @@ co.touchlab:stately-concurrent-collections-jvm:2.0.6
 co.touchlab:stately-concurrent-collections:2.0.6
 co.touchlab:stately-strict-jvm:2.0.6
 co.touchlab:stately-strict:2.0.6
+com.android.billingclient:billing-ktx:7.0.0
 com.android.billingclient:billing:7.0.0
 com.beetstra.jutf7:jutf7:1.0.0
 com.github.ByteHamster:SearchPreference:v2.3.0

--- a/app-thunderbird/dependencies/fullDailyRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fullDailyRuntimeClasspath.txt
@@ -214,11 +214,11 @@ org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1
 org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.6.1
 org.jetbrains.kotlinx:kotlinx-datetime:0.6.1
-org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3
 org.jetbrains:annotations:24.1.0
 org.jsoup:jsoup:1.17.2
 org.minidns:minidns-client:1.0.5

--- a/app-thunderbird/dependencies/fullReleaseRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fullReleaseRuntimeClasspath.txt
@@ -134,6 +134,7 @@ co.touchlab:stately-concurrent-collections-jvm:2.0.6
 co.touchlab:stately-concurrent-collections:2.0.6
 co.touchlab:stately-strict-jvm:2.0.6
 co.touchlab:stately-strict:2.0.6
+com.android.billingclient:billing-ktx:7.0.0
 com.android.billingclient:billing:7.0.0
 com.beetstra.jutf7:jutf7:1.0.0
 com.github.ByteHamster:SearchPreference:v2.3.0

--- a/app-thunderbird/dependencies/fullReleaseRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fullReleaseRuntimeClasspath.txt
@@ -214,11 +214,11 @@ org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.1
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1
 org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.6.1
 org.jetbrains.kotlinx:kotlinx-datetime:0.6.1
-org.jetbrains.kotlinx:kotlinx-serialization-bom:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.6.3
-org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3
 org.jetbrains:annotations:24.1.0
 org.jsoup:jsoup:1.17.2
 org.minidns:minidns-client:1.0.5

--- a/build-plugin/build.gradle.kts
+++ b/build-plugin/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
 
     implementation(plugin(libs.plugins.kotlin.jvm))
     implementation(plugin(libs.plugins.kotlin.android))
+    implementation(plugin(libs.plugins.kotlin.parcelize))
+    implementation(plugin(libs.plugins.kotlin.serialization))
 
     implementation(plugin(libs.plugins.android.application))
     implementation(plugin(libs.plugins.android.library))

--- a/build-plugin/build.gradle.kts
+++ b/build-plugin/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     `kotlin-dsl`
-    `kotlin-dsl-precompiled-script-plugins`
 }
 
 dependencies {

--- a/build-plugin/settings.gradle.kts
+++ b/build-plugin/settings.gradle.kts
@@ -1,16 +1,16 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        google()
-        mavenCentral()
     }
 }
 
 dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+
     repositories {
+        gradlePluginPortal()
         google()
         mavenCentral()
-        gradlePluginPortal()
     }
 
     versionCatalogs.create("libs") {

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("thunderbird.library.android")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("org.jetbrains.kotlin.plugin.serialization")
     id("thunderbird.quality.detekt.typed")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
 
     id("thunderbird.quality.spotless")

--- a/feature/funding/googleplay/build.gradle.kts
+++ b/feature/funding/googleplay/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     api(projects.feature.funding.api)
 
     implementation(libs.android.billing)
+    implementation(libs.android.billing.ktx)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,10 +15,3 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=false
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
-## Workaround for AGP still using old versions of xerces and having issues with Gradle > 8.3
-## https://docs.gradle.org/current/userguide/upgrading_version_8.html#xml_parsing_now_requires_recent_parsers
-## A fix is available in AGP 8.3.0-alpha12: https://issuetracker.google.com/issues/306301014
-## Remove this once AGP 8.3.0 works with Intellij IDEA
-systemProp.javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
-systemProp.javax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
-systemProp.javax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -114,6 +114,7 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }
 
 [libraries]
 android-billing = { module = "com.android.billingclient:billing", version.ref = "androidBilling" }
+android-billing-ktx = { module = "com.android.billingclient:billing-ktx", version.ref = "androidBilling" }
 android-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "androidDesugar" }
 android-material = { module = "com.google.android.material:material", version.ref = "androidMaterial" }
 android-tools-common = { module = "com.android.tools:common", version.ref = "androidTools" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ kotlinKsp = "2.0.20-1.0.25"
 kotlinxCoroutines = "1.8.1"
 kotlinxCollectionsImmutable = "0.3.8"
 kotlinxDateTime = "0.6.1"
+kotlinxSerialization = "1.7.3"
 ktlint = "1.2.1"
 kxml2 = "1.0"
 leakcanary = "2.13"
@@ -109,6 +110,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektPlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinBom" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinBom" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinBom" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinBom" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "kotlinKsp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }
 
@@ -209,6 +211,7 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDateTime" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 kxml2 = { module = "com.github.cketti:kxml2-extracted-from-android", version.ref = "kxml2" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 materialdrawer = { module = "com.mikepenz:materialdrawer", version.ref = "materialDrawer" }
@@ -259,6 +262,7 @@ shared-jvm-android-compose = [
   "androidx-navigation-compose",
   "koin-androidx-compose",
   "kotlinx-collections-immutable",
+  "kotlinx-serialization-json",
 ]
 shared-jvm-android-compose-debug = [
   "androidx-compose-ui-test-manifest",


### PR DESCRIPTION
Add the Kotlin KTX dependency for the biiling library and KotlinX Serialization to support type safe navigation and update the bundled version to be compatible with Kotlin 2.0.20 as part of #8162.

Cleaned up the build-plugin and Gradle setup.
