### PR TITLE
Disable Unified Inbox if there's only one account

### DIFF
--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
@@ -9,6 +9,7 @@ import app.k9mail.feature.account.setup.AccountSetupExternalContract
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
 import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import com.fsck.k9.Core
+import com.fsck.k9.K9
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.logging.Timber
@@ -78,6 +79,11 @@ class AccountCreator(
         newAccount.markSetupFinished()
 
         preferences.saveAccount(newAccount)
+
+        if (preferences.getAccounts().size > 1) {
+            K9.isShowUnifiedInbox = true
+            K9.saveSettingsAsync()
+        }
 
         Core.setServicesEnabled(context)
 

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -198,7 +198,7 @@ object K9 : KoinComponent {
     var isUseVolumeKeysForNavigation = false
 
     @JvmStatic
-    var isShowUnifiedInbox = true
+    var isShowUnifiedInbox = false
 
     @JvmStatic
     var isShowStarredCount = false
@@ -328,7 +328,7 @@ object K9 : KoinComponent {
         isSensitiveDebugLoggingEnabled = storage.getBoolean("enableSensitiveLogging", false)
         isShowAnimations = storage.getBoolean("animations", true)
         isUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false)
-        isShowUnifiedInbox = storage.getBoolean("showUnifiedInbox", true)
+        isShowUnifiedInbox = storage.getBoolean("showUnifiedInbox", false)
         isShowStarredCount = storage.getBoolean("showStarredCount", false)
         isMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false)
         isShowMessageListStars = storage.getBoolean("messageListStars", true)

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -171,7 +171,8 @@ class GeneralSettingsDescriptions {
                 new V(1, new BooleanSetting(true))
         ));
         s.put("showUnifiedInbox", Settings.versions(
-                new V(69, new BooleanSetting(true))
+                new V(69, new BooleanSetting(true)),
+                new V(101, new BooleanSetting(false))
         ));
         s.put("sortTypeEnum", Settings.versions(
                 new V(10, new EnumSetting<>(SortType.class, Account.DEFAULT_SORT_TYPE))

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -33,7 +33,7 @@ class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 100;
+    public static final int VERSION = 101;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription<?>>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {


### PR DESCRIPTION

- Disable Unified Inbox by default.
- Enable Unified Inbox Automatically when Additional Account Included .

Fixes #7556 
