### PR TITLE
Fix multiple string substitutions

### DIFF
--- a/legacy/ui/legacy/src/main/res/values-az/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-az/strings.xml
@@ -160,7 +160,7 @@
     <string name="status_loading_error">Mesaj yükləmə xətası</string>
     <string name="about_title"><xliff:g id="app_name">%s</xliff:g> haqqında</string>
     <string name="search_action">Axtar</string>
-    <string name="account_delete_dlg_instructions_fmt">\"<xliff:g id="account">%s</xliff:g>\" hesabı <xliff:g id="app_name">%s</xliff:g>-dan silinəcək.</string>
+    <string name="account_delete_dlg_instructions_fmt">\"<xliff:g id="account">%1$s</xliff:g>\" hesabı <xliff:g id="app_name">%2$s</xliff:g>-dan silinəcək.</string>
     <string name="done_action">Bitir</string>
     <string name="check_mail_action">Poçtu yoxla</string>
     <string name="send_messages_action">Mesajları göndər</string>

--- a/legacy/ui/legacy/src/main/res/values-be/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-be/strings.xml
@@ -881,11 +881,11 @@
     <string name="clipboard_label_name_and_email_address">Імя і адрас электроннай пошты</string>
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="general_settings_post_remove_action_title">Пасля выдалення або перамяшчэння ліста</string>
+    <string name="general_settings_post_remove_action_title">Пасля выдалення або перамяшчэння ліста</string>
     <string name="general_settings_post_remove_action_return_to_list">Вярнуцца да спіса лістоў</string>
     <string name="about_app_authors_thunderbird">Каманда Thunderbird Mobile</string>
     <string name="about_title">Аб дадатке <xliff:g id="app_name">%s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">Уліковый запіс \"<xliff:g id="account">%s</xliff:g>\" будзе выдален з дадатка <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Уліковый запіс \"<xliff:g id="account">%1$s</xliff:g>\" будзе выдален з дадатка <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="volume_navigation_summary">Перамяшчэнне паміж лістамі з дапамогай клавіш гучнасці падчас прагляду</string>
     <string name="general_settings_post_remove_action_show_next_message">Паказаць наступны ліст</string>
     <string name="general_settings_post_mark_as_unread_action_stay">Заставацца на бягучым лісце</string>

--- a/legacy/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-bg/strings.xml
@@ -886,5 +886,5 @@
     <string name="folder_list_show_hidden_folders">Показване на скрити папки</string>
     <string name="settings_ui_telemetry_title">Използване и технически данни</string>
     <string name="push_notification_grant_alarm_permission">Докоснете, за да дадете разрешение.</string>
-    <string name="account_delete_dlg_instructions_fmt">Профилът „<xliff:g id="account">%s</xliff:g>“ ще бъде премахнат от <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Профилът „<xliff:g id="account">%1$s</xliff:g>“ ще бъде премахнат от <xliff:g id="app_name">%2$s</xliff:g>.</string>
 </resources>

--- a/legacy/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ca/strings.xml
@@ -886,7 +886,7 @@
     <string name="about_app_authors_thunderbird">Equip del Thunderbird per al mòbil</string>
     <string name="dialog_openkeychain_info_text">L\'aplicació OpenKeychain és necessària per habilitar el suport per a l\'encriptació d\'extrem a extrem.</string>
     <string name="about_title">Quant al <xliff:g id="app_name">%s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">El compte \"<xliff:g id="account">%s</xliff:g>\" s\'eliminarà del <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">El compte \"<xliff:g id="account">%1$s</xliff:g>\" s\'eliminarà del <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="push_info_notification_explanation_text">Quan s\'utilitza Push, <xliff:g id="app_name">%1$s</xliff:g> manté una connexió amb el servidor de correu. Android requereix que es mostri una notificació en curs mentre l\'aplicació està activa en segon pla. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="folder_settings_notifications_label">Notificacions</string>
     <string name="settings_ui_data_collection">Recollida de dades</string>

--- a/legacy/ui/legacy/src/main/res/values-co/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-co/strings.xml
@@ -815,7 +815,7 @@
     <string name="clipboard_label_name_and_email_address">Nome è indirizzu elettronicu</string>
     <string name="message_list_content_description_unread_prefix">à leghje, %s</string>
     <string name="background_work_notification_remove_account">Cacciatura di u contu…</string>
-    <string name="account_delete_dlg_instructions_fmt">U contu \"<xliff:g id="account">%s</xliff:g>\" serà cacciatu da <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">U contu \"<xliff:g id="account">%1$s</xliff:g>\" serà cacciatu da <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="push_info_notification_explanation_text">Quandu s’impiegheghja a catapughjata, <xliff:g id="app_name">%1$s</xliff:g> mantene una cunnessione à u servitore di messaghjeria. Android richiede l’affissera d’una nutificazione quandu l’appiecazione hè attiva in tacca di sfondulu. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">L’appiecazione OpenKeychain hè richiesta per permette l’adopru di a cifratura da un capu à l’altru.</string>
     <string name="about_title">Apprupositu di <xliff:g id="app_name">%s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-cs/strings.xml
@@ -889,7 +889,7 @@ Tuto zprávu si můžete ponechat a použít jí jako zálohu svého tajného kl
     <string name="general_settings_post_mark_as_unread_action_stay">Zůstat na současné zprávě</string>
     <string name="general_settings_post_mark_as_unread_action_title">Po označení zprávy jako nepřečtené</string>
     <string name="general_settings_post_mark_as_unread_action_return_to_list">Vrátit se na seznam zpráv</string>
-    <string name="account_delete_dlg_instructions_fmt">Účet \"<xliff:g id="account">%s</xliff:g>\" bude odstraněn z <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Účet \"<xliff:g id="account">%1$s</xliff:g>\" bude odstraněn z <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="push_notification_state_alarm_permission_missing">Chybí oprávnění pro nastavování alarmů</string>
     <string name="dialog_openkeychain_info_text">Pro šifrování mezi odesílatelem a příjemcem je potřeba aplikace OpenKeychain.</string>
     <string name="about_title">O aplikaci <xliff:g id="app_name">%s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-de/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-de/strings.xml
@@ -878,7 +878,7 @@ Du kannst diese Nachricht aufheben und sie als Backup für deinen geheimen Schl�
     <string name="push_notification_state_alarm_permission_missing">Fehlende Berechtigung zur Zeitplanung von Alarmen</string>
     <string name="push_notification_grant_alarm_permission">Antippen, um die Berechtigung zu erteilen.</string>
     <string name="dialog_openkeychain_info_text">Die App OpenKeychain ist erforderlich, um die Unterstützung für die Ende-zu-Ende-Verschlüsselung zu aktivieren.</string>
