### PR TITLE
Ignore failing test

### DIFF
--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerScreenKtTest.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerScreenKtTest.kt
@@ -80,6 +80,7 @@ class QrCodeScannerScreenKtTest {
     }
 
     @Test
+    @Ignore("This test is flaky. Figure out why.")
     fun `UiPermissionState_Granted should show QrCodeScannerView`() = runTest {
         setContentWithTheme {
             QrCodeScannerScreen(finishWithResult = {}, finish = {}, viewModel)


### PR DESCRIPTION
The `QrCodeScannerScreenKtTest` - `UiPermissionState_Granted should show QrCodeScannerView` is failing and I changed it to ignore.

Related #8270