### PR TITLE
Fix drawer jumping account icons

### DIFF
--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatarPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatarPreview.kt
@@ -12,6 +12,7 @@ internal fun AccountAvatarPreview() {
         AccountAvatar(
             account = DISPLAY_ACCOUNT,
             onClick = {},
+            selected = false,
         )
     }
 }
@@ -25,6 +26,7 @@ internal fun AccountAvatarWithUnreadCountPreview() {
                 unreadMessageCount = 12,
             ),
             onClick = {},
+            selected = false,
         )
     }
 }
@@ -38,6 +40,21 @@ internal fun AccountAvatarWithUnreadCountMaxedPreview() {
                 unreadMessageCount = 100,
             ),
             onClick = {},
+            selected = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun AccountAvatarSelectedPreview() {
+    PreviewWithThemes {
+        AccountAvatar(
+            account = DISPLAY_ACCOUNT.copy(
+                color = 0xFFFF0000.toInt(),
+            ),
+            onClick = {},
+            selected = true,
         )
     }
 }

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListItemPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListItemPreview.kt
@@ -12,6 +12,19 @@ internal fun AccountListItemPreview() {
         AccountListItem(
             account = DISPLAY_ACCOUNT,
             onClick = { },
+            selected = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun AccountListItemSelectedPreview() {
+    PreviewWithThemes {
+        AccountListItem(
+            account = DISPLAY_ACCOUNT,
+            onClick = { },
+            selected = true,
         )
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountAvatar.kt
@@ -1,5 +1,6 @@
 package app.k9mail.feature.navigation.drawer.ui.account
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -21,40 +23,57 @@ import app.k9mail.core.ui.compose.theme2.toColorRoles
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.ui.common.labelForCount
 
+val selectedAvatarSize = 40.dp
+
 @Composable
 internal fun AccountAvatar(
     account: DisplayAccount,
-    onClick: (DisplayAccount) -> Unit,
+    selected: Boolean,
     modifier: Modifier = Modifier,
+    onClick: ((DisplayAccount) -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val accountColor = calculateAccountColor(account.color)
     val accountColorRoles = accountColor.toColorRoles(context)
 
+    val avatarSize by animateDpAsState(
+        targetValue = if (selected) selectedAvatarSize else MainTheme.sizes.iconAvatar,
+        label = "Avatar size",
+    )
+
     Box(
         modifier = modifier,
         contentAlignment = Alignment.BottomEnd,
     ) {
-        Surface(
+        val clickableModifier = if (onClick != null && !selected) Modifier.clickable { onClick(account) } else Modifier
+
+        Box(
             modifier = Modifier
-                .size(MainTheme.sizes.iconAvatar)
-                .border(2.dp, accountColor, CircleShape)
-                .clip(CircleShape)
-                .padding(2.dp)
-                .clickable(onClick = { onClick(account) }),
-            color = accountColor.copy(alpha = 0.3f),
+                .size(MainTheme.sizes.iconAvatar),
+            contentAlignment = Alignment.Center,
         ) {
-            Box(
-                contentAlignment = Alignment.Center,
+            Surface(
                 modifier = Modifier
-                    .border(2.dp, MainTheme.colors.surfaceContainerLowest, CircleShape),
+                    .size(avatarSize)
+                    .clip(CircleShape)
+                    .border(2.dp, accountColor, CircleShape)
+                    .padding(2.dp)
+                    .then(clickableModifier),
+                color = accountColor.copy(alpha = 0.3f),
             ) {
-                Placeholder(
-                    displayName = account.name,
-                )
-                // TODO: Add image loading
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .border(2.dp, MainTheme.colors.surfaceContainerLowest, CircleShape),
+                ) {
+                    Placeholder(
+                        displayName = account.name,
+                    )
+                    // TODO: Add image loading
+                }
             }
         }
+
         UnreadBadge(
             unreadCount = account.unreadMessageCount,
             accountColorRoles = accountColorRoles,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountList.kt
@@ -47,9 +47,6 @@ internal fun AccountList(
                     items = accounts,
                     key = { account -> account.id },
                 ) { account ->
-                    if (selectedAccount != null && account == selectedAccount) {
-                        return@items
-                    }
                     AccountListItem(
                         account = account,
                         onClick = { onAccountClick(account) },

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountList.kt
@@ -50,6 +50,7 @@ internal fun AccountList(
                     AccountListItem(
                         account = account,
                         onClick = { onAccountClick(account) },
+                        selected = selectedAccount == account,
                     )
                 }
             }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountListItem.kt
@@ -13,6 +13,7 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 internal fun AccountListItem(
     account: DisplayAccount,
     onClick: (DisplayAccount) -> Unit,
+    selected: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -23,6 +24,7 @@ internal fun AccountListItem(
         AccountAvatar(
             account = account,
             onClick = onClick,
+            selected = selected,
         )
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
@@ -45,7 +45,8 @@ internal fun AccountView(
                 ) {
                     AccountAvatar(
                         account = account,
-                        onClick = { },
+                        onClick = null,
+                        selected = false,
                     )
                 }
             }


### PR DESCRIPTION
This change displays all accounts in the drawer account list to prevent any jarring transitions when switching between them. For easier readability, the selected account is now displayed smaller, to help differentiating it from unselected accounts.

<img src="https://github.com/user-attachments/assets/d85b194c-bff2-482f-8043-3f74b10a1925" width="350" title="Drawer with account selection"/>