### PR TITLE
Move `FolderClass`

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsDescriptions.java
@@ -7,7 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
-import com.fsck.k9.mail.FolderClass;
+import com.fsck.k9.preferences.legacy.FolderClass;
 import com.fsck.k9.preferences.Settings.BooleanSetting;
 import com.fsck.k9.preferences.Settings.EnumSetting;
 import com.fsck.k9.preferences.Settings.SettingsDescription;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/legacy/FolderClass.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/legacy/FolderClass.kt
@@ -1,0 +1,8 @@
+package com.fsck.k9.preferences.legacy
+
+internal enum class FolderClass {
+    NO_CLASS,
+    INHERITED,
+    FIRST_CLASS,
+    SECOND_CLASS,
+}

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo100.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo100.kt
@@ -1,10 +1,10 @@
 package com.fsck.k9.preferences.upgrader
 
 import app.k9mail.legacy.account.Account.FolderMode
-import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.preferences.CombinedSettingsUpgrader
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings
+import com.fsck.k9.preferences.legacy.FolderClass
 
 class CombinedSettingsUpgraderTo100 : CombinedSettingsUpgrader {
     override fun upgrade(account: ValidatedSettings.Account): ValidatedSettings.Account {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo96.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo96.kt
@@ -1,10 +1,10 @@
 package com.fsck.k9.preferences.upgrader
 
 import app.k9mail.legacy.account.Account.FolderMode
-import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.preferences.CombinedSettingsUpgrader
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings
+import com.fsck.k9.preferences.legacy.FolderClass
 
 class CombinedSettingsUpgraderTo96 : CombinedSettingsUpgrader {
     override fun upgrade(account: ValidatedSettings.Account): ValidatedSettings.Account {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo98.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo98.kt
@@ -1,10 +1,10 @@
 package com.fsck.k9.preferences.upgrader
 
 import app.k9mail.legacy.account.Account.FolderMode
-import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.preferences.CombinedSettingsUpgrader
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings
+import com.fsck.k9.preferences.legacy.FolderClass
 
 class CombinedSettingsUpgraderTo98 : CombinedSettingsUpgrader {
     override fun upgrade(account: ValidatedSettings.Account): ValidatedSettings.Account {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo99.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo99.kt
@@ -1,10 +1,10 @@
 package com.fsck.k9.preferences.upgrader
 
 import app.k9mail.legacy.account.Account.FolderMode
-import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.preferences.CombinedSettingsUpgrader
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings
+import com.fsck.k9.preferences.legacy.FolderClass
 
 class CombinedSettingsUpgraderTo99 : CombinedSettingsUpgrader {
     override fun upgrade(account: ValidatedSettings.Account): ValidatedSettings.Account {

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo100Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo100Test.kt
@@ -3,9 +3,9 @@ package com.fsck.k9.preferences.upgrader
 import app.k9mail.legacy.account.Account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
-import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings
+import com.fsck.k9.preferences.legacy.FolderClass
 import kotlin.test.Test
 
 class CombinedSettingsUpgraderTo100Test {

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo96Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo96Test.kt
@@ -3,9 +3,9 @@ package com.fsck.k9.preferences.upgrader
 import app.k9mail.legacy.account.Account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
-import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings
+import com.fsck.k9.preferences.legacy.FolderClass
 import kotlin.test.Test
 
 class CombinedSettingsUpgraderTo96Test {

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo98Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo98Test.kt
@@ -3,9 +3,9 @@ package com.fsck.k9.preferences.upgrader
 import app.k9mail.legacy.account.Account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
-import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings
+import com.fsck.k9.preferences.legacy.FolderClass
 import kotlin.test.Test
 
 class CombinedSettingsUpgraderTo98Test {

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo99Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo99Test.kt
@@ -3,9 +3,9 @@ package com.fsck.k9.preferences.upgrader
 import app.k9mail.legacy.account.Account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
-import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings
+import com.fsck.k9.preferences.legacy.FolderClass
 import kotlin.test.Test
 
 class CombinedSettingsUpgraderTo99Test {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo70.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo70.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.storage.migrations
 
 import android.database.sqlite.SQLiteDatabase
-import com.fsck.k9.mail.FolderClass
 
 internal class MigrationTo70(private val db: SQLiteDatabase) {
     fun removePushState() {
@@ -32,7 +31,7 @@ internal class MigrationTo70(private val db: SQLiteDatabase) {
                 "poll_class TEXT, " +
                 "push_class TEXT, " +
                 "display_class TEXT, " +
-                "notify_class TEXT default '" + FolderClass.INHERITED.name + "', " +
+                "notify_class TEXT default 'INHERITED', " +
                 "more_messages TEXT default \"unknown\", " +
                 "server_id TEXT, " +
                 "local_only INTEGER, " +

--- a/mail/common/src/main/java/com/fsck/k9/mail/FolderClass.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/FolderClass.java
@@ -1,5 +1,0 @@
-package com.fsck.k9.mail;
-
-public enum FolderClass {
-    NO_CLASS, INHERITED, FIRST_CLASS, SECOND_CLASS
-}


### PR DESCRIPTION
`FolderClass` is now only used in settings migration code. So move it next to that code.