### PR TITLE
Change default preview theme to Thunderbird

### DIFF
--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/PreviewWithThemes.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/PreviewWithThemes.kt
@@ -61,7 +61,7 @@ enum class PreviewThemeType {
 
 @Composable
 fun PreviewWithTheme(
-    themeType: PreviewThemeType = PreviewThemeType.K9MAIL,
+    themeType: PreviewThemeType = PreviewThemeType.THUNDERBIRD,
     isDarkTheme: Boolean = false,
     content: @Composable () -> Unit,
 ) {


### PR DESCRIPTION
To better focus on Thunderbird for Android this changes the default Compose preview theme from K-9 Mail to Thunderbird.