### PR TITLE
Show the "Use system default" theme option on pre API 28 devices

### DIFF
--- a/legacy/core/src/main/res/values/arrays_general_settings_values.xml
+++ b/legacy/core/src/main/res/values/arrays_general_settings_values.xml
@@ -143,11 +143,6 @@
         <item>ja</item>
     </string-array>
 
-    <string-array name="theme_values_legacy" translatable="false">
-        <item>follow_system</item>
-        <item>dark</item>
-    </string-array>
-
     <string-array name="theme_values" translatable="false">
         <item>light</item>
         <item>dark</item>

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
@@ -1,12 +1,10 @@
 package com.fsck.k9.ui.settings.general
 
-import android.os.Build
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import androidx.activity.result.contract.ActivityResultContracts.CreateDocument
-import androidx.preference.ListPreference
 import androidx.preference.Preference
 import app.k9mail.feature.telemetry.api.TelemetryManager
 import com.fsck.k9.ui.R
@@ -17,7 +15,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.takisoft.preferencex.PreferenceFragmentCompat
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import com.fsck.k9.core.R as CoreR
 
 class GeneralSettingsFragment : PreferenceFragmentCompat() {
     private val viewModel: GeneralSettingsViewModel by viewModel()
@@ -40,7 +37,6 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
         setHasOptionsMenu(true)
         setPreferencesFromResource(R.xml.general_settings, rootKey)
 
-        initializeTheme()
         initializeDataCollection()
 
         viewModel.uiState.observe(this) { uiState ->
@@ -74,15 +70,6 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
         }
 
         return super.onOptionsItemSelected(item)
-    }
-
-    private fun initializeTheme() {
-        (findPreference(PREFERENCE_THEME) as? ListPreference)?.apply {
-            if (Build.VERSION.SDK_INT < 28) {
-                setEntries(R.array.theme_entries_legacy)
-                setEntryValues(CoreR.array.theme_values_legacy)
-            }
-        }
     }
 
     private fun initializeDataCollection() {
@@ -128,7 +115,6 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
     }
 
     companion object {
-        private const val PREFERENCE_THEME = "theme"
         private const val PREFERENCE_SCREEN_DEBUGGING = "debug_preferences"
         private const val PREFERENCE_DATA_COLLECTION = "data_collection"
 

--- a/legacy/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
@@ -89,11 +89,6 @@
         <item>日本語</item>
     </string-array>
 
-    <string-array name="theme_entries_legacy">
-        <item>@string/setting_theme_light</item>
-        <item>@string/setting_theme_dark</item>
-    </string-array>
-
     <string-array name="theme_entries">
         <item>@string/setting_theme_light</item>
         <item>@string/setting_theme_dark</item>

--- a/legacy/ui/theme/src/main/java/app/k9mail/legacy/ui/theme/ThemeManager.kt
+++ b/legacy/ui/theme/src/main/java/app/k9mail/legacy/ui/theme/ThemeManager.kt
@@ -2,7 +2,6 @@ package app.k9mail.legacy.ui.theme
 
 import android.content.Context
 import android.content.res.Configuration
-import android.os.Build
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatDelegate
 import app.k9mail.core.ui.theme.api.Theme
@@ -34,11 +33,7 @@ class ThemeManager(
         get() = when (generalSettings.appTheme) {
             AppTheme.LIGHT -> Theme.LIGHT
             AppTheme.DARK -> Theme.DARK
-            AppTheme.FOLLOW_SYSTEM -> if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-                Theme.LIGHT
-            } else {
-                getSystemTheme()
-            }
+            AppTheme.FOLLOW_SYSTEM -> getSystemTheme()
         }
 
     override val messageViewTheme: Theme
@@ -78,13 +73,7 @@ class ThemeManager(
         val defaultNightMode = when (appTheme) {
             AppTheme.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
             AppTheme.DARK -> AppCompatDelegate.MODE_NIGHT_YES
-            AppTheme.FOLLOW_SYSTEM -> {
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-                    AppCompatDelegate.MODE_NIGHT_NO
-                } else {
-                    AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                }
-            }
+            AppTheme.FOLLOW_SYSTEM -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
         }
         AppCompatDelegate.setDefaultNightMode(defaultNightMode)
     }


### PR DESCRIPTION
Android [Night Mode](https://developer.android.com/reference/kotlin/android/app/UiModeManager#mode_night_auto) was introduced in API 8, which enables automatic switching between day and night modes. Therefore, the follow system theme option is available on pre API 28 devices.

[output.webm](https://github.com/user-attachments/assets/d6f079e4-9335-43aa-9fc1-7e9b7f778f33)