### PR TITLE
Fix spotless being slow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Please ensure that your pull request meets the following requirements - thanks!
 - Does not contain merge commits. Rebase instead.
 - Contains commits with descriptive titles.
 - New code is written in Kotlin whenever possible.
-- Follows our existing codestyle (`gradlew spotlessCheck` to check and `gradlew spotlessFormat` to format your source code; will be checked by CI).
+- Follows our existing codestyle (`gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
 - Does not break any unit tests (`gradlew testDebugUnitTest`; will be checked by CI).
 - Uses a descriptive title; don't put issue numbers in there.
 - Contains a reference to the issue that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_) in the body text.

--- a/build-plugin/src/main/kotlin/SpotlessExtension.kt
+++ b/build-plugin/src/main/kotlin/SpotlessExtension.kt
@@ -1,0 +1,67 @@
+import com.diffplug.gradle.spotless.SpotlessExtension
+import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.Project
+
+fun SpotlessExtension.configureKotlinCheck(
+    targets: List<String>,
+    project: Project,
+    libs: LibrariesForLibs,
+) {
+    kotlin {
+        ktlint(libs.versions.ktlint.get())
+            .setEditorConfigPath("${project.rootProject.projectDir}/.editorconfig")
+            .editorConfigOverride(kotlinEditorConfigOverride)
+        target(targets)
+        targetExclude(
+            "**/build/",
+        )
+    }
+}
+
+fun SpotlessExtension.configureKotlinGradleCheck(
+    targets: List<String>,
+    project: Project,
+    libs: LibrariesForLibs,
+) {
+    kotlinGradle {
+        ktlint(libs.versions.ktlint.get())
+            .setEditorConfigPath("${project.rootProject.projectDir}/.editorconfig")
+            .editorConfigOverride(
+                mapOf(
+                    "ktlint_standard_function-signature" to "disabled",
+                )
+            )
+        target(targets)
+        targetExclude("**/build/")
+    }
+}
+
+fun SpotlessExtension.configureMarkdownCheck(
+    targets: List<String>,
+) {
+    format("markdown") {
+        prettier()
+        target(targets)
+        targetExclude(
+            "**/build/",
+        )
+    }
+}
+
+fun SpotlessExtension.configureMiscCheck() {
+    format("misc") {
+        target(
+            "*.gradle",
+            ".gitignore",
+        )
+        trimTrailingWhitespace()
+    }
+}
+
+val kotlinEditorConfigOverride = mapOf(
+    "ktlint_function_naming_ignore_when_annotated_with" to "Composable",
+    "ktlint_standard_property-naming" to "disabled",
+    "ktlint_standard_function-signature" to "disabled",
+    "ktlint_standard_parameter-list-spacing" to "disabled",
+    "ktlint_ignore_back_ticked_identifier" to "true",
+)

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("thunderbird.app.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.spotless")
 }
 
 android {

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.spotless")
 }
 
 android {

--- a/build-plugin/src/main/kotlin/thunderbird.app.jvm.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.jvm.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("application")
     id("org.jetbrains.kotlin.jvm")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.spotless")
 }
 
 java {

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.spotless")
 }
 
 android {

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.spotless")
 }
 
 android {

--- a/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     `java-library`
     id("org.jetbrains.kotlin.jvm")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.spotless")
 }
 
 java {

--- a/build-plugin/src/main/kotlin/thunderbird.quality.spotless.root.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.quality.spotless.root.gradle.kts
@@ -5,24 +5,17 @@ plugins {
 }
 
 configure<SpotlessExtension> {
-    configureKotlinCheck(
-        targets = listOf(
-            "*.kt",
-        ),
-        project = project,
-        libs = libs,
-    )
-
     configureKotlinGradleCheck(
         targets = listOf(
             "*.gradle.kts",
+            "build-plugin/**/*.gradle.kts",
         ),
         project = project,
         libs = libs,
     )
 
     configureMarkdownCheck(
-        listOf(
+        targets = listOf(
             "*.md",
         ),
     )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
 
-    id("thunderbird.quality.spotless")
+    id("thunderbird.quality.spotless.root")
     id("thunderbird.dependency.check")
 }
 

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpIntentStarter.kt
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpIntentStarter.kt
@@ -6,7 +6,6 @@ import android.app.ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
 import android.content.IntentSender
 import android.os.Build
 import android.os.Bundle
-import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 
 /**
@@ -21,10 +20,14 @@ object OpenPgpIntentStarter {
 
         activity.startIntentSender(
             intentSender,
-            /* fillInIntent = */ null,
-            /* flagsMask = */ 0,
-            /* flagsValues = */ 0,
-            /* extraFlags = */ 0,
+            /* fillInIntent = */
+            null,
+            /* flagsMask = */
+            0,
+            /* flagsValues = */
+            0,
+            /* extraFlags = */
+            0,
             options,
         )
     }
@@ -37,10 +40,14 @@ object OpenPgpIntentStarter {
         activity.startIntentSenderForResult(
             intentSender,
             requestCode,
-            /* fillInIntent = */ null,
-            /* flagsMask = */ 0,
-            /* flagsValues = */ 0,
-            /* extraFlags = */ 0,
+            /* fillInIntent = */
+            null,
+            /* flagsMask = */
+            0,
+            /* flagsValues = */
+            0,
+            /* extraFlags = */
+            0,
             options,
         )
     }
@@ -54,10 +61,14 @@ object OpenPgpIntentStarter {
         fragment.startIntentSenderForResult(
             intentSender,
             requestCode,
-            /* fillInIntent = */ null,
-            /* flagsMask = */ 0,
-            /* flagsValues = */ 0,
-            /* extraFlags = */ 0,
+            /* fillInIntent = */
+            null,
+            /* flagsMask = */
+            0,
+            /* flagsValues = */
+            0,
+            /* extraFlags = */
+            0,
             options,
         )
     }


### PR DESCRIPTION
This limits the scope of Spotless to the module it is applied to. This greatly improves the check and formatting speed. With version 7.0.0 of Spotless the configuration cache is better supported providing an additional boost. But that is currently in beta and not included yet in this changes.

Resolves #8362