-    <string name="account_delete_dlg_instructions_fmt">Das Konto \"<xliff:g id="account">%s</xliff:g>\" wird aus <xliff:g id="app_name">%s</xliff:g> entfernt.</string>
+    <string name="account_delete_dlg_instructions_fmt">Das Konto \"<xliff:g id="account">%1$s</xliff:g>\" wird aus <xliff:g id="app_name">%2$s</xliff:g> entfernt.</string>
     <string name="about_title">Über <xliff:g id="app_name">%s</xliff:g></string>
     <string name="push_info_notification_explanation_text">Wenn Push verwendet wird, hält <xliff:g id="app_name">%1$s</xliff:g> eine Verbindung zum Mailserver aufrecht. Bei Android muss eine laufende Benachrichtigung angezeigt werden, während die App im Hintergrund aktiv ist. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="about_app_authors_thunderbird">Thunderbird Mobile Team</string>

--- a/legacy/ui/legacy/src/main/res/values-el/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-el/strings.xml
@@ -887,7 +887,7 @@
     <string name="folder_settings_push_label">Ενεργοποίηση ειδοποίησεων push</string>
     <string name="folder_list_show_hidden_folders">Εμφάνιση κρυφών φακέλων</string>
     <string name="about_title">Σχετικά με το <xliff:g id="app_name">%s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">Ο λογαριασμός \"<xliff:g id="account">%s</xliff:g>\" θα αφαιρεθεί από το <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Ο λογαριασμός \"<xliff:g id="account">%1$s</xliff:g>\" θα αφαιρεθεί από το <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="folder_settings_visible_label">Εμφάνιση φακέλου</string>
     <string name="save_attachment_action">Αποθήκευση συνημμένου</string>
     <string name="volume_navigation_summary">Πλοήγηση στα μηνύματα με τα πλήκτρα έντασης στην προβολή μηνυμάτων</string>

--- a/legacy/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-eo/strings.xml
@@ -811,7 +811,7 @@ Vi povas konservi tiun ĉi mesaĝon kaj uzi ĝin kiel sekurkopion de via privata
     <!--A user visible label for the name and email address copied to the clipboard-->
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="save_attachment_action">Savi kunsendaĵon</string>
+    <string name="save_attachment_action">Savi kunsendaĵon</string>
     <string name="new_messages_title">Novaj mesaĝoj</string>
     <string name="notification_certificate_error_public">Atestilon eraro</string>
     <string name="debug_export_logs_failure">Elportado malsukcesis.</string>
@@ -821,7 +821,7 @@ Vi povas konservi tiun ĉi mesaĝon kaj uzi ĝin kiel sekurkopion de via privata
     <string name="message_view_show_remote_images_action">Montri forajn bildojn</string>
     <string name="changelog_snackbar_button_text">Vidi</string>
     <string name="about_title">Pri <xliff:g id="app_name">%s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">La konto \"<xliff:g id="account">%s</xliff:g>\" estos forigita el <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">La konto \"<xliff:g id="account">%1$s</xliff:g>\" estos forigita el <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="get_help_title">Ricevi helpon</string>
     <string name="message_view_recipients_format">al <xliff:g id="recipients">%s</xliff:g></string>
     <string name="message_view_additional_recipient_prefix">+</string>

--- a/legacy/ui/legacy/src/main/res/values-es/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-es/strings.xml
@@ -888,7 +888,7 @@ Puedes guardar este mensaje y usarlo como copia de seguridad de tu clave secreta
     <string name="about_title">Acerca de <xliff:g id="app_name">%s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">La aplicación OpenKeychain es necesaria para permitir el cifrado de extremo a extremo.</string>
     <string name="push_info_notification_explanation_text">Cuando se utiliza Push, <xliff:g id="app_name">%1$s</xliff:g> mantiene una conexión con el servidor de correo. Android requiere mostrar una notificación continua mientras la aplicación está activa en segundo plano. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">La cuenta \"<xliff:g id="account">%s</xliff:g>\" se eliminará de <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">La cuenta \"<xliff:g id="account">%1$s</xliff:g>\" se eliminará de <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="folder_settings_notifications_label">Notificaciones</string>
     <string name="settings_ui_telemetry_title">Datos técnicos y de uso</string>
     <string name="settings_ui_data_collection">Recopilación de datos</string>

--- a/legacy/ui/legacy/src/main/res/values-et/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-et/strings.xml
@@ -879,7 +879,7 @@ Palun jäta see kiri alles ning kasuta seda muu hulgas oma krüptovõtme varunda
     <string name="general_settings_post_mark_as_unread_action_return_to_list">mine tagasi sõnumite loendivaatesse</string>
     <string name="push_notification_state_alarm_permission_missing">Puuduvad õigused alarmide seadistamiseks</string>
     <string name="push_notification_grant_alarm_permission">Õiguste jagamiseks klõpsi.</string>
-    <string name="account_delete_dlg_instructions_fmt">Kasutajakonto \"<xliff:g id="account">%s</xliff:g>\" kustutatakse <xliff:g id="app_name">%s</xliff:g>ist.</string>
+    <string name="account_delete_dlg_instructions_fmt">Kasutajakonto \"<xliff:g id="account">%1$s</xliff:g>\" kustutatakse <xliff:g id="app_name">%2$s</xliff:g>ist.</string>
     <string name="push_info_notification_explanation_text">Tõuketeenuste kasutamisel <xliff:g id="app_name">%1$s</xliff:g> hoiab töös ühendust e-posti serveriga. Kui rakendus on taustal pidevalt aktiivne, siis Android eeldab, et selle kohta kuvatakse pidevat teavitust. Lisateave: <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="about_title">Teave <xliff:g id="app_name">%s</xliff:g>i kohta</string>
     <string name="dialog_openkeychain_info_text">Läbiva krüptimise kasutamiseks on vajalik OpenKeychaini rakendus.</string>

--- a/legacy/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-eu/strings.xml
@@ -881,7 +881,7 @@ Mezu hau gorde dezakezu eta zure gako sekretuaren babes-kopia gisa erabili. Hau 
     <string name="dialog_openkeychain_info_text">OpenKeychain aplikazioa beharrezkoa da muturretik muturrerako enkriptatzearen euskarria gaitzeko.</string>
     <string name="about_title"><xliff:g id="app_name">%s</xliff:g>ri buruz</string>
     <string name="push_info_notification_explanation_text">Push erabiltzean, <xliff:g id="app_name">%1$s</xliff:g>-k posta-zerbitzariarekin konexioa mantentzen du. Android-ek etengabeko jakinarazpena bistaratzea eskatzen du aplikazioa atzeko planoan aktibo dagoen bitartean. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">\"<xliff:g id="account">%s</xliff:g>\" kontua <xliff:g id="app_name">%s</xliff:g>tik kenduko da.</string>
