### PR TITLE
Fix need info workflow

### DIFF
--- a/.github/workflows/needinfo-remove.yml
+++ b/.github/workflows/needinfo-remove.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: |
+      contains(github.event.issue.labels.*.name, 'status: needs information') &&
       github.event.comment.author_association != 'OWNER' &&
       github.event.comment.author_association != 'MEMBER' &&
       github.event.comment.author_association != 'COLLABORATOR'


### PR DESCRIPTION
Prevents the workflow from running if there is no `status: needs information` label.