### PR TITLE
Switch to `ProcessCameraProvider.awaitInstance()`

### DIFF
--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/CameraPreviewView.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/CameraPreviewView.kt
@@ -1,10 +1,10 @@
 package app.k9mail.feature.migration.qrcode.ui
 
-import android.content.Context
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
 import androidx.camera.core.UseCase
 import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.lifecycle.awaitInstance
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
 import androidx.compose.runtime.Composable
@@ -16,12 +16,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
 import app.k9mail.feature.migration.qrcode.domain.QrCodeDomainContract.UseCase.CameraUseCasesProvider
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 import android.graphics.Color as AndroidColor
 
 /**
@@ -54,7 +51,7 @@ internal fun CameraPreviewView(
     }
 
     LaunchedEffect(lensFacing) {
-        val cameraProvider = getProcessCameraProvider(context)
+        val cameraProvider = ProcessCameraProvider.awaitInstance(context)
 
         val cameraxSelector = CameraSelector.Builder().requireLensFacing(lensFacing).build()
         val preview = Preview.Builder().build()
@@ -72,21 +69,4 @@ internal fun CameraPreviewView(
         factory = { previewView },
         modifier = modifier,
     )
-}
-
-/**
- * Suspending function to retrieve a [ProcessCameraProvider].
- */
-private suspend fun getProcessCameraProvider(context: Context): ProcessCameraProvider {
-    return suspendCoroutine { continuation ->
-        val mainExecutor = ContextCompat.getMainExecutor(context)
-
-        ProcessCameraProvider.getInstance(context).also { processCameraProvider ->
-            val listener = Runnable {
-                continuation.resume(processCameraProvider.get())
-            }
-
-            processCameraProvider.addListener(listener, mainExecutor)
-        }
-    }
 }


### PR DESCRIPTION
CameraX 1.4.0 introduced the `awaitInstance()` extension function.