### PR TITLE
Limit folder drawer width

### DIFF
--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -3,10 +3,13 @@ package app.k9mail.feature.navigation.drawer.ui
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
@@ -16,6 +19,10 @@ import app.k9mail.feature.navigation.drawer.ui.account.AccountView
 import app.k9mail.feature.navigation.drawer.ui.folder.FolderList
 import app.k9mail.feature.navigation.drawer.ui.setting.SettingList
 
+// As long as we use DrawerLayout, we don't have to worry about screens narrower than DRAWER_WIDTH. DrawerLayout will
+// automatically limit the width of the content view so there's still room for a scrim with minimum tap width.
+private val DRAWER_WIDTH = 360.dp
+
 @Composable
 internal fun DrawerContent(
     state: State,
@@ -24,7 +31,8 @@ internal fun DrawerContent(
 ) {
     Surface(
         modifier = modifier
-            .fillMaxSize()
+            .width(DRAWER_WIDTH)
+            .fillMaxHeight()
             .testTag("DrawerContent"),
     ) {
         val selectedAccount = state.accounts.firstOrNull { it.uuid == state.selectedAccountUuid }

--- a/feature/navigation/drawer/src/main/res/layout/navigation_drawer_content.xml
+++ b/feature/navigation/drawer/src/main/res/layout/navigation_drawer_content.xml
@@ -2,7 +2,7 @@
 <androidx.compose.ui.platform.ComposeView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@id/navigation_drawer_content"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     />


### PR DESCRIPTION
Limit drawer width to the 360dp from the Material 3 spec. https://m3.material.io/components/navigation-drawer/specs

Fixes #8392