### PR TITLE
Fix K-9 release branch

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -52,8 +52,8 @@ android {
         applicationId = "com.fsck.k9"
         testApplicationId = "com.fsck.k9.tests"
 
-        versionCode = 39009
-        versionName = "8.0"
+        versionCode = 39010
+        versionName = "8.0.1"
 
         // Keep in sync with the resource string array "supported_languages"
         resourceConfigurations.addAll(

--- a/metadata
+++ b/metadata
@@ -1,1 +1,1 @@
-app-metadata/net.thunderbird.android
+app-metadata/com.fsck.k9


### PR DESCRIPTION
* Change the metadata link, just in case release automation fails again we could pre-set it.
* Prepare for a K-9 Mail build of 8.0.1. We used 39009 for 8.0, 39010 for 8.0b5, the next bump will take it to 39011.