+    <string name="account_delete_dlg_instructions_fmt">\"<xliff:g id="account">%1$s</xliff:g>\" kontua <xliff:g id="app_name">%2$s</xliff:g>tik kenduko da.</string>
     <string name="settings_ui_data_collection">Datu bilketa</string>
     <string name="settings_ui_telemetry_title">Erabilera eta datu teknikoak</string>
     <string name="folder_settings_notifications_label">Jakinarazpenak</string>

--- a/legacy/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fa/strings.xml
@@ -880,7 +880,7 @@
     <string name="general_settings_post_remove_action_title">پس از حذف یا جابجایی یک پیام</string>
     <string name="push_notification_state_alarm_permission_missing">اجازهٔ زمان‌بندی هشدارها وجود نداره</string>
     <string name="push_notification_grant_alarm_permission">زدن برای اعطای اجازه.</string>
-    <string name="account_delete_dlg_instructions_fmt">حساب کاربری \"<xliff:g id="account">%s</xliff:g>\" از <xliff:g id="app_name">%s</xliff:g> حذف خواهد شد.</string>
+    <string name="account_delete_dlg_instructions_fmt">حساب کاربری \"<xliff:g id="account">%1$s</xliff:g>\" از <xliff:g id="app_name">%2$s</xliff:g> حذف خواهد شد.</string>
     <string name="about_title">درباره<xliff:g id="app_name">%s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">برنامه کاربردی OpenKeychain جهت فعال‌سازی رمزگذاری سرتاسری مورد نیاز است.</string>
     <string name="push_info_notification_explanation_text">در زمان استفاده از پیشرانی، <xliff:g id="app_name">%1$s</xliff:g> اتصال به کارساز را نگاه می‌دارد. اندروید نیازمند یک آگاهی همیشگی جهت فعال ماندن برنامه در پس‌زمینه است. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fr/strings.xml
@@ -881,7 +881,7 @@
     <string name="push_notification_grant_alarm_permission">Touchez pour accorder l’autorisation.</string>
     <string name="about_title">À propos de <xliff:g id="app_name">%s</xliff:g></string>
     <string name="about_app_authors_thunderbird">L’équipe Thunderbird pour appareils mobiles</string>
-    <string name="account_delete_dlg_instructions_fmt">Le compte « <xliff:g id="account">%s</xliff:g> » sera supprimé de <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Le compte « <xliff:g id="account">%1$s</xliff:g> » sera supprimé de <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="push_info_notification_explanation_text">Si le poussé est utilisé, <xliff:g id="app_name">%1$s</xliff:g> maintient une connexion vers le serveur de courriel. Android exige d’afficher une notification continue quand l’appli est active en arrière-plan. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">L’appli OpenKeychain est nécessaire pour prendre en charge le chiffrement de bout en bout.</string>
     <string name="folder_settings_notifications_label">Notifications</string>

--- a/legacy/ui/legacy/src/main/res/values-fy/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fy/strings.xml
@@ -873,7 +873,7 @@
     <string name="general_settings_post_mark_as_unread_action_return_to_list">Werom nei berjochtelist</string>
     <string name="push_notification_state_alarm_permission_missing">Tastimming om alarms te plannen ûntbrekt</string>
     <string name="push_notification_grant_alarm_permission">Tik om tastimming te jaan.</string>
-    <string name="account_delete_dlg_instructions_fmt">De account \"<xliff:g id="account">%s</xliff:g>\" sil út <xliff:g id="app_name">%s</xliff:g> fuortsmiten wurde.</string>
+    <string name="account_delete_dlg_instructions_fmt">De account \"<xliff:g id="account">%1$s</xliff:g>\" sil út <xliff:g id="app_name">%2$s</xliff:g> fuortsmiten wurde.</string>
     <string name="push_info_notification_explanation_text">By gebrûk fan Push ûnderhâldt <xliff:g id="app_name">%1$s</xliff:g> in ferbining mei de mailserver. Android fereasket it trochrinnend toanen fan in melding as de app aktyf is op de eftergrûn. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">De app OpenKeychain is fereaske om stipe foar end-to-end-fersifering mooglik te meitsjen.</string>
     <string name="about_title">Oer <xliff:g id="app_name">%s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-ga/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ga/strings.xml
@@ -826,7 +826,7 @@
     <string name="settings_ui_data_collection">Bailiú sonraí</string>
     <string name="settings_ui_telemetry_title">Úsáid agus sonraí teicniúla</string>
     <string name="settings_ui_telemetry_description">Scaireanna feidhmíocht, úsáid, crua-earraí agus sonraí saincheaptha faoin app seo le Mozilla chun cabhrú linn a dhéanamh Thunderbird níos fearr</string>
-    <string name="account_delete_dlg_instructions_fmt">Bainfear an cuntas \"<xliff:g id="account">%s</xliff:g>\" de <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Bainfear an cuntas \"<xliff:g id="account">%1$s</xliff:g>\" de <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="message_compose_reply_header_fmt_with_date">Ar <xliff:g id="sent_date">%1$s</xliff:g>, scríobh <xliff:g id="sender">%2$s</xliff:g>:</string>
     <plurals name="dialog_confirm_spam_message">
         <item quantity="one">Ar mhaith leat an teachtaireacht seo a bhogadh go dtí an fillteán turscair?</item>

--- a/legacy/ui/legacy/src/main/res/values-gl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-gl/strings.xml
@@ -816,7 +816,7 @@ Podes conservar esta mensaxe e usala como copia de seguridade da túa chave secr
     <!--A user visible label for the name and email address copied to the clipboard-->
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="new_messages_title">Novas mensaxes</string>
+    <string name="new_messages_title">Novas mensaxes</string>
     <string name="unsubscribe_action">Cancelar a subscrición</string>
     <string name="message_view_me_text">eu</string>
     <string name="message_view_show_remote_images_action">Mostra imaxes remotas</string>
@@ -885,5 +885,5 @@ Podes conservar esta mensaxe e usala como copia de seguridade da túa chave secr
     <string name="folder_settings_notifications_label">Notificacións</string>
     <string name="folder_settings_push_label">Activar Push</string>
     <string name="about_title">Acerca de <xliff:g id="app_name">%s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">A conta \"<xliff:g id="account">%s</xliff:g>\" eliminarase de <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">A conta \"<xliff:g id="account">%1$s</xliff:g>\" eliminarase de <xliff:g id="app_name">%2$s</xliff:g>.</string>
 </resources>

