### PR TITLE
Main daily build relnotes

### DIFF
--- a/.github/workflows/daily_builds.yml
+++ b/.github/workflows/daily_builds.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   trigger_daily_build:
+    if: ${{ github.repository_owner == 'thunderbird' }}
     uses: ./.github/workflows/shippable_builds.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -979,7 +979,8 @@ jobs:
 
             if (process.env.skipFtp != "true" && process.env.releaseTarget.includes("ftp") && process.env.packageFormat == 'apk') {
               await core.summary
-                .addRaw(`Published to FTP at `)
+                .addRaw(`Published to FTP at`)
+                .addEOL();
                 .addLink(process.env.ftpUrlPath, process.env.ftpUrlPath)
                 .addEOL();
 

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -794,8 +794,7 @@ jobs:
               ${APP_NAME^} ${VERSION_NAME} (${VERSION_CODE}) Daily Build
 
               The Daily version is an unstable testing and development platform, make sure you back up important data regularly!
-              If you find any issues, get in touch at https://github.com/thunderbird/thunderbird-android/issues/ and find us on Matrix at https://matrix.to/#/#tb-android-dev:mozilla.org
-              Be prepared to debug the code in Android Studio :-)
+              If you find any issues, get in touch at https://github.com/thunderbird/thunderbird-android/issues/
 
               - Built from GitHub commit: ${COMMIT_URL}
               - Built with GitHub workflow: ${WORKFLOW_URL}


### PR DESCRIPTION
Only run daily builds on https://github.com/thunderbird/thunderbird-android. This prevents forked repositories from attempting daily builds on the cron schedule.

Reduce length of daily build release notes to enable uploads to play store.

Add a newline to FTP upload links, for example:
https://github.com/thunderbird/thunderbird-android/actions/runs/12356149776#summary-34482649666