### PR TITLE
Always mark as read when archiving messages

### DIFF
--- a/legacy/core/build.gradle.kts
+++ b/legacy/core/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     implementation(projects.plugins.openpgpApiLib.openpgpApi)
     implementation(projects.feature.telemetry.api)
+    implementation(projects.core.featureflags)
 
     api(libs.androidx.annotation)
 
@@ -35,7 +36,6 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.mime4j.core)
     implementation(libs.mime4j.dom)
-    implementation(projects.core.featureflags)
 
     testApi(projects.core.testing)
     testApi(projects.core.android.testing)

--- a/legacy/core/build.gradle.kts
+++ b/legacy/core/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.mime4j.core)
     implementation(libs.mime4j.dom)
+    implementation(projects.core.featureflags)
 
     testApi(projects.core.testing)
     testApi(projects.core.android.testing)

--- a/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
@@ -73,7 +73,7 @@ internal class ArchiveOperations(
         messages: List<LocalMessage>,
         archiveFolderId: Long,
     ) {
-        val operation = when (featureFlagProvider.provide("move_and_mark_as_read".toFeatureFlagKey())) {
+        val operation = when (featureFlagProvider.provide("archive_marks_as_read".toFeatureFlagKey())) {
             FeatureFlagResult.Enabled -> MoveOrCopyFlavor.MOVE_AND_MARK_AS_READ
             FeatureFlagResult.Disabled -> MoveOrCopyFlavor.MOVE
             FeatureFlagResult.Unavailable -> MoveOrCopyFlavor.MOVE

--- a/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
@@ -1,5 +1,8 @@
 package com.fsck.k9.controller
 
+import app.k9mail.core.featureflag.FeatureFlagProvider
+import app.k9mail.core.featureflag.FeatureFlagResult
+import app.k9mail.core.featureflag.toFeatureFlagKey
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.controller.MessagingController.MessageActor
@@ -10,6 +13,7 @@ import timber.log.Timber
 
 internal class ArchiveOperations(
     private val messagingController: MessagingController,
+    private val featureFlagProvider: FeatureFlagProvider,
 ) {
     fun archiveThreads(messages: List<MessageReference>) {
         archiveByFolder("archiveThreads", messages) { account, folderId, messagesInFolder, archiveFolderId ->
@@ -69,12 +73,17 @@ internal class ArchiveOperations(
         messages: List<LocalMessage>,
         archiveFolderId: Long,
     ) {
+        val operation = when (featureFlagProvider.provide("move_and_mark_as_read".toFeatureFlagKey())) {
+            FeatureFlagResult.Enabled -> MoveOrCopyFlavor.MOVE_AND_MARK_AS_READ
+            FeatureFlagResult.Disabled -> MoveOrCopyFlavor.MOVE
+            FeatureFlagResult.Unavailable -> MoveOrCopyFlavor.MOVE
+        }
         messagingController.moveOrCopyMessageSynchronous(
             account,
             sourceFolderId,
             messages,
             archiveFolderId,
-            MoveOrCopyFlavor.MOVE,
+            operation,
         )
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.controller
 
 import android.content.Context
+import app.k9mail.core.featureflag.FeatureFlagProvider
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.message.controller.MessageCountsProvider
 import app.k9mail.legacy.message.controller.MessagingControllerRegistry
@@ -28,6 +29,7 @@ val controllerModule = module {
             get<SpecialLocalFoldersCreator>(),
             get<LocalDeleteOperationDecider>(),
             get(named("controllerExtensions")),
+            get<FeatureFlagProvider>(),
         )
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -132,7 +132,6 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     private final DraftOperations draftOperations;
     private final NotificationOperations notificationOperations;
     private final ArchiveOperations archiveOperations;
-    private final FeatureFlagProvider featureFlagProvider;
 
 
     private volatile boolean stopped = false;
@@ -160,7 +159,6 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         this.saveMessageDataCreator = saveMessageDataCreator;
         this.specialLocalFoldersCreator = specialLocalFoldersCreator;
         this.localDeleteOperationDecider = localDeleteOperationDecider;
-        this.featureFlagProvider = featureFlagProvider;
 
         controllerThread = new Thread(new Runnable() {
             @Override
@@ -176,7 +174,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
 
         draftOperations = new DraftOperations(this, messageStoreManager, saveMessageDataCreator);
         notificationOperations = new NotificationOperations(notificationController, preferences, messageStoreManager);
-        archiveOperations = new ArchiveOperations(this, this.featureFlagProvider);
+        archiveOperations = new ArchiveOperations(this, featureFlagProvider);
     }
 
     private void initializeControllerExtensions(List<ControllerExtension> controllerExtensions) {
@@ -1787,8 +1785,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
                         unreadCountAffected = true;
                         message.setFlag(Flag.SEEN, true);
                     }
-                }
-                else {
+                } else {
                     if (!unreadCountAffected && !message.isSet(Flag.SEEN)) {
                         unreadCountAffected = true;
                     }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -27,6 +27,7 @@ import android.os.SystemClock;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import app.k9mail.core.featureflag.FeatureFlagProvider;
 import app.k9mail.legacy.account.Account;
 import app.k9mail.legacy.account.Account.DeletePolicy;
 import app.k9mail.legacy.di.DI;
@@ -131,6 +132,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     private final DraftOperations draftOperations;
     private final NotificationOperations notificationOperations;
     private final ArchiveOperations archiveOperations;
+    private final FeatureFlagProvider featureFlagProvider;
 
 
     private volatile boolean stopped = false;
@@ -142,10 +144,12 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
 
 
     MessagingController(Context context, NotificationController notificationController,
-            NotificationStrategy notificationStrategy, LocalStoreProvider localStoreProvider,
-            BackendManager backendManager, Preferences preferences, MessageStoreManager messageStoreManager,
-            SaveMessageDataCreator saveMessageDataCreator, SpecialLocalFoldersCreator specialLocalFoldersCreator,
-            LocalDeleteOperationDecider localDeleteOperationDecider, List<ControllerExtension> controllerExtensions) {
+        NotificationStrategy notificationStrategy, LocalStoreProvider localStoreProvider,
+        BackendManager backendManager, Preferences preferences, MessageStoreManager messageStoreManager,
+        SaveMessageDataCreator saveMessageDataCreator, SpecialLocalFoldersCreator specialLocalFoldersCreator,
+        LocalDeleteOperationDecider localDeleteOperationDecider, List<ControllerExtension> controllerExtensions,
+        FeatureFlagProvider featureFlagProvider
+    ) {
         this.context = context;
         this.notificationController = notificationController;
         this.notificationStrategy = notificationStrategy;
@@ -156,6 +160,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         this.saveMessageDataCreator = saveMessageDataCreator;
         this.specialLocalFoldersCreator = specialLocalFoldersCreator;
         this.localDeleteOperationDecider = localDeleteOperationDecider;
+        this.featureFlagProvider = featureFlagProvider;
 
         controllerThread = new Thread(new Runnable() {
             @Override
@@ -171,7 +176,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
 
         draftOperations = new DraftOperations(this, messageStoreManager, saveMessageDataCreator);
         notificationOperations = new NotificationOperations(notificationController, preferences, messageStoreManager);
-        archiveOperations = new ArchiveOperations(this);
+        archiveOperations = new ArchiveOperations(this, this.featureFlagProvider);
     }
 
     private void initializeControllerExtensions(List<ControllerExtension> controllerExtensions) {
@@ -1754,10 +1759,6 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     void moveOrCopyMessageSynchronous(Account account, long srcFolderId, List<LocalMessage> inMessages,
             long destFolderId, MoveOrCopyFlavor operation) {
 
-        if (operation == MoveOrCopyFlavor.MOVE_AND_MARK_AS_READ) {
-            throw new UnsupportedOperationException("MOVE_AND_MARK_AS_READ unsupported");
-        }
-
         try {
             LocalStore localStore = localStoreProvider.getInstance(account);
             if (operation == MoveOrCopyFlavor.MOVE && !isMoveCapable(account)) {
@@ -1781,8 +1782,16 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
                     uids.add(uid);
                 }
 
-                if (!unreadCountAffected && !message.isSet(Flag.SEEN)) {
-                    unreadCountAffected = true;
+                if (operation == MoveOrCopyFlavor.MOVE_AND_MARK_AS_READ) {
+                    if (!message.isSet(Flag.SEEN)) {
+                        unreadCountAffected = true;
+                        message.setFlag(Flag.SEEN, true);
+                    }
+                }
+                else {
+                    if (!unreadCountAffected && !message.isSet(Flag.SEEN)) {
+                        unreadCountAffected = true;
+                    }
                 }
             }
 

--- a/legacy/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/legacy/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -7,7 +7,8 @@ import java.util.List;
 import java.util.Set;
 
 import android.content.Context;
-
+import app.k9mail.core.featureflag.FeatureFlagProvider;
+import app.k9mail.core.featureflag.FeatureFlagResult.Disabled;
 import app.k9mail.legacy.account.Account;
 import app.k9mail.legacy.message.controller.SimpleMessagingListener;
 import com.fsck.k9.K9;
@@ -111,6 +112,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
 
     private Preferences preferences;
     private String accountUuid;
+    private FeatureFlagProvider featureFlagProvider;
 
 
     @Before
@@ -120,11 +122,14 @@ public class MessagingControllerTest extends K9RobolectricTest {
         appContext = RuntimeEnvironment.getApplication();
 
         preferences = Preferences.getPreferences();
+        featureFlagProvider = key -> Disabled.INSTANCE;
 
         controller = new MessagingController(appContext, notificationController, notificationStrategy,
                 localStoreProvider, backendManager, preferences, messageStoreManager,
                 saveMessageDataCreator, specialLocalFoldersCreator, new LocalDeleteOperationDecider(),
-                Collections.<ControllerExtension>emptyList());
+                Collections.<ControllerExtension>emptyList(),
+                featureFlagProvider
+            );
 
         configureAccount();
         configureBackendManager();


### PR DESCRIPTION
- Always mark read when archiving email messages (Behind feature flag).

- Fixed #8309 