--- a/legacy/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-hr/strings.xml
@@ -749,7 +749,7 @@
     <!--A user visible label for the name and email address copied to the clipboard-->
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="search_everywhere_action">Pretraži svugdje</string>
+    <string name="search_everywhere_action">Pretraži svugdje</string>
     <string name="new_messages_title">Nove poruke</string>
     <string name="notification_channel_push_title">Sinkroniziraj (Slanje)</string>
     <string name="debug_export_logs_title">Izvezi zapise</string>
@@ -788,7 +788,7 @@
     <string name="about_title">O aplikaciji <xliff:g id="app_name">%s</xliff:g></string>
     <string name="changelog_recent_changes_title">Što je novo</string>
     <string name="changelog_show_recent_changes">Prikaži nedavne promjene kada je aplikacija ažurirana</string>
-    <string name="account_delete_dlg_instructions_fmt">Račun \"<xliff:g id="account">%s</xliff:g>\" biti će uklonjen iz <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Račun \"<xliff:g id="account">%1$s</xliff:g>\" biti će uklonjen iz <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="choose_folder_move_title">Premjesti u…</string>
     <string name="notification_notify_error_text">Došlo je do greške prilikom pokušaja stvaranja sistemske obavijesti za novu poruku. Razlog je najvjerojatnije nedostatak zvuka obavijesti.\n\nDodirnite za otvaranje postavki obavijesti.</string>
     <string name="notification_channel_push_description">Prikazano dok čekate nove poruke</string>

--- a/legacy/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-hu/strings.xml
@@ -874,7 +874,7 @@ Megtarthatja ezt az üzenetet, és felhasználhatja a titkos kulcs biztonsági m
     <string name="general_settings_post_remove_action_show_next_message">Következő üzenet megjelenítése</string>
     <string name="general_settings_post_remove_action_title">Üzenet törlése vagy áthelyezése után</string>
     <string name="about_app_authors_thunderbird">A Thunderbird Mobile csapata</string>
-    <string name="account_delete_dlg_instructions_fmt">A(z) „<xliff:g id="account">%s</xliff:g>” fiók eltávolításra kerül a <xliff:g id="app_name">%s</xliff:g> alkalmazásból.</string>
+    <string name="account_delete_dlg_instructions_fmt">A(z) „<xliff:g id="account">%1$s</xliff:g>” fiók eltávolításra kerül a <xliff:g id="app_name">%2$s</xliff:g> alkalmazásból.</string>
     <string name="push_notification_state_alarm_permission_missing">Hiányzó engedély a riasztások ütemezéséhez</string>
     <string name="push_notification_grant_alarm_permission">Koppintson az engedély megadásához.</string>
     <string name="general_settings_post_mark_as_unread_action_return_to_list">Vissza az üzenetekhez</string>

--- a/legacy/ui/legacy/src/main/res/values-in/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-in/strings.xml
@@ -876,7 +876,7 @@
     <string name="push_info_notification_explanation_text">Saat menggunakan Dorongan, <xliff:g id="app_name">%1$s</xliff:g> mempertahankan koneksi ke server surel. Android memerlukan tampilan notifikasi yang sedang berlangsung saat aplikasi aktif di latar belakang. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="about_app_authors_thunderbird">Tim Thunderbird Mobile</string>
     <string name="about_title">Tentang <xliff:g id="app_name">%s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">Akun \"<xliff:g id="account">%s</xliff:g>\" akan dihapus dari <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Akun \"<xliff:g id="account">%1$s</xliff:g>\" akan dihapus dari <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="save_attachment_action">Simpan lampiran</string>
     <string name="volume_navigation_title_short">Navigasi kunci volume</string>
     <string name="folder_settings_sync_label">Nyalakan sinkronisasi</string>

--- a/legacy/ui/legacy/src/main/res/values-is/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-is/strings.xml
@@ -881,7 +881,7 @@ Til að setja Autocrypt upp á nýju tæki, farðu þá eftir leiðbeiningunum s
     <string name="push_notification_grant_alarm_permission">Ýttu til að veita heimild.</string>
     <string name="about_title">Um <xliff:g id="app_name">%s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">Forritið OpenKeychain er nauðsynlegt til að virkja stuðning við enda-í-enda dulritun.</string>
-    <string name="account_delete_dlg_instructions_fmt">Reikningurinn \"<xliff:g id="account">%s</xliff:g>\" verður fjarlægður úr <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Reikningurinn \"<xliff:g id="account">%1$s</xliff:g>\" verður fjarlægður úr <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="push_info_notification_explanation_text">Þegar ýti-tilkynningar eru notaðar, viðheldur <xliff:g id="app_name">%1$s</xliff:g> tengingu við póstþjóninn. Android krefst þess að birta tilkynningu um það á meðan forritið er enn virkt í bakgrunni. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="about_app_authors_thunderbird">Thunderbird Mobile teymið</string>
     <string name="settings_ui_telemetry_description">Deilir með Mozilla gögnum um afköst, notkun, vélbúnað og sérsníðingu þessa forrits til að hjálpa okkur að gera Thunderbird betra</string>

--- a/legacy/ui/legacy/src/main/res/values-it/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-it/strings.xml
@@ -883,7 +883,7 @@
     <string name="about_app_authors_thunderbird">Team di Thunderbird mobile</string>
     <string name="about_title">Informazioni su <xliff:g id="app_name">%s</xliff:g></string>
     <string name="push_info_notification_explanation_text">Quando si utilizza Push, <xliff:g id="app_name">%1$s</xliff:g> mantiene una connessione al server di posta. Android richiede la visualizzazione di una notifica in corso mentre l\'app è attiva in background. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">L\'account \"<xliff:g id="account">%s</xliff:g>\" verrà rimosso da <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">L\'account \"<xliff:g id="account">%1$s</xliff:g>\" verrà rimosso da <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="folder_settings_notifications_label">Notifiche</string>
     <string name="settings_ui_telemetry_title">Utilizzo e dati tecnici</string>
     <string name="settings_ui_telemetry_description">Condividi dati su prestazioni, utilizzo, hardware e personalizzazioni di questa app con Mozilla per aiutarci a migliorare Thunderbird</string>

--- a/legacy/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-iw/strings.xml
@@ -542,7 +542,7 @@
     <!--A user visible label for the name and email address copied to the clipboard-->
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="about_app_authors_k9">מוליכי הכלבים של K-9</string>
+    <string name="about_app_authors_k9">מוליכי הכלבים של K-9</string>
     <string name="about_website_title">אתר אינטרנט</string>
     <string name="get_help_title">קבל עזרה</string>
     <string name="user_forum_title">פורום משתמשים</string>
