### PR TITLE
Use brand name instead of app name in onboarding and account setup screens

### DIFF
--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -3,6 +3,7 @@ package app.k9mail
 import app.k9mail.auth.K9OAuthConfigurationFactory
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
@@ -23,6 +24,7 @@ import com.fsck.k9.provider.UnreadWidgetProvider
 import com.fsck.k9.widget.list.MessageListWidgetProvider
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val appModule = module {
@@ -35,7 +37,7 @@ val appModule = module {
     single(named("ClientInfoAppVersion")) { BuildConfig.VERSION_NAME }
     single<AppConfig> { appConfig }
     single<OAuthConfigurationFactory> { K9OAuthConfigurationFactory() }
-    single<AppNameProvider> { K9AppNameProvider(androidContext()) }
+    single { K9AppNameProvider(androidContext()) } binds arrayOf(AppNameProvider::class, BrandNameProvider::class)
     single<ThemeProvider> { K9ThemeProvider() }
     single<FeatureThemeProvider> { K9FeatureThemeProvider() }
     single<FeatureFlagFactory> { K9FeatureFlagFactory() }

--- a/app-k9mail/src/main/kotlin/app/k9mail/provider/K9AppNameProvider.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/provider/K9AppNameProvider.kt
@@ -2,12 +2,17 @@ package app.k9mail.provider
 
 import android.content.Context
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import com.fsck.k9.R
 
 class K9AppNameProvider(
     context: Context,
-) : AppNameProvider {
+) : AppNameProvider, BrandNameProvider {
     override val appName: String by lazy {
+        context.getString(R.string.app_name)
+    }
+
+    override val brandName: String by lazy {
         context.getString(R.string.app_name)
     }
 }

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -2,6 +2,7 @@ package net.thunderbird.android
 
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.core.ui.theme.api.ThemeProvider
@@ -22,6 +23,7 @@ import net.thunderbird.android.widget.provider.MessageListWidgetProvider
 import net.thunderbird.android.widget.provider.UnreadWidgetProvider
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val appModule = module {
@@ -34,7 +36,7 @@ val appModule = module {
     single(named("ClientInfoAppVersion")) { BuildConfig.VERSION_NAME }
     single<AppConfig> { appConfig }
     single<OAuthConfigurationFactory> { TbOAuthConfigurationFactory() }
-    single<AppNameProvider> { TbAppNameProvider(androidContext()) }
+    single { TbAppNameProvider(androidContext()) } binds arrayOf(AppNameProvider::class, BrandNameProvider::class)
     single<ThemeProvider> { TbThemeProvider() }
     single<FeatureThemeProvider> { TbFeatureThemeProvider() }
     single<FeatureFlagFactory> { TbFeatureFlagFactory() }

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbAppNameProvider.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/provider/TbAppNameProvider.kt
@@ -2,12 +2,17 @@ package net.thunderbird.android.provider
 
 import android.content.Context
 import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import net.thunderbird.android.R
 
 class TbAppNameProvider(
     context: Context,
-) : AppNameProvider {
+) : AppNameProvider, BrandNameProvider {
     override val appName: String by lazy {
         context.getString(R.string.app_name)
+    }
+
+    override val brandName: String by lazy {
+        context.getString(R.string.brand_name)
     }
 }

--- a/app-thunderbird/src/main/res/values/strings.xml
+++ b/app-thunderbird/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name" translatable="false">Thunderbird</string>
+    <string name="brand_name" translatable="false">Thunderbird</string>
 </resources>

--- a/core/common/src/main/kotlin/app/k9mail/core/common/provider/BrandNameProvider.kt
+++ b/core/common/src/main/kotlin/app/k9mail/core/common/provider/BrandNameProvider.kt
@@ -1,0 +1,8 @@
+package app.k9mail.core.common.provider
+
+/**
+ * Provides the brand name, e.g. Thunderbird.
+ */
+interface BrandNameProvider {
+    val brandName: String
+}

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditIncomingServerSettingsNavHost.kt
@@ -58,7 +58,7 @@ fun EditIncomingServerSettingsNavHost(
                 viewModel = koinViewModel<IncomingServerValidationViewModel> {
                     parametersOf(accountUuid)
                 },
-                appNameProvider = koinInject(),
+                brandNameProvider = koinInject(),
             )
         }
         composable(route = NESTED_NAVIGATION_ROUTE_SAVE) {

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/EditOutgoingServerSettingsNavHost.kt
@@ -58,7 +58,7 @@ fun EditOutgoingServerSettingsNavHost(
                 viewModel = koinViewModel<OutgoingServerValidationViewModel> {
                     parametersOf(accountUuid)
                 },
-                appNameProvider = koinInject(),
+                brandNameProvider = koinInject(),
             )
         }
         composable(route = NESTED_NAVIGATION_ROUTE_SAVE) {

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreenPreview.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreenPreview.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
-import app.k9mail.feature.account.server.validation.ui.fake.FakeAppNameProvider
+import app.k9mail.feature.account.server.validation.ui.fake.FakeBrandNameProvider
 import app.k9mail.feature.account.server.validation.ui.fake.FakeIncomingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.fake.FakeOutgoingServerValidationViewModel
 
@@ -16,7 +16,7 @@ internal fun IncomingServerValidationMainScreenPreview() {
             viewModel = FakeIncomingServerValidationViewModel(
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
+            brandNameProvider = FakeBrandNameProvider,
         )
     }
 }
@@ -29,7 +29,7 @@ internal fun OutgoingServerValidationMainScreenPreview() {
             viewModel = FakeOutgoingServerValidationViewModel(
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
+            brandNameProvider = FakeBrandNameProvider,
         )
     }
 }

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenPreview.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenPreview.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
 import app.k9mail.feature.account.server.certificate.data.InMemoryServerCertificateErrorRepository
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
-import app.k9mail.feature.account.server.validation.ui.fake.FakeAppNameProvider
+import app.k9mail.feature.account.server.validation.ui.fake.FakeBrandNameProvider
 import com.fsck.k9.mail.server.ServerSettingsValidationResult
 
 @Composable
@@ -23,7 +23,7 @@ internal fun IncomingServerValidationScreenPreview() {
                 certificateErrorRepository = InMemoryServerCertificateErrorRepository(),
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
+            brandNameProvider = FakeBrandNameProvider,
         )
     }
 }
