### PR TITLE
Add funding UI - part 3

### DIFF
--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/annotation/PreviewDevices.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/annotation/PreviewDevices.kt
@@ -1,6 +1,5 @@
 package app.k9mail.core.ui.compose.common.annotation
 
-import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 
 /**
@@ -8,10 +7,10 @@ import androidx.compose.ui.tooling.preview.Preview
  *
  * It's used to provide previews for a set of different devices and form factors.
  */
-@Preview(name = "Small phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=160")
-@Preview(name = "Phone", device = Devices.PHONE)
-@Preview(name = "Phone landscape", device = "spec:shape=Normal,width=891,height=411,unit=dp,dpi=420")
-@Preview(name = "Foldable", device = Devices.FOLDABLE)
-@Preview(name = "Tablet", device = Devices.TABLET)
-@Preview(name = "Desktop", device = Devices.DESKTOP)
+@Preview(name = "Small phone", device = "spec:width=360dp,height=640dp,dpi=160")
+@Preview(name = "Phone", device = "spec:width=411dp,height=891dp,dpi=420")
+@Preview(name = "Phone landscape", device = "spec:width=891dp,height=411dp,dpi=420")
+@Preview(name = "Foldable", device = "spec:width=673dp,height=841dp,dpi=420")
+@Preview(name = "Tablet", device = "spec:width=1280dp,height=800dp,dpi=240")
+@Preview(name = "Desktop", device = "spec:width=1920dp,height=1080dp,dpi=160")
 annotation class PreviewDevices

--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/annotation/PreviewDevicesWithBackground.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/annotation/PreviewDevicesWithBackground.kt
@@ -1,6 +1,5 @@
 package app.k9mail.core.ui.compose.common.annotation
 
-import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 
 /**
@@ -8,14 +7,10 @@ import androidx.compose.ui.tooling.preview.Preview
  *
  * It's used to provide previews for a set of different devices and form factors.
  */
-@Preview(name = "Small phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=160", showBackground = true)
-@Preview(name = "Phone", device = Devices.PHONE, showBackground = true)
-@Preview(
-    name = "Phone landscape",
-    device = "spec:shape=Normal,width=891,height=411,unit=dp,dpi=420",
-    showBackground = true,
-)
-@Preview(name = "Foldable", device = Devices.FOLDABLE, showBackground = true)
-@Preview(name = "Tablet", device = Devices.TABLET, showBackground = true)
-@Preview(name = "Desktop", device = Devices.DESKTOP, showBackground = true)
+@Preview(name = "Small phone", device = "spec:width=360dp,height=640dp,dpi=160", showBackground = true)
+@Preview(name = "Phone", device = "spec:width=411dp,height=891dp,dpi=420", showBackground = true)
+@Preview(name = "Phone landscape", device = "spec:width=891dp,height=411dp,dpi=420", showBackground = true)
+@Preview(name = "Foldable", device = "spec:width=673dp,height=841dp,dpi=420", showBackground = true)
+@Preview(name = "Tablet", device = "spec:width=1280dp,height=800dp,dpi=240", showBackground = true)
+@Preview(name = "Desktop", device = "spec:width=1920dp,height=1080dp,dpi=160", showBackground = true)
 annotation class PreviewDevicesWithBackground

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/image/FixedScaleImage.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/image/FixedScaleImage.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.FixedScale
 import androidx.compose.ui.res.painterResource
 
