### PR TITLE
Add 'import from Thunderbird' screen to onboarding

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(projects.feature.widget.unread)
     implementation(projects.feature.telemetry.noop)
     implementation(projects.feature.funding.noop)
+    implementation(projects.feature.onboarding.migration.noop)
 
     implementation(libs.androidx.work.runtime)
 

--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -8,6 +8,7 @@ import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.dev.developmentModuleAdditions
 import app.k9mail.feature.funding.featureFundingModule
+import app.k9mail.feature.onboarding.migration.onboardingMigrationModule
 import app.k9mail.feature.telemetry.telemetryModule
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import app.k9mail.featureflag.K9FeatureFlagFactory
@@ -28,6 +29,7 @@ val appModule = module {
     includes(appWidgetModule)
     includes(telemetryModule)
     includes(featureFundingModule)
+    includes(onboardingMigrationModule)
 
     single(named("ClientInfoAppName")) { BuildConfig.CLIENT_INFO_APP_NAME }
     single(named("ClientInfoAppVersion")) { BuildConfig.VERSION_NAME }

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -225,6 +225,8 @@ dependencies {
     fullBetaImplementation(projects.feature.funding.googleplay)
     fullReleaseImplementation(projects.feature.funding.googleplay)
 
+    implementation(projects.feature.onboarding.migration.thunderbird)
+
     testImplementation(libs.robolectric)
 
     // Required for DependencyInjectionTest to be able to resolve OpenPgpApiManager

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -6,6 +6,7 @@ import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
 import app.k9mail.feature.funding.featureFundingModule
+import app.k9mail.feature.onboarding.migration.onboardingMigrationModule
 import app.k9mail.feature.telemetry.telemetryModule
 import app.k9mail.feature.widget.shortcut.LauncherShortcutActivity
 import com.fsck.k9.AppConfig
@@ -27,6 +28,7 @@ val appModule = module {
     includes(appWidgetModule)
     includes(telemetryModule)
     includes(featureFundingModule)
+    includes(onboardingMigrationModule)
 
     single(named("ClientInfoAppName")) { BuildConfig.CLIENT_INFO_APP_NAME }
     single(named("ClientInfoAppVersion")) { BuildConfig.VERSION_NAME }

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/card/CardFilledPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/card/CardFilledPreview.kt
@@ -1,0 +1,22 @@
+package app.k9mail.core.ui.compose.designsystem.atom.card
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+@Composable
+@Preview(showBackground = true)
+internal fun CardFilledPreview() {
+    PreviewWithThemes {
+        CardFilled {
+            Box(modifier = Modifier.padding(MainTheme.spacings.double)) {
+                TextBodyMedium("Text in card")
+            }
+        }
+    }
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/card/CardFilled.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/card/CardFilled.kt
@@ -1,0 +1,19 @@
+package app.k9mail.core.ui.compose.designsystem.atom.card
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.material3.Card as Material3Card
+
+@Composable
+fun CardFilled(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Material3Card(
+        onClick = onClick,
+        modifier = modifier,
+        content = content,
+    )
+}

--- a/feature/onboarding/main/build.gradle.kts
+++ b/feature/onboarding/main/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
     implementation(projects.feature.account.setup)
     implementation(projects.feature.settings.import)
     implementation(projects.feature.onboarding.permissions)
+    implementation(projects.feature.onboarding.migration.api)
 }

--- a/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
+++ b/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
@@ -10,16 +10,24 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import app.k9mail.feature.account.setup.navigation.AccountSetupNavHost
+import app.k9mail.feature.onboarding.migration.api.OnboardingMigrationManager
 import app.k9mail.feature.onboarding.permissions.domain.PermissionsDomainContract.UseCase.HasRuntimePermissions
 import app.k9mail.feature.onboarding.permissions.ui.PermissionsScreen
 import app.k9mail.feature.onboarding.welcome.ui.WelcomeScreen
+import app.k9mail.feature.settings.import.ui.SettingsImportAction
 import app.k9mail.feature.settings.import.ui.SettingsImportScreen
 import org.koin.compose.koinInject
 
 private const val NESTED_NAVIGATION_ROUTE_WELCOME = "welcome"
+private const val NESTED_NAVIGATION_ROUTE_MIGRATION = "migration"
 private const val NESTED_NAVIGATION_ROUTE_ACCOUNT_SETUP = "account_setup"
 private const val NESTED_NAVIGATION_ROUTE_SETTINGS_IMPORT = "settings_import"
+private const val NESTED_NAVIGATION_ROUTE_SETTINGS_IMPORT_QR_CODE = "settings_import_qr_code"
 private const val NESTED_NAVIGATION_ROUTE_PERMISSIONS = "permissions"
+
+private fun NavController.navigateToMigration() {
+    navigate(NESTED_NAVIGATION_ROUTE_MIGRATION)
+}
 
 private fun NavController.navigateToAccountSetup() {
     navigate(NESTED_NAVIGATION_ROUTE_ACCOUNT_SETUP)
@@ -27,6 +35,10 @@ private fun NavController.navigateToAccountSetup() {
 
 private fun NavController.navigateToSettingsImport() {
     navigate(NESTED_NAVIGATION_ROUTE_SETTINGS_IMPORT)
+}
+
+private fun NavController.navigateToSettingsImportQrCode() {
+    navigate(NESTED_NAVIGATION_ROUTE_SETTINGS_IMPORT_QR_CODE)
 }
 
 private fun NavController.navigateToPermissions() {
@@ -37,13 +49,23 @@ private fun NavController.navigateToPermissions() {
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 fun OnboardingNavHost(
     onFinish: (String?) -> Unit,
     hasRuntimePermissions: HasRuntimePermissions = koinInject(),
+    onboardingMigrationManager: OnboardingMigrationManager = koinInject(),
 ) {
     val navController = rememberNavController()
     var accountUuid by rememberSaveable { mutableStateOf<String?>(null) }
+
+    fun onImportSuccess() {
+        if (hasRuntimePermissions()) {
+            navController.navigateToPermissions()
+        } else {
+            onFinish(null)
+        }
+    }
 
     NavHost(
         navController = navController,
@@ -51,9 +73,22 @@ fun OnboardingNavHost(
     ) {
         composable(route = NESTED_NAVIGATION_ROUTE_WELCOME) {
             WelcomeScreen(
-                onStartClick = { navController.navigateToAccountSetup() },
+                onStartClick = {
+                    if (onboardingMigrationManager.isFeatureIncluded()) {
+                        navController.navigateToMigration()
+                    } else {
+                        navController.navigateToAccountSetup()
+                    }
+                },
                 onImportClick = { navController.navigateToSettingsImport() },
                 appNameProvider = koinInject(),
+            )
+        }
+
+        composable(route = NESTED_NAVIGATION_ROUTE_MIGRATION) {
+            onboardingMigrationManager.OnboardingMigrationScreen(
+                onQrCodeScanClick = { navController.navigateToSettingsImportQrCode() },
+                onAddAccountClick = { navController.navigateToAccountSetup() },
             )
         }
 
@@ -73,13 +108,16 @@ fun OnboardingNavHost(
 
         composable(route = NESTED_NAVIGATION_ROUTE_SETTINGS_IMPORT) {
             SettingsImportScreen(
-                onImportSuccess = {
-                    if (hasRuntimePermissions()) {
-                        navController.navigateToPermissions()
-                    } else {
-                        onFinish(null)
-                    }
-                },
+                action = SettingsImportAction.Overview,
+                onImportSuccess = ::onImportSuccess,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(route = NESTED_NAVIGATION_ROUTE_SETTINGS_IMPORT_QR_CODE) {
+            SettingsImportScreen(
+                action = SettingsImportAction.ScanQrCode,
+                onImportSuccess = ::onImportSuccess,
                 onBack = { navController.popBackStack() },
             )
         }

--- a/feature/onboarding/migration/api/build.gradle.kts
+++ b/feature/onboarding/migration/api/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    namespace = "app.k9mail.feature.onboarding.migration.api"
+    resourcePrefix = "onboarding_migration_api_"
+}
+
+dependencies {
+    api(projects.core.ui.compose.navigation)
+}

--- a/feature/onboarding/migration/api/src/main/kotlin/app/k9mail/feature/onboarding/migration/api/OnboardingMigrationManager.kt
+++ b/feature/onboarding/migration/api/src/main/kotlin/app/k9mail/feature/onboarding/migration/api/OnboardingMigrationManager.kt
@@ -1,0 +1,13 @@
+package app.k9mail.feature.onboarding.migration.api
+
+import androidx.compose.runtime.Composable
+
+interface OnboardingMigrationManager {
+    fun isFeatureIncluded(): Boolean
+
+    @Composable
+    fun OnboardingMigrationScreen(
+        onQrCodeScanClick: () -> Unit,
+        onAddAccountClick: () -> Unit,
+    )
+}

--- a/feature/onboarding/migration/noop/build.gradle.kts
+++ b/feature/onboarding/migration/noop/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "app.k9mail.feature.onboarding.migration.noop"
+    resourcePrefix = "onboarding_migration_noop_"
+}
+
+dependencies {
+    api(projects.feature.onboarding.migration.api)
+}

--- a/feature/onboarding/migration/noop/src/main/kotlin/app/k9mail/feature/onboarding/migration/OnboardingMigrationModule.kt
+++ b/feature/onboarding/migration/noop/src/main/kotlin/app/k9mail/feature/onboarding/migration/OnboardingMigrationModule.kt
@@ -1,0 +1,10 @@
+package app.k9mail.feature.onboarding.migration
+
+import app.k9mail.feature.onboarding.migration.api.OnboardingMigrationManager
+import app.k9mail.feature.onboarding.migration.noop.NoOpOnboardingMigrationManager
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val onboardingMigrationModule: Module = module {
+    single<OnboardingMigrationManager> { NoOpOnboardingMigrationManager() }
+}

--- a/feature/onboarding/migration/noop/src/main/kotlin/app/k9mail/feature/onboarding/migration/noop/NoOpOnboardingMigrationManager.kt
+++ b/feature/onboarding/migration/noop/src/main/kotlin/app/k9mail/feature/onboarding/migration/noop/NoOpOnboardingMigrationManager.kt
@@ -1,0 +1,14 @@
+package app.k9mail.feature.onboarding.migration.noop
+
+import androidx.compose.runtime.Composable
+import app.k9mail.feature.onboarding.migration.api.OnboardingMigrationManager
+
+class NoOpOnboardingMigrationManager : OnboardingMigrationManager {
+    override fun isFeatureIncluded(): Boolean = false
+
+    @Composable
+    override fun OnboardingMigrationScreen(
+        onQrCodeScanClick: () -> Unit,
+        onAddAccountClick: () -> Unit,
+    ) = Unit
+}

--- a/feature/onboarding/migration/thunderbird/build.gradle.kts
+++ b/feature/onboarding/migration/thunderbird/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "app.k9mail.feature.onboarding.migration.thunderbird"
+    resourcePrefix = "onboarding_migration_thunderbird_"
+}
+
+dependencies {
+    api(projects.feature.onboarding.migration.api)
+    implementation(projects.core.common)
+    implementation(projects.core.ui.compose.designsystem)
+    implementation(projects.feature.account.common)
+
+    testImplementation(projects.core.ui.compose.testing)
+}

--- a/feature/onboarding/migration/thunderbird/src/debug/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreenPreview.kt
+++ b/feature/onboarding/migration/thunderbird/src/debug/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreenPreview.kt
@@ -1,0 +1,23 @@
+package app.k9mail.feature.onboarding.migration.thunderbird
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
+import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.theme2.thunderbird.ThunderbirdTheme2
+
+@Composable
+@PreviewDevices
+internal fun TbOnboardingMigrationScreenPreview() {
+    ThunderbirdTheme2 {
+        Surface {
+            TbOnboardingMigrationScreen(
+                onQrCodeScanClick = {},
+                onAddAccountClick = {},
+                appNameProvider = object : AppNameProvider {
+                    override val appName: String = "Thunderbird"
+                },
+            )
+        }
+    }
+}

--- a/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/OnboardingMigrationModule.kt
+++ b/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/OnboardingMigrationModule.kt
@@ -1,0 +1,10 @@
+package app.k9mail.feature.onboarding.migration
+
+import app.k9mail.feature.onboarding.migration.api.OnboardingMigrationManager
+import app.k9mail.feature.onboarding.migration.thunderbird.TbOnboardingMigrationManager
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val onboardingMigrationModule: Module = module {
+    single<OnboardingMigrationManager> { TbOnboardingMigrationManager() }
+}

--- a/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationManager.kt
+++ b/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationManager.kt
@@ -1,0 +1,19 @@
+package app.k9mail.feature.onboarding.migration.thunderbird
+
+import androidx.compose.runtime.Composable
+import app.k9mail.feature.onboarding.migration.api.OnboardingMigrationManager
+
+class TbOnboardingMigrationManager : OnboardingMigrationManager {
+    override fun isFeatureIncluded(): Boolean = true
+
+    @Composable
+    override fun OnboardingMigrationScreen(
+        onQrCodeScanClick: () -> Unit,
+        onAddAccountClick: () -> Unit,
+    ) {
+        TbOnboardingMigrationScreen(
+            onQrCodeScanClick,
+            onAddAccountClick,
+        )
+    }
+}

--- a/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreen.kt
+++ b/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreen.kt
@@ -1,0 +1,110 @@
+package app.k9mail.feature.onboarding.migration.thunderbird
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonFilled
+import app.k9mail.core.ui.compose.designsystem.atom.card.CardFilled
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
+import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import app.k9mail.feature.account.common.ui.AppTitleTopHeader
+import org.koin.compose.koinInject
+
+@Composable
+internal fun TbOnboardingMigrationScreen(
+    onQrCodeScanClick: () -> Unit,
+    onAddAccountClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    appNameProvider: AppNameProvider = koinInject(),
+) {
+    val scrollState = rememberScrollState()
+
+    ResponsiveWidthContainer(
+        modifier = Modifier
+            .fillMaxSize()
+            .then(modifier),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState),
+        ) {
+            AppTitleTopHeader(
+                title = appNameProvider.appName,
+            )
+
+            Spacer(modifier = Modifier.height(MainTheme.spacings.double))
+
+            TextCard(title = stringResource(R.string.onboarding_migration_thunderbird_qr_code_import_title)) {
+                TextBodyMedium(
+                    text = stringResource(R.string.onboarding_migration_thunderbird_qr_code_import_description),
+                    modifier = Modifier
+                        .padding(bottom = MainTheme.spacings.double),
+                )
+
+                ButtonFilled(
+                    text = stringResource(R.string.onboarding_migration_thunderbird_qr_code_import_button_text),
+                    onClick = onQrCodeScanClick,
+                    modifier = Modifier
+                        .testTag("QrCodeImportButton")
+                        .align(Alignment.CenterHorizontally),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(MainTheme.spacings.double))
+
+            TextCard(title = stringResource(R.string.onboarding_migration_thunderbird_new_account_title)) {
+                ButtonFilled(
+                    text = stringResource(R.string.onboarding_migration_thunderbird_new_account_button_text),
+                    onClick = onAddAccountClick,
+                    modifier = Modifier
+                        .testTag("AddAccountButton")
+                        .align(Alignment.CenterHorizontally),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(MainTheme.spacings.double))
+        }
+    }
+}
+
+@Composable
+private fun TextCard(
+    title: String,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    CardFilled(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = MainTheme.spacings.quadruple),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(MainTheme.spacings.double),
+        ) {
+            TextTitleMedium(
+                text = title,
+                color = MainTheme.colors.primary,
+                modifier = Modifier
+                    .padding(bottom = MainTheme.spacings.double),
+            )
+
+            content()
+        }
+    }
+}

--- a/feature/onboarding/migration/thunderbird/src/main/res/values/strings.xml
+++ b/feature/onboarding/migration/thunderbird/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="onboarding_migration_thunderbird_qr_code_import_title">Already using Thunderbird on desktop?</string>
+    <string name="onboarding_migration_thunderbird_qr_code_import_description">You can easily import your account settings.\n\nIn your Thunderbird desktop client, go to the top menu bar, click on ‘Settings’, and select ‘Export for Mobile’.\n\nA new tab with QR codes will appear. Use your Android device to scan the codes.</string>
+    <string name="onboarding_migration_thunderbird_qr_code_import_button_text">Import settings</string>
+    <string name="onboarding_migration_thunderbird_new_account_title">New to Thunderbird?</string>
+    <string name="onboarding_migration_thunderbird_new_account_button_text">Add an email account now</string>
+</resources>

--- a/feature/onboarding/migration/thunderbird/src/test/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreenKtTest.kt
+++ b/feature/onboarding/migration/thunderbird/src/test/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreenKtTest.kt
@@ -1,0 +1,57 @@
+package app.k9mail.feature.onboarding.migration.thunderbird
+
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Test
+
+class TbOnboardingMigrationScreenKtTest : ComposeTest() {
+    @Test
+    fun `pressing QrCodeImportButton should call onQrCodeScanClick`() = runComposeTest {
+        var qrCodeScanClickCounter = 0
+        var addAccountClickCounter = 0
+        setContentWithTheme {
+            TbOnboardingMigrationScreen(
+                onQrCodeScanClick = { qrCodeScanClickCounter++ },
+                onAddAccountClick = { addAccountClickCounter++ },
+                appNameProvider = FakeAppNameProvider(),
+            )
+        }
+
+        composeTestRule.onNodeWithTag("QrCodeImportButton")
+            .performScrollTo()
+            .performClick()
+
+        assertThat(qrCodeScanClickCounter).isEqualTo(1)
+        assertThat(addAccountClickCounter).isEqualTo(0)
+    }
+
+    @Test
+    fun `pressing AddAccountButton button should call onAddAccountClick`() = runComposeTest {
+        var qrCodeScanClickCounter = 0
+        var addAccountClickCounter = 0
+        setContentWithTheme {
+            TbOnboardingMigrationScreen(
+                onQrCodeScanClick = { qrCodeScanClickCounter++ },
+                onAddAccountClick = { addAccountClickCounter++ },
+                appNameProvider = FakeAppNameProvider(),
+            )
+        }
+
+        composeTestRule.onNodeWithTag("AddAccountButton")
+            .performScrollTo()
+            .performClick()
+
+        assertThat(addAccountClickCounter).isEqualTo(1)
+        assertThat(qrCodeScanClickCounter).isEqualTo(0)
+    }
+}
+
+private class FakeAppNameProvider : AppNameProvider {
+    override val appName = "Thunderbird"
+}

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportAction.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportAction.kt
@@ -1,0 +1,25 @@
+package app.k9mail.feature.settings.import.ui
+
+import android.os.Bundle
+import androidx.core.os.bundleOf
+
+enum class SettingsImportAction(private val bundleValue: String) {
+    Overview("overview"),
+    ScanQrCode("scan_qr_code"),
+    ;
+
+    fun toBundle(): Bundle {
+        return bundleOf(
+            BUNDLE_KEY_ACTION to bundleValue,
+        )
+    }
+
+    companion object {
+        const val BUNDLE_KEY_ACTION = "action"
+
+        fun fromBundle(bundle: Bundle): SettingsImportAction {
+            val actionString = bundle.getString(BUNDLE_KEY_ACTION)
+            return entries.find { it.bundleValue == actionString } ?: Overview
+        }
+    }
+}

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportFragment.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportFragment.kt
@@ -70,6 +70,11 @@ class SettingsImportFragment : Fragment() {
 
         viewModel.getUiModel().observeNotNull(this) { viewHolder.updateUi(it) }
         viewModel.getActionEvents().observeNotNull(this) { handleActionEvents(it) }
+
+        arguments?.let { arguments ->
+            val action = SettingsImportAction.fromBundle(arguments)
+            viewModel.setAction(action)
+        }
     }
 
     private fun initializeSettingsImportList(recyclerView: RecyclerView) {

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportScreen.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/SettingsImportScreen.kt
@@ -19,6 +19,7 @@ import app.k9mail.feature.settings.importing.R
 
 @Composable
 fun SettingsImportScreen(
+    action: SettingsImportAction,
     onImportSuccess: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
@@ -38,12 +39,13 @@ fun SettingsImportScreen(
         },
         modifier = modifier,
     ) { innerPadding ->
-        SettingsImportContent(onImportSuccess, onBack, innerPadding)
+        SettingsImportContent(action, onImportSuccess, onBack, innerPadding)
     }
 }
 
 @Composable
 private fun SettingsImportContent(
+    action: SettingsImportAction,
     onImportSuccess: () -> Unit,
     onBack: () -> Unit,
     paddingValues: PaddingValues,
@@ -62,6 +64,7 @@ private fun SettingsImportContent(
     }
 
     AndroidFragment<SettingsImportFragment>(
+        arguments = action.toBundle(),
         modifier = Modifier
             .fillMaxSize()
             .padding(paddingValues),

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,9 @@ include(
     ":feature:onboarding:main",
     ":feature:onboarding:welcome",
     ":feature:onboarding:permissions",
+    ":feature:onboarding:migration:api",
+    ":feature:onboarding:migration:thunderbird",
+    ":feature:onboarding:migration:noop",
 )
 
 include(


### PR DESCRIPTION
Add a screen to the onboarding flow that asks the user if they want to import accounts from Thunderbird desktop.

![image](https://github.com/user-attachments/assets/8247d0ba-7bde-49fd-8fff-32b9bf7291c4)

Design: https://www.figma.com/design/3Xx6EzwsVgbudJECshgwL2/TBAndroid_2024_Q3_CrossDevice_v01.0?node-id=4282-7582&node-type=frame&t=QIMAmt29Z4nLBoTd-0 (this only loosely resembles the design)

Note: This PR doesn't include a button to import settings from another app, e.g. K-9 Mail. That functionality will be added in a follow-up PR.

After PR as been merged:
- [ ] Create Weblate component