@@ -42,7 +42,7 @@ internal fun OutgoingServerValidationScreenPreview() {
                 certificateErrorRepository = InMemoryServerCertificateErrorRepository(),
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
+            brandNameProvider = FakeBrandNameProvider,
         )
     }
 }

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/fake/FakeAppNameProvider.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/fake/FakeAppNameProvider.kt
@@ -1,7 +1,0 @@
-package app.k9mail.feature.account.server.validation.ui.fake
-
-import app.k9mail.core.common.provider.AppNameProvider
-
-internal object FakeAppNameProvider : AppNameProvider {
-    override val appName: String = "Fake App Name"
-}

--- a/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/fake/FakeBrandNameProvider.kt
+++ b/feature/account/server/validation/src/debug/kotlin/app/k9mail/feature/account/server/validation/ui/fake/FakeBrandNameProvider.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.account.server.validation.ui.fake
+
+import app.k9mail.core.common.provider.BrandNameProvider
+
+internal object FakeBrandNameProvider : BrandNameProvider {
+    override val brandName: String = "Fake Brand Name"
+}

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationMainScreen.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.account.server.validation.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observeWithoutEffect
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.AppTitleTopHeader
@@ -14,7 +14,7 @@ import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.
 @Composable
 internal fun ServerValidationMainScreen(
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
+    brandNameProvider: BrandNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observeWithoutEffect()
@@ -22,7 +22,7 @@ internal fun ServerValidationMainScreen(
     Scaffold(
         topBar = {
             AppTitleTopHeader(
-                title = appNameProvider.appName,
+                title = brandNameProvider.brandName,
             )
         },
         bottomBar = {

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreen.kt
@@ -4,7 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorScreen
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Effect
@@ -17,7 +17,7 @@ fun ServerValidationScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
+    brandNameProvider: BrandNameProvider,
     modifier: Modifier = Modifier,
     title: String? = null,
 ) {
@@ -52,7 +52,7 @@ fun ServerValidationScreen(
         } else {
             ServerValidationMainScreen(
                 viewModel = viewModel,
-                appNameProvider = appNameProvider,
+                brandNameProvider = brandNameProvider,
                 modifier = modifier,
             )
         }

--- a/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenKtTest.kt
+++ b/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationScreenKtTest.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.account.server.validation.ui
 
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract.Effect
@@ -24,7 +24,7 @@ class ServerValidationScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
+                brandNameProvider = FakeBrandNameProvider,
             )
         }
 
@@ -42,7 +42,7 @@ class ServerValidationScreenKtTest : ComposeTest() {
         assertThat(onBackCounter).isEqualTo(1)
     }
 
-    private object FakeAppNameProvider : AppNameProvider {
-        override val appName: String = "K-9 Mail"
+    private object FakeBrandNameProvider : BrandNameProvider {
+        override val brandName: String = "K-9 Mail"
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContentPreview.kt
@@ -15,7 +15,7 @@ internal fun AccountAutoDiscoveryContentPreview() {
             state = AccountAutoDiscoveryContract.State(),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }
@@ -30,7 +30,7 @@ internal fun AccountAutoDiscoveryContentEmailPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }
@@ -47,7 +47,7 @@ internal fun AccountAutoDiscoveryContentPasswordPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }
@@ -64,7 +64,7 @@ internal fun AccountAutoDiscoveryContentPasswordUntrustedSettingsPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }
@@ -80,7 +80,7 @@ internal fun AccountAutoDiscoveryContentPasswordNoSettingsPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }
@@ -97,7 +97,7 @@ internal fun AccountAutoDiscoveryContentOAuthPreview() {
             ),
             onEvent = {},
             oAuthViewModel = FakeAccountOAuthViewModel(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenPreview.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.ui.compose.common.annotation.PreviewDevicesWithBackground
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.fake.FakeBrandNameProvider
 
 @Composable
 @PreviewDevicesWithBackground
@@ -21,7 +21,7 @@ internal fun AccountAutoDiscoveryScreenPreview() {
                 accountStateRepository = FakeAccountStateRepository(),
                 oAuthViewModel = FakeAccountOAuthViewModel(),
             ),
-            appNameProvider = FakeAppNameProvider,
+            brandNameProvider = FakeBrandNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenPreview.kt
@@ -5,7 +5,7 @@ import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.data.InMemoryAccountStateRepository
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.fake.FakeBrandNameProvider
 
 @Composable
 @PreviewDevices
@@ -18,7 +18,7 @@ internal fun AccountOptionsScreenK9Preview() {
                 createAccount = { AccountCreatorResult.Success("irrelevant") },
                 accountStateRepository = InMemoryAccountStateRepository(),
             ),
-            appNameProvider = FakeAppNameProvider,
+            brandNameProvider = FakeBrandNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/fake/FakeAppNameProvider.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/fake/FakeAppNameProvider.kt
@@ -1,7 +1,0 @@
-package app.k9mail.feature.account.setup.ui.fake
-
-import app.k9mail.core.common.provider.AppNameProvider
-
-internal object FakeAppNameProvider : AppNameProvider {
-    override val appName: String = "Fake App Name"
-}

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/fake/FakeBrandNameProvider.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/fake/FakeBrandNameProvider.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.account.setup.ui.fake
+
+import app.k9mail.core.common.provider.BrandNameProvider
+
+internal object FakeBrandNameProvider : BrandNameProvider {
+    override val brandName: String = "Fake Brand Name"
+}

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContentPreview.kt
@@ -13,7 +13,7 @@ internal fun DisplayOptionsContentPreview() {
             state = DisplayOptionsContract.State(),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenPreview.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.fake.FakeBrandNameProvider
 
 @Composable
 @Preview(showBackground = true)
@@ -18,7 +18,7 @@ internal fun DisplayOptionsScreenPreview() {
                 accountStateRepository = FakeAccountStateRepository(),
                 accountOwnerNameProvider = { null },
             ),
-            appNameProvider = FakeAppNameProvider,
+            brandNameProvider = FakeBrandNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContentPreview.kt
@@ -13,7 +13,7 @@ internal fun SyncOptionsContentPreview() {
             state = SyncOptionsContract.State(),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenPreview.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.feature.account.common.ui.fake.FakeAccountStateRepository
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.fake.FakeBrandNameProvider
 
 @Composable
 @Preview(showBackground = true)
@@ -16,7 +16,7 @@ internal fun SyncOptionsScreenPreview() {
             viewModel = SyncOptionsViewModel(
                 accountStateRepository = FakeAccountStateRepository(),
             ),
-            appNameProvider = FakeAppNameProvider,
+            brandNameProvider = FakeBrandNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContentPreview.kt
@@ -15,7 +15,7 @@ internal fun SpecialFoldersContentLoadingPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }
@@ -30,7 +30,7 @@ internal fun SpecialFoldersContentFormPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }
@@ -46,7 +46,7 @@ internal fun SpecialFoldersContentSuccessPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }
@@ -62,7 +62,7 @@ internal fun SpecialFoldersContentErrorPreview() {
             ),
             onEvent = {},
             contentPadding = PaddingValues(),
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenPreview.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.account.setup.ui.specialfolders
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
-import app.k9mail.feature.account.setup.ui.fake.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.fake.FakeBrandNameProvider
 import app.k9mail.feature.account.setup.ui.specialfolders.fake.FakeSpecialFoldersViewModel
 
 @Composable
@@ -14,7 +14,7 @@ internal fun SpecialFoldersScreenPreview() {
             onNext = {},
             onBack = {},
             viewModel = FakeSpecialFoldersViewModel(),
-            appNameProvider = FakeAppNameProvider,
+            brandNameProvider = FakeBrandNameProvider,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
@@ -66,7 +66,7 @@ fun AccountSetupNavHost(
                 },
                 onBack = onBack,
                 viewModel = koinViewModel<AccountAutoDiscoveryViewModel>(),
-                appNameProvider = koinInject(),
+                brandNameProvider = koinInject(),
             )
         }
 
