### PR TITLE
Improve "Import from app" user experience

### DIFF
--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/ImportAppFetcher.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/ImportAppFetcher.kt
@@ -14,7 +14,7 @@ internal class ImportAppFetcher(
      */
     @WorkerThread
     fun isAtLeastOneAppInstalled(): Boolean {
-        return supportedApps.any { packageName -> packageManager.isAppInstalled(packageName) }
+        return supportedApps.any { app -> packageManager.isAppInstalled(app.packageName) }
     }
 
     @Suppress("SwallowedException")
@@ -33,17 +33,20 @@ internal class ImportAppFetcher(
     @WorkerThread
     fun getAppInfoList(): List<AppInfo> {
         return supportedApps
-            .mapNotNull { packageName -> packageManager.loadAppInfo(packageName) }
+            .mapNotNull { app -> packageManager.loadAppInfo(app) }
             .toList()
     }
 
     @Suppress("SwallowedException")
-    private fun PackageManager.loadAppInfo(packageName: String): AppInfo? {
+    private fun PackageManager.loadAppInfo(app: AppVersion): AppInfo? {
         return try {
-            val applicationInfo = getApplicationInfo(packageName, 0)
+            val packageInfo = getPackageInfo(app.packageName, 0)
+            val isImportSupported = packageInfo.versionCode >= app.minVersionCode
+
+            val applicationInfo = getApplicationInfo(app.packageName, 0)
             val appName = packageManager.getApplicationLabel(applicationInfo).toString()
 
-            AppInfo(packageName, appName)
+            AppInfo(app.packageName, appName, isImportSupported)
         } catch (e: PackageManager.NameNotFoundException) {
             null
         }
@@ -52,29 +55,35 @@ internal class ImportAppFetcher(
     /**
      * Get the list of application IDs of supported apps excluding our own app.
      */
-    private val supportedApps: Sequence<String>
+    private val supportedApps: Sequence<AppVersion>
         get() {
             val myPackageName = context.packageName
             return SUPPORTED_APPS
                 .asSequence()
-                .filterNot { packageName -> packageName == myPackageName }
+                .filterNot { app -> app.packageName == myPackageName }
         }
 
     companion object {
         private val SUPPORTED_APPS = listOf(
             // K-9 Mail
-            "com.fsck.k9",
+            AppVersion("com.fsck.k9", 39005),
             // Thunderbird for Android (release)
-            "net.thunderbird.android",
+            AppVersion("net.thunderbird.android", 1),
             // Thunderbird for Android (beta)
-            "net.thunderbird.android.beta",
+            AppVersion("net.thunderbird.android.beta", 4),
             // Thunderbird for Android (daily)
-            "net.thunderbird.android.daily",
+            AppVersion("net.thunderbird.android.daily", 1),
         )
     }
 }
 
-internal data class AppInfo(val packageName: String, private val appName: String) {
+private data class AppVersion(val packageName: String, val minVersionCode: Int)
+
+internal data class AppInfo(
+    val packageName: String,
+    val appName: String,
+    val isImportSupported: Boolean,
+) {
     // ArrayAdapter is using `toString()` when rendering list items. See PickAppDialogFragment.
     override fun toString() = appName
 }

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/ImportAppFetcher.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/ImportAppFetcher.kt
@@ -83,7 +83,4 @@ internal data class AppInfo(
     val packageName: String,
     val appName: String,
     val isImportSupported: Boolean,
-) {
-    // ArrayAdapter is using `toString()` when rendering list items. See PickAppDialogFragment.
-    override fun toString() = appName
-}
+)

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/PickAppAdapter.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/PickAppAdapter.kt
@@ -1,0 +1,41 @@
+package app.k9mail.feature.settings.import.ui
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import androidx.core.view.isVisible
+import app.k9mail.feature.settings.importing.R
+
+internal class PickAppAdapter(context: Context) : ArrayAdapter<AppInfo>(context, 0) {
+    private val inflater = LayoutInflater.from(context)
+
+    private fun getItemOrThrow(position: Int): AppInfo {
+        return getItem(position) ?: error("Item at position $position not found")
+    }
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val view = convertView ?: inflater.inflate(R.layout.settings_import_pick_app_list_item, parent, false)
+
+        val appNameTextView = view.findViewById<TextView>(R.id.settings_import_app_name)
+        val appNoteTextView = view.findViewById<View>(R.id.settings_import_app_note)
+
+        val item = getItemOrThrow(position)
+        appNameTextView.text = item.appName
+        appNoteTextView.isVisible = !item.isImportSupported
+
+        view.isEnabled = item.isImportSupported
+
+        return view
+    }
+
+    override fun areAllItemsEnabled(): Boolean {
+        return false
+    }
+
+    override fun isEnabled(position: Int): Boolean {
+        return getItemOrThrow(position).isImportSupported
+    }
+}

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/PickAppDialogFragment.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/PickAppDialogFragment.kt
@@ -4,7 +4,6 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.content.DialogInterface.OnClickListener
 import android.os.Bundle
-import android.widget.ArrayAdapter
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
@@ -29,11 +28,7 @@ internal class PickAppDialogFragment : DialogFragment() {
     private var selectedPackageName: String? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val adapter = ArrayAdapter<AppInfo>(
-            requireContext(),
-            R.layout.settings_import_pick_app_list_item,
-            R.id.settings_import_app_name,
-        )
+        val adapter = PickAppAdapter(requireContext())
 
         viewModel.appInfoFlow.observe(this) { appInfoList ->
             adapter.clear()

--- a/feature/settings/import/src/main/res/layout/settings_import_pick_app_list_item.xml
+++ b/feature/settings/import/src/main/res/layout/settings_import_pick_app_list_item.xml
@@ -6,6 +6,7 @@
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
     android:minHeight="56dp"
+    android:orientation="vertical"
     android:paddingHorizontal="24dp"
     android:paddingVertical="8dp"
     >
@@ -14,8 +15,20 @@
         android:id="@+id/settings_import_app_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:duplicateParentState="true"
         android:textAppearance="?attr/textAppearanceBodyLarge"
         tools:text="K-9 Mail"
+        />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/settings_import_app_note"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:duplicateParentState="true"
+        android:text="@string/settings_import_app_version_not_supported"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:visibility="gone"
+        tools:visibility="visible"
         />
 
 </LinearLayout>

--- a/feature/settings/import/src/main/res/values/strings.xml
+++ b/feature/settings/import/src/main/res/values/strings.xml
@@ -40,4 +40,6 @@
     <string name="settings_import_oauth_error_oauth_not_supported">OAuth 2.0 is currently not supported with this provider.</string>
     <string name="settings_import_oauth_error_browser_not_found">The app couldn\'t find a browser to use for granting access to your account.</string>
     <string name="settings_import_general_settings_item">General settings</string>
+    <!-- Displayed below the app name in the list of apps from which settings can be imported when the app is too old and doesn't support exporting settings to another app. -->
+    <string name="settings_import_app_version_not_supported">App version not supported.</string>
 </resources>

--- a/feature/settings/import/src/test/kotlin/app/k9mail/feature/settings/import/ui/ImportAppFetcherTest.kt
+++ b/feature/settings/import/src/test/kotlin/app/k9mail/feature/settings/import/ui/ImportAppFetcherTest.kt
@@ -50,28 +50,39 @@ class ImportAppFetcherTest {
     }
 
     @Test
-    fun `getAppInfoList() with another app installed`() {
-        installPackage("com.fsck.k9", "K-9 Mail")
+    fun `getAppInfoList() with another supported app installed`() {
+        installPackage("com.fsck.k9", "K-9 Mail", versionCode = 40000)
 
         val result = importAppFetcher.getAppInfoList()
 
         assertThat(result).containsExactly(
-            AppInfo("com.fsck.k9", "K-9 Mail"),
+            AppInfo("com.fsck.k9", "K-9 Mail", isImportSupported = true),
         )
     }
 
     @Test
-    fun `getAppInfoList() with multiple other apps installed`() {
-        installPackage("com.fsck.k9", "K-9 Mail")
-        installPackage("net.thunderbird.android.beta", "Thunderbird Beta")
-        installPackage("net.thunderbird.android.daily", "Thunderbird Daily")
+    fun `getAppInfoList() with another unsupported app installed`() {
+        installPackage("com.fsck.k9", "K-9 Mail", versionCode = 39004)
+
+        val result = importAppFetcher.getAppInfoList()
+
+        assertThat(result).containsExactly(
+            AppInfo("com.fsck.k9", "K-9 Mail", isImportSupported = false),
+        )
+    }
+
+    @Test
+    fun `getAppInfoList() with multiple other supported apps installed`() {
+        installPackage("com.fsck.k9", "K-9 Mail", versionCode = 39005)
+        installPackage("net.thunderbird.android.beta", "Thunderbird Beta", versionCode = 4)
+        installPackage("net.thunderbird.android.daily", "Thunderbird Daily", versionCode = 1)
 
         val result = importAppFetcher.getAppInfoList()
 
         assertThat(result).containsExactlyInAnyOrder(
-            AppInfo("com.fsck.k9", "K-9 Mail"),
-            AppInfo("net.thunderbird.android.beta", "Thunderbird Beta"),
-            AppInfo("net.thunderbird.android.daily", "Thunderbird Daily"),
+            AppInfo("com.fsck.k9", "K-9 Mail", isImportSupported = true),
+            AppInfo("net.thunderbird.android.beta", "Thunderbird Beta", isImportSupported = true),
+            AppInfo("net.thunderbird.android.daily", "Thunderbird Daily", isImportSupported = true),
         )
     }
 
@@ -82,7 +93,7 @@ class ImportAppFetcherTest {
         return appContext.createPackageContext(MY_PACKAGE_NAME, 0)
     }
 
-    private fun installPackage(packageName: String, name: String = "irrelevant") {
+    private fun installPackage(packageName: String, name: String = "irrelevant", versionCode: Int = 1) {
         val packageManager = shadowOf(appContext.packageManager)
 
         packageManager.installPackage(
@@ -91,6 +102,7 @@ class ImportAppFetcherTest {
                 this.applicationInfo = ApplicationInfo().apply {
                     this.name = name
                 }
+                this.versionCode = versionCode
             },
         )
     }


### PR DESCRIPTION
Disable list items for apps that are too old and don't support exporting settings to another app.

![image](https://github.com/user-attachments/assets/1df8dd55-7447-4a05-9951-c58164e9cf5e)

Fixes #8138
