### PR TITLE
Fix: Reduce logo size and ensure it resizes dynamically and fits all screen sizes

### DIFF
--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/window/WindowSizeClass.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/window/WindowSizeClass.kt
@@ -16,6 +16,7 @@ enum class WindowSizeClass {
         const val COMPACT_MAX_HEIGHT = 480
 
         const val MEDIUM_MAX_WIDTH = 840
+
         const val MEDIUM_MAX_HEIGHT = 900
 
         fun fromWidth(width: Int): WindowSizeClass {

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/LazyColumnWithHeaderFooter.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/LazyColumnWithHeaderFooter.kt
@@ -3,6 +3,8 @@ package app.k9mail.core.ui.compose.designsystem.template
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -22,6 +24,7 @@ import androidx.compose.ui.unit.Density
 @Composable
 fun LazyColumnWithHeaderFooter(
     modifier: Modifier = Modifier,
+    state: LazyListState = rememberLazyListState(),
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     header: @Composable () -> Unit = {},
@@ -30,6 +33,7 @@ fun LazyColumnWithHeaderFooter(
 ) {
     LazyColumn(
         modifier = modifier,
+        state = state,
         verticalArrangement = verticalArrangementWithHeaderFooter(verticalArrangement),
         horizontalAlignment = horizontalAlignment,
     ) {

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
@@ -1,7 +1,5 @@
 package app.k9mail.feature.onboarding.welcome.ui
 
-
-import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -14,7 +12,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,7 +19,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -39,19 +35,15 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import app.k9mail.core.ui.compose.common.window.WindowSizeClass
-import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonFilled
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
-import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodySmall
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextDisplayMedium
 import app.k9mail.core.ui.compose.designsystem.template.LazyColumnWithHeaderFooter
@@ -78,7 +70,7 @@ internal fun WelcomeContent(
 
     Surface(modifier = modifier) {
         Box(Modifier.fillMaxSize()) {
-        ResponsiveContent {
+            ResponsiveContent {
                 LazyColumnWithHeaderFooter(
                     state = lazyListState,
                     verticalArrangement = Arrangement.SpaceEvenly,
@@ -93,7 +85,7 @@ internal fun WelcomeContent(
                                         put(0, coordinates.size.height)
                                     }
                                 },
-                            contentAlignment = Alignment.Center
+                            contentAlignment = Alignment.Center,
                         ) {
                             WelcomeLogo()
                         }
@@ -107,7 +99,7 @@ internal fun WelcomeContent(
                                     itemHeights.value = itemHeights.value.toMutableMap().apply {
                                         put(totalItemsCount - 1, coordinates.size.height)
                                     }
-                                }
+                                },
                         ) {
                             WelcomeFooter(
                                 showImportButton = showImportButton,
@@ -115,7 +107,7 @@ internal fun WelcomeContent(
                                 onImportClick = onImportClick,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = MainTheme.spacings.quadruple)
+                                    .padding(top = MainTheme.spacings.quadruple),
                             )
                         }
                     },
@@ -127,9 +119,8 @@ internal fun WelcomeContent(
                                     .onGloballyPositioned { coordinates ->
                                         itemHeights.value = itemHeights.value.toMutableMap().apply {
                                             put(1, coordinates.size.height)
-
                                         }
-                                    }
+                                    },
                             ) {
                                 WelcomeTitle(
                                     title = appName,
@@ -145,8 +136,7 @@ internal fun WelcomeContent(
                                         itemHeights.value = itemHeights.value.toMutableMap().apply {
                                             put(2, coordinates.size.height)
                                         }
-
-                                    }
+                                    },
                             ) {
                                 WelcomeMessage(
                                     modifier = Modifier.defaultItemModifier(),
@@ -162,13 +152,11 @@ internal fun WelcomeContent(
                                         itemHeights.value = itemHeights.value.toMutableMap().apply {
                                             put(3, coords.size.height)
                                         }
-                                    }
+                                    },
                             )
                         }
-
-                    }
+                    },
                 )
-
             }
             VerticalScrollIndicator(
                 listState = lazyListState,
@@ -176,16 +164,12 @@ internal fun WelcomeContent(
                 itemHeights = itemHeights.value,
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .padding(end = MainTheme.spacings.quarter)
+                    .padding(end = MainTheme.spacings.quarter),
 
             )
         }
