### PR TITLE
Remove unused advanced crypto status mode

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
@@ -4,10 +4,7 @@ package com.fsck.k9.activity;
 import java.util.List;
 
 import android.content.Context;
-import android.content.res.Resources;
-import android.graphics.PorterDuff.Mode;
 import android.graphics.Typeface;
-import android.graphics.drawable.Drawable;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,14 +13,11 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
 
-import androidx.annotation.AttrRes;
-import androidx.annotation.DrawableRes;
 import androidx.appcompat.widget.TooltipCompat;
 import com.fsck.k9.activity.compose.RecipientAdapter;
 import com.fsck.k9.ui.ContactBadge;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
-import com.fsck.k9.view.ThemeUtils;
 import com.google.android.material.textview.MaterialTextView;
 
 
@@ -37,7 +31,6 @@ public class AlternateRecipientAdapter extends BaseAdapter {
     private final AlternateRecipientListener listener;
     private List<Recipient> recipients;
     private Recipient currentRecipient;
-    private boolean showAdvancedInfo;
 
 
     public AlternateRecipientAdapter(Context context, AlternateRecipientListener listener) {
@@ -171,67 +164,18 @@ public class AlternateRecipientAdapter extends BaseAdapter {
     }
 
     private void configureCryptoStatusView(RecipientTokenHolder holder, Recipient recipient) {
-        if (showAdvancedInfo) {
-            configureCryptoStatusViewAdvanced(holder, recipient);
-        } else {
-            bindCryptoSimple(holder, recipient);
-        }
-    }
-
-    private void configureCryptoStatusViewAdvanced(RecipientTokenHolder holder, Recipient recipient) {
         switch (recipient.getCryptoStatus()) {
-            case AVAILABLE_TRUSTED: {
-                setCryptoStatusView(holder, R.drawable.status_lock_dots_3, R.attr.openpgp_green);
-                break;
-            }
+            case AVAILABLE_TRUSTED:
             case AVAILABLE_UNTRUSTED: {
-                setCryptoStatusView(holder, R.drawable.status_lock_dots_2, R.attr.openpgp_orange);
+                holder.itemCryptoStatus.setVisibility(View.VISIBLE);
                 break;
             }
-            case UNAVAILABLE: {
-                setCryptoStatusView(holder, R.drawable.status_lock_disabled_dots_1, R.attr.openpgp_red);
-                break;
-            }
+            case UNAVAILABLE:
             case UNDEFINED: {
                 holder.itemCryptoStatus.setVisibility(View.GONE);
                 break;
             }
         }
-    }
-
-    private void setCryptoStatusView(RecipientTokenHolder holder, @DrawableRes int cryptoStatusRes,
-            @AttrRes int cryptoStatusColorAttr) {
-        Resources resources = context.getResources();
-
-        Drawable drawable = resources.getDrawable(cryptoStatusRes);
-        // noinspection ConstantConditions, we know the resource exists!
-        drawable.mutate();
-
-        int cryptoStatusColor = ThemeUtils.getStyledColor(context, cryptoStatusColorAttr);
-        drawable.setColorFilter(cryptoStatusColor, Mode.SRC_ATOP);
-
-        holder.itemCryptoStatusIcon.setImageDrawable(drawable);
-        holder.itemCryptoStatus.setVisibility(View.VISIBLE);
-    }
-
-    private void bindCryptoSimple(RecipientTokenHolder holder, Recipient recipient) {
-        holder.itemCryptoStatus.setVisibility(View.GONE);
-        switch (recipient.getCryptoStatus()) {
-            case AVAILABLE_TRUSTED:
-            case AVAILABLE_UNTRUSTED: {
-                holder.itemCryptoStatusSimple.setVisibility(View.VISIBLE);
-                break;
-            }
-            case UNAVAILABLE:
-            case UNDEFINED: {
-                holder.itemCryptoStatusSimple.setVisibility(View.GONE);
-                break;
-            }
-        }
-    }
-
-    public void setShowAdvancedInfo(boolean showAdvancedInfo) {
-        this.showAdvancedInfo = showAdvancedInfo;
     }
 
     private static class RecipientTokenHolder {
@@ -243,9 +187,7 @@ public class AlternateRecipientAdapter extends BaseAdapter {
         public final View copyEmailAddress;
         public final MaterialTextView itemAddress;
         public final MaterialTextView itemAddressLabel;
-        public final View itemCryptoStatus;
-        public final ImageView itemCryptoStatusIcon;
-        public final ImageView itemCryptoStatusSimple;
+        public final ImageView itemCryptoStatus;
 
 
         public RecipientTokenHolder(View view) {
@@ -261,10 +203,8 @@ public class AlternateRecipientAdapter extends BaseAdapter {
             TooltipCompat.setTooltipText(copyEmailAddress, copyEmailAddress.getContext().getString(R.string.copy_action));
             itemAddress = view.findViewById(R.id.alternate_address);
             itemAddressLabel = view.findViewById(R.id.alternate_address_label);
-            itemCryptoStatus = view.findViewById(R.id.alternate_crypto_status);
-            itemCryptoStatusIcon = view.findViewById(R.id.alternate_crypto_status_icon);
 
-            itemCryptoStatusSimple = view.findViewById(R.id.alternate_crypto_status_simple);
+            itemCryptoStatus = view.findViewById(R.id.alternate_crypto_status);
         }
 
         public void setShowAsHeader(boolean isHeader) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
@@ -6,7 +6,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import android.content.Context;
-import android.graphics.drawable.Drawable;
 import android.text.Spannable;
 import android.text.style.ForegroundColorSpan;
 import android.view.LayoutInflater;
@@ -17,13 +16,10 @@ import android.widget.Filter;
 import android.widget.Filterable;
 import android.widget.ImageView;
 
-import androidx.core.content.ContextCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
 import com.fsck.k9.activity.misc.ContactPicture;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
 import com.fsck.k9.view.RecipientSelectView.RecipientCryptoStatus;
-import com.fsck.k9.view.ThemeUtils;
 import com.google.android.material.textview.MaterialTextView;
 
 
@@ -31,7 +27,6 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
     private final Context context;
     private List<Recipient> recipients;
     private String highlight;
-    private boolean showAdvancedInfo;
 
 
     public RecipientAdapter(Context context) {
@@ -94,59 +89,19 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
 
         setContactPhotoOrPlaceholder(context, holder.photo, recipient);
 
-        if (showAdvancedInfo) {
-            bindCryptoAdvanced(recipient, holder);
-        } else {
-            bindCryptoSimple(recipient, holder);
-        }
+        bindCryptoStatus(recipient, holder);
     }
 
-    private void bindCryptoAdvanced(Recipient recipient, RecipientTokenHolder holder) {
-        holder.cryptoStatusSimple.setVisibility(View.GONE);
-
-        Integer cryptoStatusRes = null, cryptoStatusColor = null;
-        RecipientCryptoStatus cryptoStatus = recipient.getCryptoStatus();
-        switch (cryptoStatus) {
-            case AVAILABLE_TRUSTED: {
-                cryptoStatusRes = R.drawable.status_lock_dots_3;
-                cryptoStatusColor = ThemeUtils.getStyledColor(context, R.attr.openpgp_green);
-                break;
-            }
-            case AVAILABLE_UNTRUSTED: {
-                cryptoStatusRes = R.drawable.status_lock_dots_2;
-                cryptoStatusColor = ThemeUtils.getStyledColor(context, R.attr.openpgp_orange);
-                break;
-            }
-            case UNAVAILABLE: {
-                cryptoStatusRes = R.drawable.status_lock_disabled_dots_1;
-                cryptoStatusColor = ThemeUtils.getStyledColor(context, R.attr.openpgp_red);
-                break;
-            }
-        }
-
-        if (cryptoStatusRes != null) {
-            Drawable drawable = ContextCompat.getDrawable(context, cryptoStatusRes);
-            DrawableCompat.wrap(drawable);
-            DrawableCompat.setTint(drawable.mutate(), cryptoStatusColor);
-            holder.cryptoStatusIcon.setImageDrawable(drawable);
-            holder.cryptoStatus.setVisibility(View.VISIBLE);
-        } else {
-            holder.cryptoStatus.setVisibility(View.GONE);
-        }
-    }
-
-    private void bindCryptoSimple(Recipient recipient, RecipientTokenHolder holder) {
-        holder.cryptoStatus.setVisibility(View.GONE);
-
+    private void bindCryptoStatus(Recipient recipient, RecipientTokenHolder holder) {
         RecipientCryptoStatus cryptoStatus = recipient.getCryptoStatus();
         switch (cryptoStatus) {
             case AVAILABLE_TRUSTED:
             case AVAILABLE_UNTRUSTED: {
-                holder.cryptoStatusSimple.setVisibility(View.VISIBLE);
+                holder.cryptoStatus.setVisibility(View.VISIBLE);
                 break;
             }
             case UNAVAILABLE: {
-                holder.cryptoStatusSimple.setVisibility(View.GONE);
+                holder.cryptoStatus.setVisibility(View.GONE);
                 break;
             }
         }
@@ -179,27 +134,19 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
         };
     }
 
-    public void setShowAdvancedInfo(boolean showAdvancedInfo) {
-        this.showAdvancedInfo = showAdvancedInfo;
-    }
-
 
     private static class RecipientTokenHolder {
         public final MaterialTextView name;
         public final MaterialTextView email;
         final ImageView photo;
-        final View cryptoStatus;
-        final ImageView cryptoStatusIcon;
-        final ImageView cryptoStatusSimple;
+        final ImageView cryptoStatus;
 
 
         RecipientTokenHolder(View view) {
             name = view.findViewById(R.id.text1);
             email = view.findViewById(R.id.text2);
             photo = view.findViewById(R.id.contact_photo);
-            cryptoStatus = view.findViewById(R.id.contact_crypto_status);
-            cryptoStatusIcon = view.findViewById(R.id.contact_crypto_status_icon);
-            cryptoStatusSimple = view.findViewById(R.id.contact_crypto_status_icon_simple);
+            cryptoStatus = view.findViewById(R.id.contact_crypto_status_icon);
         }
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.kt
@@ -142,10 +142,9 @@ class RecipientMvpView(private val activity: MessageCompose) : View.OnFocusChang
     }
 
     fun setCryptoProvider(openPgpProvider: String?) {
-        // TODO move "show advanced" into settings, or somewhere?
-        toView.setCryptoProvider(openPgpProvider, false)
-        ccView.setCryptoProvider(openPgpProvider, false)
-        bccView.setCryptoProvider(openPgpProvider, false)
+        toView.setCryptoProvider(openPgpProvider)
+        ccView.setCryptoProvider(openPgpProvider)
+        bccView.setCryptoProvider(openPgpProvider)
     }
 
     fun requestFocusOnToField() {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -67,7 +67,6 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
     private RecipientAdapter adapter;
     @Nullable
     private String cryptoProvider;
-    private boolean showAdvancedInfo;
     private boolean showCryptoEnabled;
     @Nullable
     private LoaderManager loaderManager;
@@ -164,12 +163,8 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
 
         boolean isAvailable = recipient.cryptoStatus == RecipientCryptoStatus.AVAILABLE_TRUSTED ||
                 recipient.cryptoStatus == RecipientCryptoStatus.AVAILABLE_UNTRUSTED;
-        if (!showAdvancedInfo) {
-            holder.showSimpleCryptoState(isAvailable, showCryptoEnabled);
-        } else {
-            boolean isVerified = recipient.cryptoStatus == RecipientCryptoStatus.AVAILABLE_TRUSTED;
-            holder.showAdvancedCryptoState(isAvailable, isVerified);
-        }
+
+        holder.showCryptoState(isAvailable, showCryptoEnabled);
     }
 
     @Override
@@ -276,11 +271,8 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         loaderManager.restartLoader(LOADER_ID_FILTERING, args, this);
     }
 
-    public void setCryptoProvider(@Nullable String cryptoProvider, boolean showAdvancedInfo) {
+    public void setCryptoProvider(@Nullable String cryptoProvider) {
         this.cryptoProvider = cryptoProvider;
-        this.showAdvancedInfo = showAdvancedInfo;
-        adapter.setShowAdvancedInfo(showAdvancedInfo);
-        alternatesAdapter.setShowAdvancedInfo(showAdvancedInfo);
     }
 
     public void setShowCryptoEnabled(boolean showCryptoEnabled) {
@@ -595,54 +587,30 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
     private static class RecipientTokenViewHolder {
         final MaterialTextView vName;
         final CircleImageView vContactPhoto;
-        final View cryptoStatusRed;
-        final View cryptoStatusOrange;
-        final View cryptoStatusGreen;
-        final View cryptoStatusSimple;
-        final View cryptoStatusSimpleEnabled;
-        final View cryptoStatusSimpleError;
+        final View cryptoStatus;
+        final View cryptoStatusEnabled;
+        final View cryptoStatusError;
 
 
         RecipientTokenViewHolder(View view) {
             vName = view.findViewById(android.R.id.text1);
             vContactPhoto = view.findViewById(R.id.contact_photo);
-            cryptoStatusRed = view.findViewById(R.id.contact_crypto_status_red);
-            cryptoStatusOrange = view.findViewById(R.id.contact_crypto_status_orange);
-            cryptoStatusGreen = view.findViewById(R.id.contact_crypto_status_green);
 
-            cryptoStatusSimple = view.findViewById(R.id.contact_crypto_status_icon_simple);
-            cryptoStatusSimpleEnabled = view.findViewById(R.id.contact_crypto_status_icon_simple_enabled);
-            cryptoStatusSimpleError = view.findViewById(R.id.contact_crypto_status_icon_simple_error);
+            cryptoStatus = view.findViewById(R.id.contact_crypto_status_icon);
+            cryptoStatusEnabled = view.findViewById(R.id.contact_crypto_status_icon_enabled);
+            cryptoStatusError = view.findViewById(R.id.contact_crypto_status_icon_error);
         }
 
-        void showSimpleCryptoState(boolean isAvailable, boolean isShowEnabled) {
-            cryptoStatusRed.setVisibility(View.GONE);
-            cryptoStatusOrange.setVisibility(View.GONE);
-            cryptoStatusGreen.setVisibility(View.GONE);
-
-            cryptoStatusSimple.setVisibility(!isShowEnabled && isAvailable ? View.VISIBLE : View.GONE);
-            cryptoStatusSimpleEnabled.setVisibility(isShowEnabled && isAvailable ? View.VISIBLE : View.GONE);
-            cryptoStatusSimpleError.setVisibility(isShowEnabled && !isAvailable ? View.VISIBLE : View.GONE);
-        }
-
-        void showAdvancedCryptoState(boolean isAvailable, boolean isVerified) {
-            cryptoStatusRed.setVisibility(!isAvailable ? View.VISIBLE : View.GONE);
-            cryptoStatusOrange.setVisibility(isAvailable && !isVerified ? View.VISIBLE : View.GONE);
-            cryptoStatusGreen.setVisibility(isAvailable && isVerified ? View.VISIBLE : View.GONE);
-
-            cryptoStatusSimple.setVisibility(View.GONE);
-            cryptoStatusSimpleEnabled.setVisibility(View.GONE);
-            cryptoStatusSimpleError.setVisibility(View.GONE);
+        void showCryptoState(boolean isAvailable, boolean isShowEnabled) {
+            cryptoStatus.setVisibility(!isShowEnabled && isAvailable ? View.VISIBLE : View.GONE);
+            cryptoStatusEnabled.setVisibility(isShowEnabled && isAvailable ? View.VISIBLE : View.GONE);
+            cryptoStatusError.setVisibility(isShowEnabled && !isAvailable ? View.VISIBLE : View.GONE);
         }
 
         void hideCryptoState() {
-            cryptoStatusRed.setVisibility(View.GONE);
-            cryptoStatusOrange.setVisibility(View.GONE);
-            cryptoStatusGreen.setVisibility(View.GONE);
-
-            cryptoStatusSimple.setVisibility(View.GONE);
-            cryptoStatusSimpleEnabled.setVisibility(View.GONE);
-            cryptoStatusSimpleError.setVisibility(View.GONE);
+            cryptoStatus.setVisibility(View.GONE);
+            cryptoStatusEnabled.setVisibility(View.GONE);
+            cryptoStatusError.setVisibility(View.GONE);
         }
     }
 

--- a/legacy/ui/legacy/src/main/res/layout/recipient_alternate_item.xml
+++ b/legacy/ui/legacy/src/main/res/layout/recipient_alternate_item.xml
@@ -109,39 +109,12 @@
             tools:text="address@example.com"
             />
 
-        <FrameLayout
-            android:id="@+id/alternate_crypto_status"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="13dp"
-            tools:visibility="gone"
-            >
-
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="start|center_vertical"
-                app:srcCompat="@drawable/status_dots"
-                app:tint="?attr/openpgp_grey"
-                />
-
-            <ImageView
-                android:id="@+id/alternate_crypto_status_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="start|center_vertical"
-                tools:src="@drawable/status_lock_dots_2"
-                tools:tint="?attr/openpgp_grey"
-                />
-
-        </FrameLayout>
-
         <ImageView
             android:layout_width="16dp"
             android:layout_height="16dp"
             android:layout_gravity="center_vertical"
             android:layout_margin="13dp"
-            android:id="@+id/alternate_crypto_status_simple"
+            android:id="@+id/alternate_crypto_status"
             app:srcCompat="@drawable/ic_lock"
             app:tint="?attr/openpgp_black"
             android:visibility="gone"

--- a/legacy/ui/legacy/src/main/res/layout/recipient_dropdown_item.xml
+++ b/legacy/ui/legacy/src/main/res/layout/recipient_dropdown_item.xml
@@ -53,39 +53,12 @@
 
     </LinearLayout>
 
-    <FrameLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:padding="13dp"
-        android:id="@+id/contact_crypto_status"
-        android:visibility="gone"
-        >
-
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|center_vertical"
-            app:srcCompat="@drawable/status_dots"
-            app:tint="?attr/openpgp_grey"
-            />
-
-        <ImageView
-            android:id="@+id/contact_crypto_status_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|center_vertical"
-            tools:src="@drawable/status_lock_dots_2"
-            tools:tint="?attr/openpgp_grey"
-            />
-
-    </FrameLayout>
-
     <ImageView
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:layout_gravity="center_vertical"
         android:layout_margin="13dp"
-        android:id="@+id/contact_crypto_status_icon_simple"
+        android:id="@+id/contact_crypto_status_icon"
         app:srcCompat="@drawable/ic_lock"
         app:tint="?attr/openpgp_black"
         android:visibility="gone"

--- a/legacy/ui/legacy/src/main/res/layout/recipient_token_item.xml
+++ b/legacy/ui/legacy/src/main/res/layout/recipient_token_item.xml
@@ -61,7 +61,7 @@
         />
 
     <ImageView
-        android:id="@+id/contact_crypto_status_icon_simple"
+        android:id="@+id/contact_crypto_status_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:contentDescription="@null"
@@ -74,7 +74,7 @@
         />
 
     <ImageView
-        android:id="@+id/contact_crypto_status_icon_simple_enabled"
+        android:id="@+id/contact_crypto_status_icon_enabled"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:contentDescription="@null"
@@ -87,7 +87,7 @@
         />
 
     <ImageView
-        android:id="@+id/contact_crypto_status_icon_simple_error"
+        android:id="@+id/contact_crypto_status_icon_error"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:contentDescription="@null"
@@ -97,52 +97,6 @@
         app:srcCompat="@drawable/ic_status_corner"
         app:tint="?openpgp_red"
         tools:visibility="gone"
-        />
-
-    <ImageView
-        android:id="@+id/contact_crypto_status_red"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="6dp"
-        android:contentDescription="@null"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@android:id/text1"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/status_dots_1"
-        app:tint="?attr/openpgp_red"
-        tools:visibility="gone"
-        />
-
-    <ImageView
-        android:id="@+id/contact_crypto_status_orange"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="6dp"
-        android:contentDescription="@null"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@android:id/text1"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/status_dots_2"
-        app:tint="?attr/openpgp_orange"
-        tools:visibility="gone"
-        />
-
-    <ImageView
-        android:id="@+id/contact_crypto_status_green"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:contentDescription="@null"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@android:id/text1"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/status_dots_3"
-        app:tint="?attr/openpgp_green"
         />
 
 </com.fsck.k9.ui.compose.RecipientTokenConstraintLayout>


### PR DESCRIPTION
While trying to track down an error I noticed that there's still code and views in layouts for the "advanced crypto status". The "simple crypto status" was introduced in 2017 (see #2608) and the advanced one was programmatically disabled ever since. So this is just getting rid of dead code. There should be no behavior change.