@@ -893,7 +893,7 @@
     <string name="push_notification_grant_alarm_permission">לחצו למתן הרשאות.</string>
     <string name="about_app_authors_thunderbird">קבוצת המובייל של Thunderbird</string>
     <string name="dialog_openkeychain_info_text">האפליקציה OpenKeychain נחוצה על מנת לאפשר תמיכה בהצפנת קצה אל קצה.</string>
-    <string name="account_delete_dlg_instructions_fmt">החשבון \"<xliff:g id="account">%s</xliff:g>\" יוסר מ <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">החשבון \"<xliff:g id="account">%1$s</xliff:g>\" יוסר מ <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="push_info_notification_explanation_text">כאשר משתמשים בדחיפה, <xliff:g id="app_name">%1$s</xliff:g> שומר על קשר עם שרת הדואר. אנדרואיד צורך הצגת התראה מתמשכת בזמן שהאפליקציה פועלת ברקע. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="about_title">אודות <xliff:g id="app_name">%s</xliff:g></string>
     <string name="save_attachment_action">שמור קובץ מצורף</string>

--- a/legacy/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ja/strings.xml
@@ -23,7 +23,7 @@
     <!--Button text of the "snack bar" that is displayed when the app was updated.-->
     <string name="changelog_snackbar_button_text">表示</string>
     <!--General strings that include the app name-->
-    <string name="account_delete_dlg_instructions_fmt">アカウント \"<xliff:g id="account">%s</xliff:g>\" は <xliff:g id="app_name">%s</xliff:g> から削除されます。</string>
+    <string name="account_delete_dlg_instructions_fmt">アカウント \"<xliff:g id="account">%1$s</xliff:g>\" は <xliff:g id="app_name">%2$s</xliff:g> から削除されます。</string>
     <!--=== General strings ==================================================================-->
     <string name="authors">開発者</string>
     <string name="about_title"><xliff:g id="app_name">%s</xliff:g> について</string>

--- a/legacy/ui/legacy/src/main/res/values-ko/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ko/strings.xml
@@ -685,7 +685,7 @@
     <!--A user visible label for the name and email address copied to the clipboard-->
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="size_format_bytes">%d B</string>
+    <string name="size_format_bytes">%d B</string>
     <string name="notification_channel_push_description">새 메시지 받는 동안 표시됨</string>
     <string name="notification_certificate_error_public">인증 요류</string>
     <string name="size_format_gigabytes">%.1f GB</string>
@@ -767,7 +767,7 @@
     <string name="message_view_additional_recipient_prefix">+</string>
     <string name="about_title"><xliff:g id="app_name">%s</xliff:g> 정보</string>
     <string name="general_settings_post_remove_action_show_next_message">다음 메시지 보기</string>
-    <string name="account_delete_dlg_instructions_fmt">\"<xliff:g id="account">%s</xliff:g>\" 계정이 <xliff:g id="app_name">%s</xliff:g>에서 제거됩니다.</string>
+    <string name="account_delete_dlg_instructions_fmt">\"<xliff:g id="account">%1$s</xliff:g>\" 계정이 <xliff:g id="app_name">%2$s</xliff:g>에서 제거됩니다.</string>
     <string name="notification_channel_messages_description">메시지와 관련된 알림</string>
     <string name="global_settings_lock_screen_notification_visibility_message_count">새 메시지 수</string>
     <string name="volume_navigation_title_short">볼륨 버튼으로 탐색</string>

--- a/legacy/ui/legacy/src/main/res/values-lt/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-lt/strings.xml
@@ -864,7 +864,7 @@ Norėdami nustatyti automatinį šifravimą naujajame prietaise, vadovaukitės i
     <string name="clipboard_label_name_and_email_address">Vardas ir el. pašto adresas</string>
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="message_details_loading_error">Bandant įkelti laiško savybes, įvyko klaida.</string>
+    <string name="message_details_loading_error">Bandant įkelti laiško savybes, įvyko klaida.</string>
     <string name="general_settings_post_remove_action_return_to_list">Grįžti į laiškų sąrašą</string>
     <string name="general_settings_post_remove_action_show_previous_message">Rodyti ankstesnį laišką</string>
     <string name="general_settings_ui_density_relaxed">Mažesnis</string>
@@ -891,6 +891,6 @@ Norėdami nustatyti automatinį šifravimą naujajame prietaise, vadovaukitės i
     <string name="changelog_snackbar_button_text">Peržiūrėti</string>
     <string name="about_app_authors_thunderbird">„Thunderbird Mobile“ komanda</string>
     <string name="settings_ui_telemetry_description">Bendrina su „Mozilla“ šios programos veikimo, naudojimo, aparatinės įrangos ir tinkinimo duomenis, kad padėtų mums tobulinti „Thunderbird“</string>
-    <string name="account_delete_dlg_instructions_fmt">Paskyra \"<xliff:g id="account">%s</xliff:g>\" bus pašalinta iš „<xliff:g id="app_name">%s</xliff:g>“.</string>
+    <string name="account_delete_dlg_instructions_fmt">Paskyra \"<xliff:g id="account">%1$s</xliff:g>\" bus pašalinta iš „<xliff:g id="app_name">%2$s</xliff:g>“.</string>
     <string name="about_title">Apie „<xliff:g id="app_name">%s</xliff:g>“</string>
 </resources>

--- a/legacy/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-lv/strings.xml
@@ -892,7 +892,7 @@
     <string name="folder_settings_sync_label">Iespējot sinhronizāciju</string>
     <string name="folder_list_show_hidden_folders">Rādīt slēptās mapes</string>
     <string name="settings_ui_telemetry_description">Kopīgo šīs lietotnes veiktspējas, lietojuma, aparatūras un pielāgošanas datus ar Mozilla, lai palīdzētu mums uzlabot Thunderbird</string>
-    <string name="account_delete_dlg_instructions_fmt">Konts <xliff:g id="account">%s</xliff:g> tiks noņemts no <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Konts <xliff:g id="account">%1$s</xliff:g> tiks noņemts no <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="about_title">Par <xliff:g id="app_name">%s</xliff:g></string>
     <string name="folder_settings_visible_label">Rādīt mapi</string>
     <string name="settings_list_action_support">Atbalstiet <xliff:g id="app_name">%s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-nl/strings.xml
@@ -874,7 +874,7 @@
     <string name="push_notification_state_alarm_permission_missing">Toestemming om alarmen te plannen ontbreekt</string>
     <string name="push_notification_grant_alarm_permission">Tik om toestemming te geven.</string>
     <string name="dialog_openkeychain_info_text">De app OpenKeychain is vereist om ondersteuning voor end-to-end-encryptie mogelijk te maken.</string>
