### PR TITLE
Change the drawer account selector to be shown by default

### DIFF
--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -23,7 +23,7 @@ internal interface DrawerContract {
         val selectedAccountUuid: String? = null,
         val folders: ImmutableList<DisplayFolder> = persistentListOf(),
         val selectedFolderId: String? = null,
-        val showAccountSelector: Boolean = false,
+        val showAccountSelector: Boolean = true,
         val isLoading: Boolean = false,
     )
 

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -23,7 +23,7 @@ internal class DrawerStateTest {
                 selectedAccountUuid = null,
                 folders = persistentListOf(),
                 selectedFolderId = null,
-                showAccountSelector = false,
+                showAccountSelector = true,
                 isLoading = false,
             ),
         )

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -368,11 +368,11 @@ internal class DrawerViewModelTest {
 
         testSubject.event(Event.OnAccountSelectorClick)
 
-        assertThat(turbines.awaitStateItem()).isEqualTo(State(showAccountSelector = true))
+        assertThat(turbines.awaitStateItem()).isEqualTo(State(showAccountSelector = false))
 
         testSubject.event(Event.OnAccountSelectorClick)
 
-        assertThat(turbines.awaitStateItem()).isEqualTo(State(showAccountSelector = false))
+        assertThat(turbines.awaitStateItem()).isEqualTo(State(showAccountSelector = true))
     }
 
     @Test


### PR DESCRIPTION
This shows the account selector by default.