### PR TITLE
Remove `ExternalStorageProvider` support from `LockableDatabase`

### DIFF
--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -46,13 +46,6 @@ class Account(
     @set:Synchronized
     var oAuthState: String? = null
 
-    /**
-     * Storage provider ID, used to locate and manage the underlying DB/file storage.
-     */
-    @get:Synchronized
-    @set:Synchronized
-    var localStorageProviderId: String? = null
-
     @get:Synchronized
     @set:Synchronized
     override var name: String? = null

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -20,13 +20,11 @@ import app.k9mail.legacy.notification.NotificationSettings
 import app.k9mail.legacy.notification.NotificationVibration
 import app.k9mail.legacy.notification.VibratePattern
 import com.fsck.k9.helper.Utility
-import com.fsck.k9.mailstore.StorageManager
 import com.fsck.k9.preferences.Storage
 import com.fsck.k9.preferences.StorageEditor
 import timber.log.Timber
 
 class AccountPreferenceSerializer(
-    private val storageManager: StorageManager,
     private val resourceProvider: CoreResourceProvider,
     private val serverSettingsSerializer: ServerSettingsSerializer,
 ) {
@@ -42,10 +40,6 @@ class AccountPreferenceSerializer(
                 storage.getString("$accountUuid.$OUTGOING_SERVER_SETTINGS_KEY", ""),
             )
             oAuthState = storage.getString("$accountUuid.oAuthState", null)
-            localStorageProviderId = storage.getString(
-                "$accountUuid.localStorageProvider",
-                storageManager.defaultProviderId,
-            )
             name = storage.getString("$accountUuid.description", null)
             alwaysBcc = storage.getString("$accountUuid.alwaysBcc", alwaysBcc)
             automaticCheckIntervalMinutes = storage.getInt(
@@ -278,7 +272,6 @@ class AccountPreferenceSerializer(
                 serverSettingsSerializer.serialize(outgoingServerSettings),
             )
             editor.putString("$accountUuid.oAuthState", oAuthState)
-            editor.putString("$accountUuid.localStorageProvider", localStorageProviderId)
             editor.putString("$accountUuid.description", name)
             editor.putString("$accountUuid.alwaysBcc", alwaysBcc)
             editor.putInt("$accountUuid.automaticCheckIntervalMinutes", automaticCheckIntervalMinutes)
@@ -468,7 +461,6 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.defaultQuotedTextShown")
         editor.remove("$accountUuid.displayCount")
         editor.remove("$accountUuid.inboxFolderName")
-        editor.remove("$accountUuid.localStorageProvider")
         editor.remove("$accountUuid.messageFormat")
         editor.remove("$accountUuid.messageReadReceipt")
         editor.remove("$accountUuid.notifyMailCheck")
@@ -570,7 +562,6 @@ class AccountPreferenceSerializer(
 
     fun loadDefaults(account: Account) {
         with(account) {
-            localStorageProviderId = storageManager.defaultProviderId
             automaticCheckIntervalMinutes = DEFAULT_SYNC_INTERVAL
             idleRefreshMinutes = 24
             displayCount = K9.DEFAULT_VISIBLE_LIMIT

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -189,30 +189,15 @@ public class LocalStore {
         SchemaDefinition schemaDefinition = schemaDefinitionFactory.createSchemaDefinition(migrationsHelper);
 
         database = new LockableDatabase(context, account.getUuid(), schemaDefinition);
-        database.setStorageProviderId(account.getLocalStorageProviderId());
         database.open();
 
         Clock clock = DI.get(Clock.class);
         outboxStateRepository = new OutboxStateRepository(database, clock);
-
-        // If "External storage" is selected as storage location, move database to internal storage
-        //TODO: Remove this code after 2020-12-31.
-        // If the database is still on external storage after this date, we'll just ignore it and create a new one on
-        // internal storage.
-        if (!InternalStorageProvider.ID.equals(account.getLocalStorageProviderId())) {
-            switchLocalStorage(InternalStorageProvider.ID);
-            account.setLocalStorageProviderId(InternalStorageProvider.ID);
-            getPreferences().saveAccount(account);
-        }
     }
 
     public static int getDbVersion() {
         SchemaDefinitionFactory schemaDefinitionFactory = DI.get(SchemaDefinitionFactory.class);
         return schemaDefinitionFactory.getDatabaseVersion();
-    }
-
-    public void switchLocalStorage(final String newStorageProviderId) throws MessagingException {
-        database.switchProvider(newStorageProviderId);
     }
 
     Account getAccount() {

--- a/legacy/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -37,7 +37,6 @@ val coreNotificationModule = module {
     }
     single {
         AccountPreferenceSerializer(
-            storageManager = get(),
             resourceProvider = get(),
             serverSettingsSerializer = get(),
         )

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import android.content.Context;
@@ -24,7 +23,6 @@ import com.fsck.k9.AccountPreferenceSerializer;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.core.R;
-import com.fsck.k9.mailstore.StorageManager;
 import com.fsck.k9.preferences.Settings.BooleanSetting;
 import com.fsck.k9.preferences.Settings.ColorSetting;
 import com.fsck.k9.preferences.Settings.EnumSetting;
@@ -119,9 +117,6 @@ class AccountSettingsDescriptions {
         s.put("ledColor", Settings.versions(
                 new V(1, new ColorSetting(0xFF0000FF)),
                 new V(80, null)
-        ));
-        s.put("localStorageProvider", Settings.versions(
-                new V(1, new StorageProviderSetting())
         ));
         s.put("markMessageAsReadOnView", Settings.versions(
                 new V(7, new BooleanSetting(true))
@@ -404,29 +399,6 @@ class AccountSettingsDescriptions {
         public String fromString(String value) {
             //TODO: add validation
             return value;
-        }
-    }
-
-    private static class StorageProviderSetting extends SettingsDescription<String> {
-        private final Context context = DI.get(Context.class);
-
-        StorageProviderSetting() {
-            super(null);
-        }
-
-        @Override
-        public String getDefaultValue() {
-            return StorageManager.getInstance(context).getDefaultProviderId();
-        }
-
-        @Override
-        public String fromString(String value) {
-            StorageManager storageManager = StorageManager.getInstance(context);
-            Set<String> providers = storageManager.getAvailableProviders();
-            if (providers.contains(value)) {
-                return value;
-            }
-            throw new RuntimeException("Validation failed");
         }
     }
 

--- a/legacy/core/src/test/java/com/fsck/k9/PreferencesTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/PreferencesTest.kt
@@ -17,7 +17,6 @@ class PreferencesTest {
         storagePersister = InMemoryStoragePersister(),
         localStoreProvider = mock(),
         accountPreferenceSerializer = AccountPreferenceSerializer(
-            storageManager = mock(),
             resourceProvider = mock(),
             serverSettingsSerializer = mock {
                 on { serialize(any()) } doReturn ""


### PR DESCRIPTION
In the distant past K-9 Mail allowed the user to store the message database on external storage. We've stopped allowing this a very long time ago. But we've kept the code to move the message database from external storage to internal storage when users update from old K-9 Mail versions.

This change removes that migration code. That means when updating from very old K-9 Mail versions, accounts that store the message database on external storage will start over with an empty message database. I doubt this will be a problem in practice. It's not an issue at all for Thunderbird, since it never supported storing the message database on external storage.

Removing this code will eliminate one possible cause for #8516.