### PR TITLE
Use brand name in `AppTitleTopHeader`

### DIFF
--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -3,6 +3,7 @@ package app.k9mail
 import app.k9mail.auth.K9OAuthConfigurationFactory
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
@@ -22,6 +23,7 @@ import com.fsck.k9.provider.UnreadWidgetProvider
 import com.fsck.k9.widget.list.MessageListWidgetProvider
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val appModule = module {
@@ -33,7 +35,7 @@ val appModule = module {
     single(named("ClientInfoAppVersion")) { BuildConfig.VERSION_NAME }
     single<AppConfig> { appConfig }
     single<OAuthConfigurationFactory> { K9OAuthConfigurationFactory() }
-    single<AppNameProvider> { K9AppNameProvider(androidContext()) }
+    single { K9AppNameProvider(androidContext()) } binds arrayOf(AppNameProvider::class, BrandNameProvider::class)
     single<ThemeProvider> { K9ThemeProvider() }
     single<FeatureThemeProvider> { K9FeatureThemeProvider() }
     single<FeatureFlagFactory> { K9FeatureFlagFactory() }

--- a/app-k9mail/src/main/kotlin/app/k9mail/provider/K9AppNameProvider.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/provider/K9AppNameProvider.kt
@@ -2,12 +2,17 @@ package app.k9mail.provider
 
 import android.content.Context
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import com.fsck.k9.R
 
 class K9AppNameProvider(
     context: Context,
-) : AppNameProvider {
+) : AppNameProvider, BrandNameProvider {
     override val appName: String by lazy {
+        context.getString(R.string.app_name)
+    }
+
+    override val brandName: String by lazy {
         context.getString(R.string.app_name)
     }
 }

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -2,6 +2,7 @@ package net.thunderbird.android
 
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
@@ -21,6 +22,7 @@ import net.thunderbird.android.widget.provider.MessageListWidgetProvider
 import net.thunderbird.android.widget.provider.UnreadWidgetProvider
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val appModule = module {
@@ -32,7 +34,7 @@ val appModule = module {
     single(named("ClientInfoAppVersion")) { BuildConfig.VERSION_NAME }
     single<AppConfig> { appConfig }
     single<OAuthConfigurationFactory> { TbOAuthConfigurationFactory() }
-    single<AppNameProvider> { TbAppNameProvider(androidContext()) }
+    single { TbAppNameProvider(androidContext()) } binds arrayOf(AppNameProvider::class, BrandNameProvider::class)
     single<ThemeProvider> { TbThemeProvider() }
     single<FeatureThemeProvider> { TbFeatureThemeProvider() }
     single<FeatureFlagFactory> { TbFeatureFlagFactory() }

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbAppNameProvider.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbAppNameProvider.kt
@@ -2,12 +2,17 @@ package net.thunderbird.android.provider
 
 import android.content.Context
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import net.thunderbird.android.R
 
 class TbAppNameProvider(
     context: Context,
-) : AppNameProvider {
+) : AppNameProvider, BrandNameProvider {
     override val appName: String by lazy {
         context.getString(R.string.app_name)
+    }
+
+    override val brandName: String by lazy {
+        context.getString(R.string.brand_name)
     }
 }

--- a/app-thunderbird/src/main/res/values/strings.xml
+++ b/app-thunderbird/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name" translatable="false">Thunderbird</string>
+    <string name="brand_name" translatable="false">Thunderbird</string>
 </resources>

--- a/core/common/src/main/kotlin/app/k9mail/core/common/provider/BrandNameProvider.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/provider/BrandNameProvider.kt
@@ -1,0 +1,8 @@
+package app.k9mail.core.common.provider
+
+/**
+ * Provides the brand name, e.g. Thunderbird.
+ */
+interface BrandNameProvider {
+    val brandName: String
+}

--- a/feature/account/common/src/debug/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeaderPreview.kt
+++ b/feature/account/common/src/debug/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeaderPreview.kt
@@ -2,12 +2,17 @@ package app.k9mail.feature.account.common.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
 
 @Composable
 @Preview(showBackground = true)
 internal fun AppTitleTopHeaderPreview() {
     PreviewWithThemes {
-        AppTitleTopHeader(title = "Title")
+        AppTitleTopHeader(
+            brandNameProvider = object : BrandNameProvider {
+                override val brandName = "BrandName"
+            },
+        )
     }
 }

--- a/feature/account/common/src/debug/kotlin/app/k9mail/feature/account/common/ui/PreviewWithThemeAndKoin.kt
+++ b/feature/account/common/src/debug/kotlin/app/k9mail/feature/account/common/ui/PreviewWithThemeAndKoin.kt
@@ -1,0 +1,21 @@
+package app.k9mail.feature.account.common.ui
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.common.provider.BrandNameProvider
+import app.k9mail.core.ui.compose.common.koin.koinPreview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+
+@Composable
+fun PreviewWithThemeAndKoin(content: @Composable () -> Unit) {
+    koinPreview {
+        single<BrandNameProvider> {
+            object : BrandNameProvider {
+                override val brandName = "BrandName"
+            }
+        }
+    } WithContent {
+        PreviewWithTheme {
+            content()
+        }
+    }
+}

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
@@ -11,16 +11,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextDisplayMedium
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme2.MainTheme
+import org.koin.compose.koinInject
 
 private const val TITLE_ICON_SIZE_DP = 56
 
 @Composable
 fun AppTitleTopHeader(
-    title: String,
     modifier: Modifier = Modifier,
+    brandNameProvider: BrandNameProvider = koinInject(),
 ) {
     ResponsiveWidthContainer(
         modifier = Modifier
@@ -51,7 +53,7 @@ fun AppTitleTopHeader(
                 contentDescription = null,
             )
 
-            TextDisplayMedium(text = title)
+            TextDisplayMedium(text = brandNameProvider.brandName)
         }
     }
 }

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
@@ -14,7 +14,6 @@ import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSett
 import app.k9mail.feature.account.server.validation.ui.IncomingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.ServerValidationScreen
 import org.koin.androidx.compose.koinViewModel
-import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 
 private const val NESTED_NAVIGATION_ROUTE_MODIFY = "modify"
@@ -58,7 +57,6 @@ fun EditIncomingServerSettingsNavHost(
                 viewModel = koinViewModel<IncomingServerValidationViewModel> {
                     parametersOf(accountUuid)
                 },
-                appNameProvider = koinInject(),
             )
         }
         composable(route = NESTED_NAVIGATION_ROUTE_SAVE) {

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
@@ -14,7 +14,6 @@ import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSett
 import app.k9mail.feature.account.server.validation.ui.OutgoingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.ServerValidationScreen
 import org.koin.androidx.compose.koinViewModel
-import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
 
 private const val NESTED_NAVIGATION_ROUTE_MODIFY = "modify"
@@ -58,7 +57,6 @@ fun EditOutgoingServerSettingsNavHost(
                 viewModel = koinViewModel<OutgoingServerValidationViewModel> {
                     parametersOf(accountUuid)
                 },
-                appNameProvider = koinInject(),
             )
         }
         composable(route = NESTED_NAVIGATION_ROUTE_SAVE) {

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreenPreview.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreenPreview.kt
@@ -2,21 +2,19 @@ package app.k9mail.feature.account.server.validation.ui
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
-import app.k9mail.feature.account.server.validation.ui.fake.FakeAppNameProvider
 import app.k9mail.feature.account.server.validation.ui.fake.FakeIncomingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.fake.FakeOutgoingServerValidationViewModel
 
 @Composable
 @PreviewDevices
 internal fun IncomingServerValidationMainScreenPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         ServerValidationMainScreen(
             viewModel = FakeIncomingServerValidationViewModel(
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
         )
     }
 }
@@ -24,12 +22,11 @@ internal fun IncomingServerValidationMainScreenPreview() {
 @Composable
 @PreviewDevices
 internal fun OutgoingServerValidationMainScreenPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         ServerValidationMainScreen(
             viewModel = FakeOutgoingServerValidationViewModel(
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenPreview.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenPreview.kt
@@ -2,17 +2,16 @@ package app.k9mail.feature.account.server.validation.ui
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
 import app.k9mail.feature.account.server.certificate.data.InMemoryServerCertificateErrorRepository
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
-import app.k9mail.feature.account.server.validation.ui.fake.FakeAppNameProvider
 import com.fsck.k9.mail.server.ServerSettingsValidationResult
 
 @Composable
 @PreviewDevices
 internal fun IncomingServerValidationScreenPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         ServerValidationScreen(
             onNext = { },
             onBack = { },
@@ -23,7 +22,6 @@ internal fun IncomingServerValidationScreenPreview() {
                 certificateErrorRepository = InMemoryServerCertificateErrorRepository(),
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
         )
     }
 }
@@ -31,7 +29,7 @@ internal fun IncomingServerValidationScreenPreview() {
 @Composable
 @PreviewDevices
 internal fun OutgoingServerValidationScreenPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         ServerValidationScreen(
             onNext = { },
             onBack = { },
@@ -42,7 +40,6 @@ internal fun OutgoingServerValidationScreenPreview() {
                 certificateErrorRepository = InMemoryServerCertificateErrorRepository(),
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/fake/FakeAppNameProvider.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/fake/FakeAppNameProvider.kt
@@ -1,7 +1,0 @@
-package app.k9mail.feature.account.server.validation.ui.fake
-
-import app.k9mail.core.common.provider.AppNameProvider
-
-internal object FakeAppNameProvider : AppNameProvider {
-    override val appName: String = "Fake App Name"
-}

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreen.kt
@@ -2,7 +2,6 @@ package app.k9mail.feature.account.server.validation.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observeWithoutEffect
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.AppTitleTopHeader
@@ -14,16 +13,13 @@ import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.
 @Composable
 internal fun ServerValidationMainScreen(
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observeWithoutEffect()
 
     Scaffold(
         topBar = {
-            AppTitleTopHeader(
-                title = appNameProvider.appName,
-            )
+            AppTitleTopHeader()
         },
         bottomBar = {
             WizardNavigationBar(

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorScreen
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Effect
@@ -17,7 +16,6 @@ fun ServerValidationScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
     title: String? = null,
 ) {
@@ -52,7 +50,6 @@ fun ServerValidationScreen(
         } else {
             ServerValidationMainScreen(
                 viewModel = viewModel,
-                appNameProvider = appNameProvider,
                 modifier = modifier,
             )
         }

--- a/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenKtTest.kt
+++ b/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenKtTest.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.account.server.validation.ui
 
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Effect
@@ -8,9 +8,30 @@ import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
 
 class ServerValidationScreenKtTest : ComposeTest() {
+
+    @Before
+    fun setUp() {
+        startKoin {
+            modules(
+                module {
+                    single<BrandNameProvider> { FakeBrandNameProvider }
+                },
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
 
     @Test
     fun `should delegate navigation effects`() = runTest {
@@ -24,7 +45,6 @@ class ServerValidationScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
             )
         }
 
@@ -42,7 +62,7 @@ class ServerValidationScreenKtTest : ComposeTest() {
         assertThat(onBackCounter).isEqualTo(1)
     }
 
-    private object FakeAppNameProvider : AppNameProvider {
-        override val appName: String = "K-9 Mail"
+    private object FakeBrandNameProvider : BrandNameProvider {
+        override val brandName: String = "K-9 Mail"
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContentPreview.kt
@@ -2,20 +2,19 @@ package app.k9mail.feature.account.setup.ui.autodiscovery
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.domain.input.StringInputField
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
 import app.k9mail.feature.account.setup.ui.autodiscovery.fake.fakeAutoDiscoveryResultSettings
 
 @Composable
 @Preview(showBackground = true)
 internal fun AccountAutoDiscoveryContentPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         AccountAutoDiscoveryContent(
             state = AccountAutoDiscoveryContract.State(),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
         )
     }
 }
@@ -23,14 +22,13 @@ internal fun AccountAutoDiscoveryContentPreview() {
 @Composable
 @Preview(showBackground = true)
 internal fun AccountAutoDiscoveryContentEmailPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         AccountAutoDiscoveryContent(
             state = AccountAutoDiscoveryContract.State(
                 emailAddress = StringInputField(value = "test@example.com"),
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
         )
     }
 }
@@ -38,7 +36,7 @@ internal fun AccountAutoDiscoveryContentEmailPreview() {
 @Composable
 @Preview(showBackground = true)
 internal fun AccountAutoDiscoveryContentPasswordPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         AccountAutoDiscoveryContent(
             state = AccountAutoDiscoveryContract.State(
                 configStep = AccountAutoDiscoveryContract.ConfigStep.PASSWORD,
@@ -47,7 +45,6 @@ internal fun AccountAutoDiscoveryContentPasswordPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
         )
     }
 }
@@ -55,7 +52,7 @@ internal fun AccountAutoDiscoveryContentPasswordPreview() {
 @Composable
 @Preview(showBackground = true)
 internal fun AccountAutoDiscoveryContentPasswordUntrustedSettingsPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         AccountAutoDiscoveryContent(
             state = AccountAutoDiscoveryContract.State(
                 configStep = AccountAutoDiscoveryContract.ConfigStep.PASSWORD,
@@ -64,7 +61,6 @@ internal fun AccountAutoDiscoveryContentPasswordUntrustedSettingsPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
         )
     }
 }
@@ -72,7 +68,7 @@ internal fun AccountAutoDiscoveryContentPasswordUntrustedSettingsPreview() {
 @Composable
 @Preview(showBackground = true)
 internal fun AccountAutoDiscoveryContentPasswordNoSettingsPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         AccountAutoDiscoveryContent(
             state = AccountAutoDiscoveryContract.State(
                 configStep = AccountAutoDiscoveryContract.ConfigStep.PASSWORD,
@@ -80,7 +76,6 @@ internal fun AccountAutoDiscoveryContentPasswordNoSettingsPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
         )
     }
 }
@@ -88,7 +83,7 @@ internal fun AccountAutoDiscoveryContentPasswordNoSettingsPreview() {
 @Composable
 @Preview(showBackground = true)
 internal fun AccountAutoDiscoveryContentOAuthPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         AccountAutoDiscoveryContent(
             state = AccountAutoDiscoveryContract.State(
                 configStep = AccountAutoDiscoveryContract.ConfigStep.OAUTH,
@@ -97,7 +92,6 @@ internal fun AccountAutoDiscoveryContentOAuthPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenPreview.kt
@@ -6,7 +6,6 @@ import app.k9mail.core.ui.compose.common.annotation.PreviewDevicesWithBackground
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
 
 @Composable
 @PreviewDevicesWithBackground
@@ -21,7 +20,6 @@ internal fun AccountAutoDiscoveryScreenPreview() {
                 accountStateRepository = FakeAccountStateRepository(),
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenPreview.kt
@@ -2,15 +2,14 @@ package app.k9mail.feature.account.setup.ui.createaccount
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.data.InMemoryAccountStateRepository
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
 
 @Composable
 @PreviewDevices
 internal fun AccountOptionsScreenK9Preview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         CreateAccountScreen(
             onNext = {},
             onBack = {},
@@ -18,7 +17,6 @@ internal fun AccountOptionsScreenK9Preview() {
                 createAccount = { AccountCreatorResult.Success("irrelevant") },
                 accountStateRepository = InMemoryAccountStateRepository(),
             ),
-            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/fake/FakeAppNameProvider.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/fake/FakeAppNameProvider.kt
@@ -1,7 +1,0 @@
-package app.k9mail.feature.account.setup.ui.fake
-
-import app.k9mail.core.common.provider.AppNameProvider
-
-internal object FakeAppNameProvider : AppNameProvider {
-    override val appName: String = "Fake App Name"
-}

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContentPreview.kt
@@ -3,17 +3,16 @@ package app.k9mail.feature.account.setup.ui.options.display
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 
 @Composable
 @Preview(showBackground = true)
 internal fun DisplayOptionsContentPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         DisplayOptionsContent(
             state = DisplayOptionsContract.State(),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenPreview.kt
@@ -2,14 +2,13 @@ package app.k9mail.feature.account.setup.ui.options.display
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
 
 @Composable
 @Preview(showBackground = true)
 internal fun DisplayOptionsScreenPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         DisplayOptionsScreen(
             onNext = {},
             onBack = {},
@@ -18,7 +17,6 @@ internal fun DisplayOptionsScreenPreview() {
                 accountStateRepository = FakeAccountStateRepository(),
                 accountOwnerNameProvider = { null },
             ),
-            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContentPreview.kt
@@ -3,17 +3,16 @@ package app.k9mail.feature.account.setup.ui.options.sync
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 
 @Composable
 @Preview(showBackground = true)
 internal fun SyncOptionsContentPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         SyncOptionsContent(
             state = SyncOptionsContract.State(),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenPreview.kt
@@ -2,21 +2,19 @@ package app.k9mail.feature.account.setup.ui.options.sync
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
 
 @Composable
 @Preview(showBackground = true)
 internal fun SyncOptionsScreenPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         SyncOptionsScreen(
             onNext = {},
             onBack = {},
             viewModel = SyncOptionsViewModel(
                 accountStateRepository = FakeAccountStateRepository(),
             ),
-            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContentPreview.kt
@@ -3,19 +3,18 @@ package app.k9mail.feature.account.setup.ui.specialfolders
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 
 @Composable
 @Preview(showBackground = true)
 internal fun SpecialFoldersContentLoadingPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         SpecialFoldersContent(
             state = SpecialFoldersContract.State(
                 isLoading = true,
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
         )
     }
 }
@@ -23,14 +22,13 @@ internal fun SpecialFoldersContentLoadingPreview() {
 @Composable
 @Preview(showBackground = true)
 internal fun SpecialFoldersContentFormPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         SpecialFoldersContent(
             state = SpecialFoldersContract.State(
                 isLoading = false,
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
         )
     }
 }
@@ -38,7 +36,7 @@ internal fun SpecialFoldersContentFormPreview() {
 @Composable
 @Preview(showBackground = true)
 internal fun SpecialFoldersContentSuccessPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         SpecialFoldersContent(
             state = SpecialFoldersContract.State(
                 isLoading = false,
@@ -46,7 +44,6 @@ internal fun SpecialFoldersContentSuccessPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
         )
     }
 }
@@ -54,7 +51,7 @@ internal fun SpecialFoldersContentSuccessPreview() {
 @Composable
 @Preview(showBackground = true)
 internal fun SpecialFoldersContentErrorPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         SpecialFoldersContent(
             state = SpecialFoldersContract.State(
                 isLoading = false,
@@ -62,7 +59,6 @@ internal fun SpecialFoldersContentErrorPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenPreview.kt
@@ -2,19 +2,17 @@ package app.k9mail.feature.account.setup.ui.specialfolders
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 import app.k9mail.feature.account.setup.ui.specialfolders.fake.FakeSpecialFoldersViewModel
 
 @Composable
 @PreviewDevices
 internal fun SpecialFoldersScreenPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         SpecialFoldersScreen(
             onNext = {},
             onBack = {},
             viewModel = FakeSpecialFoldersViewModel(),
-            appNameProvider = FakeAppNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
@@ -27,7 +27,6 @@ import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsViewModel
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersScreen
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersViewModel
 import org.koin.androidx.compose.koinViewModel
-import org.koin.compose.koinInject
 
 private const val NESTED_NAVIGATION_AUTO_CONFIG = "autoconfig"
 private const val NESTED_NAVIGATION_INCOMING_SERVER_CONFIG = "incoming-server/config"
@@ -66,7 +65,6 @@ fun AccountSetupNavHost(
                 },
                 onBack = onBack,
                 viewModel = koinViewModel<AccountAutoDiscoveryViewModel>(),
-                appNameProvider = koinInject(),
             )
         }
 
@@ -96,7 +94,6 @@ fun AccountSetupNavHost(
                 },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<IncomingServerValidationViewModel>(),
-                appNameProvider = koinInject(),
             )
         }
 
@@ -127,7 +124,6 @@ fun AccountSetupNavHost(
                 },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<OutgoingServerValidationViewModel>(),
-                appNameProvider = koinInject(),
             )
         }
 
@@ -148,7 +144,6 @@ fun AccountSetupNavHost(
                 },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<SpecialFoldersViewModel>(),
-                appNameProvider = koinInject(),
             )
         }
 
@@ -157,7 +152,6 @@ fun AccountSetupNavHost(
                 onNext = { navController.navigate(NESTED_NAVIGATION_SYNC_OPTIONS) },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<DisplayOptionsViewModel>(),
-                appNameProvider = koinInject(),
             )
         }
 
@@ -166,7 +160,6 @@ fun AccountSetupNavHost(
                 onNext = { navController.navigate(NESTED_NAVIGATION_CREATE_ACCOUNT) },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<SyncOptionsViewModel>(),
-                appNameProvider = koinInject(),
             )
         }
 
@@ -175,7 +168,6 @@ fun AccountSetupNavHost(
                 onNext = { accountUuid -> onFinish(accountUuid.value) },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<CreateAccountViewModel>(),
-                appNameProvider = koinInject(),
             )
         }
     }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
@@ -39,7 +39,6 @@ internal fun AccountAutoDiscoveryContent(
     state: State,
     onEvent: (Event) -> Unit,
     oAuthViewModel: AccountOAuthContract.ViewModel,
-    appName: String,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -59,9 +58,7 @@ internal fun AccountAutoDiscoveryContent(
                     .verticalScroll(scrollState)
                     .imePadding(),
             ) {
-                AppTitleTopHeader(
-                    title = appName,
-                )
+                AppTitleTopHeader()
                 Spacer(modifier = Modifier.weight(1f))
                 AutoDiscoveryContent(
                     state = state,

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreen.kt
@@ -3,7 +3,6 @@ package app.k9mail.feature.account.setup.ui.autodiscovery
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.AutoDiscoveryUiResult
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.Effect
@@ -15,7 +14,6 @@ internal fun AccountAutoDiscoveryScreen(
     onNext: (AutoDiscoveryUiResult) -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -33,7 +31,6 @@ internal fun AccountAutoDiscoveryScreen(
         state = state.value,
         onEvent = { dispatch(it) },
         oAuthViewModel = viewModel.oAuthViewModel,
-        appName = appNameProvider.appName,
         modifier = modifier,
     )
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.AppTitleTopHeader
@@ -20,7 +19,6 @@ internal fun CreateAccountScreen(
     onNext: (AccountUuid) -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -40,9 +38,7 @@ internal fun CreateAccountScreen(
 
     Scaffold(
         topBar = {
-            AppTitleTopHeader(
-                title = appNameProvider.appName,
-            )
+            AppTitleTopHeader()
         },
         bottomBar = {
             WizardNavigationBar(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
@@ -33,7 +33,6 @@ internal fun DisplayOptionsContent(
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
-    appName: String,
     modifier: Modifier = Modifier,
 ) {
     val resources = LocalContext.current.resources
@@ -53,9 +52,7 @@ internal fun DisplayOptionsContent(
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {
             item {
-                AppTitleTopHeader(
-                    title = appName,
-                )
+                AppTitleTopHeader()
             }
 
             item {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
@@ -17,7 +16,6 @@ internal fun DisplayOptionsScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -48,7 +46,6 @@ internal fun DisplayOptionsScreen(
             state = state.value,
             onEvent = { dispatch(it) },
             contentPadding = innerPadding,
-            appName = appNameProvider.appName,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContent.kt
@@ -36,7 +36,6 @@ internal fun SyncOptionsContent(
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
-    appName: String,
     modifier: Modifier = Modifier,
 ) {
     val resources = LocalContext.current.resources
@@ -56,9 +55,7 @@ internal fun SyncOptionsContent(
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {
             item {
-                AppTitleTopHeader(
-                    title = appName,
-                )
+                AppTitleTopHeader()
             }
 
             item {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
@@ -17,7 +16,6 @@ internal fun SyncOptionsScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -48,7 +46,6 @@ internal fun SyncOptionsScreen(
             state = state.value,
             onEvent = { dispatch(it) },
             contentPadding = innerPadding,
-            appName = appNameProvider.appName,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
@@ -26,7 +26,6 @@ fun SpecialFoldersContent(
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
-    appName: String,
     modifier: Modifier = Modifier,
 ) {
     ResponsiveWidthContainer(
@@ -36,9 +35,7 @@ fun SpecialFoldersContent(
             .then(modifier),
     ) {
         Column {
-            AppTitleTopHeader(
-                title = appName,
-            )
+            AppTitleTopHeader()
 
             ContentLoadingErrorView(
                 state = rememberContentLoadingErrorViewState(state = state),

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
@@ -18,7 +17,6 @@ fun SpecialFoldersScreen(
     onNext: (isManualSetup: Boolean) -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -52,7 +50,6 @@ fun SpecialFoldersScreen(
             state = state.value,
             onEvent = { dispatch(it) },
             contentPadding = innerPadding,
-            appName = appNameProvider.appName,
         )
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupComposeTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupComposeTest.kt
@@ -1,0 +1,44 @@
+package app.k9mail.feature.account.setup
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.common.provider.BrandNameProvider
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.theme2.k9mail.K9MailTheme2
+import org.junit.After
+import org.junit.Before
+import org.koin.compose.KoinContext
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+
+abstract class AccountSetupComposeTest : ComposeTest() {
+    @Before
+    fun setUp() {
+        startKoin {
+            modules(
+                module {
+                    single<BrandNameProvider> {
+                        object : BrandNameProvider {
+                            override val brandName = "BrandName"
+                        }
+                    }
+                },
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    // This works around a bug in Koin. The method can probably be removed once we update to Koin 4.x
+    // See https://github.com/InsertKoinIO/koin/issues/1900
+    fun setContentWithTheme(content: @Composable () -> Unit) = composeTestRule.setContent {
+        KoinContext {
+            K9MailTheme2 {
+                content()
+            }
+        }
+    }
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenKtTest.kt
@@ -1,9 +1,8 @@
 package app.k9mail.feature.account.setup.ui.autodiscovery
 
-import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.AccountSetupComposeTest
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.Effect
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.State
 import assertk.assertThat
@@ -11,7 +10,7 @@ import assertk.assertions.isEqualTo
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-class AccountAutoDiscoveryScreenKtTest : ComposeTest() {
+class AccountAutoDiscoveryScreenKtTest : AccountSetupComposeTest() {
 
     @Test
     fun `should delegate navigation effects`() = runTest {
@@ -25,7 +24,6 @@ class AccountAutoDiscoveryScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenTest.kt
@@ -1,9 +1,8 @@
 package app.k9mail.feature.account.setup.ui.createaccount
 
-import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import app.k9mail.feature.account.setup.AccountSetupComposeTest
 import app.k9mail.feature.account.setup.domain.entity.AccountUuid
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
 import app.k9mail.feature.account.setup.ui.createaccount.CreateAccountContract.Effect
 import app.k9mail.feature.account.setup.ui.createaccount.CreateAccountContract.State
 import assertk.assertThat
@@ -13,7 +12,7 @@ import assertk.assertions.isEqualTo
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class CreateAccountScreenTest : ComposeTest() {
+class CreateAccountScreenTest : AccountSetupComposeTest() {
 
     @Test
     fun `should delegate navigation effects`() = runTest {
@@ -31,7 +30,6 @@ class CreateAccountScreenTest : ComposeTest() {
                 onNext = { accountUuid -> navigateNextArguments.add(accountUuid) },
                 onBack = { navigateBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenKtTest.kt
@@ -1,8 +1,7 @@
 package app.k9mail.feature.account.setup.ui.options.display
 
-import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.AccountSetupComposeTest
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Effect
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.State
 import assertk.assertThat
@@ -10,7 +9,7 @@ import assertk.assertions.isEqualTo
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-class DisplayOptionsScreenKtTest : ComposeTest() {
+class DisplayOptionsScreenKtTest : AccountSetupComposeTest() {
 
     @Test
     fun `should delegate navigation effects`() = runTest {
@@ -24,7 +23,6 @@ class DisplayOptionsScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenKtTest.kt
@@ -1,8 +1,7 @@
 package app.k9mail.feature.account.setup.ui.options.sync
 
-import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.AccountSetupComposeTest
 import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsContract.Effect
 import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsContract.State
 import assertk.assertThat
@@ -10,7 +9,7 @@ import assertk.assertions.isEqualTo
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-class SyncOptionsScreenKtTest : ComposeTest() {
+class SyncOptionsScreenKtTest : AccountSetupComposeTest() {
 
     @Test
     fun `should delegate navigation effects`() = runTest {
@@ -24,7 +23,6 @@ class SyncOptionsScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenKtTest.kt
@@ -1,8 +1,6 @@
 package app.k9mail.feature.account.setup.ui.specialfolders
 
-import app.k9mail.core.ui.compose.testing.ComposeTest
-import app.k9mail.core.ui.compose.testing.setContentWithTheme
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.AccountSetupComposeTest
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersContract.Effect
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersContract.State
 import app.k9mail.feature.account.setup.ui.specialfolders.fake.FakeSpecialFoldersViewModel
@@ -11,7 +9,7 @@ import assertk.assertions.isEqualTo
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-class SpecialFoldersScreenKtTest : ComposeTest() {
+class SpecialFoldersScreenKtTest : AccountSetupComposeTest() {
 
     @Test
     fun `should delegate navigation effects`() = runTest {
@@ -25,7 +23,6 @@ class SpecialFoldersScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
             )
         }
 

--- a/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionContentPreview.kt
+++ b/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionContentPreview.kt
@@ -2,12 +2,12 @@ package app.k9mail.feature.onboarding.permissions.ui
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 
 @Composable
 @PreviewDevices
 internal fun PermissionContentPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         PermissionsContent(
             state = PermissionsContract.State(
                 isLoading = false,
@@ -17,7 +17,6 @@ internal fun PermissionContentPreview() {
                 isNextButtonVisible = false,
             ),
             onEvent = {},
-            appName = "AppName",
         )
     }
 }

--- a/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionScreenPreview.kt
+++ b/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionScreenPreview.kt
@@ -2,23 +2,19 @@ package app.k9mail.feature.onboarding.permissions.ui
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.android.permissions.PermissionState
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
-import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.account.common.ui.PreviewWithThemeAndKoin
 import kotlinx.coroutines.Dispatchers
 
 @Composable
 @PreviewDevices
 internal fun PermissionScreenPreview() {
-    PreviewWithTheme {
+    PreviewWithThemeAndKoin {
         PermissionsScreen(
             viewModel = PermissionsViewModel(
                 checkPermission = { PermissionState.Denied },
                 backgroundDispatcher = Dispatchers.Main.immediate,
             ),
-            appNameProvider = object : AppNameProvider {
-                override val appName: String = "AppName"
-            },
             onNext = {},
         )
     }

--- a/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
+++ b/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
@@ -39,7 +39,6 @@ import app.k9mail.feature.account.common.R as CommonR
 internal fun PermissionsContent(
     state: State,
     onEvent: (Event) -> Unit,
-    appName: String,
 ) {
     val scrollState = rememberScrollState()
 
@@ -60,7 +59,7 @@ internal fun PermissionsContent(
                     .fillMaxHeight()
                     .verticalScroll(state = scrollState),
             ) {
-                HeaderArea(appName = appName)
+                HeaderArea()
 
                 ContentArea(state, onEvent)
 
@@ -73,15 +72,11 @@ internal fun PermissionsContent(
 }
 
 @Composable
-private fun HeaderArea(
-    appName: String,
-) {
+private fun HeaderArea() {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        AppTitleTopHeader(
-            title = appName,
-        )
+        AppTitleTopHeader()
 
         TextHeadlineSmall(
             text = stringResource(R.string.onboarding_permissions_screen_title),

--- a/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsScreen.kt
+++ b/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsScreen.kt
@@ -8,17 +8,14 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import app.k9mail.core.common.provider.AppNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.feature.onboarding.permissions.ui.PermissionsContract.Effect
 import app.k9mail.feature.onboarding.permissions.ui.PermissionsContract.Event
 import org.koin.androidx.compose.koinViewModel
-import org.koin.compose.koinInject
 
 @Composable
 fun PermissionsScreen(
     viewModel: PermissionsContract.ViewModel = koinViewModel<PermissionsViewModel>(),
-    appNameProvider: AppNameProvider = koinInject(),
     onNext: () -> Unit,
 ) {
     val contactsPermissionLauncher = rememberLauncherForActivityResult(RequestPermission()) { success ->
@@ -48,7 +45,6 @@ fun PermissionsScreen(
     PermissionsContent(
         state = state.value,
         onEvent = dispatch,
-        appName = appNameProvider.appName,
     )
 }
 


### PR DESCRIPTION
Add `BrandNameProvider` to provide a brand name in addition to the app name. E.g. even when the app name is "Thunderbird Beta" the brand name is "Thunderbird".

The brand name is then used in `AppTitleTopHeader` to implement one part of the change outlined in https://github.com/thunderbird/thunderbird-android/issues/8257#issuecomment-2413607685

This also changes the code to pass `BrandNameProvider` directly to `AppTitleTopHeader`. That way a similar change like this in the future can be accomplished by changing a lot fewer places.