### PR TITLE
Change app name sent via the IMAP ID command

### DIFF
--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -78,7 +78,7 @@ android {
             ),
         )
 
-        buildConfigField("String", "CLIENT_INFO_APP_NAME", "\"Thunderbird\"")
+        buildConfigField("String", "CLIENT_INFO_APP_NAME", "\"Thunderbird for Android\"")
     }
 
     signingConfigs {


### PR DESCRIPTION
Use "Thunderbird for Android" to allow email providers to easily distinguish between Thunderbird and Thunderbird for Android.