### PR TITLE
Automatically sync on start

### DIFF
--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -52,6 +52,10 @@ internal class DrawerViewModel(
         viewModelScope.launch {
             loadFolders()
         }
+
+        viewModelScope.launch {
+            onSyncAllAccounts()
+        }
     }
 
     private suspend fun loadAccounts() {


### PR DESCRIPTION
When user is signed in, sync account(s) on app start.

- Fixes #7257 