### PR TITLE
Change folder display options

### DIFF
--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
@@ -57,6 +57,14 @@ class DisplayFolderRepository(
         }.sortedWith(sortForDisplay)
     }
 
+    fun getDisplayFoldersFlow(account: Account, includeHiddenFolders: Boolean): Flow<List<DisplayFolder>> {
+        return if (includeHiddenFolders) {
+            getDisplayFoldersFlow(account, FolderMode.ALL)
+        } else {
+            getDisplayFoldersFlow(account.uuid)
+        }
+    }
+
     fun getDisplayFoldersFlow(account: Account, displayMode: Account.FolderMode): Flow<List<DisplayFolder>> {
         val messageStore = messageStoreManager.getMessageStore(account.uuid)
 

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
@@ -65,7 +65,7 @@ class DisplayFolderRepository(
         }
     }
 
-    fun getDisplayFoldersFlow(account: Account, displayMode: Account.FolderMode): Flow<List<DisplayFolder>> {
+    private fun getDisplayFoldersFlow(account: Account, displayMode: Account.FolderMode): Flow<List<DisplayFolder>> {
         val messageStore = messageStoreManager.getMessageStore(account.uuid)
 
         return callbackFlow {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -19,23 +18,23 @@ class ChooseFolderViewModel(
 ) : ViewModel() {
     private val inputFlow = MutableSharedFlow<DisplayMode>(replay = 1)
     private val foldersFlow = inputFlow
-        .flatMapLatest { (account, displayMode) ->
-            folderRepository.getDisplayFoldersFlow(account, displayMode)
+        .flatMapLatest { (account, showHiddenFolders) ->
+            folderRepository.getDisplayFoldersFlow(account, showHiddenFolders)
         }
 
-    var currentDisplayMode: FolderMode? = null
+    var isShowHiddenFolders: Boolean = false
         private set
 
     fun getFolders(): LiveData<List<DisplayFolder>> {
         return foldersFlow.asLiveData()
     }
 
-    fun setDisplayMode(account: Account, displayMode: FolderMode) {
-        currentDisplayMode = displayMode
+    fun setDisplayMode(account: Account, showHiddenFolders: Boolean) {
+        isShowHiddenFolders = showHiddenFolders
         viewModelScope.launch {
-            inputFlow.emit(DisplayMode(account, displayMode))
+            inputFlow.emit(DisplayMode(account, showHiddenFolders))
         }
     }
 }
 
-private data class DisplayMode(val account: Account, val displayMode: FolderMode)
+private data class DisplayMode(val account: Account, val showHiddenFolders: Boolean)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
@@ -121,10 +121,6 @@ class ManageFoldersFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.list_folders -> refreshFolderList()
-            R.id.display_1st_class -> setDisplayMode(Account.FolderMode.FIRST_CLASS)
-            R.id.display_1st_and_2nd_class -> setDisplayMode(Account.FolderMode.FIRST_AND_SECOND_CLASS)
-            R.id.display_not_second_class -> setDisplayMode(Account.FolderMode.NOT_SECOND_CLASS)
-            R.id.display_all -> setDisplayMode(Account.FolderMode.ALL)
             else -> return super.onOptionsItemSelected(item)
         }
 
@@ -133,13 +129,6 @@ class ManageFoldersFragment : Fragment() {
 
     private fun refreshFolderList() {
         messagingController.refreshFolderList(account)
-    }
-
-    private fun setDisplayMode(newMode: Account.FolderMode) {
-        account.folderDisplayMode = newMode
-        preferences.saveAccount(account)
-
-        itemAdapter.filter(null)
     }
 
     private fun folderListFilter(item: FolderListItem, constraint: CharSequence?): Boolean {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
@@ -11,6 +11,6 @@ class ManageFoldersViewModel(
     private val folderRepository: DisplayFolderRepository,
 ) : ViewModel() {
     fun getFolders(account: Account): LiveData<List<DisplayFolder>> {
-        return folderRepository.getDisplayFoldersFlow(account.uuid).asLiveData()
+        return folderRepository.getDisplayFoldersFlow(account, includeHiddenFolders = true).asLiveData()
     }
 }

--- a/legacy/ui/legacy/src/main/res/menu/choose_folder_option.xml
+++ b/legacy/ui/legacy/src/main/res/menu/choose_folder_option.xml
@@ -12,20 +12,9 @@
         app:showAsAction="collapseActionView|ifRoom"
         />
     <item
-        android:id="@+id/display_all"
-        android:title="@string/folder_list_display_mode_all"
-        />
-    <item
-        android:id="@+id/display_1st_class"
-        android:title="@string/folder_list_display_mode_first_class"
-        />
-    <item
-        android:id="@+id/display_1st_and_2nd_class"
-        android:title="@string/folder_list_display_mode_first_and_second_class"
-        />
-    <item
-        android:id="@+id/display_not_second_class"
-        android:title="@string/folder_list_display_mode_not_second_class"
+        android:id="@+id/toggle_hidden_folders"
+        android:checkable="true"
+        android:title="@string/folder_list_show_hidden_folders"
         />
     <item
         android:id="@+id/list_folders"

--- a/legacy/ui/legacy/src/main/res/menu/folder_list_option.xml
+++ b/legacy/ui/legacy/src/main/res/menu/folder_list_option.xml
@@ -11,29 +11,6 @@
         app:actionViewClass="androidx.appcompat.widget.SearchView"
         />
     <item
-        android:icon="@drawable/ic_inbox"
-        android:title="@string/folder_list_display_mode_label"
-        >
-        <menu>
-            <item
-                android:id="@+id/display_all"
-                android:title="@string/folder_list_display_mode_all"
-                />
-            <item
-                android:id="@+id/display_1st_class"
-                android:title="@string/folder_list_display_mode_first_class"
-                />
-            <item
-                android:id="@+id/display_1st_and_2nd_class"
-                android:title="@string/folder_list_display_mode_first_and_second_class"
-                />
-            <item
-                android:id="@+id/display_not_second_class"
-                android:title="@string/folder_list_display_mode_not_second_class"
-                />
-        </menu>
-    </item>
-    <item
         android:id="@+id/list_folders"
         android:icon="@drawable/ic_refresh"
         android:title="@string/refresh_folders_action"

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -621,12 +621,7 @@
     <string name="account_delete_dlg_title">Remove Account</string>
 
     <string name="folder_list_filter_hint">Folder name contains</string>
-
-    <string name="folder_list_display_mode_label">Show folders…</string>
-    <string name="folder_list_display_mode_all">All folders</string>
-    <string name="folder_list_display_mode_first_class">1st Class folders</string>
-    <string name="folder_list_display_mode_first_and_second_class">1st &amp; 2nd Class folders</string>
-    <string name="folder_list_display_mode_not_second_class">Hide 2nd Class folders</string>
+    <string name="folder_list_show_hidden_folders">Show hidden folders</string>
 
     <string name="account_settings_signature__location_label">Signature position</string>
     <string name="account_settings_signature__location_before_quoted_text">Before quoted message</string>


### PR DESCRIPTION
In preparation of removing folder display classes, this changes screens that allow the user to switch which folders are displayed.

New behavior:
- "Manage folders" now always displays all folders
- "Move to…/Copy to…" now contains a "Show hidden folders" option in the menu

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/c28d6bc8-4cba-4698-954b-eb736f33bb14)|![image](https://github.com/user-attachments/assets/99a8782d-6c14-4855-a375-415676fa7546)|
|![image](https://github.com/user-attachments/assets/814d9107-a909-4722-80a2-bfb782efbcac)|![image](https://github.com/user-attachments/assets/34f3d49a-3700-4673-bf95-78a61077af71)|
