### PR TITLE
Add funding UI - part 2

### DIFF
--- a/core/ui/compose/navigation/build.gradle.kts
+++ b/core/ui/compose/navigation/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "app.k9mail.core.ui.compose.navigation"
+    resourcePrefix = "core_ui_navigation_"
+}

--- a/core/ui/compose/navigation/src/main/kotlin/app/k9mail/core/ui/compose/navigation/Navigation.kt
+++ b/core/ui/compose/navigation/src/main/kotlin/app/k9mail/core/ui/compose/navigation/Navigation.kt
@@ -1,0 +1,23 @@
+package app.k9mail.core.ui.compose.navigation
+
+import androidx.navigation.NavGraphBuilder
+
+/**
+ * A Navigation is responsible for registering routes with the navigation graph.
+ *
+ * @param T the type of route
+ */
+interface Navigation<T : Route> {
+
+    /**
+     * Register all routes for this navigation.
+     *
+     * @param onBack the action to perform when the back button is pressed
+     * @param onFinish the action to perform when a route is finished
+     */
+    fun registerRoutes(
+        navGraphBuilder: NavGraphBuilder,
+        onBack: () -> Unit,
+        onFinish: (T) -> Unit,
+    )
+}

--- a/core/ui/compose/navigation/src/main/kotlin/app/k9mail/core/ui/compose/navigation/NavigationExtension.kt
+++ b/core/ui/compose/navigation/src/main/kotlin/app/k9mail/core/ui/compose/navigation/NavigationExtension.kt
@@ -1,0 +1,22 @@
+package app.k9mail.core.ui.compose.navigation
+
+import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
+
+inline fun <reified T : Route> NavGraphBuilder.deepLinkComposable(
+    route: T,
+    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+) {
+    composable<T>(
+        deepLinks = listOf(
+            navDeepLink<T>(
+                basePath = route.deepLink,
+            ),
+        ),
+        content = content,
+    )
+}

--- a/core/ui/compose/navigation/src/main/kotlin/app/k9mail/core/ui/compose/navigation/Route.kt
+++ b/core/ui/compose/navigation/src/main/kotlin/app/k9mail/core/ui/compose/navigation/Route.kt
@@ -1,0 +1,18 @@
+package app.k9mail.core.ui.compose.navigation
+
+import android.net.Uri
+import androidx.core.net.toUri
+
+/**
+ * A Route represents a destination in the app.
+ *
+ * It is used to navigate to a specific screen using type-safe composable navigation
+ * and deep links.
+ *
+ * @see Navigation
+ */
+interface Route {
+    val deepLink: String
+
+    fun toDeepLinkUri(): Uri = deepLink.toUri()
+}

--- a/feature/funding/api/build.gradle.kts
+++ b/feature/funding/api/build.gradle.kts
@@ -1,4 +1,13 @@
 plugins {
-    id(ThunderbirdPlugins.Library.jvm)
-    alias(libs.plugins.android.lint)
+    id(ThunderbirdPlugins.Library.androidCompose)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    namespace = "app.k9mail.feature.funding.api"
+    resourcePrefix = "funding_api_"
+}
+
+dependencies {
+    api(projects.core.ui.compose.navigation)
 }

--- a/feature/funding/api/src/main/kotlin/app/k9mail/feature/funding/api/FundingNavigation.kt
+++ b/feature/funding/api/src/main/kotlin/app/k9mail/feature/funding/api/FundingNavigation.kt
@@ -1,0 +1,16 @@
+package app.k9mail.feature.funding.api
+
+import app.k9mail.core.ui.compose.navigation.Navigation
+import app.k9mail.core.ui.compose.navigation.Route
+import kotlinx.serialization.Serializable
+
+const val FUNDING_BASE_DEEP_LINK = "app://feature/funding"
+
+sealed interface FundingRoute : Route {
+    @Serializable
+    data object Overview : FundingRoute {
+        override val deepLink: String = "$FUNDING_BASE_DEEP_LINK/overview"
+    }
+}
+
+interface FundingNavigation : Navigation<FundingRoute>

