### PR TITLE
Exclude build directories in `SpotlessExtension.configureMiscCheck()`

### DIFF
--- a/build-plugin/src/main/kotlin/SpotlessExtension.kt
+++ b/build-plugin/src/main/kotlin/SpotlessExtension.kt
@@ -54,6 +54,9 @@ fun SpotlessExtension.configureMiscCheck() {
             "*.gradle",
             ".gitignore",
         )
+        targetExclude(
+            "**/build/",
+        )
         trimTrailingWhitespace()
     }
 }


### PR DESCRIPTION
This seems to fix the problem described in https://github.com/thunderbird/thunderbird-android/pull/8395#issuecomment-2434983339