### PR TITLE
Add uplift merges script

### DIFF
--- a/.github/workflows/uplift-merges.yml
+++ b/.github/workflows/uplift-merges.yml
@@ -1,0 +1,28 @@
+---
+name: Uplift Merges
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        type: boolean
+        description: Dry run
+        default: true
+
+jobs:
+  uplift:
+    name: Uplift
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run uplift script
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRYRUN: ${{ inputs.dryRun && '' || '--no-dry-run' }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          bash scripts/uplift-merges.sh $DRYRUN --$BRANCH

--- a/scripts/uplift-merges.sh
+++ b/scripts/uplift-merges.sh
@@ -20,7 +20,7 @@ fi
 
 # Default values
 dry_run=true
-repo="thunderbird/thunderbird-android"
+repo=${GITHUB_REPOSITORY:-thunderbird/thunderbird-android}
 label="task: uplift to beta"
 branch="beta"
 

--- a/scripts/uplift-merges.sh
+++ b/scripts/uplift-merges.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Check if gh is installed
+if ! command -v gh &> /dev/null; then
+    echo "Error: gh (GitHub CLI) is not installed."
+    exit 1
+fi
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed."
+    exit 1
+fi
+
+# Check if git is installed
+if ! command -v git &> /dev/null; then
+    echo "Error: git is not installed."
+    exit 1
+fi
+
+# Default values
+dry_run=true
+repo="thunderbird/thunderbird-android"
+label="task: uplift to beta"
+branch="beta"
+
+# Parse command-line arguments
+for arg in "$@"; do
+  case $arg in
+    --no-dry-run)
+      dry_run=false
+      shift
+      ;;
+    --release)
+      label="task: uplift to release"
+      branch="release"
+      shift
+      ;;
+    --beta)
+      label="task: uplift to beta"
+      branch="beta"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $arg"
+      exit 1
+      ;;
+  esac
+done
+
+# Check if on the correct branch
+current_branch=$(git branch --show-current)
+if [ "$current_branch" != "$branch" ]; then
+    echo "Error: You are not on the $branch branch. Please switch to the $branch branch."
+    exit 1
+fi
+
+echo "Dry run: $dry_run, to disable dry run pass --no-dry-run"
+echo "Label: \"$label\""
+echo ""
+
+# Fetch the uplift commits from the GitHub repository
+json_data=$(gh pr list --repo "$repo" --label "$label" --state closed --json "mergedAt,mergeCommit,number,url")
+
+# Sort by mergedAt
+sorted_commits=$(echo "$json_data" | jq -c '. | sort_by(.mergedAt) | .[]')
+
+# Check if there are no commits to cherry-pick
+if [ -z "$sorted_commits" ]; then
+  echo "No commits to cherry-pick."
+  exit 0
+fi
+
+# Generate git cherry-pick commands
+for commit in $sorted_commits; do
+    oid=$(echo "$commit" | jq -r '.mergeCommit.oid')
+    pr_number=$(echo "$commit" | jq -r '.number')
+    pr_url=$(echo "$commit" | jq -r '.url')
+    echo "Cherry-picking $oid from $pr_url"
+
+    if [ "$dry_run" = false ]; then
+        if git cherry-pick -m 1 "$oid"; then
+          gh pr edit "$pr_number" --remove-label "$label"
+        else
+          echo "Failed to cherry-pick $oid"
+          exit 1
+        fi
+    else
+        echo "git cherry-pick -m 1 $oid"
+        echo "gh pr edit $pr_number --remove-label \"$label\""
+    fi
+    echo ""
+done


### PR DESCRIPTION
This adds a script to easily cherry-pick merges that have been labeled with `task: uplift to beta` or `task: uplift to release`.

It fetches the relevant pull requests, sorts them by merge date, and generates the necessary git cherry-pick commands. If not in dry-run mode, it executes the cherry-pick and updates the pull request labels accordingly. In case of error the script aborts and you need to manually resolve the issue.

Just run: 
- `./scripts/uplift-merges.sh --release` or `./scripts/uplift-merges.sh --release --no-dry-run`
- `./scripts/uplift-merges.sh --beta` or `./scripts/uplift-merges.sh --beta --no-dry-run`