### PR TITLE
Fix of "QR code import does not update unified inbox"

### DIFF
--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
@@ -9,7 +9,6 @@ import app.k9mail.feature.account.setup.AccountSetupExternalContract
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
 import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import com.fsck.k9.Core
-import com.fsck.k9.K9
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.logging.Timber
@@ -21,6 +20,7 @@ import com.fsck.k9.mail.store.imap.ImapStoreSettings.isUseCompression
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.pathPrefix
 import com.fsck.k9.mailstore.SpecialFolderUpdater
 import com.fsck.k9.mailstore.SpecialLocalFoldersCreator
+import com.fsck.k9.preferences.UnifiedInboxConfigurator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -35,6 +35,7 @@ class AccountCreator(
     private val messagingController: MessagingController,
     private val deletePolicyProvider: DeletePolicyProvider,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val unifiedInboxConfigurator: UnifiedInboxConfigurator,
 ) : AccountSetupExternalContract.AccountCreator {
 
     @Suppress("TooGenericExceptionCaught")
@@ -81,10 +82,7 @@ class AccountCreator(
 
         preferences.saveAccount(newAccount)
 
-        if (preferences.getAccounts().size > 1) {
-            K9.isShowUnifiedInbox = true
-            K9.saveSettingsAsync()
-        }
+        unifiedInboxConfigurator.configureUnifiedInbox()
 
         Core.setServicesEnabled(context)
 

--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountModule.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountModule.kt
@@ -29,6 +29,7 @@ val newAccountModule = module {
             context = androidApplication(),
             deletePolicyProvider = get(),
             messagingController = get(),
+            unifiedInboxConfigurator = get(),
         )
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
@@ -57,6 +57,8 @@ val preferencesModule = module {
         )
     }
 
+    factory { UnifiedInboxConfigurator(accountManager = get()) }
+
     factory {
         SettingsImporter(
             settingsFileParser = get(),
@@ -66,6 +68,7 @@ val preferencesModule = module {
             accountSettingsUpgrader = get(),
             generalSettingsWriter = get(),
             accountSettingsWriter = get(),
+            unifiedInboxConfigurator = get(),
         )
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -9,6 +9,7 @@ import com.fsck.k9.preferences.Settings.InvalidSettingValueException
 import java.io.InputStream
 import timber.log.Timber
 
+@Suppress("LongParameterList")
 class SettingsImporter internal constructor(
     private val settingsFileParser: SettingsFileParser,
     private val generalSettingsValidator: GeneralSettingsValidator,
@@ -17,6 +18,7 @@ class SettingsImporter internal constructor(
     private val accountSettingsUpgrader: AccountSettingsUpgrader,
     private val generalSettingsWriter: GeneralSettingsWriter,
     private val accountSettingsWriter: AccountSettingsWriter,
+    private val unifiedInboxConfigurator: UnifiedInboxConfigurator,
 ) {
     /**
      * Parses an import [InputStream] and returns information on whether it contains global settings and/or account
@@ -98,6 +100,10 @@ class SettingsImporter internal constructor(
 
                     erroneousAccounts.add(AccountDescription(account.name!!, account.uuid))
                 }
+            }
+
+            if (!globalSettingsImported) {
+                unifiedInboxConfigurator.configureUnifiedInbox()
             }
 
             return ImportResults(globalSettingsImported, importedAccounts, erroneousAccounts)

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/UnifiedInboxConfigurator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/UnifiedInboxConfigurator.kt
@@ -1,0 +1,18 @@
+package com.fsck.k9.preferences
+
+import app.k9mail.legacy.account.AccountManager
+import com.fsck.k9.K9
+
+/**
+ * Configures the unified inbox after an account has been added.
+ */
+class UnifiedInboxConfigurator(
+    private val accountManager: AccountManager,
+) {
+    fun configureUnifiedInbox() {
+        if (accountManager.getAccounts().size > 1) {
+            K9.isShowUnifiedInbox = true
+            K9.saveSettingsAsync()
+        }
+    }
+}


### PR DESCRIPTION
-  Currently QR import doesn't update Unified inbox value to true if , after importing account , account number > 1.
This PR fixes the issue.

- Fixes #8531 

