### PR TITLE
[CI] Set a default for --skip in environment creation script.

### DIFF
--- a/scripts/setup_release_automation
+++ b/scripts/setup_release_automation
@@ -381,7 +381,7 @@ def main():
     )
     parser.add_argument("--branch", "-b", help="Branch to limit the environment to")
     parser.add_argument(
-        "--skip", "-s", action="append", help="In all mode, skip this environment"
+        "--skip", "-s", action="append", help="In all mode, skip this environment", default=[]
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Running setup_release_automation with "--all-environments" and no "--skip" argument, Python throws a 'NoneType' is not iterable error at line 397. `skipset = set(args.skip)`

This change sets a default (an empty list) value that is iterable and allows the script to proceed.
