### PR TITLE
Display link to support page when signing in with Google

### DIFF
--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthContent.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/AccountOAuthContent.kt
@@ -14,6 +14,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.account.oauth.R
 import app.k9mail.feature.account.oauth.ui.AccountOAuthContract.Event
 import app.k9mail.feature.account.oauth.ui.AccountOAuthContract.State
+import app.k9mail.feature.account.oauth.ui.view.GoogleSignInSupportText
 import app.k9mail.feature.account.oauth.ui.view.SignInView
 
 @Composable
@@ -36,11 +37,17 @@ internal fun AccountOAuthContent(
                 message = stringResource(id = R.string.account_oauth_loading_message),
             )
         } else if (state.error != null) {
-            ErrorView(
-                title = stringResource(id = R.string.account_oauth_loading_error),
-                message = state.error.toResourceString(resources),
-                onRetry = { onEvent(Event.OnRetryClicked) },
-            )
+            Column {
+                ErrorView(
+                    title = stringResource(id = R.string.account_oauth_loading_error),
+                    message = state.error.toResourceString(resources),
+                    onRetry = { onEvent(Event.OnRetryClicked) },
+                )
+
+                if (state.isGoogleSignIn) {
+                    GoogleSignInSupportText()
+                }
+            }
         } else {
             SignInView(
                 onSignInClick = { onEvent(Event.SignInClicked) },

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/GoogleSignInSupportText.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/GoogleSignInSupportText.kt
@@ -1,0 +1,41 @@
+package app.k9mail.feature.account.oauth.ui.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+import app.k9mail.core.ui.compose.common.resources.annotatedStringResource
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodySmall
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import app.k9mail.feature.account.oauth.R
+
+private const val GOOGLE_OAUTH_SUPPORT_PAGE = "https://support.thunderbird.net/kb/gmail-thunderbird-android"
+
+@Composable
+internal fun GoogleSignInSupportText() {
+    val extraText = annotatedStringResource(
+        id = R.string.account_oauth_google_sign_in_support_text,
+        argument = buildAnnotatedString {
+            withStyle(
+                style = SpanStyle(
+                    color = MainTheme.colors.primary,
+                    textDecoration = TextDecoration.Underline,
+                ),
+            ) {
+                withLink(LinkAnnotation.Url(GOOGLE_OAUTH_SUPPORT_PAGE)) {
+                    append(stringResource(R.string.account_oauth_google_sign_in_support_text_link_text))
+                }
+            }
+        },
+    )
+
+    TextBodySmall(
+        text = extraText,
+        textAlign = TextAlign.Center,
+    )
+}

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInView.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/ui/view/SignInView.kt
@@ -34,6 +34,8 @@ internal fun SignInView(
                 onClick = onSignInClick,
                 enabled = isEnabled,
             )
+
+            GoogleSignInSupportText()
         } else {
             ButtonFilled(
                 text = stringResource(id = R.string.account_oauth_sign_in_button),

--- a/feature/account/oauth/src/main/res/values/strings.xml
+++ b/feature/account/oauth/src/main/res/values/strings.xml
@@ -11,4 +11,8 @@
     <string name="account_oauth_error_not_supported">OAuth 2.0 is currently not supported with this provider.</string>
     <string name="account_oauth_error_browser_not_available">The app couldn\'t find a browser to use for granting access to your account.</string>
 
+    <!-- This is displayed below the "Sign in with Google" button. {placeHolder} will be replaced with the text from account_oauth_google_sign_in_support_text_link_text. -->
+    <string name="account_oauth_google_sign_in_support_text">"If you're experiencing problems when signing in with Google, please consult our {placeHolder}."</string>
+    <!-- The {placeHolder} in account_oauth_google_sign_in_support_text will be replaced by this text (that, in the user interface, will be a link to the support article). -->
+    <string name="account_oauth_google_sign_in_support_text_link_text">support article</string>
 </resources>


### PR DESCRIPTION
Trying to provide some help for users affected by #8598 (or other Google OAuth issues).

|Sign-in|Sign-in error|
|-|-|
|![image](https://github.com/user-attachments/assets/892ab5c1-06d1-4fe1-864d-9cafef7be971)|![image](https://github.com/user-attachments/assets/08a7f2b3-0426-4675-923d-b42a07aced31)|
|![image](https://github.com/user-attachments/assets/3a7aa951-ba02-4229-b193-be5864a6b32d)|![image](https://github.com/user-attachments/assets/9f23d020-a8be-4ed6-afae-e3baae0146f5)|