### PR TITLE
Add billing client

### DIFF
--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -220,7 +220,7 @@ dependencies {
 
     "fossImplementation"(projects.feature.funding.link)
 
-    fullDebugImplementation(projects.feature.funding.link)
+    fullDebugImplementation(projects.feature.funding.googleplay)
     fullDailyImplementation(projects.feature.funding.googleplay)
     fullBetaImplementation(projects.feature.funding.googleplay)
     fullReleaseImplementation(projects.feature.funding.googleplay)

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -8,7 +8,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
             FeatureFlag(FeatureFlagKey("material3_navigation_drawer"), true),
-            FeatureFlag(FeatureFlagKey("funding_google_play"), false),
+            FeatureFlag(FeatureFlagKey("funding_google_play"), true),
         )
     }
 }

--- a/feature/funding/googleplay/build.gradle.kts
+++ b/feature/funding/googleplay/build.gradle.kts
@@ -10,10 +10,12 @@ android {
 dependencies {
     api(projects.feature.funding.api)
 
+    implementation(projects.core.common)
     implementation(projects.core.ui.compose.designsystem)
 
     implementation(libs.android.billing)
     implementation(libs.android.billing.ktx)
+    implementation(libs.timber)
 
     testImplementation(projects.core.ui.compose.testing)
 }

--- a/feature/funding/googleplay/src/debug/AndroidManifest.xml
+++ b/feature/funding/googleplay/src/debug/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+
+        <meta-data
+            android:name="com.google.android.play.largest_release_audience.NONPRODUCTION"
+            android:value=""
+            />
+        <meta-data
+            android:name="com.google.android.play.billingclient.enableBillingOverridesTesting"
+            android:value="true"
+            />
+
+    </application>
+
+</manifest>

--- a/feature/funding/googleplay/src/debug/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionFooterPreview.kt
+++ b/feature/funding/googleplay/src/debug/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionFooterPreview.kt
@@ -11,8 +11,10 @@ fun ContributionFooterPreview() {
         ContributionFooter(
             onPurchaseClick = {},
             onManagePurchaseClick = {},
+            onShowContributionListClick = {},
             purchasedContribution = null,
             isPurchaseEnabled = true,
+            isContributionListShown = true,
         )
     }
 }
