### PR TITLE
Fix MessageList colors for better contrast

### DIFF
--- a/app-k9mail/src/main/res/values/themes.xml
+++ b/app-k9mail/src/main/res/values/themes.xml
@@ -15,13 +15,6 @@
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_light</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_light</item>
 
-        <item name="messageListRegularItemBackgroundColor">?android:attr/windowBackground</item>
-        <item name="messageListReadItemBackgroundColor">#ffd8d8d8</item>
-        <item name="messageListUnreadItemBackgroundColor">?attr/messageListRegularItemBackgroundColor</item>
-        <item name="messageListActiveItemBackgroundColor">?attr/colorSecondaryVariant</item>
-        <item name="messageListActiveItemBackgroundAlphaFraction">60%</item>
-        <item name="messageListActiveItemBackgroundAlphaBackground">?attr/colorSurface</item>
-
         <item name="messageListSwipeSelectColor">@color/material_blue_600</item>
         <item name="messageListSwipeToggleReadColor">@color/material_blue_600</item>
         <item name="messageListSwipeToggleStarColor">@color/material_orange_600</item>
@@ -58,13 +51,6 @@
 
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_dark</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_dark</item>
-
-        <item name="messageListRegularItemBackgroundColor">?android:attr/windowBackground</item>
-        <item name="messageListReadItemBackgroundColor">?attr/messageListRegularItemBackgroundColor</item>
-        <item name="messageListUnreadItemBackgroundColor">#ff505050</item>
-        <item name="messageListActiveItemBackgroundColor">?attr/colorSecondaryVariant</item>
-        <item name="messageListActiveItemBackgroundAlphaFraction">50%</item>
-        <item name="messageListActiveItemBackgroundAlphaBackground">?attr/colorSurface</item>
 
         <item name="messageListSwipeSelectColor">@color/material_blue_700</item>
         <item name="messageListSwipeToggleReadColor">@color/material_blue_700</item>

--- a/app-thunderbird/src/main/res/values/themes.xml
+++ b/app-thunderbird/src/main/res/values/themes.xml
@@ -15,13 +15,6 @@
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_light</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_light</item>
 
-        <item name="messageListRegularItemBackgroundColor">?android:attr/windowBackground</item>
-        <item name="messageListReadItemBackgroundColor">#ffd8d8d8</item>
-        <item name="messageListUnreadItemBackgroundColor">?attr/messageListRegularItemBackgroundColor</item>
-        <item name="messageListActiveItemBackgroundColor">?attr/colorSecondaryVariant</item>
-        <item name="messageListActiveItemBackgroundAlphaFraction">60%</item>
-        <item name="messageListActiveItemBackgroundAlphaBackground">?attr/colorSurface</item>
-
         <item name="messageListSwipeSelectColor">@color/material_blue_600</item>
         <item name="messageListSwipeToggleReadColor">@color/material_blue_600</item>
         <item name="messageListSwipeToggleStarColor">@color/material_orange_600</item>
@@ -58,13 +51,6 @@
 
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_dark</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_dark</item>
-
-        <item name="messageListRegularItemBackgroundColor">?android:attr/windowBackground</item>
-        <item name="messageListReadItemBackgroundColor">?attr/messageListRegularItemBackgroundColor</item>
-        <item name="messageListUnreadItemBackgroundColor">#ff505050</item>
-        <item name="messageListActiveItemBackgroundColor">?attr/colorSecondaryVariant</item>
-        <item name="messageListActiveItemBackgroundAlphaFraction">50%</item>
-        <item name="messageListActiveItemBackgroundAlphaBackground">?attr/colorSurface</item>
 
         <item name="messageListSwipeSelectColor">@color/material_blue_700</item>
         <item name="messageListSwipeToggleReadColor">@color/material_blue_700</item>

--- a/legacy/ui/legacy/build.gradle.kts
+++ b/legacy/ui/legacy/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(projects.uiUtils.toolbarBottomSheet)
 
     implementation(projects.core.featureflags)
+    implementation(projects.core.ui.theme.api)
     implementation(projects.feature.launcher)
     implementation(projects.feature.navigation.drawer)
     // TODO: Remove AccountOauth dependency

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/ThemeExtensions.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/ThemeExtensions.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.ui
 
 import android.content.res.Resources.Theme