-
     }
 }
-
-
-
 
 @Composable
 fun VerticalScrollIndicator(
@@ -198,7 +182,7 @@ fun VerticalScrollIndicator(
 
     BoxWithConstraints(
         modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.TopEnd
+        contentAlignment = Alignment.TopEnd,
     ) {
         val density = LocalDensity.current
         val viewportHeightPx = with(density) { maxHeight.toPx() }
@@ -260,43 +244,15 @@ fun VerticalScrollIndicator(
                 .alpha(animatedAlpha)
                 .draggable(
                     orientation = Orientation.Vertical,
-                    state = draggableState
+                    state = draggableState,
                 )
                 .background(
                     color = MainTheme.colors.onSurfaceVariant,
-                    shape = MainTheme.shapes.extraSmall
-                )
+                    shape = MainTheme.shapes.extraSmall,
+                ),
         )
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 @Composable
 private fun WelcomeLogo(

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
@@ -1,42 +1,68 @@
 package app.k9mail.feature.onboarding.welcome.ui
 
+
+import android.util.Log
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.coerceAtMost
 import androidx.compose.ui.unit.dp
+import app.k9mail.core.ui.compose.common.window.WindowSizeClass
+import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonFilled
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodySmall
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextDisplayMedium
 import app.k9mail.core.ui.compose.designsystem.template.LazyColumnWithHeaderFooter
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveContent
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.onboarding.welcome.R
+import kotlinx.coroutines.launch
 
 private const val CIRCLE_COLOR = 0xFFEEEEEE
-private const val CIRCLE_SIZE_DP = 300
-private const val LOGO_SIZE_DP = 200
+private const val CIRCLE_SIZE_DP = 200
+private const val LOGO_SIZE_DP = 125
 
 @Composable
 internal fun WelcomeContent(
@@ -46,79 +72,255 @@ internal fun WelcomeContent(
     showImportButton: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
-        modifier = modifier,
-    ) {
+    val itemHeights = remember { mutableStateOf<Map<Int, Int>>(emptyMap()) }
+    val lazyListState = rememberLazyListState()
+    val totalItemsCount = 5
+
+    Surface(modifier = modifier) {
+        Box(Modifier.fillMaxSize()) {
         ResponsiveContent {
-            LazyColumnWithHeaderFooter(
-                modifier = Modifier.fillMaxSize(),
-                footer = {
-                    WelcomeFooter(
-                        showImportButton = showImportButton,
-                        onStartClick = onStartClick,
-                        onImportClick = onImportClick,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = MainTheme.spacings.quadruple),
-                    )
-                },
-                verticalArrangement = Arrangement.SpaceEvenly,
-            ) {
-                item {
-                    WelcomeLogo(
-                        modifier = Modifier
-                            .defaultItemModifier()
-                            .padding(top = MainTheme.spacings.double),
-                    )
-                }
-                item {
-                    WelcomeTitle(
-                        title = appName,
-                        modifier = Modifier.defaultItemModifier(),
-                    )
-                }
-                item {
-                    WelcomeMessage(
-                        modifier = Modifier.defaultItemModifier(),
-                    )
-                }
+                LazyColumnWithHeaderFooter(
+                    state = lazyListState,
+                    verticalArrangement = Arrangement.SpaceEvenly,
+                    header = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .defaultItemModifier()
+                                .padding(top = MainTheme.spacings.double)
+                                .onGloballyPositioned { coordinates ->
+                                    itemHeights.value = itemHeights.value.toMutableMap().apply {
+                                        put(0, coordinates.size.height)
+                                    }
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            WelcomeLogo()
+                        }
+                    },
+                    footer = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = MainTheme.spacings.quadruple)
+                                .onGloballyPositioned { coordinates ->
+                                    itemHeights.value = itemHeights.value.toMutableMap().apply {
+                                        put(totalItemsCount - 1, coordinates.size.height)
+                                    }
+                                }
+                        ) {
+                            WelcomeFooter(
+                                showImportButton = showImportButton,
+                                onStartClick = onStartClick,
+                                onImportClick = onImportClick,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = MainTheme.spacings.quadruple)
+                            )
+                        }
+                    },
+                    content = {
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .defaultItemModifier()
+                                    .onGloballyPositioned { coordinates ->
+                                        itemHeights.value = itemHeights.value.toMutableMap().apply {
+                                            put(1, coordinates.size.height)
+
+                                        }
+                                    }
+                            ) {
+                                WelcomeTitle(
+                                    title = appName,
+                                    modifier = Modifier.defaultItemModifier(),
+                                )
+                            }
+                        }
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .defaultItemModifier()
+                                    .onGloballyPositioned { coordinates ->
+                                        itemHeights.value = itemHeights.value.toMutableMap().apply {
+                                            put(2, coordinates.size.height)
+                                        }
+
+                                    }
+                            ) {
+                                WelcomeMessage(
+                                    modifier = Modifier.defaultItemModifier(),
+                                )
+                            }
+                        }
+                        item {
+                            Spacer(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(40.dp)
+                                    .onGloballyPositioned { coords ->
+                                        itemHeights.value = itemHeights.value.toMutableMap().apply {
+                                            put(3, coords.size.height)
+                                        }
+                                    }
+                            )
+                        }
+
+                    }
+                )
+
             }
