### PR TITLE
Fix drawer not updating on account changes

### DIFF
--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
@@ -30,7 +30,7 @@ internal fun DrawerContentWithAccountPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(DISPLAY_ACCOUNT),
-                selectedAccountId = DISPLAY_ACCOUNT.uuid,
+                selectedAccountId = DISPLAY_ACCOUNT.id,
                 folders = persistentListOf(),
             ),
             onEvent = {},
@@ -67,7 +67,7 @@ internal fun DrawerContentWithSelectedFolderPreview() {
                 accounts = persistentListOf(
                     DISPLAY_ACCOUNT,
                 ),
-                selectedAccountId = DISPLAY_ACCOUNT.uuid,
+                selectedAccountId = DISPLAY_ACCOUNT.id,
                 folders = persistentListOf(
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,
@@ -88,7 +88,7 @@ internal fun DrawerContentWithSelectedUnifiedFolderPreview() {
                 accounts = persistentListOf(
                     DISPLAY_ACCOUNT,
                 ),
-                selectedAccountId = DISPLAY_ACCOUNT.uuid,
+                selectedAccountId = DISPLAY_ACCOUNT.id,
                 folders = persistentListOf(
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContentPreview.kt
@@ -15,7 +15,7 @@ internal fun DrawerContentPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(),
-                selectedAccountUuid = null,
+                selectedAccountId = null,
                 folders = persistentListOf(),
             ),
             onEvent = {},
@@ -30,7 +30,7 @@ internal fun DrawerContentWithAccountPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(DISPLAY_ACCOUNT),
-                selectedAccountUuid = DISPLAY_ACCOUNT.uuid,
+                selectedAccountId = DISPLAY_ACCOUNT.uuid,
                 folders = persistentListOf(),
             ),
             onEvent = {},
@@ -47,7 +47,7 @@ internal fun DrawerContentWithFoldersPreview() {
                 accounts = persistentListOf(
                     DISPLAY_ACCOUNT,
                 ),
-                selectedAccountUuid = null,
+                selectedAccountId = null,
                 folders = persistentListOf(
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,
@@ -67,7 +67,7 @@ internal fun DrawerContentWithSelectedFolderPreview() {
                 accounts = persistentListOf(
                     DISPLAY_ACCOUNT,
                 ),
-                selectedAccountUuid = DISPLAY_ACCOUNT.uuid,
+                selectedAccountId = DISPLAY_ACCOUNT.uuid,
                 folders = persistentListOf(
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,
@@ -88,7 +88,7 @@ internal fun DrawerContentWithSelectedUnifiedFolderPreview() {
                 accounts = persistentListOf(
                     DISPLAY_ACCOUNT,
                 ),
-                selectedAccountUuid = DISPLAY_ACCOUNT.uuid,
+                selectedAccountId = DISPLAY_ACCOUNT.uuid,
                 folders = persistentListOf(
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
@@ -48,7 +48,7 @@ internal object FakeData {
     )
 
     val DISPLAY_FOLDER = DisplayAccountFolder(
-        accountUuid = ACCOUNT_UUID,
+        accountId = ACCOUNT_UUID,
         folder = FOLDER,
         isInTopGroup = false,
         unreadMessageCount = 14,

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
@@ -1,5 +1,7 @@
 package app.k9mail.feature.navigation.drawer.ui
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
@@ -35,7 +37,10 @@ internal object FakeData {
     }
 
     val DISPLAY_ACCOUNT = DisplayAccount(
-        account = ACCOUNT,
+        id = ACCOUNT_UUID,
+        name = DISPLAY_NAME,
+        email = EMAIL_ADDRESS,
+        color = Color.Red.toArgb(),
         unreadMessageCount = 0,
         starredMessageCount = 0,
     )

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
@@ -22,7 +22,7 @@ internal data class FolderDrawerState(
 
 class FolderDrawer(
     override val parent: AppCompatActivity,
-    private val openAccount: (account: Account) -> Unit,
+    private val openAccount: (accountId: String) -> Unit,
     private val openFolder: (folderId: Long) -> Unit,
     private val openUnifiedFolder: () -> Unit,
     private val openManageFolders: () -> Unit,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -17,7 +17,7 @@ internal interface DomainContract {
         }
 
         fun interface GetDisplayFoldersForAccount {
-            operator fun invoke(accountUuid: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>>
+            operator fun invoke(accountId: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>>
         }
 
         /**

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccount.kt
@@ -1,11 +1,10 @@
 package app.k9mail.feature.navigation.drawer.domain.entity
 
-import app.k9mail.legacy.account.Account
-
 internal data class DisplayAccount(
-    val account: Account,
+    val id: String,
+    val name: String,
+    val email: String,
+    val color: Int,
     val unreadMessageCount: Int,
     val starredMessageCount: Int,
-) {
-    val uuid: String = account.uuid
-}
+)

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/DisplayAccountFolder.kt
@@ -3,15 +3,15 @@ package app.k9mail.feature.navigation.drawer.domain.entity
 import app.k9mail.core.mail.folder.api.Folder
 
 internal data class DisplayAccountFolder(
-    val accountUuid: String,
+    val accountId: String,
     val folder: Folder,
     val isInTopGroup: Boolean,
     override val unreadMessageCount: Int,
     override val starredMessageCount: Int,
 ) : DisplayFolder {
-    override val id: String = createDisplayAccountFolderId(accountUuid, folder.id)
+    override val id: String = createDisplayAccountFolderId(accountId, folder.id)
 }
 
-fun createDisplayAccountFolderId(accountUuid: String, folderId: Long): String {
-    return "${accountUuid}_$folderId"
+fun createDisplayAccountFolderId(accountId: String, folderId: Long): String {
+    return "${accountId}_$folderId"
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayAccounts.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayAccounts.kt
@@ -37,7 +37,10 @@ internal class GetDisplayAccounts(
                 combine(messageCountsFlows) { messageCountsList ->
                     messageCountsList.mapIndexed { index, messageCounts ->
                         DisplayAccount(
-                            account = accounts[index],
+                            id = accounts[index].uuid,
+                            name = accounts[index].displayName,
+                            email = accounts[index].email,
+                            color = accounts[index].chipColor,
                             unreadMessageCount = messageCounts.unread,
                             starredMessageCount = messageCounts.starred,
                         )

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
@@ -17,11 +17,11 @@ internal class GetDisplayFoldersForAccount(
     private val repository: DisplayFolderRepository,
     private val messageCountsProvider: MessageCountsProvider,
 ) : UseCase.GetDisplayFoldersForAccount {
-    override fun invoke(accountUuid: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>> {
-        return repository.getDisplayFoldersFlow(accountUuid).map { displayFolders ->
+    override fun invoke(accountId: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>> {
+        return repository.getDisplayFoldersFlow(accountId).map { displayFolders ->
             displayFolders.map { displayFolder ->
                 DisplayAccountFolder(
-                    accountUuid = accountUuid,
+                    accountId = accountId,
                     folder = displayFolder.folder,
                     isInTopGroup = displayFolder.isInTopGroup,
                     unreadMessageCount = displayFolder.unreadMessageCount,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -35,7 +35,7 @@ internal fun DrawerContent(
             .fillMaxHeight()
             .testTag("DrawerContent"),
     ) {
-        val selectedAccount = state.accounts.firstOrNull { it.uuid == state.selectedAccountId }
+        val selectedAccount = state.accounts.firstOrNull { it.id == state.selectedAccountId }
         Column {
             selectedAccount?.let {
                 AccountView(

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -35,7 +35,7 @@ internal fun DrawerContent(
             .fillMaxHeight()
             .testTag("DrawerContent"),
     ) {
-        val selectedAccount = state.accounts.firstOrNull { it.uuid == state.selectedAccountUuid }
+        val selectedAccount = state.accounts.firstOrNull { it.uuid == state.selectedAccountId }
         Column {
             selectedAccount?.let {
                 AccountView(

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -20,7 +20,7 @@ internal interface DrawerContract {
             showStarredCount = false,
         ),
         val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
-        val selectedAccountUuid: String? = null,
+        val selectedAccountId: String? = null,
         val folders: ImmutableList<DisplayFolder> = persistentListOf(),
         val selectedFolderId: String? = null,
         val showAccountSelector: Boolean = true,
@@ -28,7 +28,7 @@ internal interface DrawerContract {
     )
 
     sealed interface Event {
-        data class SelectAccount(val accountUuid: String?) : Event
+        data class SelectAccount(val accountId: String?) : Event
         data class SelectFolder(val folderId: String?) : Event
         data class OnAccountClick(val account: DisplayAccount) : Event
         data class OnAccountViewClick(val account: DisplayAccount) : Event

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -5,7 +5,6 @@ import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
-import app.k9mail.legacy.account.Account
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -41,7 +40,7 @@ internal interface DrawerContract {
     }
 
     sealed interface Effect {
-        data class OpenAccount(val account: Account) : Effect
+        data class OpenAccount(val accountId: String) : Effect
         data class OpenFolder(val folderId: Long) : Effect
         data object OpenUnifiedFolder : Effect
         data object OpenManageFolders : Effect

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerView.kt
@@ -8,13 +8,12 @@ import app.k9mail.feature.navigation.drawer.FolderDrawerState
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.ViewModel
-import app.k9mail.legacy.account.Account
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
 internal fun DrawerView(
     drawerState: FolderDrawerState,
-    openAccount: (account: Account) -> Unit,
+    openAccount: (accountId: String) -> Unit,
     openFolder: (folderId: Long) -> Unit,
     openUnifiedFolder: () -> Unit,
     openManageFolders: () -> Unit,
@@ -24,7 +23,7 @@ internal fun DrawerView(
 ) {
     val (state, dispatch) = viewModel.observe { effect ->
         when (effect) {
-            is Effect.OpenAccount -> openAccount(effect.account)
+            is Effect.OpenAccount -> openAccount(effect.accountId)
             is Effect.OpenFolder -> openFolder(effect.folderId)
             Effect.OpenUnifiedFolder -> openUnifiedFolder()
             is Effect.OpenManageFolders -> openManageFolders()

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -61,13 +61,13 @@ internal class DrawerViewModel(
     }
 
     private fun updateAccounts(accounts: List<DisplayAccount>) {
-        val selectedAccount = accounts.find { it.uuid == state.value.selectedAccountId }
+        val selectedAccount = accounts.find { it.id == state.value.selectedAccountId }
             ?: accounts.firstOrNull()
 
         updateState {
             it.copy(
                 accounts = accounts.toImmutableList(),
-                selectedAccountId = selectedAccount?.uuid,
+                selectedAccountId = selectedAccount?.id,
             )
         }
     }
@@ -139,7 +139,7 @@ internal class DrawerViewModel(
 
     private fun openAccount(account: DisplayAccount?) {
         if (account != null) {
-            emitEffect(Effect.OpenAccount(account.uuid))
+            emitEffect(Effect.OpenAccount(account.id))
         }
     }
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -61,13 +61,13 @@ internal class DrawerViewModel(
     }
 
     private fun updateAccounts(accounts: List<DisplayAccount>) {
-        val selectedAccount = accounts.find { it.uuid == state.value.selectedAccountUuid }
+        val selectedAccount = accounts.find { it.uuid == state.value.selectedAccountId }
             ?: accounts.firstOrNull()
 
         updateState {
             it.copy(
                 accounts = accounts.toImmutableList(),
-                selectedAccountUuid = selectedAccount?.uuid,
+                selectedAccountId = selectedAccount?.uuid,
             )
         }
     }
@@ -75,13 +75,13 @@ internal class DrawerViewModel(
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun loadFolders() {
         state.map {
-            it.selectedAccountUuid?.let { accountUuid ->
-                Pair(accountUuid, it.config.showUnifiedFolders)
+            it.selectedAccountId?.let { accountId ->
+                Pair(accountId, it.config.showUnifiedFolders)
             }
         }.filterNotNull()
             .distinctUntilChanged()
-            .flatMapLatest { (accountUuid, showUnifiedInbox) ->
-                getDisplayFoldersForAccount(accountUuid, showUnifiedInbox)
+            .flatMapLatest { (accountId, showUnifiedInbox) ->
+                getDisplayFoldersForAccount(accountId, showUnifiedInbox)
             }.collectLatest { folders ->
                 updateFolders(folders)
             }
@@ -102,7 +102,7 @@ internal class DrawerViewModel(
 
     override fun event(event: Event) {
         when (event) {
-            is Event.SelectAccount -> selectAccount(event.accountUuid)
+            is Event.SelectAccount -> selectAccount(event.accountId)
             is Event.SelectFolder -> selectFolder(event.folderId)
 
             is Event.OnAccountClick -> openAccount(event.account)
@@ -121,10 +121,10 @@ internal class DrawerViewModel(
         }
     }
 
-    private fun selectAccount(accountUuid: String?) {
+    private fun selectAccount(accountId: String?) {
         updateState {
             it.copy(
-                selectedAccountUuid = accountUuid,
+                selectedAccountId = accountId,
             )
         }
     }
@@ -168,14 +168,14 @@ internal class DrawerViewModel(
     }
 
     private fun onSyncAccount() {
-        if (state.value.isLoading || state.value.selectedAccountUuid == null) return
+        if (state.value.isLoading || state.value.selectedAccountId == null) return
 
         viewModelScope.launch {
             updateState {
                 it.copy(isLoading = true)
             }
 
-            state.value.selectedAccountUuid?.let { syncAccount(it).collect() }
+            state.value.selectedAccountId?.let { syncAccount(it).collect() }
 
             updateState {
                 it.copy(isLoading = false)

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -139,7 +139,7 @@ internal class DrawerViewModel(
 
     private fun openAccount(account: DisplayAccount?) {
         if (account != null) {
-            emitEffect(Effect.OpenAccount(account.account))
+            emitEffect(Effect.OpenAccount(account.uuid))
         }
     }
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
@@ -28,7 +28,7 @@ internal fun AccountAvatar(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val accountColor = calculateAccountColor(account.account.chipColor)
+    val accountColor = calculateAccountColor(account.color)
     val accountColorRoles = accountColor.toColorRoles(context)
 
     Box(
@@ -50,7 +50,7 @@ internal fun AccountAvatar(
                     .border(2.dp, MainTheme.colors.surfaceContainerLowest, CircleShape),
             ) {
                 Placeholder(
-                    displayName = account.account.displayName,
+                    displayName = account.name,
                 )
                 // TODO: Add image loading
             }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountList.kt
@@ -45,7 +45,7 @@ internal fun AccountList(
             ) {
                 items(
                     items = accounts,
-                    key = { account -> account.account.uuid },
+                    key = { account -> account.id },
                 ) { account ->
                     if (selectedAccount != null && account == selectedAccount) {
                         return@items

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
@@ -65,7 +65,7 @@ internal fun AccountView(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             AccountIndicator(
-                accountColor = account.account.chipColor,
+                accountColor = account.color,
                 modifier = Modifier
                     .fillMaxHeight()
                     .padding(end = MainTheme.spacings.oneHalf),
@@ -74,11 +74,11 @@ internal fun AccountView(
                 verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
             ) {
                 TextBodyLarge(
-                    text = account.account.displayName,
+                    text = account.name,
                     color = MainTheme.colors.onSurface,
                 )
                 TextBodyMedium(
-                    text = account.account.email,
+                    text = account.email,
                     color = MainTheme.colors.onSurfaceVariant,
                 )
             }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerStateTest.kt
@@ -20,7 +20,7 @@ internal class DrawerStateTest {
                     showStarredCount = false,
                 ),
                 accounts = persistentListOf(),
-                selectedAccountUuid = null,
+                selectedAccountId = null,
                 folders = persistentListOf(),
                 selectedFolderId = null,
                 showAccountSelector = true,

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewKtTest.kt
@@ -40,7 +40,7 @@ internal class DrawerViewKtTest : ComposeTest() {
 
         assertThat(counter).isEqualTo(verifyCounter)
 
-        viewModel.effect(Effect.OpenAccount(FakeData.ACCOUNT))
+        viewModel.effect(Effect.OpenAccount(FakeData.DISPLAY_ACCOUNT.id))
 
         verifyCounter.openAccountCount++
         assertThat(counter).isEqualTo(verifyCounter)

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -64,7 +64,7 @@ internal class DrawerViewModelTest {
     fun `should change loading state when OnSyncAccount event is received`() = runMviTest {
         val initialState = State(
             accounts = listOf(DISPLAY_ACCOUNT).toImmutableList(),
-            selectedAccountUuid = DISPLAY_ACCOUNT.uuid,
+            selectedAccountId = DISPLAY_ACCOUNT.uuid,
         )
         val testSubject = createTestSubject(
             initialState = initialState,
@@ -84,7 +84,7 @@ internal class DrawerViewModelTest {
 
     @Test
     fun `should skip loading when no account is selected and OnSyncAccount event is received`() = runMviTest {
-        val initialState = State(selectedAccountUuid = null)
+        val initialState = State(selectedAccountId = null)
         var counter = 0
         val testSubject = createTestSubject(
             initialState = initialState,
@@ -187,7 +187,7 @@ internal class DrawerViewModelTest {
 
         assertThat(testSubject.state.value.accounts.size).isEqualTo(displayAccounts.size)
         assertThat(testSubject.state.value.accounts).isEqualTo(displayAccounts)
-        assertThat(testSubject.state.value.selectedAccountUuid).isEqualTo(displayAccounts.first().uuid)
+        assertThat(testSubject.state.value.selectedAccountId).isEqualTo(displayAccounts.first().uuid)
     }
 
     @Test
@@ -207,7 +207,7 @@ internal class DrawerViewModelTest {
 
         assertThat(testSubject.state.value.accounts.size).isEqualTo(newDisplayAccounts.size)
         assertThat(testSubject.state.value.accounts).isEqualTo(newDisplayAccounts)
-        assertThat(testSubject.state.value.selectedAccountUuid).isEqualTo(newDisplayAccounts.first().uuid)
+        assertThat(testSubject.state.value.selectedAccountId).isEqualTo(newDisplayAccounts.first().uuid)
     }
 
     @Test
@@ -220,7 +220,7 @@ internal class DrawerViewModelTest {
         advanceUntilIdle()
 
         assertThat(testSubject.state.value.accounts.size).isEqualTo(0)
-        assertThat(testSubject.state.value.selectedAccountUuid).isEqualTo(null)
+        assertThat(testSubject.state.value.selectedAccountId).isEqualTo(null)
     }
 
     @Test
@@ -234,7 +234,7 @@ internal class DrawerViewModelTest {
             testSubject,
             State(
                 accounts = displayAccounts.toImmutableList(),
-                selectedAccountUuid = displayAccounts.first().uuid,
+                selectedAccountId = displayAccounts.first().uuid,
             ),
         )
 
@@ -305,7 +305,7 @@ internal class DrawerViewModelTest {
         val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
         val initialState = State(
             accounts = displayAccounts.toImmutableList(),
-            selectedAccountUuid = displayAccounts[0].uuid,
+            selectedAccountId = displayAccounts[0].uuid,
             folders = displayFoldersMap[displayAccounts[0].account.uuid]!!.toImmutableList(),
             selectedFolderId = displayFoldersMap[displayAccounts[0].account.uuid]!![0].id,
         )
@@ -339,7 +339,7 @@ internal class DrawerViewModelTest {
             val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
             val initialState = State(
                 accounts = displayAccounts.toImmutableList(),
-                selectedAccountUuid = displayAccounts[0].account.uuid,
+                selectedAccountId = displayAccounts[0].account.uuid,
                 folders = displayFoldersMap[displayAccounts[0].account.uuid]!!.toImmutableList(),
                 selectedFolderId = displayFoldersMap[displayAccounts[0].account.uuid]!![0].id,
             )
@@ -411,8 +411,8 @@ internal class DrawerViewModelTest {
             initialState = initialState,
             getDrawerConfig = { drawerConfigFlow },
             getDisplayAccounts = { displayAccountsFlow },
-            getDisplayFoldersForAccount = { accountUuid, _ ->
-                displayFoldersFlow.map { it[accountUuid] ?: emptyList() }
+            getDisplayFoldersForAccount = { accountid, _ ->
+                displayFoldersFlow.map { it[accountid] ?: emptyList() }
             },
             syncAccount = { syncAccountFlow },
             syncAllAccounts = { syncAllAccounts },
@@ -468,7 +468,7 @@ internal class DrawerViewModelTest {
     }
 
     private fun createDisplayFolder(
-        accountUuid: String = "uuid",
+        accountId: String = "uuid",
         id: Long = 1234,
         name: String = "name",
         type: FolderType = FolderType.REGULAR,
@@ -483,7 +483,7 @@ internal class DrawerViewModelTest {
         )
 
         return DisplayAccountFolder(
-            accountUuid = accountUuid,
+            accountId = accountId,
             folder = folder,
             isInTopGroup = false,
             unreadMessageCount = unreadCount,

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -17,8 +17,6 @@ import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
 import app.k9mail.feature.navigation.drawer.ui.FakeData.DISPLAY_ACCOUNT
-import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Identity
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
@@ -64,7 +62,7 @@ internal class DrawerViewModelTest {
     fun `should change loading state when OnSyncAccount event is received`() = runMviTest {
         val initialState = State(
             accounts = listOf(DISPLAY_ACCOUNT).toImmutableList(),
-            selectedAccountId = DISPLAY_ACCOUNT.uuid,
+            selectedAccountId = DISPLAY_ACCOUNT.id,
         )
         val testSubject = createTestSubject(
             initialState = initialState,
@@ -187,7 +185,7 @@ internal class DrawerViewModelTest {
 
         assertThat(testSubject.state.value.accounts.size).isEqualTo(displayAccounts.size)
         assertThat(testSubject.state.value.accounts).isEqualTo(displayAccounts)
-        assertThat(testSubject.state.value.selectedAccountId).isEqualTo(displayAccounts.first().uuid)
+        assertThat(testSubject.state.value.selectedAccountId).isEqualTo(displayAccounts.first().id)
     }
 
     @Test
@@ -207,7 +205,7 @@ internal class DrawerViewModelTest {
 
         assertThat(testSubject.state.value.accounts.size).isEqualTo(newDisplayAccounts.size)
         assertThat(testSubject.state.value.accounts).isEqualTo(newDisplayAccounts)
-        assertThat(testSubject.state.value.selectedAccountId).isEqualTo(newDisplayAccounts.first().uuid)
+        assertThat(testSubject.state.value.selectedAccountId).isEqualTo(newDisplayAccounts.first().id)
     }
 
     @Test
@@ -234,7 +232,7 @@ internal class DrawerViewModelTest {
             testSubject,
             State(
                 accounts = displayAccounts.toImmutableList(),
-                selectedAccountId = displayAccounts.first().uuid,
+                selectedAccountId = displayAccounts.first().id,
             ),
         )
 
@@ -245,7 +243,7 @@ internal class DrawerViewModelTest {
         advanceUntilIdle()
 
         turbines.assertThatAndEffectTurbineConsumed {
-            isEqualTo(Effect.OpenAccount(displayAccounts[1].account.uuid))
+            isEqualTo(Effect.OpenAccount(displayAccounts[1].id))
         }
     }
 
@@ -254,7 +252,7 @@ internal class DrawerViewModelTest {
         val displayAccounts = createDisplayAccountList(3)
         val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
         val displayFoldersMap = mapOf(
-            displayAccounts[0].uuid to createDisplayFolderList(3),
+            displayAccounts[0].id to createDisplayFolderList(3),
         )
         val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
         val testSubject = createTestSubject(
@@ -264,7 +262,7 @@ internal class DrawerViewModelTest {
 
         advanceUntilIdle()
 
-        val displayFolders = displayFoldersMap[displayAccounts[0].uuid] ?: emptyList()
+        val displayFolders = displayFoldersMap[displayAccounts[0].id] ?: emptyList()
         assertThat(testSubject.state.value.folders.size).isEqualTo(displayFolders.size)
         assertThat(testSubject.state.value.folders).isEqualTo(displayFolders)
     }
@@ -274,9 +272,9 @@ internal class DrawerViewModelTest {
         val displayAccounts = createDisplayAccountList(3)
         val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
         val displayFoldersMap = mapOf(
-            displayAccounts[0].uuid to createDisplayFolderList(1),
-            displayAccounts[1].uuid to createDisplayFolderList(5),
-            displayAccounts[2].uuid to createDisplayFolderList(10),
+            displayAccounts[0].id to createDisplayFolderList(1),
+            displayAccounts[1].id to createDisplayFolderList(5),
+            displayAccounts[2].id to createDisplayFolderList(10),
         )
         val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
         val testSubject = createTestSubject(
@@ -286,11 +284,11 @@ internal class DrawerViewModelTest {
 
         advanceUntilIdle()
 
-        testSubject.event(Event.SelectAccount(displayAccounts[1].uuid))
+        testSubject.event(Event.SelectAccount(displayAccounts[1].id))
 
         advanceUntilIdle()
 
-        val displayFolders = displayFoldersMap[displayAccounts[1].account.uuid] ?: emptyList()
+        val displayFolders = displayFoldersMap[displayAccounts[1].id] ?: emptyList()
         assertThat(testSubject.state.value.folders.size).isEqualTo(displayFolders.size)
         assertThat(testSubject.state.value.folders).isEqualTo(displayFolders)
     }
@@ -300,14 +298,14 @@ internal class DrawerViewModelTest {
         val displayAccounts = createDisplayAccountList(3)
         val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
         val displayFoldersMap = mapOf(
-            displayAccounts[0].account.uuid to createDisplayFolderList(3),
+            displayAccounts[0].id to createDisplayFolderList(3),
         )
         val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
         val initialState = State(
             accounts = displayAccounts.toImmutableList(),
-            selectedAccountId = displayAccounts[0].uuid,
-            folders = displayFoldersMap[displayAccounts[0].account.uuid]!!.toImmutableList(),
-            selectedFolderId = displayFoldersMap[displayAccounts[0].account.uuid]!![0].id,
+            selectedAccountId = displayAccounts[0].id,
+            folders = displayFoldersMap[displayAccounts[0].id]!!.toImmutableList(),
+            selectedFolderId = displayFoldersMap[displayAccounts[0].id]!![0].id,
         )
         val testSubject = createTestSubject(
             displayAccountsFlow = getDisplayAccountsFlow,
@@ -317,7 +315,7 @@ internal class DrawerViewModelTest {
 
         advanceUntilIdle()
 
-        val displayFolders = displayFoldersMap[displayAccounts[0].account.uuid] ?: emptyList()
+        val displayFolders = displayFoldersMap[displayAccounts[0].id] ?: emptyList()
         testSubject.event(Event.OnFolderClick(displayFolders[1]))
 
         assertThat(turbines.awaitEffectItem()).isEqualTo(Effect.OpenFolder(displayFolders[1].folder.id))
@@ -333,15 +331,15 @@ internal class DrawerViewModelTest {
             val displayAccounts = createDisplayAccountList(1)
             val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
             val displayFoldersMap = mapOf(
-                displayAccounts[0].account.uuid to
+                displayAccounts[0].id to
                     createDisplayFolderList(1) + listOf(createDisplayUnifiedFolder()),
             )
             val displayFoldersFlow = MutableStateFlow(displayFoldersMap)
             val initialState = State(
                 accounts = displayAccounts.toImmutableList(),
-                selectedAccountId = displayAccounts[0].account.uuid,
-                folders = displayFoldersMap[displayAccounts[0].account.uuid]!!.toImmutableList(),
-                selectedFolderId = displayFoldersMap[displayAccounts[0].account.uuid]!![0].id,
+                selectedAccountId = displayAccounts[0].id,
+                folders = displayFoldersMap[displayAccounts[0].id]!!.toImmutableList(),
+                selectedFolderId = displayFoldersMap[displayAccounts[0].id]!![0].id,
             )
             val testSubject = createTestSubject(
                 displayAccountsFlow = getDisplayAccountsFlow,
@@ -351,7 +349,7 @@ internal class DrawerViewModelTest {
 
             advanceUntilIdle()
 
-            val displayFolders = displayFoldersMap[displayAccounts[0].account.uuid] ?: emptyList()
+            val displayFolders = displayFoldersMap[displayAccounts[0].id] ?: emptyList()
             testSubject.event(Event.OnFolderClick(displayFolders[1]))
 
             assertThat(turbines.awaitEffectItem()).isEqualTo(Effect.OpenUnifiedFolder)
@@ -430,30 +428,17 @@ internal class DrawerViewModelTest {
     }
 
     private fun createDisplayAccount(
-        uuid: String = "uuid",
+        id: String = "uuid",
         name: String = "name",
         email: String = "test@example.com",
         unreadCount: Int = 0,
         starredCount: Int = 0,
     ): DisplayAccount {
-        val account = Account(
-            uuid = uuid,
-        ).also {
-            it.identities = ArrayList()
-
-            val identity = Identity(
-                signatureUse = false,
-                signature = "",
-                description = "",
-            )
-            it.identities.add(identity)
-
-            it.name = name
-            it.email = email
-        }
-
         return DisplayAccount(
-            account = account,
+            id = id,
+            name = name,
+            email = email,
+            color = 0,
             unreadMessageCount = unreadCount,
             starredMessageCount = starredCount,
         )
@@ -462,7 +447,7 @@ internal class DrawerViewModelTest {
     private fun createDisplayAccountList(count: Int): List<DisplayAccount> {
         return List(count) { index ->
             createDisplayAccount(
-                uuid = "uuid-$index",
+                id = "uuid-$index",
             )
         }
     }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModelTest.kt
@@ -245,7 +245,7 @@ internal class DrawerViewModelTest {
         advanceUntilIdle()
 
         turbines.assertThatAndEffectTurbineConsumed {
-            isEqualTo(Effect.OpenAccount(displayAccounts[1].account))
+            isEqualTo(Effect.OpenAccount(displayAccounts[1].account.uuid))
         }
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -593,7 +593,7 @@ open class MessageList :
     private fun initializeFolderDrawer() {
         navigationDrawer = FolderDrawer(
             parent = this,
-            openAccount = { account -> openRealAccount(account) },
+            openAccount = { accountId -> openRealAccount(accountId) },
             openFolder = { folderId -> openFolder(folderId) },
             openUnifiedFolder = { openUnifiedInbox() },
             openManageFolders = { launchManageFoldersScreen() },
@@ -666,17 +666,14 @@ open class MessageList :
         ManageFoldersActivity.launch(this, account!!)
     }
 
-    fun openRealAccount(account: Account): Boolean {
-        val shouldCloseDrawer = account.autoExpandFolderId != null
-
+    fun openRealAccount(accountId: String) {
+        val account = accountManager.getAccount(accountId) ?: return
         val folderId = defaultFolderProvider.getDefaultFolder(account)
 
         val search = LocalSearch()
         search.addAllowedFolder(folderId)
         search.addAccountUuid(account.uuid)
         actionDisplaySearch(this, search, noThreading = false, newTask = false)
-
-        return shouldCloseDrawer
     }
 
     private fun performSearch(search: LocalSearch) {


### PR DESCRIPTION
The `Account` object uses the `uuid` for `equals` and `hasCode` only. This leads to Compose not beeing able to detect change when any other account data was changed. All necessary data is now mapped to `DisplayAccount` to properly allow Compose to detect change.

Fixes #8533