### PR TITLE
Extract chip initials from display name

### DIFF
--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
@@ -50,7 +50,7 @@ internal fun AccountAvatar(
                     .border(2.dp, MainTheme.colors.surfaceContainerLowest, CircleShape),
             ) {
                 Placeholder(
-                    email = account.account.email,
+                    displayName = account.account.displayName,
                 )
                 // TODO: Add image loading
             }
@@ -64,11 +64,11 @@ internal fun AccountAvatar(
 
 @Composable
 private fun Placeholder(
-    email: String,
+    displayName: String,
     modifier: Modifier = Modifier,
 ) {
     TextTitleMedium(
-        text = extractDomainInitials(email).uppercase(),
+        text = extractNameInitials(displayName).uppercase(),
         modifier = modifier,
     )
 }
@@ -102,6 +102,6 @@ private fun UnreadBadge(
     }
 }
 
-private fun extractDomainInitials(email: String): String {
-    return email.split("@")[1].take(2)
+private fun extractNameInitials(displayName: String): String {
+    return displayName.take(2)
 }


### PR DESCRIPTION
Fixes #8381 

The chip abbreviation is extracted from display name different parts splitting by special characters if present or taking two first letters simply, giving more possible combinations by default and also allowing the user customizes it through account name on general settings.

I think we should take into consideration some of the suggestions shared on this and related issues to future enhancements like add a picture option #8238 or full name below chip https://github.com/thunderbird/thunderbird-android/issues/8381#issuecomment-2453493668