### PR TITLE
Fix crash when removing a push-capable account

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
@@ -306,11 +306,13 @@ class PushController internal constructor(
         synchronized(lock) {
             // Stop listening to push enabled changes in accounts we no longer monitor
             val accountUuids = accounts.mapToSet { it.uuid }
-            for (accountUuid in pushEnabledCollectorJobs.keys) {
+            val iterator = pushEnabledCollectorJobs.iterator()
+            while (iterator.hasNext()) {
+                val (accountUuid, collectorJob) = iterator.next()
                 if (accountUuid !in accountUuids) {
                     Timber.v("..Stopping to listen for push enabled changes in account: %s", accountUuid)
-                    val collectorJob = pushEnabledCollectorJobs.remove(accountUuid)
-                    collectorJob?.cancel()
+                    iterator.remove()
+                    collectorJob.cancel()
                 }
             }
 


### PR DESCRIPTION
This fixes the crash currently on position 1 on Google Play.

```text
Exception java.util.ConcurrentModificationException:
  at java.util.LinkedHashMap$LinkedHashIterator.nextNode (LinkedHashMap.java:1061)
  at java.util.LinkedHashMap$LinkedKeyIterator.next (LinkedHashMap.java:1084)
  at com.fsck.k9.controller.push.PushController.updatePushEnabledListeners (PushController.kt:309)
  at com.fsck.k9.controller.push.PushController.updatePushers (PushController.kt:214)
  at com.fsck.k9.controller.push.PushController.access$onAlarmPermissionGranted (PushController.kt:34)
  at com.fsck.k9.controller.push.PushController.access$updatePushers (PushController.kt:34)
  at com.fsck.k9.controller.push.PushController$launchUpdatePushers$1.invokeSuspend (PushController.kt:153)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
  at kotlinx.coroutines.CoroutineContextKt.withContinuationContext (CoroutineContext.kt:104)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:86)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:104)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1145)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:644)
  at java.lang.Thread.run (Thread.java:1012)
```

The old code was removing entries from a map while iterating over its contents. The new code does this properly by using `Iterator.remove()`.

### Testing instructions
This code path can be triggered by removing push-capable (IMAP) accounts.

Fixes #8242