### PR TITLE
Disable language split for Thunderbird's AAB

### DIFF
--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -174,6 +174,14 @@ android {
         }
     }
 
+    @Suppress("UnstableApiUsage")
+    bundle {
+        language {
+            // Don't split by language. Otherwise our in-app language switcher won't work.
+            enableSplit = false
+        }
+    }
+
     packaging {
         jniLibs {
             excludes += listOf("kotlin/**")


### PR DESCRIPTION
Don't split by language. Otherwise our in-app language switcher won't work.

Fixes #8200