### PR TITLE
Add build engineers as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-.github/* @coreycb
 * @cketti @wmontwe
+/.github/ @coreycb @jfx2006 @dandarnell
+


### PR DESCRIPTION
Also change pattern, because `.github/*` only matches direct children, not subdirectories.

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners