### PR TITLE
Restart push after app update

### DIFF
--- a/legacy/common/src/main/AndroidManifest.xml
+++ b/legacy/common/src/main/AndroidManifest.xml
@@ -228,6 +228,7 @@
             >
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/BootCompleteReceiver.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/BootCompleteReceiver.kt
@@ -15,7 +15,7 @@ class BootCompleteReceiver : BroadcastReceiver(), KoinComponent {
     private val pushController: PushController by inject()
 
     override fun onReceive(context: Context, intent: Intent?) {
-        Timber.v("BootCompleteReceiver.onReceive()")
+        Timber.v("BootCompleteReceiver.onReceive() - %s", intent?.action)
 
         pushController.init()
     }


### PR DESCRIPTION
Steps to test:
- Install app without this change applied and configure Push
- Update app without this change applied (`gradlew :app:thunderbird:installFullDebug`, will update but not start the app) → push service is not started
- Update app with this change applied (`gradlew :app:thunderbird:installFullDebug`) → push service is started

Fixes #8665