### PR TITLE
Try autoconfig server at email provider after MX lookup

### DIFF
--- a/cli/autodiscovery-cli/src/main/kotlin/app/k9mail/cli/autodiscovery/AutoDiscoveryCli.kt
+++ b/cli/autodiscovery-cli/src/main/kotlin/app/k9mail/cli/autodiscovery/AutoDiscoveryCli.kt
@@ -54,7 +54,7 @@ class AutoDiscoveryCli : CliktCommand(
         try {
             val providerDiscovery = createProviderAutoconfigDiscovery(okHttpClient, config)
             val ispDbDiscovery = createIspDbAutoconfigDiscovery(okHttpClient)
-            val mxDiscovery = createMxLookupAutoconfigDiscovery(okHttpClient)
+            val mxDiscovery = createMxLookupAutoconfigDiscovery(okHttpClient, config)
 
             val runnables = listOf(providerDiscovery, ispDbDiscovery, mxDiscovery)
                 .flatMap { it.initDiscovery(emailAddress.toUserEmailAddress()) }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MxLookupAutoconfigDiscovery.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/MxLookupAutoconfigDiscovery.kt
@@ -48,7 +48,7 @@ class MxLookupAutoconfigDiscovery internal constructor(
 
         var latestResult: AutoDiscoveryResult = NoUsableSettingsFound
         for (domainToCheck in listOfNotNull(mxSubDomain, mxBaseDomain)) {
-            for (autoconfigUrl in urlProvider.getAutoconfigUrls(domainToCheck)) {
+            for (autoconfigUrl in urlProvider.getAutoconfigUrls(domainToCheck, email)) {
                 val discoveryResult = autoconfigFetcher.fetchAutoconfig(autoconfigUrl, email)
                 if (discoveryResult is Settings) {
                     return discoveryResult.copy(
@@ -85,7 +85,10 @@ class MxLookupAutoconfigDiscovery internal constructor(
     }
 }
 
-fun createMxLookupAutoconfigDiscovery(okHttpClient: OkHttpClient): MxLookupAutoconfigDiscovery {
+fun createMxLookupAutoconfigDiscovery(
+    okHttpClient: OkHttpClient,
+    config: AutoconfigUrlConfig,
+): MxLookupAutoconfigDiscovery {
     val baseDomainExtractor = OkHttpBaseDomainExtractor()
     val autoconfigFetcher = RealAutoconfigFetcher(
         fetcher = OkHttpFetcher(okHttpClient),
@@ -95,7 +98,7 @@ fun createMxLookupAutoconfigDiscovery(okHttpClient: OkHttpClient): MxLookupAutoc
         mxResolver = SuspendableMxResolver(MiniDnsMxResolver()),
         baseDomainExtractor = baseDomainExtractor,
         subDomainExtractor = RealSubDomainExtractor(baseDomainExtractor),
-        urlProvider = IspDbAutoconfigUrlProvider(),
+        urlProvider = createPostMxLookupAutoconfigUrlProvider(config),
         autoconfigFetcher = autoconfigFetcher,
     )
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/PostMxLookupAutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/PostMxLookupAutoconfigUrlProvider.kt
@@ -1,0 +1,39 @@
+package app.k9mail.autodiscovery.autoconfig
+
+import app.k9mail.core.common.mail.EmailAddress
+import app.k9mail.core.common.net.Domain
+import okhttp3.HttpUrl
+
+internal class PostMxLookupAutoconfigUrlProvider(
+    private val ispDbUrlProvider: AutoconfigUrlProvider,
+    private val config: AutoconfigUrlConfig,
+) : AutoconfigUrlProvider {
+    override fun getAutoconfigUrls(domain: Domain, email: EmailAddress?): List<HttpUrl> {
+        return buildList {
+            add(createProviderUrl(domain, email))
+            addAll(ispDbUrlProvider.getAutoconfigUrls(domain, email))
+        }
+    }
+
+    private fun createProviderUrl(domain: Domain, email: EmailAddress?): HttpUrl {
+        // After an MX lookup only the following provider URL is checked:
+        // https://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
+        return HttpUrl.Builder()
+            .scheme("https")
+            .host("autoconfig.${domain.value}")
+            .addEncodedPathSegments("mail/config-v1.1.xml")
+            .apply {
+                if (email != null && config.includeEmailAddress) {
+                    addQueryParameter("emailaddress", email.address)
+                }
+            }
+            .build()
+    }
+}
+
+internal fun createPostMxLookupAutoconfigUrlProvider(config: AutoconfigUrlConfig): AutoconfigUrlProvider {
+    return PostMxLookupAutoconfigUrlProvider(
+        ispDbUrlProvider = IspDbAutoconfigUrlProvider(),
+        config = config,
+    )
+}

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/MockAutoconfigFetcher.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/MockAutoconfigFetcher.kt
@@ -18,6 +18,9 @@ internal class MockAutoconfigFetcher : AutoconfigFetcher {
     val callCount: Int
         get() = callArguments.size
 
+    val urls: List<String>
+        get() = callArguments.map { (url, _) -> url.toString() }
+
     private val results = mutableListOf<AutoDiscoveryResult>()
 
     fun addResult(discoveryResult: AutoDiscoveryResult) {

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/PostMxLookupAutoconfigUrlProviderTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/PostMxLookupAutoconfigUrlProviderTest.kt
@@ -1,0 +1,42 @@
+package app.k9mail.autodiscovery.autoconfig
+
+import app.k9mail.core.common.mail.toEmailAddressOrThrow
+import app.k9mail.core.common.net.toDomain
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.extracting
+import org.junit.Test
+
+class PostMxLookupAutoconfigUrlProviderTest {
+    @Test
+    fun `getAutoconfigUrls with including email address`() {
+        val urlProvider = createPostMxLookupAutoconfigUrlProvider(
+            AutoconfigUrlConfig(httpsOnly = false, includeEmailAddress = true),
+        )
+        val domain = "domain.example".toDomain()
+        val emailAddress = "test@domain.example".toEmailAddressOrThrow()
+
+        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain, emailAddress)
+
+        assertThat(autoconfigUrls).extracting { it.toString() }.containsExactly(
+            "https://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
+            "https://autoconfig.thunderbird.net/v1.1/domain.example",
+        )
+    }
+
+    @Test
+    fun `getAutoconfigUrls without including email address`() {
+        val urlProvider = createPostMxLookupAutoconfigUrlProvider(
+            AutoconfigUrlConfig(httpsOnly = false, includeEmailAddress = false),
+        )
+        val domain = "domain.example".toDomain()
+        val emailAddress = "test@domain.example".toEmailAddressOrThrow()
+
+        val autoconfigUrls = urlProvider.getAutoconfigUrls(domain, emailAddress)
+
+        assertThat(autoconfigUrls).extracting { it.toString() }.containsExactly(
+            "https://autoconfig.domain.example/mail/config-v1.1.xml",
+            "https://autoconfig.thunderbird.net/v1.1/domain.example",
+        )
+    }
+}

--- a/feature/autodiscovery/service/src/main/kotlin/app/k9mail/autodiscovery/service/RealAutoDiscoveryRegistry.kt
+++ b/feature/autodiscovery/service/src/main/kotlin/app/k9mail/autodiscovery/service/RealAutoDiscoveryRegistry.kt
@@ -34,6 +34,7 @@ class RealAutoDiscoveryRegistry(
                 ),
                 createMxLookupAutoconfigDiscovery(
                     okHttpClient = okHttpClient,
+                    config = autoconfigUrlConfig,
                 ),
             )
         }


### PR DESCRIPTION
After an MX lookup, don't only check ISPDB, but check the email provider's autoconfig server first.

This was added to Thunderbird desktop some time ago (see [711472](https://bugzilla.mozilla.org/show_bug.cgi?id=711472)).