### PR TITLE
Release Automation Improvements

### DIFF
--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -166,7 +166,7 @@ jobs:
             RELEASE_TYPE=release
           fi
 
-          ./gradlew :app-${APP_NAME}:printVersionInfo -PbuildType=${RELEASE_TYPE} -PflavorName=${PACKAGE_FLAVOR}
+          ./gradlew :app-${APP_NAME}:printVersionInfo -PbuildType=${RELEASE_TYPE} -PflavorName=${PACKAGE_FLAVOR} --configure-on-demand
 
       - name: Bump version code
         id: bump_version_code

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -211,7 +211,7 @@ jobs:
           VERSION_CODE: ${{ steps.bump_version_code.outputs.CODE }}
           FULL_VERSION_NAME: ${{ steps.appinfo.outputs.VERSION_NAME }}${{ steps.bump_version_suffix.outputs.SUFFIX || steps.appinfo.outputs.VERSION_NAME_SUFFIX }}
         run: |
-          echo "<h2>${APPLICATION_LABEL} ${FULL_VERSION_NAME} Release Notes </h2><pre>" | tee -a $GITHUB_STEP_SUMMARY
+          echo "<h2>${APPLICATION_LABEL} ${FULL_VERSION_NAME} Release Notes (${VERSION_CODE})</h2><pre>" | tee -a $GITHUB_STEP_SUMMARY
           mkdir -p ./app-metadata/${APPLICATION_ID}/en-US/changelogs
           python ./scripts/render-notes.py ${APPLICATION_ID} ${FULL_VERSION_NAME} ${VERSION_CODE} | tee -a $GITHUB_STEP_SUMMARY
           echo "</pre>" | tee -a $GITHUB_STEP_SUMMARY
@@ -273,6 +273,27 @@ jobs:
           fi
 
           echo "${APP_NAME}_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Summary
+        if: ${{ contains(matrix.releaseTarget, 'github') }}
+        uses: actions/github-script@v7
+        env:
+          bump_sha: ${{ steps.commit.outputs.sha }}
+          applicationId: ${{ steps.appinfo.outputs.APPLICATION_ID }}
+          oldFullVersion: ${{ steps.appinfo.outputs.VERSION_NAME }}${{ steps.appinfo.outputs.VERSION_NAME_SUFFIX }}
+          oldVersionCode: ${{ steps.appinfo.outputs.VERSION_CODE }}
+          newFullVersion: ${{ steps.appinfo.outputs.VERSION_NAME }}${{ steps.bump_version_suffix.outputs.SUFFIX || steps.appinfo.outputs.VERSION_NAME_SUFFIX }}
+          newVersionCode: ${{ steps.bump_version_code.outputs.CODE }}
+        with:
+          script: |
+            let env = process.env;
+            console.log(env);
+            await core.summary
+              .addRaw(`Version for ${env.applicationId} bumped from ${env.oldFullVersion} (${env.oldVersionCode}) to ${env.newFullVersion} (${env.newVersionCode}) in `)
+              .addLink(process.env.bump_sha, `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${env.bump_sha}`)
+              .addEOL()
+              .write();
 
   build_unsigned:
     name: Build Unsigned

--- a/scripts/render-notes.py
+++ b/scripts/render-notes.py
@@ -8,7 +8,15 @@ import yaml
 from jinja2 import Template
 
 
-def render_notes(version, versioncode, application, applicationid):
+def render_notes(
+    version,
+    versioncode,
+    application,
+    applicationid,
+    printonly=False,
+    notesrepo="thunderbird/thunderbird-notes",
+    notesbranch="master",
+):
     """Update changelog files based on release notes from thunderbird-notes."""
     tb_notes_filename = f"{version}.yml"
     tb_notes_directory = "android_release"
@@ -16,8 +24,8 @@ def render_notes(version, versioncode, application, applicationid):
         tb_notes_filename = f"{version[0:-1]}eta.yml"
         tb_notes_directory = "android_beta"
     tb_notes_url = os.path.join(
-        "https://raw.githubusercontent.com/thunderbird/thunderbird-notes/",
-        "refs/heads/master/",
+        f"https://raw.githubusercontent.com/{notesrepo}/",
+        f"refs/heads/{notesbranch}",
         tb_notes_directory,
         tb_notes_filename,
     )
@@ -69,17 +77,37 @@ def render_notes(version, versioncode, application, applicationid):
                             break
                         lines.insert(index + 1, rendered)
                         break
-            with open(render_files[render_file]["outfile"], "w") as file:
-                file.writelines(lines)
+            if not printonly:
+                with open(render_files[render_file]["outfile"], "w") as file:
+                    file.writelines(lines)
         elif render_file == "changelog.txt":
             stripped = rendered.lstrip()
-            with open(render_files[render_file]["outfile"], "w") as file:
-                file.write(stripped)
+            if not printonly:
+                with open(render_files[render_file]["outfile"], "x") as file:
+                    file.write(stripped)
             print(stripped)
 
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--print",
+        "-p",
+        action="store_true",
+        help="Only print the processed release notes",
+    )
+    parser.add_argument(
+        "--repository",
+        "-r",
+        default="thunderbird/thunderbird-notes",
+        help="Repository to retrieve thunderbird-notes from",
+    )
+    parser.add_argument(
+        "--branch",
+        "-b",
+        default="master",
+        help="Branch to retrieve thunderbird-notes from",
+    )
     parser.add_argument(
         "applicationid",
         type=str,
@@ -99,7 +127,15 @@ def main():
     else:
         application = "thunderbird"
 
-    render_notes(args.version, args.versioncode, application, args.applicationid)
+    render_notes(
+        args.version,
+        args.versioncode,
+        application,
+        args.applicationid,
+        printonly=args.print,
+        notesrepo=args.repository,
+        notesbranch=args.branch,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/setup_release_automation
+++ b/scripts/setup_release_automation
@@ -30,15 +30,14 @@ CHANNEL_ENVIRONMENTS = {
                 {
                     "appName": "thunderbird",
                     "releaseTarget": "play",
-                    "playTargetTrack": "internal",  # TODO change this to alpha once ready, final promotion should happen in web ui
+                    "playTargetTrack": "internal",
                     "packageFormat": "aab",
                     "packageFlavor": "full",
                 },
                 {
                     "appName": "k9mail",
                     "releaseTarget": "github|play",
-                    # TODO enable this when ready to publish
-                    # "playTargetTrack": "production",
+                    "playTargetTrack": "internal",
                     "packageFormat": "apk",
                 },
             ],
@@ -58,15 +57,14 @@ CHANNEL_ENVIRONMENTS = {
                 {
                     "appName": "thunderbird",
                     "releaseTarget": "play",
-                    "playTargetTrack": "internal",  # TODO change this to production once ready
+                    "playTargetTrack": "internal",
                     "packageFormat": "aab",
                     "packageFlavor": "full",
                 },
                 {
                     "appName": "k9mail",
                     "releaseTarget": "github|play",
-                    # TODO enable this when ready to publish
-                    # "playTargetTrack": "beta",
+                    "playTargetTrack": "internal",
                     "packageFormat": "apk",
                 },
             ],


### PR DESCRIPTION
* Speed up printVersionInfo by using configure-on-demand
* Allow passing repository and branch to render-notes
* Make sure changelog files are not overwritten in render-notes (catches us using the wrong version code)
* Print-only mode for local testing with render-notes
* Always release to internal testing track so we can promote from there