+            VerticalScrollIndicator(
+                listState = lazyListState,
+                totalItemsCount = totalItemsCount,
+                itemHeights = itemHeights.value,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = MainTheme.spacings.quarter)
+
+            )
         }
+
     }
 }
+
+
+
+
+@Composable
+fun VerticalScrollIndicator(
+    listState: LazyListState,
+    totalItemsCount: Int,
+    itemHeights: Map<Int, Int>,
+    modifier: Modifier = Modifier,
+) {
+    val coroutineScope = rememberCoroutineScope()
+
+    BoxWithConstraints(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopEnd
+    ) {
+        val density = LocalDensity.current
+        val viewportHeightPx = with(density) { maxHeight.toPx() }
+
+        val averageHeight: Float = if (itemHeights.isNotEmpty()) {
+            itemHeights.values.sum().toFloat() / itemHeights.size
+        } else {
+            viewportHeightPx / 2f
+        }
+
+        val totalContentHeightPx = (0 until totalItemsCount).sumOf { idx ->
+            val measuredHeight = itemHeights[idx]
+            (measuredHeight ?: averageHeight).toDouble()
+        }.toFloat()
+
+        val isScrollable = totalContentHeightPx > viewportHeightPx
+
+        val firstVisibleIndex by remember { derivedStateOf { listState.firstVisibleItemIndex } }
+        val firstVisibleItemOffset by remember { derivedStateOf { listState.firstVisibleItemScrollOffset.toFloat() } }
+
+        val offsetBeforeFirst = (0 until firstVisibleIndex).sumOf { index ->
+            (itemHeights[index] ?: averageHeight).toDouble()
+        }.toFloat()
+
+        val currentScrollOffsetPx = offsetBeforeFirst + firstVisibleItemOffset
+
+        val scrollableRange = (totalContentHeightPx - viewportHeightPx).coerceAtLeast(1f)
+        val scrolledFraction = (currentScrollOffsetPx / scrollableRange).coerceIn(0f, 1f)
+
+        val visibleFraction = (viewportHeightPx / totalContentHeightPx).coerceIn(0.1f, 1f)
+
+        val rawScrollbarHeightPx = viewportHeightPx * visibleFraction
+        val scrollbarHeightPx = rawScrollbarHeightPx
+            .coerceAtMost(viewportHeightPx * 0.2f)
+            .coerceAtLeast(20f)
+        val scrollbarHeight = with(density) { scrollbarHeightPx.toDp() }
+        val scrollbarWidth = 4.dp
+
+        val scrollbarOffsetY = with(density) {
+            (scrolledFraction * (viewportHeightPx - scrollbarHeightPx)).toDp()
+        }
+
+        val targetAlpha = if (isScrollable) 1f else 0f
+        val animatedAlpha by animateFloatAsState(targetValue = targetAlpha, label = "")
+
+        val draggableState = rememberDraggableState { delta ->
+            val scrollDelta = delta * (scrollableRange / (viewportHeightPx - scrollbarHeightPx))
+            coroutineScope.launch {
+                listState.scrollBy(scrollDelta)
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .padding(end = MainTheme.spacings.default)
+                .width(scrollbarWidth)
+                .height(scrollbarHeight)
+                .offset(y = scrollbarOffsetY)
+                .alpha(animatedAlpha)
+                .draggable(
+                    orientation = Orientation.Vertical,
+                    state = draggableState
+                )
+                .background(
+                    color = MainTheme.colors.onSurfaceVariant,
+                    shape = MainTheme.shapes.extraSmall
+                )
+        )
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 @Composable
 private fun WelcomeLogo(
     modifier: Modifier = Modifier,
 ) {
-    BoxWithConstraints (
-        modifier = modifier
-            .fillMaxWidth()
-            .wrapContentHeight(),
-        contentAlignment = Alignment.Center,
-        ) {
-            val maxLogoSize = maxWidth * 0.3f
-            val circleSize = maxLogoSize.coerceAtMost(150.dp)
-            val logoSize = (circleSize * 0.7f).coerceAtMost(100.dp)
-
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         Box(
             modifier = Modifier
                 .clip(CircleShape)
                 .background(Color(CIRCLE_COLOR))
-                .size(circleSize),
+                .size(CIRCLE_SIZE_DP.dp),
         ) {
             Image(
                 painter = painterResource(id = MainTheme.images.logo),
                 contentDescription = null,
                 modifier = Modifier
-                    .size(logoSize)
+                    .size(LOGO_SIZE_DP.dp)
                     .align(Alignment.Center),
             )
         }
-
-
     }
-
 }
 
 @Composable

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
@@ -1,6 +1,5 @@
 package app.k9mail.feature.onboarding.welcome.ui
 
-
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -32,11 +31,9 @@ import app.k9mail.core.ui.compose.designsystem.template.ResponsiveContent
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.onboarding.welcome.R
 
-
 private const val CIRCLE_COLOR = 0xFFEEEEEE
 private const val CIRCLE_SIZE_DP = 200
 private const val LOGO_SIZE_DP = 125
-
 
 @Composable
 internal fun WelcomeContent(
@@ -46,7 +43,6 @@ internal fun WelcomeContent(
     showImportButton: Boolean,
     modifier: Modifier = Modifier,
 ) {
-
     Surface(
         modifier = modifier,
     ) {
@@ -68,10 +64,6 @@ internal fun WelcomeContent(
                     item { WelcomeMessageItem() }
                 },
             )
-            }
-
-
-
         }
     }
 }
@@ -80,13 +72,11 @@ internal fun WelcomeContent(
 private fun WelcomeHeaderSection(
     title: String,
     modifier: Modifier = Modifier,
-){
+) {
     Column(
         modifier = modifier
             .fillMaxWidth()
             .defaultItemModifier()
-            .padding(top = MainTheme.spacings.double),
-            contentAlignment = Alignment.Center,
             .padding(top = MainTheme.spacings.quadruple),
         verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.double),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -94,7 +84,6 @@ private fun WelcomeHeaderSection(
         WelcomeLogo()
         WelcomeTitleItem(title = title)
     }
-
 }
 
 @Composable
@@ -122,22 +111,19 @@ private fun WelcomeLogo(
     }
 }
 
-
 @Composable
 private fun WelcomeTitleItem(
     title: String,
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier
-            .defaultItemModifier()
+        modifier = modifier,
     ) {
         WelcomeTitle(
             title = title,
             modifier = Modifier.defaultItemModifier(),
         )
     }
-
 }
 
 @Composable
