### PR TITLE
Ignore `.idea/inspectionProfiles/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ out/
 # IDEA/Android Studio includes
 !.idea/icon.png
 !.idea/codeStyles/
-!.idea/inspectionProfiles/
 !.idea/fileTemplates/
 
 # Android Studio captures folder


### PR DESCRIPTION
Lately Android Studio insists that I need have a project-specific inspection profile. But to me it doesn't look like something we need to share between developers.