### PR TITLE
Fix "Sent” folder: Missing space between "To" and address

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/helper/MessageHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/helper/MessageHelper.kt
@@ -34,7 +34,7 @@ class MessageHelper(
         }
         val repository = if (isShowContactName) contactRepository else null
         val recipients = toFriendly(addresses, repository)
-        return SpannableStringBuilder(resourceProvider.contactDisplayNamePrefix()).append(recipients)
+        return SpannableStringBuilder(resourceProvider.contactDisplayNamePrefix()).append(' ').append(recipients)
     }
 
     companion object {


### PR DESCRIPTION
Hey!

This PR Fixes #8170. 

The issue reported has a missing space between the label "To:" and contact information.

I added the space and some unit test to test the behavior of `MessageHelper.kt`.

See 
![Fix8170](https://github.com/user-attachments/assets/05093074-8357-499b-8067-0dffe3c22b26)


Looking forward to hearing your feedback!

Thanks,
Álvaro
