### PR TITLE
[CASA] Add validation workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,9 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,13 +31,13 @@ jobs:
         with:
           cache-read-only: true
 
-      - uses: github/codeql-action/init@36b4953ccc146c80e767661afed94af92787aa99 # v3.27.7
+      - uses: github/codeql-action/init@babb554ede22fd5605947329c4d04d8e7a0b8155 # v3.27.7
         with:
           languages: java
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@6b4953ccc146c80e767661afed94af92787aa99 # v3.27.7
+        uses: github/codeql-action/autobuild@babb554ede22fd5605947329c4d04d8e7a0b8155 # v3.27.7
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@6b4953ccc146c80e767661afed94af92787aa99 # v3.27.7
+        uses: github/codeql-action/analyze@babb554ede22fd5605947329c4d04d8e7a0b8155 # v3.27.7
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 10 * * 1'
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   codeql-scan:
 

--- a/.github/workflows/daily_builds.yml
+++ b/.github/workflows/daily_builds.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '8 20 * * *'
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   trigger_daily_build:
     uses: ./.github/workflows/shippable_builds.yml

--- a/.github/workflows/gradle-cache.yml
+++ b/.github/workflows/gradle-cache.yml
@@ -14,6 +14,9 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -6,6 +6,9 @@ on:
       - '**.md'
       - '.github/workflows/markdown.yml'
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   markdown_quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/needinfo-remove.yml
+++ b/.github/workflows/needinfo-remove.yml
@@ -6,6 +6,9 @@ on:
     types:
       - created
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/needinfo-stale.yml
+++ b/.github/workflows/needinfo-stale.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,73 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '19 22 * * 3'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@6b4953ccc146c80e767661afed94af92787aa99 # v3.27.7
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,6 +68,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@6b4953ccc146c80e767661afed94af92787aa99 # v3.27.7
+        uses: github/codeql-action/upload-sarif@babb554ede22fd5605947329c4d04d8e7a0b8155 # v3.27.7
         with:
           sarif_file: results.sarif

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -29,6 +29,9 @@ on:
         type: boolean
         description: Upload to FTP stage instead of prod
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   get_environment:
     name: Determine Release Environment

--- a/.github/workflows/uplift-merges.yml
+++ b/.github/workflows/uplift-merges.yml
@@ -8,6 +8,9 @@ on:
         description: Dry run
         default: true
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   uplift:
     name: Uplift

--- a/.github/workflows/validate-gradle.yml
+++ b/.github/workflows/validate-gradle.yml
@@ -1,0 +1,15 @@
+name: "Validate Gradle Wrapper"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate-gradle:
+    name: "validate-gradle"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: gradle/actions/wrapper-validation@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1

--- a/.github/workflows/validate-gradle.yml
+++ b/.github/workflows/validate-gradle.yml
@@ -4,12 +4,13 @@ on:
   push:
   pull_request:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   validate-gradle:
     name: "validate-gradle"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: gradle/actions/wrapper-validation@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,0 +1,31 @@
+name: "Validate Workflows"
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        type: boolean
+        description: Dry run
+        default: true
+      debug:
+        type: boolean
+        description: Debug mode
+        default: false
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  validate-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Ensure GitHub actions are SHA pinned
+        env:
+          DRY_RUN: ${{ !inputs.dryRun && '--no-dry-run' || '' }}
+          DEBUG: ${{ inputs.debug && '--debug' || '' }}
+        run: |
+          bash scripts/validate-github-actions-pinned.sh $DRY_RUN $DEBUG

--- a/scripts/validate-github-actions-pinned.sh
+++ b/scripts/validate-github-actions-pinned.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -e
+
+sha1_regex='^[a-f0-9]{40}$'
+sha256_regex='^[A-Fa-f0-9]{64}$'
+
+# Default values
+workflows_path=".github/workflows"
+dry_run=true
+debug=false
+action_has_error=false
+
+# Parse command-line arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --workflows-path) workflows_path=$2; shift 2;;
+    --no-dry-run) dry_run=false; shift;;
+    --debug) debug=true; shift;;
+    *) echo "Unknown argument: $1"; exit 1;;
+  esac
+done
+
+function debug() {
+  if [[ "$debug" == true ]]; then
+    echo "DEBUG: $*"
+  fi
+}
+
+function fail() {
+  echo "ERROR: $*"
+  exit 1
+}
+
+function assert_uses_version() {
+  local uses="$1"
+  [[ "$uses" == *@* ]]
+}
+
+function assert_uses_sha() {
+  local uses="$1"
+  if [[ "$uses" == docker://* ]]; then
+    [[ "$uses" =~ sha256:$sha256_regex ]]
+  else
+    local sha_part
+    sha_part=$(echo "$uses" | awk -F'@' '{print $2}' | awk '{print $1}')
+    [[ "$sha_part" =~ $sha1_regex ]]
+  fi
+}
+
+function run_assertions() {
+  local uses="$1"
+  has_error=false
+
+  debug "Processing uses=$uses"
+
+  if assert_uses_version "$uses" && ! assert_uses_sha "$uses"; then
+    local message="$uses is not pinned to a full length commit SHA."
+
+    if [[ "$dry_run" == true ]]; then
+      echo "WARNING: $message"
+    else
+      echo "ERROR: $message" >&2
+    fi
+
+    has_error=true
+  else
+    debug "$uses passed all checks."
+  fi
+
+  $has_error && return 1 || return 0
+}
+
+function check_workflow() {
+  local file="$1"
+  local file_has_error=false
+
+  echo ""
+  echo "Processing $file..."
+
+  if ! grep -q "jobs:" "$file"; then
+    fail "The $(basename "$file") workflow does not contain jobs."
+  fi
+
+  jobs=$(sed -n '/jobs:/,/^[^ ]/p' "$file")
+
+  while read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*uses: || "$line" =~ ^[[:space:]]*-\ uses: ]]; then
+        uses=$(echo "$line" | awk -F: '{print $2}' | xargs)
+        run_assertions "$uses" || file_has_error=true
+    fi
+  done <<< "$jobs"
+
+  $file_has_error && return 1 || echo "No issues were found in $file." && return 0
+}
+
+# Main script logic
+while IFS= read -r -d '' file; do
+  if [[ -f "$file" ]]; then
+    check_workflow "$file" || action_has_error=true
+  fi
+done < <(find "$workflows_path" -type f \( -name '*.yaml' -o -name '*.yml' \) -print0)
+
+if [[ "$dry_run" != true && "$action_has_error" == true ]]; then
+  echo ""
+  fail "At least one workflow contains an unpinned GitHub Action version." >&2
+fi
+
+exit 0


### PR DESCRIPTION
This adds workflows for validating the project:

- Gradle Wrapper validation
- [Scorecard](https://github.com/ossf/scorecard) to check for using best practises
- Script to check that GitHub actions are pinned to a Git hash

Workflow permissons are now by default `read-only` and further permissions need to be granted on job level.