@@ -161,14 +147,12 @@ private fun WelcomeMessageItem(
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier
-            .defaultItemModifier()
+        modifier = modifier,
     ) {
         WelcomeMessage(
             modifier = Modifier.defaultItemModifier(),
         )
     }
-
 }
 
 @Composable
@@ -198,7 +182,7 @@ private fun WelcomeFooterSection(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .padding(top = MainTheme.spacings.quadruple)
+            .padding(top = MainTheme.spacings.quadruple),
     ) {
         WelcomeFooter(
             showImportButton = showImportButton,
@@ -206,7 +190,7 @@ private fun WelcomeFooterSection(
             onImportClick = onImportClick,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = MainTheme.spacings.quadruple)
+                .padding(top = MainTheme.spacings.quadruple),
         )
     }
 }

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
@@ -47,26 +47,27 @@ internal fun WelcomeContent(
     modifier: Modifier = Modifier,
 ) {
 
-    Surface(modifier = modifier) {
-        Box(Modifier.fillMaxSize()) {
-            ResponsiveContent {
-                LazyColumnWithHeaderFooter(
-                    verticalArrangement = Arrangement.SpaceEvenly,
-                    header = {
-                        WelcomeHeaderSection()
-                    },
-                    footer = {
-                        WelcomeFooterSection(
-                            showImportButton = showImportButton,
-                            onStartClick = onStartClick,
-                            onImportClick = onImportClick,
-                        )
-                    },
-                    content = {
-                        item {WelcomeTitleItem(title = appName)}
-                        item {WelcomeMessageItem()}
-                    },
-                )
+    Surface(
+        modifier = modifier,
+    ) {
+        ResponsiveContent {
+            LazyColumnWithHeaderFooter(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.SpaceEvenly,
+                header = {
+                    WelcomeHeaderSection(title = appName)
+                },
+                footer = {
+                    WelcomeFooterSection(
+                        showImportButton = showImportButton,
+                        onStartClick = onStartClick,
+                        onImportClick = onImportClick,
+                    )
+                },
+                content = {
+                    item { WelcomeMessageItem() }
+                },
+            )
             }
 
 
@@ -77,16 +78,21 @@ internal fun WelcomeContent(
 
 @Composable
 private fun WelcomeHeaderSection(
-
+    title: String,
+    modifier: Modifier = Modifier,
 ){
-    Box(
-        modifier = Modifier
+    Column(
+        modifier = modifier
             .fillMaxWidth()
             .defaultItemModifier()
             .padding(top = MainTheme.spacings.double),
             contentAlignment = Alignment.Center,
+            .padding(top = MainTheme.spacings.quadruple),
+        verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.double),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         WelcomeLogo()
+        WelcomeTitleItem(title = title)
     }
 
 }
@@ -120,9 +126,10 @@ private fun WelcomeLogo(
 @Composable
 private fun WelcomeTitleItem(
     title: String,
+    modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .defaultItemModifier()
     ) {
         WelcomeTitle(
@@ -151,9 +158,10 @@ private fun WelcomeTitle(
 
 @Composable
 private fun WelcomeMessageItem(
-){
+    modifier: Modifier = Modifier,
+) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .defaultItemModifier()
     ) {
         WelcomeMessage(
@@ -184,10 +192,11 @@ private fun WelcomeMessage(
 private fun WelcomeFooterSection(
     showImportButton: Boolean,
     onStartClick: () -> Unit,
-    onImportClick: () -> Unit
+    onImportClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(top = MainTheme.spacings.quadruple)
     ) {

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
@@ -1,41 +1,22 @@
 package app.k9mail.feature.onboarding.welcome.ui
 
-import androidx.compose.animation.core.animateFloatAsState
+
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.draggable
-import androidx.compose.foundation.gestures.rememberDraggableState
-import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -50,11 +31,12 @@ import app.k9mail.core.ui.compose.designsystem.template.LazyColumnWithHeaderFoot
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveContent
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.onboarding.welcome.R
-import kotlinx.coroutines.launch
+
 
 private const val CIRCLE_COLOR = 0xFFEEEEEE
 private const val CIRCLE_SIZE_DP = 200
 private const val LOGO_SIZE_DP = 125
+
 
 @Composable
 internal fun WelcomeContent(
@@ -64,194 +46,49 @@ internal fun WelcomeContent(
     showImportButton: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val itemHeights = remember { mutableStateOf<Map<Int, Int>>(emptyMap()) }
-    val lazyListState = rememberLazyListState()
-    val totalItemsCount = 5
 
     Surface(modifier = modifier) {
         Box(Modifier.fillMaxSize()) {
             ResponsiveContent {
                 LazyColumnWithHeaderFooter(
-                    state = lazyListState,
                     verticalArrangement = Arrangement.SpaceEvenly,
                     header = {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .defaultItemModifier()
-                                .padding(top = MainTheme.spacings.double)
-                                .onGloballyPositioned { coordinates ->
-                                    itemHeights.value = itemHeights.value.toMutableMap().apply {
-                                        put(0, coordinates.size.height)
-                                    }
-                                },
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            WelcomeLogo()
-                        }
+                        WelcomeHeaderSection()
                     },
                     footer = {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = MainTheme.spacings.quadruple)
-                                .onGloballyPositioned { coordinates ->
-                                    itemHeights.value = itemHeights.value.toMutableMap().apply {
-                                        put(totalItemsCount - 1, coordinates.size.height)
-                                    }
-                                },
-                        ) {
-                            WelcomeFooter(
-                                showImportButton = showImportButton,
-                                onStartClick = onStartClick,
-                                onImportClick = onImportClick,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = MainTheme.spacings.quadruple),
-                            )
-                        }
+                        WelcomeFooterSection(
+                            showImportButton = showImportButton,
+                            onStartClick = onStartClick,
+                            onImportClick = onImportClick,
+                        )
                     },
                     content = {
-                        item {
-                            Box(
-                                modifier = Modifier
-                                    .defaultItemModifier()
-                                    .onGloballyPositioned { coordinates ->
-                                        itemHeights.value = itemHeights.value.toMutableMap().apply {
-                                            put(1, coordinates.size.height)
-                                        }
-                                    },
-                            ) {
-                                WelcomeTitle(
-                                    title = appName,
-                                    modifier = Modifier.defaultItemModifier(),
-                                )
-                            }
-                        }
-                        item {
-                            Box(
-                                modifier = Modifier
-                                    .defaultItemModifier()
-                                    .onGloballyPositioned { coordinates ->
-                                        itemHeights.value = itemHeights.value.toMutableMap().apply {
-                                            put(2, coordinates.size.height)
-                                        }
-                                    },
-                            ) {
-                                WelcomeMessage(
-                                    modifier = Modifier.defaultItemModifier(),
-                                )
-                            }
-                        }
-                        item {
-                            Spacer(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(40.dp)
-                                    .onGloballyPositioned { coords ->
-                                        itemHeights.value = itemHeights.value.toMutableMap().apply {
-                                            put(3, coords.size.height)
-                                        }
-                                    },
-                            )
-                        }
+                        item {WelcomeTitleItem(title = appName)}
+                        item {WelcomeMessageItem()}
                     },
                 )
             }
-            VerticalScrollIndicator(
-                listState = lazyListState,
-                totalItemsCount = totalItemsCount,
-                itemHeights = itemHeights.value,
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .padding(end = MainTheme.spacings.quarter),
 
-            )
+
+
         }
     }
 }
 
 @Composable
-fun VerticalScrollIndicator(
-    listState: LazyListState,
-    totalItemsCount: Int,
-    itemHeights: Map<Int, Int>,
-    modifier: Modifier = Modifier,
-) {
-    val coroutineScope = rememberCoroutineScope()
+private fun WelcomeHeaderSection(
 
-    BoxWithConstraints(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.TopEnd,
+){
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .defaultItemModifier()
+            .padding(top = MainTheme.spacings.double),
+            contentAlignment = Alignment.Center,
     ) {
-        val density = LocalDensity.current
-        val viewportHeightPx = with(density) { maxHeight.toPx() }
-
-        val averageHeight: Float = if (itemHeights.isNotEmpty()) {
-            itemHeights.values.sum().toFloat() / itemHeights.size
-        } else {
-            viewportHeightPx / 2f
-        }
-
-        val totalContentHeightPx = (0 until totalItemsCount).sumOf { idx ->
-            val measuredHeight = itemHeights[idx]
-            (measuredHeight ?: averageHeight).toDouble()
-        }.toFloat()
-
-        val isScrollable = totalContentHeightPx > viewportHeightPx
-
-        val firstVisibleIndex by remember { derivedStateOf { listState.firstVisibleItemIndex } }
-        val firstVisibleItemOffset by remember { derivedStateOf { listState.firstVisibleItemScrollOffset.toFloat() } }
-
-        val offsetBeforeFirst = (0 until firstVisibleIndex).sumOf { index ->
-            (itemHeights[index] ?: averageHeight).toDouble()
-        }.toFloat()
-
-        val currentScrollOffsetPx = offsetBeforeFirst + firstVisibleItemOffset
-
-        val scrollableRange = (totalContentHeightPx - viewportHeightPx).coerceAtLeast(1f)
-        val scrolledFraction = (currentScrollOffsetPx / scrollableRange).coerceIn(0f, 1f)
-
-        val visibleFraction = (viewportHeightPx / totalContentHeightPx).coerceIn(0.1f, 1f)
-
-        val rawScrollbarHeightPx = viewportHeightPx * visibleFraction
-        val scrollbarHeightPx = rawScrollbarHeightPx
-            .coerceAtMost(viewportHeightPx * 0.2f)
-            .coerceAtLeast(20f)
-        val scrollbarHeight = with(density) { scrollbarHeightPx.toDp() }
-        val scrollbarWidth = 4.dp
-
-        val scrollbarOffsetY = with(density) {
-            (scrolledFraction * (viewportHeightPx - scrollbarHeightPx)).toDp()
-        }
-
-        val targetAlpha = if (isScrollable) 1f else 0f
-        val animatedAlpha by animateFloatAsState(targetValue = targetAlpha, label = "")
-
-        val draggableState = rememberDraggableState { delta ->
-            val scrollDelta = delta * (scrollableRange / (viewportHeightPx - scrollbarHeightPx))
-            coroutineScope.launch {
-                listState.scrollBy(scrollDelta)
-            }
-        }
-
-        Box(
-            modifier = Modifier
-                .padding(end = MainTheme.spacings.default)
-                .width(scrollbarWidth)
-                .height(scrollbarHeight)
-                .offset(y = scrollbarOffsetY)
-                .alpha(animatedAlpha)
-                .draggable(
-                    orientation = Orientation.Vertical,
-                    state = draggableState,
-                )
-                .background(
-                    color = MainTheme.colors.onSurfaceVariant,
-                    shape = MainTheme.shapes.extraSmall,
-                ),
-        )
+        WelcomeLogo()
     }
+
 }
 
 @Composable
@@ -279,6 +116,23 @@ private fun WelcomeLogo(
     }
 }
 
+
+@Composable
+private fun WelcomeTitleItem(
+    title: String,
+) {
+    Box(
+        modifier = Modifier
+            .defaultItemModifier()
+    ) {
+        WelcomeTitle(
+            title = title,
+            modifier = Modifier.defaultItemModifier(),
+        )
+    }
+
+}
+
 @Composable
 private fun WelcomeTitle(
     title: String,
@@ -296,6 +150,20 @@ private fun WelcomeTitle(
 }
 
 @Composable
+private fun WelcomeMessageItem(
+){
+    Box(
+        modifier = Modifier
+            .defaultItemModifier()
+    ) {
+        WelcomeMessage(
+            modifier = Modifier.defaultItemModifier(),
+        )
+    }
+
+}
+
+@Composable
 private fun WelcomeMessage(
     modifier: Modifier = Modifier,
 ) {
@@ -308,6 +176,28 @@ private fun WelcomeMessage(
         TextBodyLarge(
             text = stringResource(id = R.string.onboarding_welcome_text),
             textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun WelcomeFooterSection(
+    showImportButton: Boolean,
+    onStartClick: () -> Unit,
+    onImportClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = MainTheme.spacings.quadruple)
+    ) {
+        WelcomeFooter(
+            showImportButton = showImportButton,
+            onStartClick = onStartClick,
+            onImportClick = onImportClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = MainTheme.spacings.quadruple)
         )
     }
 }

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
@@ -4,11 +4,13 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,6 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.coerceAtMost
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonFilled
@@ -88,25 +91,34 @@ internal fun WelcomeContent(
 private fun WelcomeLogo(
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
+    BoxWithConstraints (
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        contentAlignment = Alignment.Center,
+        ) {
+            val maxLogoSize = maxWidth * 0.3f
+            val circleSize = maxLogoSize.coerceAtMost(150.dp)
+            val logoSize = (circleSize * 0.7f).coerceAtMost(100.dp)
+
         Box(
             modifier = Modifier
                 .clip(CircleShape)
                 .background(Color(CIRCLE_COLOR))
-                .size(CIRCLE_SIZE_DP.dp),
+                .size(circleSize),
         ) {
             Image(
                 painter = painterResource(id = MainTheme.images.logo),
                 contentDescription = null,
                 modifier = Modifier
-                    .size(LOGO_SIZE_DP.dp)
+                    .size(logoSize)
                     .align(Alignment.Center),
             )
         }
+
+
     }
+
 }
 
 @Composable


### PR DESCRIPTION
Fixes #8458

### Description
This PR addresses #8458 where the logo on the onboarding screen flattened the text below. The `WelcomeLogo` composable has been updated to ensure dynamic resizing using `BoxWithConstraints` ensuring that the logo scales proportionally based on screen dimensions and fits properly without overlapping or pushing other components off-screen.

### Changes Made
- Updated `WelcomeLogo` to use `BoxWithConstraints` for adaptive sizing.
- Limited logo and circle sizes to a maximum based on screen width.
- Ensured `LazyColumnWithHeaderFooter` components are unaffected by the logo's size.
- Verified compatibility across various screen sizes (small, medium, large, and tablets).

### Testing
- Tested on multiple screen sizes to ensure no scrolling is required and all components fit properly.


### Visual Example
![Screenshot 2024-12-29 at 3 33 02 PM](https://github.com/user-attachments/assets/b41cb34e-b6d0-4ae1-a952-f1a353f8c54b)
![Screenshot 2024-12-29 at 3 28 56 PM](https://github.com/user-attachments/assets/8c7579c3-1b94-4dc3-a811-102f8d67ee2d)
![Screenshot 2024-12-29 at 3 29 19 PM](https://github.com/user-attachments/assets/a550ceb2-3b50-4a52-8afa-9c6111a4ad34)