@@ -96,7 +96,7 @@ fun AccountSetupNavHost(
                 },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<IncomingServerValidationViewModel>(),
-                appNameProvider = koinInject(),
+                brandNameProvider = koinInject(),
             )
         }
 
@@ -127,7 +127,7 @@ fun AccountSetupNavHost(
                 },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<OutgoingServerValidationViewModel>(),
-                appNameProvider = koinInject(),
+                brandNameProvider = koinInject(),
             )
         }
 
@@ -148,7 +148,7 @@ fun AccountSetupNavHost(
                 },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<SpecialFoldersViewModel>(),
-                appNameProvider = koinInject(),
+                brandNameProvider = koinInject(),
             )
         }
 
@@ -157,7 +157,7 @@ fun AccountSetupNavHost(
                 onNext = { navController.navigate(NESTED_NAVIGATION_SYNC_OPTIONS) },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<DisplayOptionsViewModel>(),
-                appNameProvider = koinInject(),
+                brandNameProvider = koinInject(),
             )
         }
 
@@ -166,7 +166,7 @@ fun AccountSetupNavHost(
                 onNext = { navController.navigate(NESTED_NAVIGATION_CREATE_ACCOUNT) },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<SyncOptionsViewModel>(),
-                appNameProvider = koinInject(),
+                brandNameProvider = koinInject(),
             )
         }
 
