### PR TITLE
Always listen to push enabled changes in push-capable accounts

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
@@ -206,12 +206,7 @@ class PushController internal constructor(
             pushers.isNotEmpty()
         }
 
-        val potentialPushAccounts = if (shouldDisablePushAccounts) {
-            emptySet()
-        } else {
-            getPushCapableAccounts()
-        }
-        updatePushEnabledListeners(potentialPushAccounts)
+        updatePushEnabledListeners(getPushCapableAccounts())
 
         when {
             realPushAccounts.isEmpty() -> {


### PR DESCRIPTION
This ensures `PushService` is started as soon as there is one folder with push enabled. If the conditions to actually use push are not met (missing permission, no network, etc.), the push service notification will display the reason for it to the user.

Steps to test:
1. Set up an IMAP account
2. Go to *Manage folders → Inbox* and turn on *Enable Push*

The push service notification should be displayed. On Android 13+ the "Missing permission to schedule alarms" message should be displayed in the notification.