-import android.graphics.Color
 import android.util.TypedValue
 
 fun Theme.resolveColorAttribute(attrId: Int): Int {
@@ -13,32 +12,6 @@ fun Theme.resolveColorAttribute(attrId: Int): Int {
     }
 
     return typedValue.data
-}
-
-fun Theme.resolveColorAttribute(colorAttrId: Int, alphaFractionAttrId: Int, backgroundColorAttrId: Int): Int {
-    val typedValue = TypedValue()
-
-    if (!resolveAttribute(colorAttrId, typedValue, true)) {
-        error("Couldn't resolve attribute ($colorAttrId)")
-    }
-    val color = typedValue.data
-
-    if (!resolveAttribute(alphaFractionAttrId, typedValue, true)) {
-        error("Couldn't resolve attribute ($alphaFractionAttrId)")
-    }
-    val colorPercentage = TypedValue.complexToFloat(typedValue.data)
-    val backgroundPercentage = 1 - colorPercentage
-
-    if (!resolveAttribute(backgroundColorAttrId, typedValue, true)) {
-        error("Couldn't resolve attribute ($colorAttrId)")
-    }
-    val backgroundColor = typedValue.data
-
-    val red = colorPercentage * Color.red(color) + backgroundPercentage * Color.red(backgroundColor)
-    val green = colorPercentage * Color.green(color) + backgroundPercentage * Color.green(backgroundColor)
-    val blue = colorPercentage * Color.blue(color) + backgroundPercentage * Color.blue(backgroundColor)
-
-    return Color.rgb(red.toInt(), green.toInt(), blue.toInt())
 }
 
 fun Theme.getIntArray(attrId: Int): IntArray {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -57,19 +57,25 @@ class MessageListAdapter internal constructor(
     private val answeredIcon: Drawable = ResourcesCompat.getDrawable(res, Icons.Outlined.Reply, theme)!!
     private val forwardedAnsweredIcon: Drawable =
         ResourcesCompat.getDrawable(res, Icons.Outlined.CompareArrows, theme)!!
-    private val activeItemBackgroundColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorPrimary)
-    private val selectedItemBackgroundColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorPrimary)
 
+    private val activeItemBackgroundColor: Int =
+        theme.resolveColorAttribute(MaterialR.attr.colorSecondaryContainer)
+    private val selectedItemBackgroundColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorSurfaceVariant)
     private val regularItemBackgroundColor: Int =
         theme.resolveColorAttribute(MaterialR.attr.colorSurface)
     private val readItemBackgroundColor: Int =
-        theme.resolveColorAttribute(MaterialR.attr.colorSurfaceContainerHigh)
+        theme.resolveColorAttribute(MaterialR.attr.colorSurfaceContainer)
     private val unreadItemBackgroundColor: Int =
         theme.resolveColorAttribute(MaterialR.attr.colorSurface)
 
-    private val unreadTextColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSurface)
-    private val readTextColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSurfaceVariant)
+    private val activeItemColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSecondaryContainer)
+    private val selectedItemColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSurfaceVariant)
+    private val regularItemColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSurface)
+    private val readItemColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSurface)
+    private val unreadItemColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSurface)
+
     private val previewTextColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSurfaceVariant)
+    private val previewActiveTextColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSecondary)
 
     private val compactVerticalPadding = res.getDimensionPixelSize(R.dimen.messageListCompactVerticalPadding)
     private val compactTextViewMarginTop = res.getDimensionPixelSize(R.dimen.messageListCompactTextViewMargin)
