### PR TITLE
Change url from raw to api to retrieve the release notes

### DIFF
--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -786,7 +786,7 @@ jobs:
           mkdir whatsnew
           if [[ "$RELEASE_TYPE" = "beta" || "$RELEASE_TYPE" = "release" ]]; then
             FILEPATH=app-metadata/${APPLICATION_ID}/en-US/changelogs/${VERSION_CODE}.txt
-            wget -O whatsnew/whatsnew-en-US https://raw.githubusercontent.com/${REPO}/${APP_SHA}/${FILEPATH}?token=$(date +%s)
+            wget --header="Accept: application/vnd.github.v3.raw" -O whatsnew/whatsnew-en-US https://api.github.com/repos/${REPO}/contents/${FILEPATH}?ref=${APP_SHA}
           elif [[ "$RELEASE_TYPE" = "daily" ]]; then
             COMMIT_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
             WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/scripts/render-notes.py
+++ b/scripts/render-notes.py
@@ -4,7 +4,6 @@ import argparse
 import os
 import requests
 import yaml
-import time
 import sys
 
 from jinja2 import Template
@@ -40,16 +39,16 @@ def render_notes(
     else:
         tb_notes_url = (
             os.path.join(
-                f"https://raw.githubusercontent.com/{notesrepo}/",
-                f"refs/heads/{notesbranch}",
-                tb_notes_directory,
-                tb_notes_filename,
+                f"https://api.github.com/repos/{notesrepo}/",
+                f"contents/{tb_notes_directory}/{tb_notes_filename}?ref={notesbranch}",
             )
-            + "?token="
-            + str(int(time.time()))
         )
 
-        response = requests.get(tb_notes_url)
+        headers = {
+            "Accept": "application/vnd.github.v3.raw"
+        }
+
+        response = requests.get(tb_notes_url, headers=headers)
         response.raise_for_status()
         yaml_content = yaml.safe_load(response.text)
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+PyNaCl
+PyYAML
+Jinja2
+requests


### PR DESCRIPTION
Using the Github API allows retrieval of notes and doesn't need the `token=$(date +%s)`, which [fails](https://github.com/thunderbird/thunderbird-android/actions/runs/12240553099/job/34143674356).

Also added a `requirments.txt` for easier Python dependency installation.