### PR TITLE
Fix color roles calculation

### DIFF
--- a/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/SelectThemeColorScheme.kt
+++ b/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/SelectThemeColorScheme.kt
@@ -1,5 +1,6 @@
 package app.k9mail.core.ui.compose.theme2
 
+import android.content.Context
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -113,4 +114,21 @@ private fun ColorScheme.toDynamicThemeColorScheme(
     )
 }
 
+data class ColorRoles(
+    val accent: Color,
+    val onAccent: Color,
+    val accentContainer: Color,
+    val onAccentContainer: Color,
+)
+
 fun Color.toHarmonizedColor(target: Color) = Color(MaterialColors.harmonize(toArgb(), target.toArgb()))
+
+fun Color.toColorRoles(context: Context): ColorRoles {
+    val colorRoles = MaterialColors.getColorRoles(context, this.toArgb())
+    return ColorRoles(
+        accent = Color(colorRoles.accent),
+        onAccent = Color(colorRoles.onAccent),
+        accentContainer = Color(colorRoles.accentContainer),
+        onAccentContainer = Color(colorRoles.onAccentContainer),
+    )
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
@@ -14,7 +14,9 @@ import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextLabelSmall
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
+import app.k9mail.core.ui.compose.theme2.ColorRoles
 import app.k9mail.core.ui.compose.theme2.MainTheme
+import app.k9mail.core.ui.compose.theme2.toColorRoles
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.ui.common.labelForCount
 
@@ -24,8 +26,9 @@ internal fun AccountAvatar(
     onClick: (DisplayAccount) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
     val accountColor = calculateAccountColor(account.account.chipColor)
-    val accountColorRoles = ColorRoles.from(accountColor)
+    val accountColorRoles = accountColor.toColorRoles(context)
 
     Box(
         modifier = modifier,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/CalculateAccountColor.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/CalculateAccountColor.kt
@@ -2,11 +2,8 @@ package app.k9mail.feature.navigation.drawer.ui.account
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.core.ui.compose.theme2.toHarmonizedColor
-import com.google.android.material.color.MaterialColors
 
 @Composable
 internal fun calculateAccountColor(accountColor: Int): Color {
@@ -14,26 +11,5 @@ internal fun calculateAccountColor(accountColor: Int): Color {
         MainTheme.colors.primary
     } else {
         Color(accountColor).toHarmonizedColor(MainTheme.colors.surface)
-    }
-}
-
-data class ColorRoles(
-    val accent: Color,
-    val onAccent: Color,
-    val accentContainer: Color,
-    val onAccentContainer: Color,
-) {
-    companion object {
-        @Composable
-        fun from(color: Color): ColorRoles {
-            val context = LocalContext.current
-            val colorRoles = MaterialColors.getColorRoles(context, color.toArgb())
-            return ColorRoles(
-                accent = Color(colorRoles.accent),
-                onAccent = Color(colorRoles.onAccent),
-                accentContainer = Color(colorRoles.accentContainer),
-                onAccentContainer = Color(colorRoles.onAccentContainer),
-            )
-        }
     }
 }


### PR DESCRIPTION
Debug variant includes the Material 3 library, but release not. I moved the `ColorRoles` to the `theme` module where it has access to the `MaterialColors` class for all variants.