@@ -375,7 +381,7 @@ class MessageListAdapter internal constructor(
         }
 
         with(messageListItem) {
-            val textColor = if (isRead) readTextColor else unreadTextColor
+            val foregroundColor = selectForegroundColor(isSelected, isRead, isActive)
             val maybeBoldTypeface = if (isRead) Typeface.NORMAL else Typeface.BOLD
             val displayDate = relativeDateTimeFormatter.formatDate(messageDate)
             val displayThreadCount = if (appearance.showingThreadedList) threadCount else 0
@@ -399,7 +405,7 @@ class MessageListAdapter internal constructor(
             if (appearance.showContactPicture && holder.contactPicture.isVisible) {
                 setContactPicture(holder.contactPicture, displayAddress)
             }
-            setBackgroundColor(holder.itemView, isSelected, isRead, isActive)
+            holder.itemView.setBackgroundColor(selectBackgroundColor(isSelected, isRead, isActive))
             updateWithThreadCount(holder, displayThreadCount)
             val beforePreviewText = if (appearance.senderAboveSubject) subject else displayName
             val messageStringBuilder = SpannableStringBuilder(beforePreviewText)
@@ -409,13 +415,13 @@ class MessageListAdapter internal constructor(
                     messageStringBuilder.append(" – ").append(preview)
                 }
             }
-            holder.preview.setTextColor(textColor)
+            holder.preview.setTextColor(foregroundColor)
             holder.preview.setText(messageStringBuilder, TextView.BufferType.SPANNABLE)
 
-            formatPreviewText(holder.preview, beforePreviewText, isRead)
+            formatPreviewText(holder.preview, beforePreviewText, isRead, isActive, isSelected)
 
             holder.subject.typeface = Typeface.create(holder.subject.typeface, maybeBoldTypeface)
-            holder.subject.setTextColor(textColor)
+            holder.subject.setTextColor(foregroundColor)
 
             val firstLineText = if (appearance.senderAboveSubject) displayName else subject
             holder.subject.text = firstLineText
@@ -427,7 +433,7 @@ class MessageListAdapter internal constructor(
             }
 
             holder.date.typeface = Typeface.create(holder.date.typeface, maybeBoldTypeface)
-            holder.date.setTextColor(textColor)
+            holder.date.setTextColor(foregroundColor)
             holder.date.text = displayDate
             holder.attachment.isVisible = hasAttachments
 
@@ -445,14 +451,21 @@ class MessageListAdapter internal constructor(
         holder.text.text = footerText
     }
 
-    private fun formatPreviewText(preview: MaterialTextView, beforePreviewText: CharSequence, messageRead: Boolean) {
+    private fun formatPreviewText(
+        preview: MaterialTextView,
+        beforePreviewText: CharSequence,
+        messageRead: Boolean,
+        active: Boolean,
+        selected: Boolean,
+    ) {
         val previewText = preview.text as Spannable
+        val textColor = selectPreviewTextColor(active, selected)
 
         val beforePreviewLength = beforePreviewText.length
         addBeforePreviewSpan(previewText, beforePreviewLength, messageRead)
 
         previewText.setSpan(
-            ForegroundColorSpan(previewTextColor),
+            ForegroundColorSpan(textColor),
             beforePreviewLength,
             previewText.length,
             Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
@@ -496,17 +509,34 @@ class MessageListAdapter internal constructor(
         return null
     }
 
-    private fun setBackgroundColor(view: View, selected: Boolean, read: Boolean, active: Boolean) {
+    private fun selectBackgroundColor(selected: Boolean, read: Boolean, active: Boolean): Int {
         val backGroundAsReadIndicator = appearance.backGroundAsReadIndicator
-        val backgroundColor = when {
+        return when {
             active -> activeItemBackgroundColor
             selected -> selectedItemBackgroundColor
             backGroundAsReadIndicator && read -> readItemBackgroundColor
             backGroundAsReadIndicator && !read -> unreadItemBackgroundColor
             else -> regularItemBackgroundColor
         }
+    }
 
-        view.setBackgroundColor(backgroundColor)
+    private fun selectForegroundColor(selected: Boolean, read: Boolean, active: Boolean): Int {
+        val backGroundAsReadIndicator = appearance.backGroundAsReadIndicator
+        return when {
+            active -> activeItemColor
+            selected -> selectedItemColor
+            backGroundAsReadIndicator && read -> readItemColor
+            backGroundAsReadIndicator && !read -> unreadItemColor
+            else -> regularItemColor
+        }
+    }
+
+    private fun selectPreviewTextColor(active: Boolean, selected: Boolean): Int {
+        return when {
+            selected -> previewTextColor
+            active -> previewActiveTextColor
+            else -> previewTextColor
+        }
     }
 
     private fun updateWithThreadCount(holder: MessageViewHolder, threadCount: Int) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -512,8 +512,8 @@ class MessageListAdapter internal constructor(
     private fun selectBackgroundColor(selected: Boolean, read: Boolean, active: Boolean): Int {
         val backGroundAsReadIndicator = appearance.backGroundAsReadIndicator
         return when {
-            active -> activeItemBackgroundColor
             selected -> selectedItemBackgroundColor
+            active -> activeItemBackgroundColor
             backGroundAsReadIndicator && read -> readItemBackgroundColor
             backGroundAsReadIndicator && !read -> unreadItemBackgroundColor
             else -> regularItemBackgroundColor
@@ -523,8 +523,8 @@ class MessageListAdapter internal constructor(
     private fun selectForegroundColor(selected: Boolean, read: Boolean, active: Boolean): Int {
         val backGroundAsReadIndicator = appearance.backGroundAsReadIndicator
         return when {
-            active -> activeItemColor
             selected -> selectedItemColor
+            active -> activeItemColor
             backGroundAsReadIndicator && read -> readItemColor
             backGroundAsReadIndicator && !read -> unreadItemColor
             else -> regularItemColor

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -57,18 +57,15 @@ class MessageListAdapter internal constructor(
     private val answeredIcon: Drawable = ResourcesCompat.getDrawable(res, Icons.Outlined.Reply, theme)!!
     private val forwardedAnsweredIcon: Drawable =
         ResourcesCompat.getDrawable(res, Icons.Outlined.CompareArrows, theme)!!
-    private val activeItemBackgroundColor: Int = theme.resolveColorAttribute(
-        colorAttrId = R.attr.messageListActiveItemBackgroundColor,
-        alphaFractionAttrId = R.attr.messageListActiveItemBackgroundAlphaFraction,
-        backgroundColorAttrId = R.attr.messageListActiveItemBackgroundAlphaBackground,
-    )
-    private val selectedItemBackgroundColor: Int =
-        theme.resolveColorAttribute(com.google.android.material.R.attr.colorSurfaceContainerHigh)
+    private val activeItemBackgroundColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorPrimary)
+    private val selectedItemBackgroundColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorPrimary)
+
     private val regularItemBackgroundColor: Int =
-        theme.resolveColorAttribute(R.attr.messageListRegularItemBackgroundColor)
-    private val readItemBackgroundColor: Int = theme.resolveColorAttribute(R.attr.messageListReadItemBackgroundColor)
+        theme.resolveColorAttribute(MaterialR.attr.colorSurface)
+    private val readItemBackgroundColor: Int =
+        theme.resolveColorAttribute(MaterialR.attr.colorSurfaceContainerHigh)
     private val unreadItemBackgroundColor: Int =
-        theme.resolveColorAttribute(R.attr.messageListUnreadItemBackgroundColor)
+        theme.resolveColorAttribute(MaterialR.attr.colorSurface)
 
     private val unreadTextColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSurface)
     private val readTextColor: Int = theme.resolveColorAttribute(MaterialR.attr.colorOnSurfaceVariant)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -395,6 +395,11 @@ class MessageListAdapter internal constructor(
 
             if (appearance.stars) {
                 holder.star.isSelected = isStarred
+                if (isStarred) {
+                    holder.star.clearColorFilter()
+                } else {
+                    holder.star.setColorFilter(foregroundColor)
+                }
                 holder.starClickArea.contentDescription = if (isStarred) {
                     res.getString(R.string.unflag_action)
                 } else {
@@ -436,6 +441,7 @@ class MessageListAdapter internal constructor(
             holder.date.setTextColor(foregroundColor)
             holder.date.text = displayDate
             holder.attachment.isVisible = hasAttachments
+            holder.attachment.setColorFilter(foregroundColor)
 
             val statusHolder = buildStatusHolder(isForwarded, isAnswered)
             if (statusHolder != null) {

--- a/legacy/ui/legacy/src/main/res/drawable/message_list_item_selection_background.xml
+++ b/legacy/ui/legacy/src/main/res/drawable/message_list_item_selection_background.xml
@@ -4,5 +4,5 @@
     android:shape="oval"
     >
 
-    <solid android:color="?attr/colorPrimary" />
+    <solid android:color="?attr/colorSecondaryContainer" />
 </shape>

--- a/legacy/ui/legacy/src/main/res/layout/message_list_item.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list_item.xml
@@ -25,7 +25,7 @@
         android:background="@drawable/message_list_item_selection_background"
         android:padding="4dp"
         android:visibility="gone"
-        app:tint="?attr/colorOnPrimary"
+        app:tint="?attr/colorOnSecondaryContainer"
         app:layout_constraintBottom_toTopOf="@+id/bottom_guideline"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/top_guideline"

--- a/legacy/ui/legacy/src/main/res/layout/message_list_item_footer.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list_item_footer.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="?android:attr/listPreferredItemHeight"
-    android:background="?attr/messageListRegularItemBackgroundColor"
+    android:background="?attr/colorSurface"
     android:foreground="?attr/selectableItemBackground"
     android:gravity="center"
     android:orientation="horizontal"

--- a/legacy/ui/legacy/src/main/res/values/attrs.xml
+++ b/legacy/ui/legacy/src/main/res/values/attrs.xml
@@ -4,12 +4,6 @@
     <declare-styleable name="K9Styles">
         <attr name="textColorPrimaryRecipientDropdown" format="reference" />
         <attr name="textColorSecondaryRecipientDropdown" format="reference" />
-        <attr name="messageListRegularItemBackgroundColor" format="reference|color" />
-        <attr name="messageListReadItemBackgroundColor" format="reference|color" />
-        <attr name="messageListUnreadItemBackgroundColor" format="reference|color" />
-        <attr name="messageListActiveItemBackgroundColor" format="reference|color" />
-        <attr name="messageListActiveItemBackgroundAlphaFraction" format="fraction" />
-        <attr name="messageListActiveItemBackgroundAlphaBackground" format="reference|color" />
         <attr name="messageListSwipeSelectColor" format="reference|color" />
         <attr name="messageListSwipeToggleReadColor" format="reference|color" />
         <attr name="messageListSwipeToggleStarColor" format="reference|color" />

--- a/legacy/ui/legacy/src/main/res/values/themes.xml
+++ b/legacy/ui/legacy/src/main/res/values/themes.xml
@@ -3,12 +3,6 @@
 
     <!-- TODO remove when properties have been replaced -->
     <style name="Theme.Legacy.Test" parent="Theme.Material3.Light">
-        <item name="messageListActiveItemBackgroundColor">?attr/colorSecondaryVariant</item>
-        <item name="messageListActiveItemBackgroundAlphaFraction">50%</item>
-        <item name="messageListActiveItemBackgroundAlphaBackground">?attr/colorSurface</item>
-        <item name="messageListRegularItemBackgroundColor">?android:attr/windowBackground</item>
-        <item name="messageListReadItemBackgroundColor">?attr/messageListRegularItemBackgroundColor</item>
-        <item name="messageListUnreadItemBackgroundColor">?attr/messageListRegularItemBackgroundColor</item>
         <item name="contactTokenBackgroundColor">#ccc</item>
         <item name="openpgp_black">#000</item>
         <item name="openpgp_orange">#FF8800</item>

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
@@ -38,7 +38,7 @@ private const val DATE_DEFAULT_FONT_SIZE = 14f
 
 class MessageListAdapterTest : RobolectricTest() {
     val activity = Robolectric.buildActivity(AppCompatActivity::class.java).create().get()
-    val context: Context = ContextThemeWrapper(activity, R.style.Theme_Legacy_Test)
+    val context: Context = ContextThemeWrapper(activity, com.google.android.material.R.style.Theme_Material3_Light)
 
     val contactsPictureLoader: ContactPictureLoader = mock()
     val listItemListener: MessageListItemActionListener = mock()


### PR DESCRIPTION
This removes the custom color attributes and replaces them by Material 3 colors. 

In result it's already better for the light theme, while the dark theme could be still tweaked to enhance the visual distinction between read and unread emails.

Resolves: [#9039](https://github.com/thunderbird/thunderbird-android/issues/9039)

Portrait:

<img src="https://github.com/user-attachments/assets/f3ac4291-8de1-4302-a806-2c562136d8cd" width="250em" />

<img src="https://github.com/user-attachments/assets/532ab994-44e2-4f5f-b7ca-686b3d2d0ab3" width="500em" />

Landscape:

<img src="https://github.com/user-attachments/assets/7b45f832-dc67-4da0-affc-44016f4c0c28" width="250em" />

<img src="https://github.com/user-attachments/assets/2862dbb1-f6b7-4e3e-a1c8-2dbf1cfcea37" width="500em" />