-    <string name="account_delete_dlg_instructions_fmt">De account \"<xliff:g id="account">%s</xliff:g>\" zal uit <xliff:g id="app_name">%s</xliff:g> worden verwijderd.</string>
+    <string name="account_delete_dlg_instructions_fmt">De account \"<xliff:g id="account">%1$s</xliff:g>\" zal uit <xliff:g id="app_name">%2$s</xliff:g> worden verwijderd.</string>
     <string name="about_title">Over <xliff:g id="app_name">%s</xliff:g></string>
     <string name="push_info_notification_explanation_text">Bij gebruik van Push onderhoudt <xliff:g id="app_name">%1$s</xliff:g> een verbinding met de mailserver. Android vereist het doorlopend tonen van een melding als de app actief is op de achtergrond. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="about_app_authors_thunderbird">Thunderbird Mobile-team</string>

--- a/legacy/ui/legacy/src/main/res/values-nn/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-nn/strings.xml
@@ -469,7 +469,7 @@
     <!--A user visible label for the name and email address copied to the clipboard-->
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="spam_action">Spam</string>
+    <string name="spam_action">Spam</string>
     <string name="account_settings_vibrate_pattern_default">Standard</string>
     <string name="swipe_action_spam">Spam</string>
     <string name="choose_folder_move_title">Flytt til…</string>
@@ -559,7 +559,7 @@
     <string name="debug_export_logs_success">Vellykka eksport. Loggar kan innehalde sensitiv informasjon. Ver forsiktig med kven du sender dei til.</string>
     <string name="message_view_no_viewer">Finn ikkje framvisar for <xliff:g id="mimetype">%s</xliff:g>.</string>
     <string name="general_settings_post_remove_action_show_previous_message">Vis førre melding</string>
-    <string name="account_delete_dlg_instructions_fmt">Kontoen \"<xliff:g id="account">%s</xliff:g>\" vil bli fjerna frå <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Kontoen \"<xliff:g id="account">%1$s</xliff:g>\" vil bli fjerna frå <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="global_settings_messageview_fixedwidth_summary">Bruk skifttype med fast breidd under visning av rein tekst</string>
     <string name="message_view_sender_label">via %1$s</string>
     <string name="debug_export_logs_failure">Eksport feila.</string>

--- a/legacy/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-pl/strings.xml
@@ -23,7 +23,7 @@
     <!--Button text of the "snack bar" that is displayed when the app was updated.-->
     <string name="changelog_snackbar_button_text">Wyświetl</string>
     <!--General strings that include the app name-->
-    <string name="account_delete_dlg_instructions_fmt">Konto \"<xliff:g id="account">%s</xliff:g>\" zostanie usunięte z <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Konto \"<xliff:g id="account">%1$s</xliff:g>\" zostanie usunięte z <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <!--=== General strings ==================================================================-->
     <string name="authors">Autorzy</string>
     <string name="about_title">O aplikacji <xliff:g id="app_name">%s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -887,7 +887,7 @@ Você pode guardar esta mensagem e usá-la como um backup da sua chave secreta. 
     <string name="about_title">Sobre <xliff:g id="app_name">%s</xliff:g></string>
     <string name="push_info_notification_explanation_text">Ao usar o Push, <xliff:g id="app_name">%1$s</xliff:g> mantém uma conexão ao servidor de e-mail. O Android requer que uma notificação seja mostrada enquanto o app está rodando em segundo plano. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">O app OpenKeychain é necessário para ativar o suporte à criptografia de ponta a ponta.</string>
-    <string name="account_delete_dlg_instructions_fmt">A conta \"<xliff:g id="account">%s</xliff:g>\"será removida de <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">A conta \"<xliff:g id="account">%1$s</xliff:g>\"será removida de <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="about_app_authors_thunderbird">Equipe do Thunderbird Mobile</string>
     <string name="folder_settings_notifications_label">Notificações</string>
     <string name="settings_ui_data_collection">Coleta de dados</string>

--- a/legacy/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -884,7 +884,7 @@ Pode manter esta mensagem e usá-la como uma cópia de segurança para a sua cha
     <string name="general_settings_post_remove_action_title">Depois de apagar ou mover mensagem</string>
     <string name="background_work_notification_remove_account">A remover conta…</string>
     <string name="about_app_authors_thunderbird">Equipa do Thunderbird Mobile</string>
-    <string name="account_delete_dlg_instructions_fmt">A conta \"<xliff:g id="account">%s</xliff:g>\"será removida de <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">A conta \"<xliff:g id="account">%1$s</xliff:g>\"será removida de <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="push_notification_state_alarm_permission_missing">Falta a permissão para agendar alarmes</string>
     <string name="push_notification_grant_alarm_permission">Toque para conceder a permissão.</string>
     <string name="about_title">Acerca de <xliff:g id="app_name">%s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ro/strings.xml
@@ -886,7 +886,7 @@ Poți păstra acest mesaj și să îl folosești drept copie de siguranță a ch
     <string name="push_notification_grant_alarm_permission">Atinge pentru a acorda permisiunea.</string>
     <string name="dialog_openkeychain_info_text">Aplicația OpenKeychain este necesară pentru a activa suportul pentru criptarea end-to-end.</string>
     <string name="push_info_notification_explanation_text">Când utilizezi Push, <xliff:g id="app_name">%1$s</xliff:g> menține o conexiune la serverul de e-mail. Android necesită afișarea unei notificări în curs de desfășurare în timp ce aplicația este activă în fundal. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">Contul „<xliff:g id="account">%s</xliff:g>” va fi eliminat din <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Contul „<xliff:g id="account">%1$s</xliff:g>” va fi eliminat din <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="about_title">Despre <xliff:g id="app_name">%s</xliff:g></string>
     <string name="about_app_authors_thunderbird">Echipa Thunderbird Mobile</string>
     <string name="folder_settings_notifications_label">Notificări</string>

--- a/legacy/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ru/strings.xml
@@ -882,7 +882,7 @@
     <string name="clipboard_label_name_and_email_address">Имя и адрес эл. почты</string>
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="general_settings_post_mark_as_unread_action_title">После пометки сообщения как непрочитанного</string>
+    <string name="general_settings_post_mark_as_unread_action_title">После пометки сообщения как непрочитанного</string>
     <string name="background_work_notification_remove_account">Удаление учётной записи…</string>
     <string name="message_list_content_description_unread_prefix">не прочитано, %s</string>
     <string name="general_settings_post_remove_action_title">После удаления или перемещения сообщения</string>
