### PR TITLE
Catch ZXing's `NotFoundException`

### DIFF
--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/domain/usecase/QrCodeAnalyzer.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/domain/usecase/QrCodeAnalyzer.kt
@@ -5,6 +5,7 @@ import androidx.camera.core.ImageProxy
 import com.google.zxing.BinaryBitmap
 import com.google.zxing.DecodeHintType
 import com.google.zxing.LuminanceSource
+import com.google.zxing.NotFoundException
 import com.google.zxing.PlanarYUVLuminanceSource
 import com.google.zxing.common.HybridBinarizer
 import com.google.zxing.multi.qrcode.QRCodeMultiReader
@@ -36,13 +37,15 @@ internal class QrCodeAnalyzer(
         image.close()
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun decodeSource(source: LuminanceSource): List<String> {
         return try {
             val bitmap = createBinaryBitmap(source)
             val results = qrCodeReader.decodeMultiple(bitmap, DECODER_HINTS)
 
             results.map { it.text }
+        } catch (e: NotFoundException) {
+            emptyList()
         } catch (e: Exception) {
             Timber.e(e, "Error while trying to read QR code")
             emptyList()


### PR DESCRIPTION
It looks like `QRCodeMultiReader.decodeMultiple()` sometimes returns an empty result and sometimes throws a `NotFoundException`. Add a special case for `NotFoundException` so we don't spam the log with messages when no QR code is found.