### PR TITLE
Avoid race condition in release automation and fix display

### DIFF
--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -324,8 +324,8 @@ jobs:
 
           # Ready to commit. Make sure to pull again to reduce likelihood of race conditions
           git status
-          git pull
           git commit -m "Release: ${APPLICATION_LABEL} ${FULL_VERSION_NAME}"
+          git pull --rebase -X ours
           git log -n 5
 
           set +e
@@ -337,6 +337,7 @@ jobs:
             echo "Push rejected, trying again once in 5 seconds"
             sleep 5
             git pull --rebase -X ours
+            git log -n 5
             git push
           fi
 
@@ -840,7 +841,7 @@ jobs:
           matrixRoomId: ${{ vars.MATRIX_NOTIFY_ROOM }}
           matrixToken: ${{ secrets.MATRIX_NOTIFY_TOKEN }}
           message: >-
-            ${{ needs.publish_release.k9mail_full_version_name }} [is available](${{ needs.publish_release.outputs.k9mail_release_url }})
+            ${{ needs.publish_release.outputs.k9mail_full_version_name }} [is available](${{ needs.publish_release.outputs.k9mail_release_url }})
 
       - name: Notify Success (Daily)
         if: ${{ vars.MATRIX_NOTIFY_ROOM && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.dump_config.outputs.releaseType == 'daily' && steps.last_status.outputs.last_status == 'failure' }}


### PR DESCRIPTION
This better avoids a race condition, and also the case where the order of release commits is not strictly tb -> k9 -> tb