### PR TITLE
Change `K9WorkerFactory` to not load classes outside of our namespace

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/job/K9WorkerFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/K9WorkerFactory.kt
@@ -13,6 +13,11 @@ class K9WorkerFactory : WorkerFactory() {
         workerClassName: String,
         workerParameters: WorkerParameters,
     ): ListenableWorker? {
+        // Don't attempt to load classes outside of our namespace.
+        if (!workerClassName.startsWith("com.fsck.k9")) {
+            return null
+        }
+
         val workerClass = Class.forName(workerClassName).kotlin
         return getKoin().getOrNull(workerClass) { parametersOf(workerParameters) }
     }

--- a/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
@@ -11,6 +11,7 @@ import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.mail.AuthType
 import timber.log.Timber
 
+// IMPORTANT: Update K9WorkerFactory when moving this class and the FQCN no longer starts with "com.fsck.k9".
 class MailSyncWorker(
     private val messagingController: MessagingController,
     private val preferences: Preferences,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/account/AccountRemoverWorker.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/account/AccountRemoverWorker.kt
@@ -14,6 +14,7 @@ import com.fsck.k9.ui.R
 /**
  * A [Worker] to remove an account in the background.
  */
+// IMPORTANT: Update K9WorkerFactory when moving this class and the FQCN no longer starts with "com.fsck.k9".
 class AccountRemoverWorker(
     private val accountRemover: AccountRemover,
     private val notificationController: BackgroundWorkNotificationController,


### PR DESCRIPTION
I wasn't able to reproduce the `ClassNotFoundException` reported via the Google Play console. But hopefully this change will avoid the crash.