### PR TITLE
Replaced deprecated kotlinOptions with compilerOptions

### DIFF
--- a/build-plugin/src/main/kotlin/KotlinExtension.kt
+++ b/build-plugin/src/main/kotlin/KotlinExtension.kt
@@ -1,11 +1,12 @@
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun Project.configureKotlinJavaCompatibility() {
     tasks.withType<KotlinCompile> {
-        kotlinOptions {
-            jvmTarget = ThunderbirdProjectConfig.javaCompatibilityVersion.toString()
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(ThunderbirdProjectConfig.javaCompatibilityVersion.toString()))
         }
     }
 }


### PR DESCRIPTION
As `kotlinOptions` is deprecated, I replaced it with the new `compilerOptions` DSL syntax.

See also: https://kotl.in/u1r8ln

```
w: file:///home/shellwen/Projects/Kotlin/thunderbird-android/build-plugin/src/main/kotlin/KotlinExtension.kt:7:9 'kotlinOptions(KotlinJvmOptionsDeprecated /* = KotlinJvmOptions */.() -> Unit): Unit' is deprecated. Please migrate to the compilerOptions DSL. More details are here: https://kotl.in/u1r8ln
```