@@ -895,7 +895,7 @@
     <string name="push_notification_state_alarm_permission_missing">Отсутствует разрешение на установку будильников</string>
     <string name="dialog_openkeychain_info_text">Для сквозного шифрования в требуется приложение OpenKeychain.</string>
     <string name="push_info_notification_explanation_text">При использовании push <xliff:g id="app_name">%1$s</xliff:g> поддерживает соединение с почтовым сервером. Android требует отображения постоянного уведомления, пока приложение активно в фоновом режиме. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">Учётная запись \"<xliff:g id="account">%s</xliff:g>\" будет удалена из приложения <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Учётная запись \"<xliff:g id="account">%1$s</xliff:g>\" будет удалена из приложения <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="about_title">О приложении <xliff:g id="app_name">%s</xliff:g></string>
     <string name="about_app_authors_thunderbird">Команда Thunderbird Mobile</string>
     <string name="folder_settings_notifications_label">Уведомления</string>

--- a/legacy/ui/legacy/src/main/res/values-sk/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sk/strings.xml
@@ -851,7 +851,7 @@
     <string name="toast_openpgp_provider_error">Chyba pripojenia k %s!</string>
     <string name="message_list_error_title">Chyba</string>
     <string name="message_list_content_description_unread_prefix">neprečítaných, %s</string>
-    <string name="account_delete_dlg_instructions_fmt">Konto \"<xliff:g id="account">%s</xliff:g>\" bude zmazané z <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Konto \"<xliff:g id="account">%1$s</xliff:g>\" bude zmazané z <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="general_settings_post_mark_as_unread_action_stay">Zostať na aktuálnej správe</string>
     <string name="account_settings_open_notification_settings_messages_summary">Nastaviť notifikácie pre nové správy</string>
     <string name="crypto_msg_title_plaintext">Čistý text</string>

--- a/legacy/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sl/strings.xml
@@ -888,7 +888,7 @@ Sporočilo lahko shranite in ga uporabite kot varno kopijo šifrirnega ključa. 
     <string name="general_settings_post_mark_as_unread_action_stay">Ostani na trenutnem sporočilu</string>
     <string name="general_settings_post_mark_as_unread_action_title">Ko označite sporočilo kot neprebrano</string>
     <string name="general_settings_post_mark_as_unread_action_return_to_list">Vrni se na seznam sporočil</string>
-    <string name="account_delete_dlg_instructions_fmt">Račun \"<xliff:g id="account">%s</xliff:g>\" bo odstranjen iz <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Račun \"<xliff:g id="account">%1$s</xliff:g>\" bo odstranjen iz <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="settings_ui_telemetry_title">Uporaba in tehnični podatki</string>
     <string name="settings_ui_data_collection">Zbiranje podatkov</string>
     <string name="push_notification_state_alarm_permission_missing">Manjka dovoljenje za nastavitev alarma.</string>

--- a/legacy/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sq/strings.xml
@@ -875,7 +875,7 @@
     <string name="push_notification_state_alarm_permission_missing">Mungojnë leje për të planifikuar alarme</string>
     <string name="dialog_openkeychain_info_text">Aplikacioni OpenKeychain është i domosdoshëm për të aktivizuar mbulim fshehtëzimi skaj-më-skaj.</string>
     <string name="about_title">Mbi <xliff:g id="app_name">%s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">Llogaria \"<xliff:g id="account">%s</xliff:g>\" do të hiqet nga <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Llogaria \"<xliff:g id="account">%1$s</xliff:g>\" do të hiqet nga <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="push_info_notification_explanation_text">Kur përdoret Push, <xliff:g id="app_name">%1$s</xliff:g> mban një lidhje me shërbyesin e postës. Android-i lyp shfaqjen e vazhdueshme të një njoftimi, teksa aplikacioni është aktiv në prapaskenë. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="about_app_authors_thunderbird">Ekipi i Thunderbird-it Për Celular</string>
     <string name="settings_ui_data_collection">Grumbullim të dhënash</string>

--- a/legacy/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sr/strings.xml
@@ -787,7 +787,7 @@
     <!--A user visible label for the name and email address copied to the clipboard-->
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
-<string name="about_app_authors_thunderbird">Тхундербирд Мобиле Теам</string>
+    <string name="about_app_authors_thunderbird">Тхундербирд Мобиле Теам</string>
     <string name="changelog_show_recent_changes">Прикажи недавне промене када је апликација ажурирана</string>
     <string name="changelog_recent_changes_title">Шта има ново</string>
     <string name="get_help_title">Потражите помоћ</string>
@@ -815,7 +815,7 @@
     <string name="global_settings_lock_screen_notification_visibility_message_count">Број нових порука</string>
     <string name="account_settings_open_notification_settings_messages_summary">Конфигуриши обавештења за нове поруке</string>
     <string name="swipe_action_move">Премести…</string>
-    <string name="account_delete_dlg_instructions_fmt">Налог \"<xliff:g id="account">%s</xliff:g>\" ће бити уклоњен из <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Налог \"<xliff:g id="account">%1$s</xliff:g>\" ће бити уклоњен из <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="search_everywhere_action">Претражи свуда</string>
     <string name="new_messages_title">Нове поруке</string>
     <string name="copy_subject_to_clipboard">Текст теме је копиран у клипборд</string>

--- a/legacy/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sv/strings.xml
@@ -880,7 +880,7 @@ Du kan behålla detta meddelande och använda det som en säkerhetskopia för di
     <string name="push_notification_state_alarm_permission_missing">Saknar behörigheter för att schemalägga larm</string>
     <string name="push_notification_grant_alarm_permission">Tryck för att ge behörigheter.</string>
     <string name="dialog_openkeychain_info_text">Appen OpenKeychain krävs för att möjliggöra stöd för end-to-end-kryptering.</string>
-    <string name="account_delete_dlg_instructions_fmt">Kontot \"<xliff:g id="account">%s</xliff:g>\" kommer att tas bort ifrån <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Kontot \"<xliff:g id="account">%1$s</xliff:g>\" kommer att tas bort ifrån <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="about_title">Om <xliff:g id="app_name">%s</xliff:g></string>
     <string name="about_app_authors_thunderbird">Thunderbird mobilteam</string>
     <string name="folder_settings_push_label">Aktivera pushnotiser</string>

--- a/legacy/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-tr/strings.xml
@@ -872,7 +872,7 @@
     <string name="general_settings_post_mark_as_unread_action_return_to_list">İleti listesine dön</string>
     <string name="push_notification_state_alarm_permission_missing">Alarmları zamanlamak için izin eksik</string>
     <string name="push_notification_grant_alarm_permission">İzin vermek için dokunun.</string>