@@ -22,9 +24,11 @@ fun ContributionFooterPreview() {
 fun ContributionFooterDisabledPreview() {
     PreviewWithTheme {
         ContributionFooter(
+            purchasedContribution = null,
             onPurchaseClick = {},
             onManagePurchaseClick = {},
-            purchasedContribution = null,
+            onShowContributionListClick = {},
+            isContributionListShown = false,
             isPurchaseEnabled = false,
         )
     }
@@ -35,10 +39,42 @@ fun ContributionFooterDisabledPreview() {
 fun ContributionFooterWithRecurringContributionPreview() {
     PreviewWithTheme {
         ContributionFooter(
+            purchasedContribution = FakeData.recurringContribution,
             onPurchaseClick = {},
             onManagePurchaseClick = {},
-            purchasedContribution = FakeData.recurringContribution,
+            onShowContributionListClick = {},
             isPurchaseEnabled = true,
+            isContributionListShown = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun ContributionFooterWithOneTimeContributionPreview() {
+    PreviewWithTheme {
+        ContributionFooter(
+            purchasedContribution = FakeData.oneTimeContribution,
+            onPurchaseClick = {},
+            onManagePurchaseClick = {},
+            onShowContributionListClick = {},
+            isPurchaseEnabled = true,
+            isContributionListShown = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun ContributionFooterWithOneTimeContributionAndListPreview() {
+    PreviewWithTheme {
+        ContributionFooter(
+            purchasedContribution = FakeData.oneTimeContribution,
+            onPurchaseClick = {},
+            onManagePurchaseClick = {},
+            onShowContributionListClick = {},
+            isPurchaseEnabled = true,
+            isContributionListShown = true,
         )
     }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -6,6 +6,7 @@ import app.k9mail.feature.funding.googleplay.GooglePlayFundingManager
 import app.k9mail.feature.funding.googleplay.GooglePlayFundingNavigation
 import app.k9mail.feature.funding.googleplay.data.DataContract
 import app.k9mail.feature.funding.googleplay.data.mapper.ProductDetailsMapper
+import app.k9mail.feature.funding.googleplay.domain.BillingManager
 import app.k9mail.feature.funding.googleplay.domain.ContributionIdProvider
 import app.k9mail.feature.funding.googleplay.domain.DomainContract
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionViewModel
@@ -24,5 +25,16 @@ val featureFundingModule = module {
         ContributionIdProvider()
     }
 
-    viewModel { ContributionViewModel() }
+    single<DomainContract.BillingManager> {
+        BillingManager(
+            billingClient = get(),
+            contributionIdProvider = get(),
+        )
+    }
+
+    viewModel {
+        ContributionViewModel(
+            billingManager = get(),
+        )
+    }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -1,10 +1,12 @@
 package app.k9mail.feature.funding
 
+import app.k9mail.core.common.cache.InMemoryCache
 import app.k9mail.feature.funding.api.FundingManager
 import app.k9mail.feature.funding.api.FundingNavigation
 import app.k9mail.feature.funding.googleplay.GooglePlayFundingManager
 import app.k9mail.feature.funding.googleplay.GooglePlayFundingNavigation
 import app.k9mail.feature.funding.googleplay.data.DataContract
+import app.k9mail.feature.funding.googleplay.data.GoogleBillingClient
 import app.k9mail.feature.funding.googleplay.data.mapper.ProductDetailsMapper
 import app.k9mail.feature.funding.googleplay.domain.BillingManager
 import app.k9mail.feature.funding.googleplay.domain.ContributionIdProvider
@@ -19,6 +21,14 @@ val featureFundingModule = module {
 
     single<DataContract.Mapper.Product> {
         ProductDetailsMapper()
+    }
+
+    single<DataContract.BillingClient> {
+        GoogleBillingClient(
+            context = get(),
+            productMapper = get(),
+            productCache = InMemoryCache(),
+        )
     }
 
     single<DomainContract.ContributionIdProvider> {

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -6,6 +6,8 @@ import app.k9mail.feature.funding.googleplay.GooglePlayFundingManager
 import app.k9mail.feature.funding.googleplay.GooglePlayFundingNavigation
 import app.k9mail.feature.funding.googleplay.data.DataContract
 import app.k9mail.feature.funding.googleplay.data.mapper.ProductDetailsMapper
+import app.k9mail.feature.funding.googleplay.domain.ContributionIdProvider
+import app.k9mail.feature.funding.googleplay.domain.DomainContract
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -17,5 +19,10 @@ val featureFundingModule = module {
     single<DataContract.Mapper.Product> {
         ProductDetailsMapper()
     }
+
+    single<DomainContract.ContributionIdProvider> {
+        ContributionIdProvider()
+    }
+
     viewModel { ContributionViewModel() }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/FeatureFundingModule.kt
@@ -4,6 +4,8 @@ import app.k9mail.feature.funding.api.FundingManager
 import app.k9mail.feature.funding.api.FundingNavigation
 import app.k9mail.feature.funding.googleplay.GooglePlayFundingManager
 import app.k9mail.feature.funding.googleplay.GooglePlayFundingNavigation
+import app.k9mail.feature.funding.googleplay.data.DataContract
+import app.k9mail.feature.funding.googleplay.data.mapper.ProductDetailsMapper
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -12,5 +14,8 @@ val featureFundingModule = module {
     single<FundingManager> { GooglePlayFundingManager() }
     single<FundingNavigation> { GooglePlayFundingNavigation() }
 
+    single<DataContract.Mapper.Product> {
+        ProductDetailsMapper()
+    }
     viewModel { ContributionViewModel() }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/DataContract.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/DataContract.kt
@@ -1,0 +1,18 @@
+package app.k9mail.feature.funding.googleplay.data
+
+import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
+import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
+import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
+import com.android.billingclient.api.ProductDetails
+
+interface DataContract {
+
+    interface Mapper {
+        interface Product {
+            fun mapToContribution(product: ProductDetails): Contribution
+
+            fun mapToOneTimeContribution(product: ProductDetails): OneTimeContribution
+            fun mapToRecurringContribution(product: ProductDetails): RecurringContribution
+        }
+    }
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/DataContract.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/DataContract.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.funding.googleplay.data
 
+import android.app.Activity
 import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
 import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
 import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
@@ -14,5 +15,47 @@ interface DataContract {
             fun mapToOneTimeContribution(product: ProductDetails): OneTimeContribution
             fun mapToRecurringContribution(product: ProductDetails): RecurringContribution
         }
+    }
+
+    interface BillingClient {
+
+        /**
+         * Connect to the billing service.
+         *
+         * @param onConnected Callback to be invoked when the billing service is connected.
+         */
+        suspend fun <T> connect(onConnected: suspend () -> T): T
+
+        /**
+         * Disconnect from the billing service.
+         */
+        fun disconnect()
+
+        /**
+         * Load one-time contributions.
+         */
+        suspend fun loadOneTimeContributions(
+            productIds: List<String>,
+        ): List<OneTimeContribution>
+
+        /**
+         * Load recurring contributions.
+         */
+        suspend fun loadRecurringContributions(
+            productIds: List<String>,
+        ): List<RecurringContribution>
+
+        /**
+         * Load purchased contributions.
+         */
+        suspend fun loadPurchasedContributions(): List<Contribution>
+
+        /**
+         * Purchase a contribution.
+         */
+        suspend fun purchaseContribution(
+            activity: Activity,
+            contribution: Contribution,
+        ): Contribution?
     }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/GoogleBillingClient.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/GoogleBillingClient.kt
@@ -94,7 +94,8 @@ class GoogleBillingClient(
 
     override fun disconnect() {
         productCache.clear()
-        billingClient.endConnection()
+        // TODO: this is not working as expected and leads to crashes: SERVICE_DISCONNECTED
+//        billingClient.endConnection()
     }
 
     override suspend fun loadOneTimeContributions(productIds: List<String>): List<OneTimeContribution> {

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/GoogleBillingClient.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/GoogleBillingClient.kt
@@ -1,0 +1,306 @@
+package app.k9mail.feature.funding.googleplay.data
+
+import android.app.Activity
+import android.content.Context
+import app.k9mail.core.common.cache.Cache
+import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
+import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
+import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingClient.ProductType
+import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingFlowParams.ProductDetailsParams
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ConsumeParams
+import com.android.billingclient.api.PendingPurchasesParams
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.ProductDetailsResult
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchasesResult
+import com.android.billingclient.api.PurchasesUpdatedListener
+import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryPurchaseHistoryParams
+import com.android.billingclient.api.QueryPurchasesParams
+import com.android.billingclient.api.acknowledgePurchase
+import com.android.billingclient.api.consumePurchase
+import com.android.billingclient.api.queryProductDetails
+import com.android.billingclient.api.queryPurchaseHistory
+import com.android.billingclient.api.queryPurchasesAsync
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import timber.log.Timber
+
+@Suppress("TooManyFunctions")
+class GoogleBillingClient(
+    private val context: Context,
+    private val productMapper: DataContract.Mapper.Product,
+    private val productCache: Cache<String, ProductDetails>,
+    backgroundDispatcher: CoroutineContext = Dispatchers.IO,
+) : DataContract.BillingClient, PurchasesUpdatedListener {
+
+    private val coroutineScope = CoroutineScope(backgroundDispatcher)
+
+    private val billingClient: BillingClient by lazy {
+        BillingClient.newBuilder(context)
+            .setListener(this)
+            .enablePendingPurchases(
+                PendingPurchasesParams.newBuilder()
+                    .enableOneTimeProducts()
+                    .build(),
+            )
+            .build()
+    }
+
+    override suspend fun <T> connect(onConnected: suspend () -> T): T {
+        return suspendCancellableCoroutine { continuation ->
+            billingClient.startConnection(
+                object : BillingClientStateListener {
+                    override fun onBillingSetupFinished(billingResult: BillingResult) {
+                        if (billingResult.responseCode == BillingResponseCode.OK) {
+                            continuation.resumeWith(
+                                Result.runCatching {
+                                    runBlocking { onConnected() }
+                                },
+                            )
+                        } else {
+                            continuation.resumeWith(
+                                Result.failure(
+                                    IllegalStateException(
+                                        "Error connecting to billing service: ${billingResult.responseCode}",
+                                    ),
+                                ),
+                            )
+                        }
+                    }
+
+                    override fun onBillingServiceDisconnected() {
+                        continuation.resumeWith(
+                            Result.failure(
+                                IllegalStateException("Billing service disconnected"),
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    override fun disconnect() {
+        productCache.clear()
+        billingClient.endConnection()
+    }
+
+    override suspend fun loadOneTimeContributions(productIds: List<String>): List<OneTimeContribution> {
+        val oneTimeProductsResult = queryProducts(ProductType.INAPP, productIds)
+        return if (oneTimeProductsResult.billingResult.responseCode == BillingResponseCode.OK) {
+            oneTimeProductsResult.productDetailsList.orEmpty().map {
+                val contribution = productMapper.mapToOneTimeContribution(it)
+                productCache[it.productId] = it
+                contribution
+            }
+        } else {
+            Timber.e(
+                "Error loading one-time products: ${oneTimeProductsResult.billingResult.responseCode}",
+            )
+            emptyList()
+        }
+    }
+
+    override suspend fun loadRecurringContributions(productIds: List<String>): List<RecurringContribution> {
+        val recurringProductsResult = queryProducts(ProductType.SUBS, productIds)
+        return if (recurringProductsResult.billingResult.responseCode == BillingResponseCode.OK) {
+            recurringProductsResult.productDetailsList.orEmpty().map {
+                val contribution = productMapper.mapToRecurringContribution(it)
+                productCache[it.productId] = it
+                contribution
+            }
+        } else {
+            Timber.e(
+                "Error querying recurring products: ${recurringProductsResult.billingResult.debugMessage}",
+            )
+            emptyList()
+        }
+    }
+
+    override suspend fun loadPurchasedContributions(): List<Contribution> {
+        val inAppPurchases = queryPurchase(ProductType.INAPP)
+        val subscriptionPurchases = queryPurchase(ProductType.SUBS)
+        val contributions = handlePurchases(inAppPurchases.purchasesList + subscriptionPurchases.purchasesList)
+        val recentContribution = if (inAppPurchases.purchasesList.isEmpty()) {
+            loadInAppPurchaseHistory()
+        } else {
+            null
+        }
+
+        return if (recentContribution != null) {
+            contributions + recentContribution
+        } else {
+            contributions
+        }
+    }
+
+    private suspend fun loadInAppPurchaseHistory(): Contribution? {
+        val queryPurchaseHistoryParams = QueryPurchaseHistoryParams.newBuilder()
+            .setProductType(ProductType.INAPP)
+            .build()
+
+        val result = billingClient.queryPurchaseHistory(queryPurchaseHistoryParams)
+        return if (result.billingResult.responseCode == BillingResponseCode.OK) {
+            val recentPurchaseId = result.purchaseHistoryRecordList.orEmpty().firstOrNull()?.products?.filter {
+                productCache.hasKey(it)
+            }?.firstOrNull()
+
+            if (recentPurchaseId != null) {
+                val recentPurchase = productCache[recentPurchaseId]
+                productMapper.mapToContribution(recentPurchase!!)
+            } else {
+                Timber.e("No recent purchase found: ${result.billingResult.debugMessage}")
+                null
+            }
+        } else {
+            Timber.e("Error querying purchase history: ${result.billingResult.debugMessage}")
+            null
+        }
+    }
+
+    private suspend fun queryProducts(
+        productType: String,
+        productIds: List<String>,
+    ): ProductDetailsResult {
+        val productList = productIds.map { mapIdToProduct(productType, it) }
+
+        val queryProductDetailsParams = QueryProductDetailsParams.newBuilder()
+            .setProductList(productList)
+            .build()
+
+        return billingClient.queryProductDetails(queryProductDetailsParams)
+    }
+
+    private fun mapIdToProduct(
+        productType: String,
+        productId: String,
+    ): QueryProductDetailsParams.Product {
+        return QueryProductDetailsParams.Product.newBuilder()
+            .setProductType(productType)
+            .setProductId(productId)
+            .build()
+    }
+
+    private suspend fun queryPurchase(productType: String): PurchasesResult {
+        val queryPurchaseParams = QueryPurchasesParams.newBuilder()
+            .setProductType(productType)
+            .build()
+
+        return billingClient.queryPurchasesAsync(queryPurchaseParams)
+    }
+
+    override suspend fun purchaseContribution(activity: Activity, contribution: Contribution): Contribution? {
+        val productDetails = productCache[contribution.id] ?: return null
+        val offerToken = productDetails.subscriptionOfferDetails?.firstOrNull()?.offerToken
+
+        val productDetailsParamsList = listOf(
+            ProductDetailsParams.newBuilder()
+                .setProductDetails(productDetails)
+                .apply {
+                    if (offerToken != null) {
+                        setOfferToken(offerToken)
+                    }
+                }
+                .build(),
+        )
+
+        val billingFlowParams = BillingFlowParams.newBuilder()
+            .setProductDetailsParamsList(productDetailsParamsList)
+            .build()
+
+        val result = billingClient.launchBillingFlow(activity, billingFlowParams)
+        return if (result.responseCode == BillingResponseCode.OK) {
+            contribution
+        } else {
+            null
+        }
+    }
+
+    override fun onPurchasesUpdated(billingResult: BillingResult, purchases: MutableList<Purchase>?) {
+        when (billingResult.responseCode) {
+            BillingResponseCode.OK -> coroutineScope.launch {
+                handlePurchases(purchases)
+            }
+
+            BillingResponseCode.USER_CANCELED -> {
+                Timber.d("User canceled the purchase")
+            }
+
+            BillingResponseCode.ITEM_ALREADY_OWNED -> coroutineScope.launch {
+                Timber.d("Item already owned by the user")
+                // TODO: Update purchases in this case
+            }
+
+            BillingResponseCode.DEVELOPER_ERROR -> {
+                // Make sure the SKU product id is correct and the test apk is signed with a release key.
+                Timber.e("Developer error: ${billingResult.debugMessage}")
+            }
+
+            else -> {
+                Timber.e(
+                    "Response Code: ${billingResult.responseCode} " +
+                        "Billing error: ${billingResult.debugMessage}",
+                )
+            }
+        }
+    }
+
+    private suspend fun handlePurchases(purchases: List<Purchase>?): List<Contribution> {
+        return purchases?.mapNotNull { purchase ->
+            handlePurchase(purchase)
+        } ?: emptyList()
+    }
+
+    private suspend fun handlePurchase(purchase: Purchase): Contribution? {
+        consumePurchase(purchase)
+
+        return if (purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
+            val product = purchase.products.firstOrNull()?.let { productCache[it] } ?: return null
+            val contribution = productMapper.mapToContribution(product)
+
+            if (!purchase.isAcknowledged) {
+                val acknowledgePurchaseParams = AcknowledgePurchaseParams.newBuilder()
+                    .setPurchaseToken(purchase.purchaseToken)
+                    .build()
+
+                val acknowledgeResult: BillingResult = billingClient.acknowledgePurchase(acknowledgePurchaseParams)
+
+                if (acknowledgeResult.responseCode != BillingResponseCode.OK) {
+                    contribution
+                } else {
+                    // handle acknowledge error
+                    Timber.e("acknowledgePurchase failed")
+                    null
+                }
+            } else {
+                Timber.e("purchase already acknowledged")
+                null
+            }
+        } else {
+            Timber.e("purchase not purchased")
+            null
+        }
+    }
+
+    private suspend fun consumePurchase(purchase: Purchase) {
+        val consumeParams = ConsumeParams.newBuilder()
+            .setPurchaseToken(purchase.purchaseToken)
+            .build()
+
+        // This could fail but we can ignore the error as we handle purchases
+        // the next time the purchases are requested
+        billingClient.consumePurchase(consumeParams)
+    }
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/mapper/ProductDetailsMapper.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/mapper/ProductDetailsMapper.kt
@@ -1,0 +1,57 @@
+package app.k9mail.feature.funding.googleplay.data.mapper
+
+import app.k9mail.feature.funding.googleplay.data.DataContract.Mapper
+import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
+import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
+import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.ProductDetails
+
+class ProductDetailsMapper : Mapper.Product {
+
+    override fun mapToContribution(product: ProductDetails): Contribution {
+        return when (product.productType) {
+            BillingClient.ProductType.INAPP -> mapToOneTimeContribution(product)
+            BillingClient.ProductType.SUBS -> mapToRecurringContribution(product)
+            else -> throw IllegalArgumentException("Unknown product type: ${product.productType}")
+        }
+    }
+
+    override fun mapToOneTimeContribution(product: ProductDetails): OneTimeContribution {
+        require(product.productType == BillingClient.ProductType.INAPP) { "Product type must be INAPP" }
+
+        val offerDetails = product.oneTimePurchaseOfferDetails
+
+        return if (offerDetails != null) {
+            OneTimeContribution(
+                id = product.productId,
+                title = product.name,
+                description = product.description.replace("\n", ""),
+                price = offerDetails.priceAmountMicros,
+                priceFormatted = offerDetails.formattedPrice,
+            )
+        } else {
+            error("One-time product has no offer details: ${product.productId}")
+        }
+    }
+
+    override fun mapToRecurringContribution(product: ProductDetails): RecurringContribution {
+        require(product.productType == BillingClient.ProductType.SUBS) { "Product type must be SUBS" }
+
+        // We assume the product has only one offer and one pricing phase
+        val pricingPhase =
+            product.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()
+
+        return if (pricingPhase != null) {
+            RecurringContribution(
+                id = product.productId,
+                title = product.name,
+                description = product.description.replace("\n", ""),
+                price = pricingPhase.priceAmountMicros,
+                priceFormatted = pricingPhase.formattedPrice,
+            )
+        } else {
+            error("Subscription product has no pricing phase: ${product.productId}")
+        }
+    }
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/BillingManager.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/BillingManager.kt
@@ -1,0 +1,44 @@
+package app.k9mail.feature.funding.googleplay.domain
+
+import android.app.Activity
+import app.k9mail.feature.funding.googleplay.data.DataContract
+import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
+import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
+import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
+
+class BillingManager(
+    private val billingClient: DataContract.BillingClient,
+    private val contributionIdProvider: DomainContract.ContributionIdProvider,
+) : DomainContract.BillingManager {
+
+    override suspend fun loadOneTimeContributions(): List<OneTimeContribution> {
+        return billingClient.connect {
+            billingClient.loadOneTimeContributions(contributionIdProvider.oneTimeContributionIds)
+                .sortedByDescending { it.price }
+        }
+    }
+
+    override suspend fun loadRecurringContributions(): List<RecurringContribution> {
+        return billingClient.connect {
+            billingClient.loadRecurringContributions(contributionIdProvider.recurringContributionIds)
+                .sortedByDescending { it.price }
+        }
+    }
+
+    override suspend fun loadPurchasedContributions(): List<Contribution> {
+        return billingClient.connect {
+            billingClient.loadPurchasedContributions()
+                .sortedByDescending { it.price }
+        }
+    }
+
+    override suspend fun purchaseContribution(activity: Activity, contribution: Contribution): Contribution? {
+        return billingClient.connect {
+            billingClient.purchaseContribution(activity, contribution)
+        }
+    }
+
+    override fun clear() {
+        billingClient.disconnect()
+    }
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/ContributionIdProvider.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/ContributionIdProvider.kt
@@ -1,0 +1,26 @@
+package app.k9mail.feature.funding.googleplay.domain
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+// TODO should be provided externally per app variant
+class ContributionIdProvider :
+    DomainContract.ContributionIdProvider {
+    override val oneTimeContributionIds: ImmutableList<String> = persistentListOf(
+        "contribution_tfa_onetime_xs",
+        "contribution_tfa_onetime_s",
+        "contribution_tfa_onetime_m",
+        "contribution_tfa_onetime_l",
+        "contribution_tfa_onetime_xl",
+        "contribution_tfa_onetime_xxl",
+    )
+
+    override val recurringContributionIds: ImmutableList<String> = persistentListOf(
+        "contribution_tfa_monthly_xs",
+        "contribution_tfa_monthly_s",
+        "contribution_tfa_monthly_m",
+        "contribution_tfa_monthly_l",
+        "contribution_tfa_monthly_xl",
+        "contribution_tfa_monthly_xxl",
+    )
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/DomainContract.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/DomainContract.kt
@@ -1,5 +1,9 @@
 package app.k9mail.feature.funding.googleplay.domain
 
+import android.app.Activity
+import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
+import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
+import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
 import kotlinx.collections.immutable.ImmutableList
 
 interface DomainContract {
@@ -7,5 +11,39 @@ interface DomainContract {
     interface ContributionIdProvider {
         val oneTimeContributionIds: ImmutableList<String>
         val recurringContributionIds: ImmutableList<String>
+    }
+
+    interface BillingManager {
+        /**
+         * Load contributions.
+         */
+        suspend fun loadOneTimeContributions(): List<OneTimeContribution>
+
+        /**
+         * Load recurring contributions.
+         */
+        suspend fun loadRecurringContributions(): List<RecurringContribution>
+
+        /**
+         * Load purchased contributions.
+         */
+        suspend fun loadPurchasedContributions(): List<Contribution>
+
+        /**
+         * Purchase a contribution.
+         *
+         * @param activity The activity to use for the purchase flow.
+         * @param contribution The contribution to purchase.
+         * @return The purchased contribution or null if the purchase failed.
+         */
+        suspend fun purchaseContribution(
+            activity: Activity,
+            contribution: Contribution,
+        ): Contribution?
+
+        /**
+         * Release all resources.
+         */
+        fun clear()
     }
 }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/DomainContract.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/DomainContract.kt
@@ -1,0 +1,11 @@
+package app.k9mail.feature.funding.googleplay.domain
+
+import kotlinx.collections.immutable.ImmutableList
+
+interface DomainContract {
+
+    interface ContributionIdProvider {
+        val oneTimeContributionIds: ImmutableList<String>
+        val recurringContributionIds: ImmutableList<String>
+    }
+}

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/entity/OneTimeContribution.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/entity/OneTimeContribution.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.funding.googleplay.domain.entity
 
-class OneTimeContribution(
+data class OneTimeContribution(
     override val id: String,
     override val title: String,
     override val description: String,

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContent.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContent.kt
@@ -44,27 +44,31 @@ internal fun ContributionContent(
                 purchasedContribution = state.purchasedContribution,
             )
 
-            ContributionList(
-                oneTimeContributions = state.oneTimeContributions,
-                recurringContributions = state.recurringContributions,
-                selectedItem = state.selectedContribution,
-                isRecurringContributionSelected = state.isRecurringContributionSelected,
-                onOneTimeContributionTypeClick = {
-                    onEvent(Event.OnOneTimeContributionSelected)
-                },
-                onRecurringContributionTypeClick = {
-                    onEvent(Event.OnRecurringContributionSelected)
-                },
-                onItemClick = {
-                    onEvent(Event.OnContributionItemClicked(it))
-                },
-            )
+            if (state.showContributionList) {
+                ContributionList(
+                    oneTimeContributions = state.oneTimeContributions,
+                    recurringContributions = state.recurringContributions,
+                    selectedItem = state.selectedContribution,
+                    isRecurringContributionSelected = state.isRecurringContributionSelected,
+                    onOneTimeContributionTypeClick = {
+                        onEvent(Event.OnOneTimeContributionSelected)
+                    },
+                    onRecurringContributionTypeClick = {
+                        onEvent(Event.OnRecurringContributionSelected)
+                    },
+                    onItemClick = {
+                        onEvent(Event.OnContributionItemClicked(it))
+                    },
+                )
+            }
 
             ContributionFooter(
+                purchasedContribution = state.purchasedContribution,
                 onPurchaseClick = { onEvent(Event.OnPurchaseClicked(activity)) },
                 onManagePurchaseClick = { onEvent(Event.OnManagePurchaseClicked(it)) },
-                purchasedContribution = state.purchasedContribution,
+                onShowContributionListClick = { onEvent(Event.OnShowContributionListClicked) },
                 isPurchaseEnabled = state.selectedContribution != null,
+                isContributionListShown = state.showContributionList,
             )
         }
     }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContract.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContract.kt
@@ -17,14 +17,17 @@ internal class ContributionContract {
     data class State(
         val oneTimeContributions: ImmutableList<OneTimeContribution> = persistentListOf(),
         val recurringContributions: ImmutableList<RecurringContribution> = persistentListOf(),
-        val purchasedContribution: Contribution? = null,
         val selectedContribution: Contribution? = null,
+        val purchasedContribution: Contribution? = null,
+        val showContributionList: Boolean = true,
         val isRecurringContributionSelected: Boolean = false,
     )
 
     sealed interface Event {
         data object OnOneTimeContributionSelected : Event
         data object OnRecurringContributionSelected : Event
+
+        data object OnShowContributionListClicked : Event
 
         data class OnContributionItemClicked(
             val item: Contribution,

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionFooter.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionFooter.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonFilled
 import app.k9mail.feature.funding.googleplay.R
 import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
+import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
 import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
 
 @Composable
@@ -15,20 +16,36 @@ internal fun ContributionFooter(
     purchasedContribution: Contribution?,
     onPurchaseClick: () -> Unit,
     onManagePurchaseClick: (Contribution) -> Unit,
+    onShowContributionListClick: () -> Unit,
     isPurchaseEnabled: Boolean,
+    isContributionListShown: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
     ) {
-        if (purchasedContribution != null && purchasedContribution is RecurringContribution) {
-            ButtonFilled(
-                text = stringResource(
-                    R.string.funding_googleplay_contribution_footer_manage_button,
-                ),
-                onClick = { onManagePurchaseClick(purchasedContribution) },
-                modifier = Modifier.fillMaxWidth(),
-            )
+        if (purchasedContribution != null && !isContributionListShown) {
+            when (purchasedContribution) {
+                is RecurringContribution -> {
+                    ButtonFilled(
+                        text = stringResource(
+                            R.string.funding_googleplay_contribution_footer_manage_button,
+                        ),
+                        onClick = { onManagePurchaseClick(purchasedContribution) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                is OneTimeContribution -> {
+                    ButtonFilled(
+                        text = stringResource(
+                            R.string.funding_googleplay_contribution_footer_show_contribution_list_button,
+                        ),
+                        onClick = onShowContributionListClick,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
         } else {
             ButtonFilled(
                 text = stringResource(

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
@@ -21,7 +21,8 @@ internal class ContributionViewModel(
     init {
         viewModelScope.launch {
             loadOneTimeContributions()
-            loadRecurringContributions()
+            // TODO load recurring contributions
+            // loadRecurringContributions()
             loadPurchasedContribution()
             selectDefaultContribution()
         }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
@@ -99,6 +99,7 @@ internal class ContributionViewModel(
             it.copy(
                 isRecurringContributionSelected = false,
                 selectedContribution = it.oneTimeContributions.getSecondLowestOrNull(),
+                showContributionList = true,
             )
         }
     }
@@ -108,6 +109,7 @@ internal class ContributionViewModel(
             it.copy(
                 isRecurringContributionSelected = true,
                 selectedContribution = it.recurringContributions.getSecondLowestOrNull(),
+                showContributionList = true,
             )
         }
     }

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
@@ -95,7 +95,7 @@ internal class ContributionViewModel(
         updateState {
             it.copy(
                 isRecurringContributionSelected = false,
-                selectedContribution = it.oneTimeContributions.firstOrNull(),
+                selectedContribution = it.oneTimeContributions.getSecondLowestOrNull(),
             )
         }
     }
@@ -104,8 +104,16 @@ internal class ContributionViewModel(
         updateState {
             it.copy(
                 isRecurringContributionSelected = true,
-                selectedContribution = it.recurringContributions.firstOrNull(),
+                selectedContribution = it.recurringContributions.getSecondLowestOrNull(),
             )
+        }
+    }
+
+    private fun List<Contribution>.getSecondLowestOrNull(): Contribution? {
+        return when {
+            this.size > 1 -> this.sortedBy { it.price }[1]
+            this.size == 1 -> this[0]
+            else -> null
         }
     }
 

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
@@ -69,6 +69,7 @@ internal class ContributionViewModel(
         updateState { state ->
             state.copy(
                 purchasedContribution = purchasedContribution,
+                showContributionList = purchasedContribution == null,
             )
         }
     }
@@ -89,6 +90,7 @@ internal class ContributionViewModel(
             is Event.OnContributionItemClicked -> onContributionItemClicked(event.item)
             is Event.OnPurchaseClicked -> onPurchaseClicked(event.activity)
             is Event.OnManagePurchaseClicked -> onManagePurchaseClicked(event.contribution)
+            Event.OnShowContributionListClicked -> onShowContributionListClicked()
         }
     }
 
@@ -134,6 +136,7 @@ internal class ContributionViewModel(
                 updateState {
                     it.copy(
                         purchasedContribution = result,
+                        showContributionList = false,
                     )
                 }
             }
@@ -143,6 +146,14 @@ internal class ContributionViewModel(
     @Suppress("UnusedParameter")
     private fun onManagePurchaseClicked(contribution: Contribution) {
         // TODO: Implement manage purchase logic
+    }
+
+    private fun onShowContributionListClicked() {
+        updateState {
+            it.copy(
+                showContributionList = true,
+            )
+        }
     }
 
     override fun onCleared() {

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
@@ -1,16 +1,85 @@
 package app.k9mail.feature.funding.googleplay.ui.contribution
 
 import android.app.Activity
+import androidx.lifecycle.viewModelScope
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import app.k9mail.feature.funding.googleplay.domain.DomainContract
 import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.Event
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.State
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.ViewModel
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.launch
 
+@Suppress("TooManyFunctions")
 internal class ContributionViewModel(
+    private val billingManager: DomainContract.BillingManager,
     initialState: State = State(),
 ) : BaseViewModel<State, Event, Nothing>(initialState),
     ViewModel {
+
+    init {
+        viewModelScope.launch {
+            loadOneTimeContributions()
+            loadRecurringContributions()
+            loadPurchasedContribution()
+            selectDefaultContribution()
+        }
+    }
+
+    private suspend fun loadOneTimeContributions() {
+        val result = billingManager.loadOneTimeContributions()
+
+        updateState { state ->
+            state.copy(
+                oneTimeContributions = result.toImmutableList(),
+                selectedContribution = if (
+                    !state.isRecurringContributionSelected &&
+                    result.contains(state.selectedContribution).not()
+                ) {
+                    result.firstOrNull()
+                } else {
+                    state.selectedContribution
+                },
+            )
+        }
+    }
+
+    private suspend fun loadRecurringContributions() {
+        val result = billingManager.loadRecurringContributions()
+
+        updateState { state ->
+            state.copy(
+                recurringContributions = result.toImmutableList(),
+                selectedContribution = if (
+                    state.isRecurringContributionSelected &&
+                    result.contains(state.selectedContribution).not()
+                ) {
+                    result.firstOrNull()
+                } else {
+                    state.selectedContribution
+                },
+            )
+        }
+    }
+
+    private suspend fun loadPurchasedContribution() {
+        val purchasedContribution = billingManager.loadPurchasedContributions().firstOrNull()
+        updateState { state ->
+            state.copy(
+                purchasedContribution = purchasedContribution,
+            )
+        }
+    }
+
+    private fun selectDefaultContribution() {
+        val selectedContribution = state.value.selectedContribution ?: return
+        if (state.value.oneTimeContributions.contains(selectedContribution)) {
+            onOneTimeContributionSelected()
+        } else if (state.value.recurringContributions.contains(selectedContribution)) {
+            onRecurringContributionSelected()
+        }
+    }
 
     override fun event(event: Event) {
         when (event) {
@@ -48,13 +117,27 @@ internal class ContributionViewModel(
         }
     }
 
-    @Suppress("UnusedParameter")
     private fun onPurchaseClicked(activity: Activity) {
-        // TODO: Implement purchase logic
+        viewModelScope.launch {
+            val result = billingManager.purchaseContribution(activity, state.value.selectedContribution!!)
+
+            if (result != null) {
+                updateState {
+                    it.copy(
+                        purchasedContribution = result,
+                    )
+                }
+            }
+        }
     }
 
     @Suppress("UnusedParameter")
     private fun onManagePurchaseClicked(contribution: Contribution) {
         // TODO: Implement manage purchase logic
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        billingManager.clear()
     }
 }

--- a/feature/funding/googleplay/src/main/res/values/strings.xml
+++ b/feature/funding/googleplay/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
 
     <string name="funding_googleplay_contribution_footer_payment_button">Continue to payment</string>
     <string name="funding_googleplay_contribution_footer_manage_button">Modify monthly payment</string>
+    <string name="funding_googleplay_contribution_footer_show_contribution_list_button">Help keep Thunderbird alive</string>
 </resources>

--- a/feature/funding/googleplay/src/main/res/values/strings.xml
+++ b/feature/funding/googleplay/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="funding_googleplay_contribution_title">Settings</string>
+    <string name="funding_googleplay_contribution_title">Support Thunderbird</string>
 
     <string name="funding_googleplay_contribution_header_title">Support Thunderbird</string>
     <string name="funding_googleplay_contribution_header_description">We never show advertisements or sell your data. We are fully funded by financial contributions from our users. If you’re enjoying Thunderbird, please help support it.  We can’t do this without you!</string>

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/data/mapper/ProductDetailsMapperTest.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/data/mapper/ProductDetailsMapperTest.kt
@@ -1,0 +1,159 @@
+package app.k9mail.feature.funding.googleplay.data.mapper
+
+import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
+import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import com.android.billingclient.api.BillingClient.ProductType
+import com.android.billingclient.api.ProductDetails
+import kotlin.test.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class ProductDetailsMapperTest {
+
+    private val testSubject = ProductDetailsMapper()
+
+    @Test
+    fun `mapToOneTimeContribution returns OneTimeContribution when product type is INAPP`() {
+        val productDetails = createInAppProductDetails()
+
+        val result = testSubject.mapToOneTimeContribution(productDetails)
+
+        assertThat(result).isEqualTo(ONE_TIME_CONTRIBUTION)
+    }
+
+    @Test
+    fun `mapToOneTimeContribution throws IllegalStateException when in app product has no offer details`() {
+        val productDetails = createInAppProductDetails(hasOfferDetails = false)
+
+        assertFailure {
+            testSubject.mapToOneTimeContribution(productDetails)
+        }.isInstanceOf(IllegalStateException::class)
+    }
+
+    @Test
+    fun `mapToRecurringContribution returns RecurringContribution when product type is SUBS`() {
+        val productDetails = createSubscriptionProductDetails()
+
+        val result = testSubject.mapToRecurringContribution(productDetails)
+
+        assertThat(result).isEqualTo(RECURRING_CONTRIBUTION)
+    }
+
+    @Test
+    fun `mapToRecurringContribution throws IllegalStateException when subscription product has no pricing phase`() {
+        val productDetails = createSubscriptionProductDetails(hasPricingPhase = false)
+
+        assertFailure {
+            testSubject.mapToRecurringContribution(productDetails)
+        }.isInstanceOf(IllegalStateException::class)
+    }
+
+    @Test
+    fun `mapToContribution return contribution for all supported types`() {
+        val inAppProductDetails = createInAppProductDetails()
+        val subscriptionProductDetails = createSubscriptionProductDetails()
+
+        val oneTimeContribution = testSubject.mapToContribution(inAppProductDetails)
+        val recurringContribution = testSubject.mapToContribution(subscriptionProductDetails)
+
+        assertThat(oneTimeContribution).isEqualTo(ONE_TIME_CONTRIBUTION)
+        assertThat(recurringContribution).isEqualTo(RECURRING_CONTRIBUTION)
+    }
+
+    @Test
+    fun `mapToContribution throws IllegalArgumentException when product type is unknown`() {
+        val productDetails = mock<ProductDetails> {
+            on { productType } doReturn "unknown"
+        }
+
+        assertFailure {
+            testSubject.mapToContribution(productDetails)
+        }.isInstanceOf(IllegalArgumentException::class)
+    }
+
+    private fun createInAppProductDetails(
+        hasOfferDetails: Boolean = true,
+    ): ProductDetails {
+        val oneTimePurchaseOfferDetails = mock<ProductDetails.OneTimePurchaseOfferDetails> {
+            on { priceAmountMicros }.thenReturn(ONE_TIME_PRICE)
+            on { formattedPrice }.thenReturn(ONE_TIME_PRICE_FORMATTED)
+        }
+
+        return mock<ProductDetails> {
+            on { productType } doReturn ProductType.INAPP
+            on { productId } doReturn ONE_TIME_ID
+            on { name } doReturn ONE_TIME_TITLE
+            on { description } doReturn ONE_TIME_DESCRIPTION_WITH_NEW_LINE
+            on { getOneTimePurchaseOfferDetails() } doReturn if (hasOfferDetails) {
+                oneTimePurchaseOfferDetails
+            } else {
+                null
+            }
+        }
+    }
+
+    private fun createSubscriptionProductDetails(
+        hasPricingPhase: Boolean = true,
+    ): ProductDetails {
+        val pricingPhase = mock<ProductDetails.PricingPhase> {
+            on { priceAmountMicros } doReturn RECURRING_PRICE
+            on { formattedPrice } doReturn RECURRING_PRICE_FORMATTED
+        }
+
+        val pricingPhaseList = mock<ProductDetails.PricingPhases> {
+            on { pricingPhaseList } doReturn listOf(pricingPhase)
+        }
+
+        val subscriptionOfferDetails = mock<ProductDetails.SubscriptionOfferDetails> {
+            on { pricingPhases } doReturn pricingPhaseList
+        }
+
+        return mock<ProductDetails> {
+            on { productType } doReturn ProductType.SUBS
+            on { productId } doReturn RECURRING_ID
+            on { name } doReturn RECURRING_TITLE
+            on { description } doReturn RECURRING_DESCRIPTION_WITH_NEW_LINE
+            on { getSubscriptionOfferDetails() } doReturn if (hasPricingPhase) {
+                listOf(subscriptionOfferDetails)
+            } else {
+                null
+            }
+        }
+    }
+
+    private companion object {
+        const val ONE_TIME_ID = "one_time_id"
+        const val ONE_TIME_TITLE = "One-Time"
+        const val ONE_TIME_DESCRIPTION = "One-Time Description"
+        const val ONE_TIME_DESCRIPTION_WITH_NEW_LINE = "One-Time\n Description"
+        const val ONE_TIME_PRICE = 1_000L
+        const val ONE_TIME_PRICE_FORMATTED = "$10.00"
+
+        val ONE_TIME_CONTRIBUTION = OneTimeContribution(
+            id = ONE_TIME_ID,
+            title = ONE_TIME_TITLE,
+            description = ONE_TIME_DESCRIPTION,
+            price = ONE_TIME_PRICE,
+            priceFormatted = ONE_TIME_PRICE_FORMATTED,
+        )
+
+        const val RECURRING_ID = "recurring_product_id"
+        const val RECURRING_TITLE = "Recurring"
+        const val RECURRING_DESCRIPTION = "Recurring Description"
+        const val RECURRING_DESCRIPTION_WITH_NEW_LINE = "Recurring\n Description"
+        const val RECURRING_PRICE = 2_000L
+        const val RECURRING_PRICE_FORMATTED = "$20.00"
+
+        val RECURRING_CONTRIBUTION = RecurringContribution(
+            id = RECURRING_ID,
+            title = RECURRING_TITLE,
+            description = RECURRING_DESCRIPTION,
+            price = RECURRING_PRICE,
+            priceFormatted = RECURRING_PRICE_FORMATTED,
+        )
+    }
+}

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModelTest.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModelTest.kt
@@ -25,7 +25,7 @@ class ContributionViewModelTest {
             oneTimeContributions = FakeData.oneTimeContributions,
             recurringContributions = FakeData.recurringContributions,
             purchasedContribution = FakeData.oneTimeContributions.first(),
-            selectedContribution = FakeData.recurringContributions.first(),
+            selectedContribution = FakeData.recurringContributions[FakeData.recurringContributions.size - 2],
         )
 
         contributionRobot(initialState) {
@@ -41,7 +41,7 @@ class ContributionViewModelTest {
             oneTimeContributions = FakeData.oneTimeContributions,
             recurringContributions = FakeData.recurringContributions,
             purchasedContribution = FakeData.oneTimeContributions.first(),
-            selectedContribution = FakeData.oneTimeContributions.first(),
+            selectedContribution = FakeData.oneTimeContributions[FakeData.oneTimeContributions.size - 2],
         )
 
         contributionRobot(initialState) {
@@ -57,7 +57,7 @@ class ContributionViewModelTest {
             oneTimeContributions = FakeData.oneTimeContributions,
             recurringContributions = FakeData.recurringContributions,
             purchasedContribution = FakeData.oneTimeContributions.first(),
-            selectedContribution = FakeData.recurringContributions.first(),
+            selectedContribution = FakeData.recurringContributions[FakeData.oneTimeContributions.size - 2],
         )
         val selectedContribution = FakeData.recurringContributions[2]
 
@@ -98,7 +98,7 @@ private class ContributionRobot(
         assertThat(turbines.awaitStateItem()).isEqualTo(
             initialState.copy(
                 isRecurringContributionSelected = false,
-                selectedContribution = initialState.oneTimeContributions.first(),
+                selectedContribution = initialState.oneTimeContributions[initialState.oneTimeContributions.size - 2],
             ),
         )
     }
@@ -111,7 +111,8 @@ private class ContributionRobot(
         assertThat(turbines.awaitStateItem()).isEqualTo(
             initialState.copy(
                 isRecurringContributionSelected = true,
-                selectedContribution = initialState.recurringContributions.first(),
+                selectedContribution = initialState
+                    .recurringContributions[initialState.recurringContributions.size - 2],
             ),
         )
     }

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModelTest.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModelTest.kt
@@ -23,6 +23,9 @@ class ContributionViewModelTest {
         val initialState = State(
             isRecurringContributionSelected = true,
             oneTimeContributions = FakeData.oneTimeContributions,
+            recurringContributions = FakeData.recurringContributions,
+            purchasedContribution = FakeData.oneTimeContributions.first(),
+            selectedContribution = FakeData.recurringContributions.first(),
         )
 
         contributionRobot(initialState) {
@@ -35,7 +38,10 @@ class ContributionViewModelTest {
     fun `should change selected contribution and selected type when recurring contribution selected`() = runMviTest {
         val initialState = State(
             isRecurringContributionSelected = false,
+            oneTimeContributions = FakeData.oneTimeContributions,
             recurringContributions = FakeData.recurringContributions,
+            purchasedContribution = FakeData.oneTimeContributions.first(),
+            selectedContribution = FakeData.oneTimeContributions.first(),
         )
 
         contributionRobot(initialState) {
@@ -48,7 +54,10 @@ class ContributionViewModelTest {
     fun `should change selected contribution when contribution item clicked`() = runMviTest {
         val initialState = State(
             isRecurringContributionSelected = true,
+            oneTimeContributions = FakeData.oneTimeContributions,
             recurringContributions = FakeData.recurringContributions,
+            purchasedContribution = FakeData.oneTimeContributions.first(),
+            selectedContribution = FakeData.recurringContributions.first(),
         )
         val selectedContribution = FakeData.recurringContributions[2]
 
@@ -71,7 +80,10 @@ private class ContributionRobot(
     private val mviContext: MviContext,
     private val initialState: State = State(),
 ) {
-    private val viewModel = ContributionViewModel(initialState)
+    private val viewModel: ContributionContract.ViewModel = ContributionViewModel(
+        initialState = initialState,
+        billingManager = FakeBillingManager(),
+    )
     private lateinit var turbines: MviTurbines<State, Nothing>
 
     suspend fun initialize() {

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModelTest.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModelTest.kt
@@ -26,6 +26,7 @@ class ContributionViewModelTest {
             recurringContributions = FakeData.recurringContributions,
             purchasedContribution = FakeData.oneTimeContributions.first(),
             selectedContribution = FakeData.recurringContributions[FakeData.recurringContributions.size - 2],
+            showContributionList = true,
         )
 
         contributionRobot(initialState) {
@@ -42,6 +43,7 @@ class ContributionViewModelTest {
             recurringContributions = FakeData.recurringContributions,
             purchasedContribution = FakeData.oneTimeContributions.first(),
             selectedContribution = FakeData.oneTimeContributions[FakeData.oneTimeContributions.size - 2],
+            showContributionList = true,
         )
 
         contributionRobot(initialState) {
@@ -58,6 +60,7 @@ class ContributionViewModelTest {
             recurringContributions = FakeData.recurringContributions,
             purchasedContribution = FakeData.oneTimeContributions.first(),
             selectedContribution = FakeData.recurringContributions[FakeData.oneTimeContributions.size - 2],
+            showContributionList = true,
         )
         val selectedContribution = FakeData.recurringContributions[2]
 
@@ -99,6 +102,7 @@ private class ContributionRobot(
             initialState.copy(
                 isRecurringContributionSelected = false,
                 selectedContribution = initialState.oneTimeContributions[initialState.oneTimeContributions.size - 2],
+                showContributionList = true,
             ),
         )
     }
@@ -113,6 +117,7 @@ private class ContributionRobot(
                 isRecurringContributionSelected = true,
                 selectedContribution = initialState
                     .recurringContributions[initialState.recurringContributions.size - 2],
+                showContributionList = true,
             ),
         )
     }

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/FakeBillingManager.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/FakeBillingManager.kt
@@ -1,0 +1,22 @@
+package app.k9mail.feature.funding.googleplay.ui.contribution
+
+import android.app.Activity
+import app.k9mail.feature.funding.googleplay.domain.DomainContract
+import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
+
+class FakeBillingManager : DomainContract.BillingManager {
+
+    override suspend fun loadOneTimeContributions() = FakeData.oneTimeContributions
+
+    override suspend fun loadRecurringContributions() = FakeData.recurringContributions
+
+    override suspend fun loadPurchasedContributions(): List<Contribution> {
+        return listOf(
+            FakeData.oneTimeContributions.first(),
+        )
+    }
+
+    override suspend fun purchaseContribution(activity: Activity, contribution: Contribution) = Unit
+
+    override fun clear() = Unit
+}

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/FakeBillingManager.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/FakeBillingManager.kt
@@ -16,7 +16,8 @@ class FakeBillingManager : DomainContract.BillingManager {
         )
     }
 
-    override suspend fun purchaseContribution(activity: Activity, contribution: Contribution) = Unit
+    override suspend fun purchaseContribution(activity: Activity, contribution: Contribution) =
+        FakeData.oneTimeContributions.first()
 
     override fun clear() = Unit
 }


### PR DESCRIPTION
This adds the billing client implementation. It is currently limited to one-time purchases. Due to issues with the connectivity state, disconnect is disabled.

To test this, you need to use the `beta` `full` version of the TB app and ensure that it's changed to `debuggable = true` and signed with the release key. Ensure that the account used for the play store app is the same as registered in the licence testing group.

I'm not happy with the current solution, but given the time constraints, it is in a should work state.

Resolves: #8162
