### PR TITLE
Fix for Uncaught Exception and Crash, Lost Messages in Unsynchronized Local-Only Folders

### DIFF
--- a/issueTestCases.txt
+++ b/issueTestCases.txt
@@ -11,7 +11,7 @@ Failing cases: starring/unstarring messages moved anywhere offline, but the acti
 Task 2:
 No working cases
 Failing cases: any "ghost folders" existing in the app but NOT on the IMAP server will allow a user to move a message into the folder but not out of the folder (both online and offline)
-Test cases:
+Test cases (for move, copy, archive, spam, move to drafts, move to outbox, move to arbitrary folder):
 
 -- ONLINE --
 - Move/copy message into a ghost folder from List View

--- a/issueTestCases.txt
+++ b/issueTestCases.txt
@@ -1,0 +1,25 @@
+Task 1:
+Working cases: starring/unstarring messages moved anywhere offline so long as it happens in the LIST VIEW
+Failing cases: starring/unstarring messages moved anywhere offline, but the action is performed in MESSAGE VIEW
+- Move to spam, then star/unstar
+- Move to drafts, then star/unstar
+- Move to outbox, then star/unstar
+- Move to archive, then star/unstar
+- Move to arbitrary folder (e.g. "Important"), then star/unstar
+
+
+Task 2:
+No working cases
+Failing cases: any "ghost folders" existing in the app but NOT on the IMAP server will allow a user to move a message into the folder but not out of the folder (both online and offline)
+Test cases:
+
+-- ONLINE --
+- Move/copy message into a ghost folder from List View
+- Move/copy message into a ghost folder from Message View
+  - In both cases, message list should get refreshed before prompting user for target folder, and the app will not allow the user to complete the operation (folder no longer exists)
+
+-- OFFLINE --
+- Move/copy message into ghost folder from List View
+- Move/copy message into ghost folder from Message View
+  - In each case, pop-up should appear prompting user to cancel the operation, proceed anyways, or to not show the pop-up again and to proceed
+    - If "don't show again" is selected, the pop-up should not appear if a user closes, reopens the app and repeats behavior (i.e. memory between sessions)

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -974,8 +974,18 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
     private void queueSetFlag(Account account, long folderId, boolean newState, Flag flag, List<String> uids) {
-        PendingCommand command = PendingSetFlag.create(folderId, newState, flag, uids);
-        queuePendingCommand(account, command);
+        //PendingCommand command = PendingSetFlag.create(folderId, newState, flag, uids);
+        String commandDescription = null;
+        try{
+            PendingCommand command = PendingSetFlag.create(folderId, newState, flag, uids);
+            if (command != null) {
+                commandDescription = command.getCommandName();
+            }
+            queuePendingCommand(account, command);
+        } catch (Exception e){
+
+            Timber.e(e, "Error running command '%s'", commandDescription);
+        }
     }
 
     /**


### PR DESCRIPTION
These are our fixes to address issues #7688 and #823

**Uncaught Exception, Crash: Issue #7688** 
Problem:
- Previously, if a user goes offline, moves a message into another folder, opens the message, and stars/unstars it, the app would consistently crash
    - This did NOT happen when a message was starred/unstarred from the List View.
 
Solution:
- Now we catch an exception in `queueSetFlag()` to avoid the crash; this is how it is handled in List View.
    - List View catches the exception in `runInBackground()`
 


**"Lost" Messages in Unsynchronized, Local-Only Folders: Issue #823** 
Problem:
- A user using Thunderbird with an account having no archive folder reported that, on moving a message to archive, they were not able to move it elsewhere in any way; the message effectively became local-only and lost to the server.
- Potentially happens with other folders that only exist locally but not on the server

Solution:
- Online Fix: If a user has connectivity, refresh the folder list before making any move operations
- Offline Fix: A dialog/prompt shows up, informing the user that the operation might lead to data loss
    - The user is allowed to proceed anyways, cancel the operation, or to proceed and never show the warning again
- Applies to moving (to arbitrary folders, or also to drafts and spam), copying, archiving.





Authors: @dnicules @gkhourii