-    <string name="account_delete_dlg_instructions_fmt">\"<xliff:g id="account">%s</xliff:g>\" hesabı <xliff:g id="app_name">%s</xliff:g> uygulamasından kaldırılacak.</string>
+    <string name="account_delete_dlg_instructions_fmt">\"<xliff:g id="account">%1$s</xliff:g>\" hesabı <xliff:g id="app_name">%2$s</xliff:g> uygulamasından kaldırılacak.</string>
     <string name="about_title"><xliff:g id="app_name">%s</xliff:g> Hakkında</string>
     <string name="push_info_notification_explanation_text">Anında ilet kullanılırken <xliff:g id="app_name">%1$s</xliff:g>, e-posta sunucusuyla bağlantıyı sürdürür. Uygulama arka planda etkin durumdayken Android\'in sürekli bir bildirim görüntülemesi gerekir. <xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">Uçtan uca şifreleme desteğini etkinleştirmek için OpenKeychain uygulaması gereklidir.</string>

--- a/legacy/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-uk/strings.xml
@@ -897,7 +897,7 @@
     <string name="folder_list_show_hidden_folders">Показати приховані теки</string>
     <string name="folder_settings_visible_label">Показати теку</string>
     <string name="settings_list_action_support">Підтримка <xliff:g id="app_name">%s</xliff:g></string>
-    <string name="account_delete_dlg_instructions_fmt">Обліковий запис\"<xliff:g id="account">%s</xliff:g>\" буде вилучено з <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Обліковий запис\"<xliff:g id="account">%1$s</xliff:g>\" буде вилучено з <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="dialog_openkeychain_info_text">Застосунок OpenKeychain необхідний для підтримки наскрізного шифрування.</string>
     <string name="push_notification_state_alarm_permission_missing">Відсутній дозвіл на планування оповіщень</string>
     <string name="push_notification_grant_alarm_permission">Торкніться, щоб надати дозвіл.</string>

--- a/legacy/ui/legacy/src/main/res/values-vi/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-vi/strings.xml
@@ -873,7 +873,7 @@
     <string name="generic_loading_error">Có lỗi xảy ra khi đang tải dữ liệu</string>
     <string name="push_info_disable_push_text">Nếu bạn không cần thông báo tức thì về tin nhắn mới, bạn nên tắt tính năng Đẩy và sử dụng Thăm dò. Thăm dò kiểm tra thư mới theo định kỳ và không cần thông báo.</string>
     <string name="push_info_disable_push_action">Vô hiệu hóa Đẩy</string>
-    <string name="account_delete_dlg_instructions_fmt">Tài khoản \"<xliff:g id="account">%s</xliff:g>\" sẽ bị loại khỏi <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">Tài khoản \"<xliff:g id="account">%1$s</xliff:g>\" sẽ bị loại khỏi <xliff:g id="app_name">%2$s</xliff:g>.</string>
     <string name="dialog_openkeychain_info_text">Cần có ứng dụng OpenKeychain để hỗ trợ mã hóa đầu cuối.</string>
     <string name="push_info_notification_explanation_text">Khi sử dụng Push, <xliff:g id="app_name">%1$s</xliff:g> duy trì kết nối với máy chủ thư. Android yêu cầu hiển thị thông báo liên tục trong khi ứng dụng đang hoạt động ở chế độ nền. <xliff:g id="Optional_extends_explanation">%2$s</xliff:g></string>
     <string name="about_title">Giới thiệu về <xliff:g id="app_name">%s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -867,7 +867,7 @@
     <string name="general_settings_post_mark_as_unread_action_return_to_list">返回邮件列表</string>
     <string name="push_notification_state_alarm_permission_missing">缺少设置闹钟的权限</string>
     <string name="push_notification_grant_alarm_permission">轻击以授予权限。</string>
-    <string name="account_delete_dlg_instructions_fmt">账号“<xliff:g id="account">%s</xliff:g>”将从 <xliff:g id="app_name">%s</xliff:g> 中移除。</string>
+    <string name="account_delete_dlg_instructions_fmt">账号“<xliff:g id="account">%1$s</xliff:g>”将从 <xliff:g id="app_name">%2$s</xliff:g> 中移除。</string>
     <string name="about_title">关于 <xliff:g id="app_name">%s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">启用对端到端加密的支持需要使用 OpenKeychain。</string>
     <string name="push_info_notification_explanation_text">使用推送功能时，<xliff:g id="app_name">%1$s</xliff:g> 会保持与邮件服务器的连接。Android 要求在应用处于后台活动状态时显示持续通知。<xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-zh-rTW/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-zh-rTW/strings.xml
@@ -875,7 +875,7 @@
     <string name="about_app_authors_thunderbird">Thunderbird Mobile Team</string>
     <string name="push_info_notification_explanation_text">使用推送時，<xliff:g id="app_name">%1$s</xliff:g> 會保持與郵件伺服器的連接。當應用程式在背景中運行時，Android 需要顯示持續通知。<xliff:g id="optional_extended_explanation">%2$s</xliff:g></string>
     <string name="dialog_openkeychain_info_text">需要安裝 OpenKeychain 應用程式以支援端到端加密。</string>
-    <string name="account_delete_dlg_instructions_fmt">帳戶 \"<xliff:g id="account">%s</xliff:g>\" 將從 <xliff:g id="app_name">%s</xliff:g> 中移除。</string>
+    <string name="account_delete_dlg_instructions_fmt">帳戶 \"<xliff:g id="account">%1$s</xliff:g>\" 將從 <xliff:g id="app_name">%2$s</xliff:g> 中移除。</string>
     <string name="about_title">關於 <xliff:g id="app_name">%s</xliff:g></string>
     <string name="settings_ui_data_collection">數據收集</string>
     <string name="folder_settings_notifications_label">通知</string>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="changelog_snackbar_button_text">View</string>
 
     <!-- General strings that include the app name -->
-    <string name="account_delete_dlg_instructions_fmt">The account \"<xliff:g id="account">%s</xliff:g>\" will be removed from <xliff:g id="app_name">%s</xliff:g>.</string>
+    <string name="account_delete_dlg_instructions_fmt">The account \"<xliff:g id="account">%1$s</xliff:g>\" will be removed from <xliff:g id="app_name">%2$s</xliff:g>.</string>
 
 
     <!-- === General strings ================================================================== -->


### PR DESCRIPTION
This resolves the warning about multiple substitutions specified in non-positional format of string resource.

Tasks:

- [ ] Unlock weblate once this is merged and synced