### PR TITLE
Fix gradle cache run

### DIFF
--- a/.github/workflows/gradle-cache.yml
+++ b/.github/workflows/gradle-cache.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
 
-      - run: ./gradlew assembleDebug
+      - run: ./gradlew assemble


### PR DESCRIPTION
Change to `assemble` as lint requires all variants build and they are not present in the build cache. This should improve build times for pull-requests.