@@ -175,7 +175,7 @@ fun AccountSetupNavHost(
                 onNext = { accountUuid -> onFinish(accountUuid.value) },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<CreateAccountViewModel>(),
-                appNameProvider = koinInject(),
+                brandNameProvider = koinInject(),
             )
         }
     }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
@@ -39,7 +39,7 @@ internal fun AccountAutoDiscoveryContent(
     state: State,
     onEvent: (Event) -> Unit,
     oAuthViewModel: AccountOAuthContract.ViewModel,
-    appName: String,
+    brandName: String,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -60,7 +60,7 @@ internal fun AccountAutoDiscoveryContent(
                     .imePadding(),
             ) {
                 AppTitleTopHeader(
-                    title = appName,
+                    title = brandName,
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 AutoDiscoveryContent(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreen.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.account.setup.ui.autodiscovery
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.AutoDiscoveryUiResult
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.Effect
@@ -15,7 +15,7 @@ internal fun AccountAutoDiscoveryScreen(
     onNext: (AutoDiscoveryUiResult) -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
+    brandNameProvider: BrandNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -33,7 +33,7 @@ internal fun AccountAutoDiscoveryScreen(
         state = state.value,
         onEvent = { dispatch(it) },
         oAuthViewModel = viewModel.oAuthViewModel,
-        appName = appNameProvider.appName,
+        brandName = brandNameProvider.brandName,
         modifier = modifier,
     )
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreen.kt
@@ -4,7 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.AppTitleTopHeader
@@ -20,7 +20,7 @@ internal fun CreateAccountScreen(
     onNext: (AccountUuid) -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
+    brandNameProvider: BrandNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -41,7 +41,7 @@ internal fun CreateAccountScreen(
     Scaffold(
         topBar = {
             AppTitleTopHeader(
-                title = appNameProvider.appName,
+                title = brandNameProvider.brandName,
             )
         },
         bottomBar = {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
@@ -33,7 +33,7 @@ internal fun DisplayOptionsContent(
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
-    appName: String,
+    brandName: String,
     modifier: Modifier = Modifier,
 ) {
     val resources = LocalContext.current.resources
@@ -54,7 +54,7 @@ internal fun DisplayOptionsContent(
         ) {
             item {
                 AppTitleTopHeader(
-                    title = appName,
+                    title = brandName,
                 )
             }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreen.kt
@@ -4,7 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
@@ -17,7 +17,7 @@ internal fun DisplayOptionsScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
+    brandNameProvider: BrandNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -48,7 +48,7 @@ internal fun DisplayOptionsScreen(
             state = state.value,
             onEvent = { dispatch(it) },
             contentPadding = innerPadding,
-            appName = appNameProvider.appName,
+            brandName = brandNameProvider.brandName,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContent.kt
@@ -36,7 +36,7 @@ internal fun SyncOptionsContent(
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
-    appName: String,
+    brandName: String,
     modifier: Modifier = Modifier,
 ) {
     val resources = LocalContext.current.resources
@@ -57,7 +57,7 @@ internal fun SyncOptionsContent(
         ) {
             item {
                 AppTitleTopHeader(
-                    title = appName,
+                    title = brandName,
                 )
             }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreen.kt
@@ -4,7 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
@@ -17,7 +17,7 @@ internal fun SyncOptionsScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
+    brandNameProvider: BrandNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -48,7 +48,7 @@ internal fun SyncOptionsScreen(
             state = state.value,
             onEvent = { dispatch(it) },
             contentPadding = innerPadding,
-            appName = appNameProvider.appName,
+            brandName = brandNameProvider.brandName,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
@@ -26,7 +26,7 @@ fun SpecialFoldersContent(
     state: State,
     onEvent: (Event) -> Unit,
     contentPadding: PaddingValues,
-    appName: String,
+    brandName: String,
     modifier: Modifier = Modifier,
 ) {
     ResponsiveWidthContainer(
@@ -37,7 +37,7 @@ fun SpecialFoldersContent(
     ) {
         Column {
             AppTitleTopHeader(
-                title = appName,
+                title = brandName,
             )
 
             ContentLoadingErrorView(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreen.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreen.kt
@@ -4,7 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.core.ui.compose.designsystem.template.Scaffold
 import app.k9mail.feature.account.common.ui.WizardNavigationBar
@@ -18,7 +18,7 @@ fun SpecialFoldersScreen(
     onNext: (isManualSetup: Boolean) -> Unit,
     onBack: () -> Unit,
     viewModel: ViewModel,
-    appNameProvider: AppNameProvider,
+    brandNameProvider: BrandNameProvider,
     modifier: Modifier = Modifier,
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
@@ -52,7 +52,7 @@ fun SpecialFoldersScreen(
             state = state.value,
             onEvent = { dispatch(it) },
             contentPadding = innerPadding,
-            appName = appNameProvider.appName,
+            brandName = brandNameProvider.brandName,
         )
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.account.setup
 import android.content.Context
 import app.k9mail.autodiscovery.api.AutoDiscovery
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.feature.account.common.AccountCommonExternalContract
 import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
@@ -14,7 +14,7 @@ import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSett
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.FakeBrandNameProvider
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract
 import app.k9mail.feature.account.setup.ui.createaccount.CreateAccountContract
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract
@@ -66,7 +66,7 @@ class AccountSetupModuleKtTest : KoinTest {
         single<AccountCommonExternalContract.AccountStateLoader> { mock() }
         factory<AccountSetupExternalContract.AccountOwnerNameProvider> { mock() }
         single<List<AutoDiscovery>>(named("extraAutoDiscoveries")) { emptyList() }
-        single<AppNameProvider> { FakeAppNameProvider }
+        single<BrandNameProvider> { FakeBrandNameProvider }
     }
 
     @Test

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/FakeAppNameProvider.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/FakeAppNameProvider.kt
@@ -1,7 +1,0 @@
-package app.k9mail.feature.account.setup.ui
-
-import app.k9mail.core.common.provider.AppNameProvider
-
-internal object FakeAppNameProvider : AppNameProvider {
-    override val appName: String = "Fake App Name"
-}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/FakeBrandNameProvider.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/FakeBrandNameProvider.kt
@@ -1,0 +1,7 @@
+package app.k9mail.feature.account.setup.ui
+
+import app.k9mail.core.common.provider.BrandNameProvider
+
+internal object FakeBrandNameProvider : BrandNameProvider {
+    override val brandName: String = "Fake Brand Name"
+}

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryScreenKtTest.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.account.setup.ui.autodiscovery
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.FakeBrandNameProvider
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.Effect
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.State
 import assertk.assertThat
@@ -25,7 +25,7 @@ class AccountAutoDiscoveryScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
+                brandNameProvider = FakeBrandNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountScreenTest.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.account.setup.ui.createaccount
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import app.k9mail.feature.account.setup.domain.entity.AccountUuid
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.FakeBrandNameProvider
 import app.k9mail.feature.account.setup.ui.createaccount.CreateAccountContract.Effect
 import app.k9mail.feature.account.setup.ui.createaccount.CreateAccountContract.State
 import assertk.assertThat
@@ -31,7 +31,7 @@ class CreateAccountScreenTest : ComposeTest() {
                 onNext = { accountUuid -> navigateNextArguments.add(accountUuid) },
                 onBack = { navigateBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
+                brandNameProvider = FakeBrandNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsScreenKtTest.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.account.setup.ui.options.display
 
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.FakeBrandNameProvider
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Effect
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.State
 import assertk.assertThat
@@ -24,7 +24,7 @@ class DisplayOptionsScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
+                brandNameProvider = FakeBrandNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsScreenKtTest.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.account.setup.ui.options.sync
 
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.FakeBrandNameProvider
 import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsContract.Effect
 import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsContract.State
 import assertk.assertThat
@@ -24,7 +24,7 @@ class SyncOptionsScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
+                brandNameProvider = FakeBrandNameProvider,
             )
         }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersScreenKtTest.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.account.setup.ui.specialfolders
 
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
-import app.k9mail.feature.account.setup.ui.FakeAppNameProvider
+import app.k9mail.feature.account.setup.ui.FakeBrandNameProvider
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersContract.Effect
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersContract.State
 import app.k9mail.feature.account.setup.ui.specialfolders.fake.FakeSpecialFoldersViewModel
@@ -25,7 +25,7 @@ class SpecialFoldersScreenKtTest : ComposeTest() {
                 onNext = { onNextCounter++ },
                 onBack = { onBackCounter++ },
                 viewModel = viewModel,
-                appNameProvider = FakeAppNameProvider,
+                brandNameProvider = FakeBrandNameProvider,
             )
         }
 

--- a/feature/onboarding/migration/thunderbird/src/debug/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreenPreview.kt
+++ b/feature/onboarding/migration/thunderbird/src/debug/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreenPreview.kt
@@ -1,7 +1,7 @@
 package app.k9mail.feature.onboarding.migration.thunderbird
 
 import androidx.compose.runtime.Composable
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.thunderbird.ThunderbirdTheme2
@@ -14,8 +14,8 @@ internal fun TbOnboardingMigrationScreenPreview() {
             TbOnboardingMigrationScreen(
                 onQrCodeScanClick = {},
                 onAddAccountClick = {},
-                appNameProvider = object : AppNameProvider {
-                    override val appName: String = "Thunderbird"
+                brandNameProvider = object : BrandNameProvider {
+                    override val brandName: String = "Thunderbird"
                 },
             )
         }

--- a/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreen.kt
+++ b/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonFilled
 import app.k9mail.core.ui.compose.designsystem.atom.card.CardFilled
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
@@ -29,7 +29,7 @@ internal fun TbOnboardingMigrationScreen(
     onQrCodeScanClick: () -> Unit,
     onAddAccountClick: () -> Unit,
     modifier: Modifier = Modifier,
-    appNameProvider: AppNameProvider = koinInject(),
+    brandNameProvider: BrandNameProvider = koinInject(),
 ) {
     val scrollState = rememberScrollState()
 
@@ -44,7 +44,7 @@ internal fun TbOnboardingMigrationScreen(
                 .verticalScroll(scrollState),
         ) {
             AppTitleTopHeader(
-                title = appNameProvider.appName,
+                title = brandNameProvider.brandName,
             )
 
             Spacer(modifier = Modifier.height(MainTheme.spacings.double))

--- a/feature/onboarding/migration/thunderbird/src/test/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreenKtTest.kt
+++ b/feature/onboarding/migration/thunderbird/src/test/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreenKtTest.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.onboarding.migration.thunderbird
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import assertk.assertThat
@@ -19,7 +19,7 @@ class TbOnboardingMigrationScreenKtTest : ComposeTest() {
             TbOnboardingMigrationScreen(
                 onQrCodeScanClick = { qrCodeScanClickCounter++ },
                 onAddAccountClick = { addAccountClickCounter++ },
-                appNameProvider = FakeAppNameProvider(),
+                brandNameProvider = FakeBrandNameProvider,
             )
         }
 
@@ -39,7 +39,7 @@ class TbOnboardingMigrationScreenKtTest : ComposeTest() {
             TbOnboardingMigrationScreen(
                 onQrCodeScanClick = { qrCodeScanClickCounter++ },
                 onAddAccountClick = { addAccountClickCounter++ },
-                appNameProvider = FakeAppNameProvider(),
+                brandNameProvider = FakeBrandNameProvider,
             )
         }
 
@@ -52,6 +52,6 @@ class TbOnboardingMigrationScreenKtTest : ComposeTest() {
     }
 }
 
-private class FakeAppNameProvider : AppNameProvider {
-    override val appName = "Thunderbird"
+private object FakeBrandNameProvider : BrandNameProvider {
+    override val brandName = "Thunderbird"
 }

--- a/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionContentPreview.kt
+++ b/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionContentPreview.kt
@@ -17,7 +17,7 @@ internal fun PermissionContentPreview() {
                 isNextButtonVisible = false,
             ),
             onEvent = {},
-            appName = "AppName",
+            brandName = "BrandName",
         )
     }
 }

--- a/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionScreenPreview.kt
+++ b/feature/onboarding/permissions/src/debug/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionScreenPreview.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.onboarding.permissions.ui
 
 import androidx.compose.runtime.Composable
 import app.k9mail.core.android.permissions.PermissionState
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import kotlinx.coroutines.Dispatchers
@@ -16,8 +16,8 @@ internal fun PermissionScreenPreview() {
                 checkPermission = { PermissionState.Denied },
                 backgroundDispatcher = Dispatchers.Main.immediate,
             ),
-            appNameProvider = object : AppNameProvider {
-                override val appName: String = "AppName"
+            brandNameProvider = object : BrandNameProvider {
+                override val brandName: String = "BrandName"
             },
             onNext = {},
         )

--- a/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
+++ b/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
@@ -39,7 +39,7 @@ import app.k9mail.feature.account.common.R as CommonR
 internal fun PermissionsContent(
     state: State,
     onEvent: (Event) -> Unit,
-    appName: String,
+    brandName: String,
 ) {
     val scrollState = rememberScrollState()
 
@@ -60,7 +60,7 @@ internal fun PermissionsContent(
                     .fillMaxHeight()
                     .verticalScroll(state = scrollState),
             ) {
-                HeaderArea(appName = appName)
+                HeaderArea(brandName = brandName)
 
                 ContentArea(state, onEvent)
 
@@ -74,13 +74,13 @@ internal fun PermissionsContent(
 
 @Composable
 private fun HeaderArea(
-    appName: String,
+    brandName: String,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         AppTitleTopHeader(
-            title = appName,
+            title = brandName,
         )
 
         TextHeadlineSmall(

--- a/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsScreen.kt
+++ b/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsScreen.kt
@@ -8,7 +8,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import app.k9mail.core.common.provider.AppNameProvider
+import app.k9mail.core.common.provider.BrandNameProvider
 import app.k9mail.core.ui.compose.common.mvi.observe
 import app.k9mail.feature.onboarding.permissions.ui.PermissionsContract.Effect
 import app.k9mail.feature.onboarding.permissions.ui.PermissionsContract.Event
@@ -18,7 +18,7 @@ import org.koin.compose.koinInject
 @Composable
 fun PermissionsScreen(
     viewModel: PermissionsContract.ViewModel = koinViewModel<PermissionsViewModel>(),
-    appNameProvider: AppNameProvider = koinInject(),
+    brandNameProvider: BrandNameProvider = koinInject(),
     onNext: () -> Unit,
 ) {
     val contactsPermissionLauncher = rememberLauncherForActivityResult(RequestPermission()) { success ->
@@ -48,7 +48,7 @@ fun PermissionsScreen(
     PermissionsContent(
         state = state.value,
         onEvent = dispatch,
-        appName = appNameProvider.appName,
+        brandName = brandNameProvider.brandName,
     )
 }
 


### PR DESCRIPTION
Part of #8257