### PR TITLE
Change Gmail OAuth setup

### DIFF
--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -233,6 +233,10 @@ dependencies {
     implementation(projects.feature.onboarding.migration.thunderbird)
     implementation(projects.feature.migration.launcher.thunderbird)
 
+    // TODO remove once OAuth ids have been moved from TBD to TBA
+    "betaImplementation"(libs.appauth)
+    releaseImplementation(libs.appauth)
+
     testImplementation(libs.robolectric)
 
     // Required for DependencyInjectionTest to be able to resolve OpenPgpApiManager

--- a/app-thunderbird/src/beta/AndroidManifest.xml
+++ b/app-thunderbird/src/beta/AndroidManifest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?><!-- TODO remove once OAuth ids have been moved from TBD to TBA -->
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:installLocation="auto"
+    >
+
+    <application>
+        <activity
+            android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            android:exported="true"
+            >
+
+            <!-- The library's default intent filter with `appAuthRedirectScheme` replaced by `applicationId` -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="${applicationId}" />
+                <data android:scheme="${applicationId}.desktop" />
+            </intent-filter>
+
+            <!-- Microsoft uses a special redirect URI format for Android apps -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="${applicationId}"
+                    android:scheme="msauth"
+                    />
+            </intent-filter>
+        </activity>
+
+    </application>
+</manifest>

--- a/app-thunderbird/src/beta/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/beta/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -42,6 +42,7 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
         )
     }
 
+    // TODO: Update clientId and redirectUri once new client ID is available
     private fun createGmailConfiguration(): Pair<List<String>, OAuthConfiguration> {
         return listOf(
             "imap.gmail.com",
@@ -49,11 +50,11 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
             "smtp.gmail.com",
             "smtp.googlemail.com",
         ) to OAuthConfiguration(
-            clientId = "406964657835-c88sdh5fpqjhavlje1bs9ac9tf8qv5c2.apps.googleusercontent.com",
+            clientId = "406964657835-808044gjdn5vac6dsn99jtka3v8igtle.apps.googleusercontent.com",
             scopes = listOf("https://mail.google.com/"),
             authorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth",
             tokenEndpoint = "https://oauth2.googleapis.com/token",
-            redirectUri = "${BuildConfig.APPLICATION_ID}:/oauth2redirect",
+            redirectUri = "${BuildConfig.APPLICATION_ID}.desktop:/oauth2redirect",
         )
     }
 

--- a/app-thunderbird/src/daily/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/daily/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -49,7 +49,7 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
             "smtp.gmail.com",
             "smtp.googlemail.com",
         ) to OAuthConfiguration(
-            clientId = "406964657835-2bpeeeb9mqlpg0mca8digjdv40m5ja8e.apps.googleusercontent.com",
+            clientId = "560629489500-hbru1fssmec60eoa22b8k8l5tbmj0sc1.apps.googleusercontent.com",
             scopes = listOf("https://mail.google.com/"),
             authorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth",
             tokenEndpoint = "https://oauth2.googleapis.com/token",

--- a/app-thunderbird/src/release/AndroidManifest.xml
+++ b/app-thunderbird/src/release/AndroidManifest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?><!-- TODO remove once OAuth ids have been moved from TBD to TBA -->
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:installLocation="auto"
+    >
+
+    <application>
+        <activity
+            android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            android:exported="true"
+            >
+
+            <!-- The library's default intent filter with `appAuthRedirectScheme` replaced by `applicationId` -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="${applicationId}" />
+                <data android:scheme="${applicationId}.desktop" />
+            </intent-filter>
+
+            <!-- Microsoft uses a special redirect URI format for Android apps -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="${applicationId}"
+                    android:scheme="msauth"
+                    />
+            </intent-filter>
+        </activity>
+
+    </application>
+</manifest>

--- a/app-thunderbird/src/release/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/release/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -42,6 +42,7 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
         )
     }
 
+    // TODO: Update clientId and redirectUri once new client ID is available
     private fun createGmailConfiguration(): Pair<List<String>, OAuthConfiguration> {
         return listOf(
             "imap.gmail.com",
@@ -49,11 +50,11 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
             "smtp.gmail.com",
             "smtp.googlemail.com",
         ) to OAuthConfiguration(
-            clientId = "406964657835-7e8ersi8i85g742ksqdh0mtgpps3rvoq.apps.googleusercontent.com",
+            clientId = "406964657835-pq5dckrt5j6ijkicfp2jf4vdhesncql6.apps.googleusercontent.com",
             scopes = listOf("https://mail.google.com/"),
             authorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth",
             tokenEndpoint = "https://oauth2.googleapis.com/token",
-            redirectUri = "${BuildConfig.APPLICATION_ID}:/oauth2redirect",
+            redirectUri = "${BuildConfig.APPLICATION_ID}.desktop:/oauth2redirect",
         )
     }
 


### PR DESCRIPTION
This adds new Gmail OAuth client ids to allow migration from the TB desktop (TBD) project to the TB Android (TBA) project.
With this, the configuration for `beta` and `release` could coexist in TBD and TBA. We could migrate from one to the other if needed.

Debug:
- Is already on TBA

Daily:
- Use the new client id from TBA

Beta:
- Change the client id to a dedicated desktop version with the `desktop` namespace
- This should allow us to migrate users from the old client id to this intermediate id. 
- Once enough users migrated we could delete the old client id from TBD and create a new one in TBA using the proper package id.

Release:
- Change the client id to a dedicated desktop version with the `desktop` namespace
- This should give us options to do a production release when TBA is not ready yet and migrate later.
- If TBA is ready in time we could switch before releasing the first version.
