### PR TITLE
Add archive methods to `MessagingController`

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
@@ -1,0 +1,91 @@
+package com.fsck.k9.controller
+
+import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.message.controller.MessageReference
+import com.fsck.k9.controller.MessagingController.MessageActor
+import com.fsck.k9.controller.MessagingController.MoveOrCopyFlavor
+import com.fsck.k9.mailstore.LocalFolder
+import com.fsck.k9.mailstore.LocalMessage
+import timber.log.Timber
+
+internal class ArchiveOperations(
+    private val messagingController: MessagingController,
+) {
+    fun archiveThreads(messages: List<MessageReference>) {
+        archiveByFolder("archiveThreads", messages) { account, folderId, messagesInFolder, archiveFolderId ->
+            archiveThreads(account, folderId, messagesInFolder, archiveFolderId)
+        }
+    }
+
+    fun archiveMessages(messages: List<MessageReference>) {
+        archiveByFolder("archiveMessages", messages) { account, folderId, messagesInFolder, archiveFolderId ->
+            archiveMessages(account, folderId, messagesInFolder, archiveFolderId)
+        }
+    }
+
+    fun archiveMessage(message: MessageReference) {
+        archiveMessages(listOf(message))
+    }
+
+    private fun archiveByFolder(
+        description: String,
+        messages: List<MessageReference>,
+        action: (account: Account, folderId: Long, messagesInFolder: List<LocalMessage>, archiveFolderId: Long) -> Unit,
+    ) {
+        actOnMessagesGroupedByAccountAndFolder(messages) { account, messageFolder, messagesInFolder ->
+            val sourceFolderId = messageFolder.databaseId
+            when (val archiveFolderId = account.archiveFolderId) {
+                null -> {
+                    Timber.v("No archive folder configured for account %s", account)
+                }
+
+                sourceFolderId -> {
+                    Timber.v("Skipping messages already in archive folder")
+                }
+
+                else -> {
+                    messagingController.suppressMessages(account, messagesInFolder)
+                    messagingController.putBackground(description, null) {
+                        action(account, sourceFolderId, messagesInFolder, archiveFolderId)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun archiveThreads(
+        account: Account,
+        sourceFolderId: Long,
+        messages: List<LocalMessage>,
+        archiveFolderId: Long,
+    ) {
+        val messagesInThreads = messagingController.collectMessagesInThreads(account, messages)
+        archiveMessages(account, sourceFolderId, messagesInThreads, archiveFolderId)
+    }
+
+    private fun archiveMessages(
+        account: Account,
+        sourceFolderId: Long,
+        messages: List<LocalMessage>,
+        archiveFolderId: Long,
+    ) {
+        messagingController.moveOrCopyMessageSynchronous(
+            account,
+            sourceFolderId,
+            messages,
+            archiveFolderId,
+            MoveOrCopyFlavor.MOVE,
+        )
+    }
+
+    private fun actOnMessagesGroupedByAccountAndFolder(
+        messages: List<MessageReference>,
+        block: (account: Account, messageFolder: LocalFolder, messages: List<LocalMessage>) -> Unit,
+    ) {
+        val actor = MessageActor { account, messageFolder, messagesInFolder ->
+            block(account, messageFolder, messagesInFolder)
+        }
+
+        messagingController.actOnMessagesGroupedByAccountAndFolder(messages, actor)
+    }
+}

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionService.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionService.kt
@@ -54,7 +54,7 @@ class NotificationActionService : Service() {
         when (intent.action) {
             ACTION_MARK_AS_READ -> markMessagesAsRead(intent, account)
             ACTION_DELETE -> deleteMessages(intent)
-            ACTION_ARCHIVE -> archiveMessages(intent, account)
+            ACTION_ARCHIVE -> archiveMessages(intent)
             ACTION_SPAM -> markMessageAsSpam(intent, account)
             ACTION_DISMISS -> Timber.i("Notification dismissed")
         }
@@ -88,24 +88,13 @@ class NotificationActionService : Service() {
         messagingController.deleteMessages(messageReferences)
     }
 
-    private fun archiveMessages(intent: Intent, account: Account) {
+    private fun archiveMessages(intent: Intent) {
         Timber.i("NotificationActionService archiving messages")
-
-        val archiveFolderId = account.archiveFolderId
-        if (archiveFolderId == null || !messagingController.isMoveCapable(account)) {
-            Timber.w("Cannot archive messages")
-            return
-        }
 
         val messageReferenceStrings = intent.getStringArrayListExtra(EXTRA_MESSAGE_REFERENCES)
         val messageReferences = MessageReferenceHelper.toMessageReferenceList(messageReferenceStrings)
 
-        for (messageReference in messageReferences) {
-            if (messagingController.isMoveCapable(messageReference)) {
-                val sourceFolderId = messageReference.folderId
-                messagingController.moveMessage(account, sourceFolderId, messageReference, archiveFolderId)
-            }
-        }
+        messagingController.archiveMessages(messageReferences)
     }
 
     private fun markMessageAsSpam(intent: Intent, account: Account) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -1113,10 +1113,12 @@ class MessageListFragment :
     }
 
     private fun onArchive(messages: List<MessageReference>) {
-        for ((account, messagesInAccount) in groupMessagesByAccount(messages)) {
-            account.archiveFolderId?.let { archiveFolderId ->
-                move(messagesInAccount, archiveFolderId)
-            }
+        if (!checkCopyOrMovePossible(messages, FolderOperation.MOVE)) return
+
+        if (showingThreadedList) {
+            messagingController.archiveThreads(messages)
+        } else {
+            messagingController.archiveMessages(messages)
         }
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -536,7 +536,15 @@ class MessageViewFragment :
     }
 
     fun onArchive() {
-        onRefile(account.archiveFolderId)
+        if (!account.hasArchiveFolder()) return
+
+        if (!messagingController.isMoveCapable(messageReference)) {
+            Toast.makeText(activity, R.string.move_copy_cannot_copy_unsynced_message, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        fragmentListener.performNavigationAfterMessageRemoval()
+        messagingController.archiveMessage(messageReference)
     }
 
     private fun onSpam() {


### PR DESCRIPTION
This is moving the knowledge that "archive" is just a move operation out of the UI code and into `MessagingController`. With this change merged, the necessary changes for #8309 become much smaller (see PR #8602).