--- a/feature/funding/googleplay/build.gradle.kts
+++ b/feature/funding/googleplay/build.gradle.kts
@@ -10,6 +10,8 @@ android {
 dependencies {
     api(projects.feature.funding.api)
 
+    implementation(projects.core.ui.compose.designsystem)
+
     implementation(libs.android.billing)
     implementation(libs.android.billing.ktx)
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -1,9 +1,12 @@
 package app.k9mail.feature.funding
 
 import app.k9mail.feature.funding.api.FundingManager
+import app.k9mail.feature.funding.api.FundingNavigation
 import app.k9mail.feature.funding.googleplay.GooglePlayFundingManager
+import app.k9mail.feature.funding.googleplay.GooglePlayFundingNavigation
 import org.koin.dsl.module
 
 val featureFundingModule = module {
     single<FundingManager> { GooglePlayFundingManager() }
+    single<FundingNavigation> { GooglePlayFundingNavigation() }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/GooglePlayFundingNavigation.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/GooglePlayFundingNavigation.kt
@@ -1,0 +1,24 @@
+package app.k9mail.feature.funding.googleplay
+
+import androidx.navigation.NavGraphBuilder
+import app.k9mail.core.ui.compose.navigation.deepLinkComposable
+import app.k9mail.feature.funding.api.FundingNavigation
+import app.k9mail.feature.funding.api.FundingRoute
+import app.k9mail.feature.funding.googleplay.ui.overview.FundingOverviewScreen
+
+class GooglePlayFundingNavigation : FundingNavigation {
+
+    override fun registerRoutes(
+        navGraphBuilder: NavGraphBuilder,
+        onBack: () -> Unit,
+        onFinish: (FundingRoute) -> Unit,
+    ) {
+        with(navGraphBuilder) {
+            deepLinkComposable(FundingRoute.Overview) {
+                FundingOverviewScreen(
+                    onBack = onBack,
+                )
+            }
+        }
+    }
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/overview/FundingOverviewScreen.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/overview/FundingOverviewScreen.kt
@@ -1,0 +1,26 @@
+package app.k9mail.feature.funding.googleplay.ui.overview
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
+
+@Composable
+internal fun FundingOverviewScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BackHandler {
+        onBack()
+    }
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        TextTitleLarge(text = "Funding Overview")
+    }
+}

--- a/feature/funding/link/build.gradle.kts
+++ b/feature/funding/link/build.gradle.kts
@@ -1,6 +1,10 @@
 plugins {
-    id(ThunderbirdPlugins.Library.jvm)
-    alias(libs.plugins.android.lint)
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "app.k9mail.feature.funding.link"
+    resourcePrefix = "funding_link_"
 }
 
 dependencies {

--- a/feature/funding/link/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/link/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -1,9 +1,12 @@
 package app.k9mail.feature.funding
 
 import app.k9mail.feature.funding.api.FundingManager
+import app.k9mail.feature.funding.api.FundingNavigation
 import app.k9mail.feature.funding.link.LinkFundingManager
+import app.k9mail.feature.funding.link.LinkFundingNavigation
 import org.koin.dsl.module
 
 val featureFundingModule = module {
     single<FundingManager> { LinkFundingManager() }
+    single<FundingNavigation> { LinkFundingNavigation() }
 }

--- a/feature/funding/link/src/main/kotlin/app/k9mail/feature/funding/link/LinkFundingNavigation.kt
+++ b/feature/funding/link/src/main/kotlin/app/k9mail/feature/funding/link/LinkFundingNavigation.kt
@@ -1,0 +1,15 @@
+package app.k9mail.feature.funding.link
+
+import androidx.navigation.NavGraphBuilder
+import app.k9mail.feature.funding.api.FundingNavigation
+import app.k9mail.feature.funding.api.FundingRoute
+
+class LinkFundingNavigation : FundingNavigation {
+    override fun registerRoutes(
+        navGraphBuilder: NavGraphBuilder,
+        onBack: () -> Unit,
+        onFinish: (FundingRoute) -> Unit,
+    ) {
+        // no-op
+    }
+}

--- a/feature/funding/noop/build.gradle.kts
+++ b/feature/funding/noop/build.gradle.kts
@@ -1,6 +1,10 @@
 plugins {
-    id(ThunderbirdPlugins.Library.jvm)
-    alias(libs.plugins.android.lint)
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "app.k9mail.feature.funding.noop"
+    resourcePrefix = "funding_noop_"
 }
 
 dependencies {

--- a/feature/funding/noop/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/noop/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -1,9 +1,12 @@
 package app.k9mail.feature.funding
 
 import app.k9mail.feature.funding.api.FundingManager
+import app.k9mail.feature.funding.api.FundingNavigation
 import app.k9mail.feature.funding.noop.NoOpFundingManager
+import app.k9mail.feature.funding.noop.NoOpFundingNavigation
 import org.koin.dsl.module
 
 val featureFundingModule = module {
     single<FundingManager> { NoOpFundingManager() }
+    single<FundingNavigation> { NoOpFundingNavigation() }
 }

--- a/feature/funding/noop/src/main/kotlin/app/k9mail/feature/funding/noop/NoOpFundingNavigation.kt
+++ b/feature/funding/noop/src/main/kotlin/app/k9mail/feature/funding/noop/NoOpFundingNavigation.kt
@@ -1,0 +1,15 @@
+package app.k9mail.feature.funding.noop
+
+import androidx.navigation.NavGraphBuilder
+import app.k9mail.feature.funding.api.FundingNavigation
+import app.k9mail.feature.funding.api.FundingRoute
+
+class NoOpFundingNavigation : FundingNavigation {
+    override fun registerRoutes(
+        navGraphBuilder: NavGraphBuilder,
+        onBack: () -> Unit,
+        onFinish: (FundingRoute) -> Unit,
+    ) {
+        // no-op
+    }
+}

--- a/feature/launcher/build.gradle.kts
+++ b/feature/launcher/build.gradle.kts
@@ -15,5 +15,7 @@ dependencies {
     implementation(projects.feature.account.setup)
     implementation(projects.feature.account.edit)
 
+    implementation(projects.feature.funding.api)
+
     testImplementation(projects.core.ui.compose.testing)
 }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
@@ -30,7 +30,7 @@ class FeatureLauncherActivity : K9Activity() {
         @JvmStatic
         fun getIntent(context: Context, target: FeatureLauncherTarget): Intent {
             return Intent(context, FeatureLauncherActivity::class.java).apply {
-                data = target.toDeepLinkUri()
+                data = target.deepLinkUri
                 if (target.flags != null) {
                     flags = target.flags
                 }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherTarget.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherTarget.kt
@@ -5,39 +5,31 @@ import android.net.Uri
 import app.k9mail.core.ui.compose.common.navigation.toDeepLinkUri
 import app.k9mail.feature.account.edit.navigation.withAccountUuid
 import app.k9mail.feature.account.setup.navigation.NAVIGATION_ROUTE_ACCOUNT_SETUP
+import app.k9mail.feature.funding.api.FundingRoute
 import app.k9mail.feature.onboarding.main.navigation.NAVIGATION_ROUTE_ONBOARDING
 
 sealed class FeatureLauncherTarget(
-    val route: String,
+    val deepLinkUri: Uri,
     val flags: Int? = null,
 ) {
     data object Onboarding : FeatureLauncherTarget(
-        route = NAVIGATION_ROUTE_ONBOARDING,
+        deepLinkUri = NAVIGATION_ROUTE_ONBOARDING.toDeepLinkUri(),
         flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK,
     )
 
     data object AccountSetup : FeatureLauncherTarget(
-        route = NAVIGATION_ROUTE_ACCOUNT_SETUP,
+        deepLinkUri = NAVIGATION_ROUTE_ACCOUNT_SETUP.toDeepLinkUri(),
     )
 
     data class AccountEditIncomingSettings(val accountUuid: String) : FeatureLauncherTarget(
-        route = NAVIGATION_ROUTE_ACCOUNT_SETUP,
+        deepLinkUri = NAVIGATION_ROUTE_ACCOUNT_SETUP.withAccountUuid(accountUuid).toDeepLinkUri(),
     )
 
     data class AccountEditOutgoingSettings(val accountUuid: String) : FeatureLauncherTarget(
-        route = NAVIGATION_ROUTE_ACCOUNT_SETUP,
+        deepLinkUri = NAVIGATION_ROUTE_ACCOUNT_SETUP.withAccountUuid(accountUuid).toDeepLinkUri(),
     )
 
     data object Funding : FeatureLauncherTarget(
-        route = "TODO",
+        deepLinkUri = FundingRoute.Overview.toDeepLinkUri(),
     )
-
-    fun toDeepLinkUri(): Uri {
-        return when (this) {
-            is AccountEditIncomingSettings -> route.withAccountUuid(accountUuid).toDeepLinkUri()
-            is AccountEditOutgoingSettings -> route.withAccountUuid(accountUuid).toDeepLinkUri()
-
-            else -> route.toDeepLinkUri()
-        }
-    }
 }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.NavHost
 import app.k9mail.core.ui.compose.common.activity.LocalActivity
 import app.k9mail.feature.account.edit.navigation.accountEditRoute
 import app.k9mail.feature.account.setup.navigation.accountSetupRoute
+import app.k9mail.feature.funding.api.FundingNavigation
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.AccountSetupFinishedLauncher
 import app.k9mail.feature.onboarding.main.navigation.NAVIGATION_ROUTE_ONBOARDING
 import app.k9mail.feature.onboarding.main.navigation.onboardingRoute
@@ -18,6 +19,7 @@ fun FeatureLauncherNavHost(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
     accountSetupFinishedLauncher: AccountSetupFinishedLauncher = koinInject(),
+    fundingNavigation: FundingNavigation = koinInject(),
 ) {
     val activity = LocalActivity.current
 
@@ -39,6 +41,12 @@ fun FeatureLauncherNavHost(
         accountEditRoute(
             onBack = onBack,
             onFinish = { activity.finish() },
+        )
+
+        fundingNavigation.registerRoutes(
+            navGraphBuilder = this,
+            onBack = onBack,
+            onFinish = { onBack() },
         )
     }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
@@ -138,27 +138,38 @@ class SettingsListFragment : Fragment(), ItemTouchCallback {
                     icon = Icons.Outlined.Help,
                 )
 
-                when (fundingManager.getFundingType()) {
-                    FundingType.GOOGLE_PLAY -> {
-                        // TODO add funding action
-                    }
-
-                    FundingType.LINK -> {
-                        addUrlAction(
-                            text = getString(R.string.settings_list_action_support, appNameProvider.appName),
-                            url = getString(R.string.donate_url),
-                            icon = Icons.Outlined.Favorite,
-                        )
-                    }
-
-                    FundingType.NO_FUNDING -> {
-                        // no-op
-                    }
-                }
+                addFunding()
             }
         }
 
         itemAdapter.setNewList(listItems)
+    }
+
+    private fun SettingsListBuilder.addFunding() {
+        when (fundingManager.getFundingType()) {
+            FundingType.GOOGLE_PLAY -> {
+                addIntent(
+                    text = getString(R.string.settings_list_action_support, appNameProvider.appName),
+                    icon = Icons.Outlined.Favorite,
+                    intent = FeatureLauncherActivity.getIntent(
+                        context = requireActivity(),
+                        target = FeatureLauncherTarget.Funding,
+                    ),
+                )
+            }
+
+            FundingType.LINK -> {
+                addUrlAction(
+                    text = getString(R.string.settings_list_action_support, appNameProvider.appName),
+                    url = getString(R.string.donate_url),
+                    icon = Icons.Outlined.Favorite,
+                )
+            }
+
+            FundingType.NO_FUNDING -> {
+                // no-op
+            }
+        }
     }
 
     private fun handleItemClick(item: GenericItem) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -99,6 +99,7 @@ include(
     ":core:android:testing",
     ":core:ui:compose:common",
     ":core:ui:compose:designsystem",
+    ":core:ui:compose:navigation",
     ":core:ui:compose:theme2:common",
     ":core:ui:compose:theme2:k9mail",
     ":core:ui:compose:theme2:thunderbird",


### PR DESCRIPTION
This adds type safe composable navigation and adds a route to the funding overview screen. The navigation is designed to support deep links, currently limited to the `app://` schema.