@@ -30,6 +31,31 @@ fun FixedScaleImage(
             .wrapContentSize(align = alignment, unbounded = allowOverflow)
             .then(modifier),
         painter = painterResource(id),
+        contentDescription = contentDescription,
+        contentScale = FixedScale(scale),
+    )
+}
+
+/**
+ * An image that has a fixed size and does not scale with the available space. It could be cropped, if the size of the
+ * container is smaller than the image. Use allowOverflow to control this behavior.
+ * The [alignment] allows to control the position of the image in the container.
+ */
+@Composable
+fun FixedScaleImage(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+    scale: Float = 1f,
+    alignment: Alignment = Alignment.Center,
+    allowOverflow: Boolean = false,
+    contentDescription: String? = null,
+) {
+    Image(
+        modifier = Modifier
+            .fillMaxSize()
+            .wrapContentSize(align = alignment, unbounded = allowOverflow)
+            .then(modifier),
+        imageVector = imageVector,
         contentDescription = contentDescription,
         contentScale = FixedScale(scale),
     )

--- a/core/ui/compose/testing/src/main/kotlin/app/k9mail/core/ui/compose/testing/ComposeTest.kt
+++ b/core/ui/compose/testing/src/main/kotlin/app/k9mail/core/ui/compose/testing/ComposeTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
+import androidx.test.espresso.Espresso
 import app.k9mail.core.ui.compose.theme2.k9mail.K9MailTheme2
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -104,3 +105,5 @@ fun ComposeTest.onAllNodesWithContentDescription(
 ) = composeTestRule.onAllNodesWithContentDescription(label, substring, ignoreCase, useUnmergedTree)
 
 fun ComposeTest.onRoot(useUnmergedTree: Boolean = false) = composeTestRule.onRoot(useUnmergedTree)
+
+fun ComposeTest.pressBack() = Espresso.pressBack()

--- a/feature/funding/api/src/main/kotlin/app/k9mail/feature/funding/api/FundingNavigation.kt
+++ b/feature/funding/api/src/main/kotlin/app/k9mail/feature/funding/api/FundingNavigation.kt
@@ -8,8 +8,8 @@ const val FUNDING_BASE_DEEP_LINK = "app://feature/funding"
 
 sealed interface FundingRoute : Route {
     @Serializable
-    data object Overview : FundingRoute {
-        override val deepLink: String = "$FUNDING_BASE_DEEP_LINK/overview"
+    data object Contribution : FundingRoute {
+        override val deepLink: String = "$FUNDING_BASE_DEEP_LINK/contribution"
     }
 }
 

--- a/feature/funding/googleplay/build.gradle.kts
+++ b/feature/funding/googleplay/build.gradle.kts
@@ -14,4 +14,6 @@ dependencies {
 
     implementation(libs.android.billing)
     implementation(libs.android.billing.ktx)
+
+    testImplementation(projects.core.ui.compose.testing)
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -4,9 +4,13 @@ import app.k9mail.feature.funding.api.FundingManager
 import app.k9mail.feature.funding.api.FundingNavigation
 import app.k9mail.feature.funding.googleplay.GooglePlayFundingManager
 import app.k9mail.feature.funding.googleplay.GooglePlayFundingNavigation
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val featureFundingModule = module {
     single<FundingManager> { GooglePlayFundingManager() }
     single<FundingNavigation> { GooglePlayFundingNavigation() }
+
+    viewModel { ContributionViewModel() }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/GooglePlayFundingNavigation.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/GooglePlayFundingNavigation.kt
@@ -4,7 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import app.k9mail.core.ui.compose.navigation.deepLinkComposable
 import app.k9mail.feature.funding.api.FundingNavigation
 import app.k9mail.feature.funding.api.FundingRoute
-import app.k9mail.feature.funding.googleplay.ui.overview.FundingOverviewScreen
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionScreen
 
 class GooglePlayFundingNavigation : FundingNavigation {
 
@@ -14,8 +14,8 @@ class GooglePlayFundingNavigation : FundingNavigation {
         onFinish: (FundingRoute) -> Unit,
     ) {
         with(navGraphBuilder) {
-            deepLinkComposable(FundingRoute.Overview) {
-                FundingOverviewScreen(
+            deepLinkComposable(FundingRoute.Contribution) {
+                ContributionScreen(
                     onBack = onBack,
                 )
             }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/entity/Contribution.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/entity/Contribution.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.funding.googleplay.domain.entity
+
+interface Contribution {
+    val id: String
+    val title: String
+    val price: String
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/entity/OneTimeContribution.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/entity/OneTimeContribution.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.funding.googleplay.domain.entity
+
+class OneTimeContribution(
+    override val id: String,
+    override val title: String,
+    override val price: String,
+) : Contribution

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/entity/RecurringContribution.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/entity/RecurringContribution.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.funding.googleplay.domain.entity
+
+data class RecurringContribution(
+    override val id: String,
+    override val title: String,
+    override val price: String,
+) : Contribution

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContent.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContent.kt
@@ -1,0 +1,36 @@
+package app.k9mail.feature.funding.googleplay.ui.contribution
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.Event
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.State
+
+@Composable
+internal fun ContributionContent(
+    state: State,
+    onEvent: (Event) -> Unit,
+    contentPadding: PaddingValues,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize()
+            .padding(contentPadding)
+            .clickable(
+                enabled = false,
+                onClick = { onEvent(Event.OnPurchaseClicked) },
+            ),
+    ) {
+        TextTitleLarge(
+            text = "ContributionScreen",
+        )
+
+        TextBodyMedium(text = "is recurring selected: ${state.isRecurringContributionSelected}")
+    }
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContract.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContract.kt
@@ -1,0 +1,29 @@
+package app.k9mail.feature.funding.googleplay.ui.contribution
+
+import androidx.compose.runtime.Stable
+import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
+import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
+import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
+import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+internal class ContributionContract {
+
+    interface ViewModel : UnidirectionalViewModel<State, Event, Nothing>
+
+    @Stable
+    data class State(
+        val recurringContributions: ImmutableList<RecurringContribution> = persistentListOf(),
+        val oneTimeContributions: ImmutableList<OneTimeContribution> = persistentListOf(),
+        val selectedContribution: Contribution? = null,
+        val isRecurringContributionSelected: Boolean = false,
+    )
+
+    sealed interface Event {
+        data object OnOneTimeContributionClicked : Event
+        data object OnRecurringContributionClicked : Event
+        data class OnContributionClicked(val item: Contribution) : Event
+        data object OnPurchaseClicked : Event
+    }
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionScreen.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionScreen.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.funding.googleplay.ui.overview
+package app.k9mail.feature.funding.googleplay.ui.contribution
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
 
 @Composable
-internal fun FundingOverviewScreen(
+internal fun ContributionScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -21,6 +21,6 @@ internal fun FundingOverviewScreen(
         modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        TextTitleLarge(text = "Funding Overview")
+        TextTitleLarge(text = "ContributionScreen")
     }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionScreen.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionScreen.kt
@@ -1,26 +1,32 @@
 package app.k9mail.feature.funding.googleplay.ui.contribution
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
+import app.k9mail.core.ui.compose.common.mvi.observe
+import app.k9mail.core.ui.compose.designsystem.template.Scaffold
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.ViewModel
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 internal fun ContributionScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: ViewModel = koinViewModel<ContributionViewModel>(),
 ) {
+    val (state, dispatch) = viewModel.observe { }
+
     BackHandler {
         onBack()
     }
 
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        TextTitleLarge(text = "ContributionScreen")
+    Scaffold(
+        modifier = modifier,
+    ) { innerPadding ->
+        ContributionContent(
+            state = state.value,
+            onEvent = { dispatch(it) },
+            contentPadding = innerPadding,
+        )
     }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
@@ -1,0 +1,25 @@
+package app.k9mail.feature.funding.googleplay.ui.contribution
+
+import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.Event
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.State
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.ViewModel
+
+internal class ContributionViewModel(
+    initialState: State = State(),
+) : BaseViewModel<State, Event, Nothing>(initialState),
+    ViewModel {
+
+    override fun event(event: Event) {
+        when (event) {
+            is Event.OnContributionClicked -> TODO()
+
+            Event.OnOneTimeContributionClicked -> TODO()
+            Event.OnPurchaseClicked -> {
+                // TODO
+            }
+
+            Event.OnRecurringContributionClicked -> TODO()
+        }
+    }
+}

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionScreenKtTest.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionScreenKtTest.kt
@@ -1,0 +1,33 @@
+package app.k9mail.feature.funding.googleplay.ui.contribution
+
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.testing.pressBack
+import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.State
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+internal class ContributionScreenKtTest : ComposeTest() {
+
+    @Test
+    fun `should observe state and send events to view model`() = runTest {
+        val initialState = State()
+        val viewModel = FakeContributionViewModel(initialState)
+        var onBackCounter = 0
+
+        setContentWithTheme {
+            ContributionScreen(
+                onBack = { onBackCounter++ },
+                viewModel = viewModel,
+            )
+        }
+
+        assertThat(onBackCounter).isEqualTo(0)
+
+        pressBack()
+
+        assertThat(onBackCounter).isEqualTo(1)
+    }
+}

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionStateTest.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionStateTest.kt
@@ -1,0 +1,24 @@
+package app.k9mail.feature.funding.googleplay.ui.contribution
+
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.State
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.collections.immutable.persistentListOf
+
+internal class ContributionStateTest {
+
+    @Test
+    fun `should set default values`() {
+        val state = State()
+
+        assertThat(state).isEqualTo(
+            State(
+                recurringContributions = persistentListOf(),
+                oneTimeContributions = persistentListOf(),
+                selectedContribution = null,
+                isRecurringContributionSelected = false,
+            ),
+        )
+    }
+}

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/FakeContributionViewModel.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/FakeContributionViewModel.kt
@@ -1,0 +1,10 @@
+package app.k9mail.feature.funding.googleplay.ui.contribution
+
+import app.k9mail.core.ui.compose.testing.BaseFakeViewModel
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.Event
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.State
+import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.ViewModel
+
+internal class FakeContributionViewModel(
+    initialState: State = State(),
+) : BaseFakeViewModel<State, Event, Nothing>(initialState), ViewModel

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherTarget.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherTarget.kt
@@ -34,6 +34,6 @@ sealed class FeatureLauncherTarget(
     )
 
     data object Funding : FeatureLauncherTarget(
-        deepLinkUri = FundingRoute.Overview.toDeepLinkUri(),
+        deepLinkUri = FundingRoute.Contribution.toDeepLinkUri(),
     )
 }


### PR DESCRIPTION
This adds the base setup for the contribution screen (renamed from `overview` to `contribution`). Fixed the device previews and add `ImageVector` support to `FixedScaleImage`.

Part of #8163

Depends on #8275