### PR TITLE
Add accessible name for contact picture checkbox

### DIFF
--- a/legacy/ui/legacy/src/main/res/layout/message_list_item.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list_item.xml
@@ -226,6 +226,7 @@
         android:id="@+id/contact_picture_click_area"
         android:layout_width="@dimen/messageListStartKeyline"
         android:layout_height="0dp"
+        android:contentDescription="@string/checkbox_content_description"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -1078,4 +1078,5 @@ You can keep this message and use it as a backup for your secret key. If you wan
     <string name="settings_ui_telemetry_title">Usage and technical data</string>
     <!-- Description of the "Usage and technical data" setting used in the "data collection" section of the general settings screen -->
     <string name="settings_ui_telemetry_description">Shares performance, usage, hardware and customization data about this app with Mozilla to help us make Thunderbird better</string>
+    <string name="checkbox_content_description">Checkbox</string>
 </resources>


### PR DESCRIPTION
_Fixes #8446_ for the most part, but announcing the checked state seems to mostly be already handled by the "X selected" announcement. Maybe need some clarification about what needs to be changed there if that is still considered an issue. This PR only handles the issue with the checkbox itself being unlabeled. 
