### PR TITLE
Fix of  "Title wraps within word in Improve the Experience screen"

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextDisplayMedium.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextDisplayMedium.kt
@@ -1,10 +1,17 @@
 package app.k9mail.core.ui.compose.designsystem.atom.text
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.isUnspecified
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import androidx.compose.material3.Text as Material3Text
 
@@ -37,5 +44,45 @@ fun TextDisplayMedium(
         color = color,
         textAlign = textAlign,
         style = MainTheme.typography.displayMedium,
+    )
+}
+
+@Composable
+fun AutoResizeableTextDisplayMedium(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
+    style: TextStyle = MainTheme.typography.displayMedium,
+) {
+    var shouldDraw by remember { mutableStateOf(false) }
+    var resizedTextStyle by remember { mutableStateOf(style) }
+    val defaultFontSize = style.fontSize
+
+    Material3Text(
+        text = text,
+        modifier = modifier.drawWithContent {
+            if (shouldDraw) {
+                drawContent()
+            }
+        },
+        color = color,
+        textAlign = textAlign,
+        softWrap = false,
+        style = resizedTextStyle,
+        onTextLayout = { result ->
+            if (result.didOverflowWidth) {
+                if (style.fontSize.isUnspecified) {
+                    resizedTextStyle = resizedTextStyle.copy(
+                        fontSize = defaultFontSize,
+                    )
+                }
+                resizedTextStyle = resizedTextStyle.copy(
+                    fontSize = resizedTextStyle.fontSize * 0.95,
+                )
+            } else {
+                shouldDraw = true
+            }
+        },
     )
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextDisplayMedium.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextDisplayMedium.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.isUnspecified
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import androidx.compose.material3.Text as Material3Text
 
@@ -48,16 +47,15 @@ fun TextDisplayMedium(
 }
 
 @Composable
-fun AutoResizeableTextDisplayMedium(
+fun TextDisplayMediumAutoResize(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
     textAlign: TextAlign? = null,
-    style: TextStyle = MainTheme.typography.displayMedium,
 ) {
+    val style: TextStyle = MainTheme.typography.displayMedium
     var shouldDraw by remember { mutableStateOf(false) }
     var resizedTextStyle by remember { mutableStateOf(style) }
-    val defaultFontSize = style.fontSize
 
     Material3Text(
         text = text,
@@ -72,11 +70,6 @@ fun AutoResizeableTextDisplayMedium(
         style = resizedTextStyle,
         onTextLayout = { result ->
             if (result.didOverflowWidth) {
-                if (style.fontSize.isUnspecified) {
-                    resizedTextStyle = resizedTextStyle.copy(
-                        fontSize = defaultFontSize,
-                    )
-                }
                 resizedTextStyle = resizedTextStyle.copy(
                     fontSize = resizedTextStyle.fontSize * 0.95,
                 )

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import app.k9mail.core.ui.compose.designsystem.atom.text.AutoResizeableTextDisplayMedium
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextDisplayMediumAutoResize
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme2.MainTheme
 
@@ -51,7 +51,7 @@ fun AppTitleTopHeader(
                 contentDescription = null,
             )
 
-            AutoResizeableTextDisplayMedium(text = title)
+            TextDisplayMediumAutoResize(text = title)
         }
     }
 }

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
@@ -1,7 +1,8 @@
 package app.k9mail.feature.account.common.ui
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -9,9 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import app.k9mail.core.ui.compose.designsystem.atom.text.TextDisplayMedium
+import app.k9mail.core.ui.compose.designsystem.atom.text.AutoResizeableTextDisplayMedium
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme2.MainTheme
 
@@ -31,15 +31,16 @@ fun AppTitleTopHeader(
             )
             .then(modifier),
     ) {
-        Column(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
-                    start = MainTheme.spacings.double,
-                    end = MainTheme.spacings.double,
+                    start = MainTheme.spacings.half,
+                    end = MainTheme.spacings.quadruple,
                 )
                 .then(modifier),
-            horizontalAlignment = Alignment.CenterHorizontally,
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Image(
                 painter = painterResource(id = MainTheme.images.logo),
@@ -50,7 +51,7 @@ fun AppTitleTopHeader(
                 contentDescription = null,
             )
 
-            TextDisplayMedium(text = title, textAlign = TextAlign.Center)
+            AutoResizeableTextDisplayMedium(text = title)
         }
     }
 }

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
@@ -1,7 +1,6 @@
 package app.k9mail.feature.account.common.ui
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextDisplayMedium
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
@@ -35,11 +35,10 @@ fun AppTitleTopHeader(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
-                    start = MainTheme.spacings.half,
-                    end = MainTheme.spacings.quadruple,
+                    start = MainTheme.spacings.double,
+                    end = MainTheme.spacings.double,
                 )
                 .then(modifier),
-            verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Image(
@@ -51,7 +50,7 @@ fun AppTitleTopHeader(
                 contentDescription = null,
             )
 
-            TextDisplayMedium(text = title)
+            TextDisplayMedium(text = title, textAlign = TextAlign.Center)
         }
     }
 }

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.account.common.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -31,7 +31,7 @@ fun AppTitleTopHeader(
             )
             .then(modifier),
     ) {
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
@@ -39,8 +39,8 @@ fun AppTitleTopHeader(
                     end = MainTheme.spacings.quadruple,
                 )
                 .then(modifier),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Image(
                 painter = painterResource(id = MainTheme.images.logo),


### PR DESCRIPTION
- In **Improve the Experience** screen,  made title auto-resize so it always fits in the available width

Fixes #8257 
