### PR TITLE
Fix issue with extracting initials from an account email

### DIFF
--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
@@ -51,9 +51,17 @@ private fun Placeholder(
     modifier: Modifier = Modifier,
 ) {
     TextTitleMedium(
-        text = extractDomainInitials(email).uppercase(),
+        text = extractInitials(email).uppercase(),
         modifier = modifier,
     )
+}
+
+private fun extractInitials(email: String): String {
+    if (email.contains("@")) {
+        return extractDomainInitials(email)
+    } else {
+        return email.take(2)
+    }
 }
 
 private fun extractDomainInitials(email: String): String {


### PR DESCRIPTION
This fixes the issue, but I wonder how it is possible to have an email set that doesn't include an `@`. Maybe an old config import? -> see ticket, it is possible to remove the email from the account settings so it fails. This fix is covering that case.

Resolves #8301 