### PR TITLE
Center align text on all button variants

### DIFF
--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonElevatedPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonElevatedPreview.kt
@@ -26,3 +26,14 @@ internal fun ButtonElevatedDisabledPreview() {
         )
     }
 }
+
+@Composable
+@Preview(showBackground = true)
+internal fun ButtonElevatedMultiLinePreview() {
+    PreviewWithThemes {
+        ButtonElevated(
+            text = "First\nSecond line",
+            onClick = {},
+        )
+    }
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilledPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilledPreview.kt
@@ -17,7 +17,7 @@ internal fun ButtonFilledPreview() {
 
 @Composable
 @Preview(showBackground = true)
-internal fun ButtonFilledlDisabledPreview() {
+internal fun ButtonFilledDisabledPreview() {
     PreviewWithThemes {
         ButtonFilled(
             text = "Button Filled Disabled",

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilledPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilledPreview.kt
@@ -26,3 +26,14 @@ internal fun ButtonFilledDisabledPreview() {
         )
     }
 }
+
+@Composable
+@Preview(showBackground = true)
+internal fun ButtonFilledMultiLinePreview() {
+    PreviewWithThemes {
+        ButtonFilled(
+            text = "First\nSecond line",
+            onClick = {},
+        )
+    }
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilledTonalPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilledTonalPreview.kt
@@ -26,3 +26,14 @@ internal fun ButtonFilledTonalDisabledPreview() {
         )
     }
 }
+
+@Composable
+@Preview(showBackground = true)
+internal fun ButtonFilledTonalMultiLinePreview() {
+    PreviewWithThemes {
+        ButtonFilledTonal(
+            text = "First\nSecond line",
+            onClick = {},
+        )
+    }
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlinedPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlinedPreview.kt
@@ -26,3 +26,14 @@ internal fun ButtonOutlinedDisabledPreview() {
         )
     }
 }
+
+@Composable
+@Preview(showBackground = true)
+internal fun ButtonOutlinedMultiLinePreview() {
+    PreviewWithThemes {
+        ButtonOutlined(
+            text = "First\nSecond line",
+            onClick = {},
+        )
+    }
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonTextPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonTextPreview.kt
@@ -39,3 +39,14 @@ internal fun ButtonTextDisabledPreview() {
         )
     }
 }
+
+@Composable
+@Preview(showBackground = true)
+internal fun ButtonTextMultiLinePreview() {
+    PreviewWithThemes {
+        ButtonText(
+            text = "First\nSecond line",
+            onClick = {},
+        )
+    }
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonElevated.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonElevated.kt
@@ -2,6 +2,7 @@ package app.k9mail.core.ui.compose.designsystem.atom.button
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.material3.ElevatedButton as Material3ElevatedButton
 import androidx.compose.material3.Text as Material3Text
 
@@ -17,6 +18,9 @@ fun ButtonElevated(
         modifier = modifier,
         enabled = enabled,
     ) {
-        Material3Text(text = text)
+        Material3Text(
+            text = text,
+            textAlign = TextAlign.Center,
+        )
     }
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilled.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilled.kt
@@ -20,7 +20,7 @@ fun ButtonFilled(
     ) {
         Material3Text(
             text = text,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilledTonalButton.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilledTonalButton.kt
@@ -2,6 +2,7 @@ package app.k9mail.core.ui.compose.designsystem.atom.button
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.material3.FilledTonalButton as Material3FilledTonalButton
 import androidx.compose.material3.Text as Material3Text
 
@@ -17,6 +18,9 @@ fun ButtonFilledTonal(
         modifier = modifier,
         enabled = enabled,
     ) {
-        Material3Text(text = text)
+        Material3Text(
+            text = text,
+            textAlign = TextAlign.Center,
+        )
     }
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlined.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlined.kt
@@ -2,6 +2,7 @@ package app.k9mail.core.ui.compose.designsystem.atom.button
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.material3.OutlinedButton as Material3OutlinedButton
 import androidx.compose.material3.Text as Material3Text
 
@@ -17,6 +18,9 @@ fun ButtonOutlined(
         modifier = modifier,
         enabled = enabled,
     ) {
-        Material3Text(text = text)
+        Material3Text(
+            text = text,
+            textAlign = TextAlign.Center,
+        )
     }
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonText.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonText.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import androidx.compose.material3.Text as Material3Text
 import androidx.compose.material3.TextButton as Material3TextButton
@@ -24,6 +25,9 @@ fun ButtonText(
             contentColor = color ?: MainTheme.colors.primary,
         ),
     ) {
-        Material3Text(text = text)
+        Material3Text(
+            text = text,
+            textAlign = TextAlign.Center,
+        )
     }
 }


### PR DESCRIPTION
Apply the change from #8457 to all button variants.