### PR TITLE
Allow to hide accounts from the unified inbox

### DIFF
--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/domain/entity/AccountDisplayOptions.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/domain/entity/AccountDisplayOptions.kt
@@ -4,4 +4,5 @@ data class AccountDisplayOptions(
     val accountName: String,
     val displayName: String,
     val emailSignature: String?,
+    val showInUnifiedInbox: Boolean,
 )

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/domain/entity/AccountOptions.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/domain/entity/AccountOptions.kt
@@ -7,4 +7,5 @@ data class AccountOptions(
     val checkFrequencyInMinutes: Int,
     val messageDisplayCount: Int,
     val showNotification: Boolean,
+    val showInUnifiedInbox: Boolean,
 )

--- a/feature/account/common/src/test/kotlin/app/k9mail/feature/account/common/data/InMemoryAccountStateRepositoryTest.kt
+++ b/feature/account/common/src/test/kotlin/app/k9mail/feature/account/common/data/InMemoryAccountStateRepositoryTest.kt
@@ -182,6 +182,7 @@ class InMemoryAccountStateRepositoryTest {
             accountName = "accountName",
             displayName = "displayName",
             emailSignature = "emailSignature",
+            showInUnifiedInbox = true,
         )
 
         val SYNC_OPTIONS = AccountSyncOptions(

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/domain/usecase/GetAccountStateTest.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/domain/usecase/GetAccountStateTest.kt
@@ -77,12 +77,14 @@ class GetAccountStateTest {
             checkFrequencyInMinutes = 15,
             messageDisplayCount = 25,
             showNotification = true,
+            showInUnifiedInbox = true,
         )
 
         val DISPLAY_OPTIONS = AccountDisplayOptions(
             accountName = "accountName",
             displayName = "displayName",
             emailSignature = null,
+            showInUnifiedInbox = true,
         )
 
         val SYNC_OPTIONS = AccountSyncOptions(

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/domain/usecase/LoadAccountStateTest.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/domain/usecase/LoadAccountStateTest.kt
@@ -77,6 +77,7 @@ class LoadAccountStateTest {
             accountName = "accountName",
             displayName = "displayName",
             emailSignature = null,
+            showInUnifiedInbox = true,
         )
 
         val SYNC_OPTIONS = AccountSyncOptions(

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/domain/usecase/SaveServerSettingsTest.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/domain/usecase/SaveServerSettingsTest.kt
@@ -148,6 +148,7 @@ class SaveServerSettingsTest {
             accountName = "accountName",
             displayName = "displayName",
             emailSignature = null,
+            showInUnifiedInbox = true,
         )
 
         val SYNC_OPTIONS = AccountSyncOptions(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/CreateAccount.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/CreateAccount.kt
@@ -39,6 +39,7 @@ class CreateAccount(
             checkFrequencyInMinutes = syncOptions.checkFrequencyInMinutes,
             messageDisplayCount = syncOptions.messageDisplayCount,
             showNotification = syncOptions.showNotification,
+            showInUnifiedInbox = displayOptions.showInUnifiedInbox,
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextLabelSmall
+import app.k9mail.core.ui.compose.designsystem.molecule.input.SwitchInput
 import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
 import app.k9mail.core.ui.compose.theme2.MainTheme
@@ -26,6 +27,7 @@ import app.k9mail.feature.account.common.ui.item.defaultItemPadding
 import app.k9mail.feature.account.setup.R
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Event
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.State
+import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsContract
 
 @Suppress("LongMethod")
 @Composable
@@ -96,6 +98,15 @@ internal fun DisplayOptionsContent(
                     label = stringResource(id = R.string.account_setup_options_email_signature_label),
                     contentPadding = defaultItemPadding(),
                     isSingleLine = false,
+                )
+            }
+
+            item {
+                SwitchInput(
+                    text = stringResource(id = R.string.account_setup_options_show_in_unified_inbox_label),
+                    checked = state.showInUnifiedInbox,
+                    onCheckedChange = { onEvent(Event.OnShowInUnifiedInboxChanged(it)) },
+                    contentPadding = defaultItemPadding(),
                 )
             }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContract.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.account.setup.ui.options.display
 import app.k9mail.core.common.domain.usecase.validation.ValidationResult
 import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.account.common.domain.input.StringInputField
+import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsContract.Event
 
 interface DisplayOptionsContract {
 
@@ -12,12 +13,14 @@ interface DisplayOptionsContract {
         val accountName: StringInputField = StringInputField(),
         val displayName: StringInputField = StringInputField(),
         val emailSignature: StringInputField = StringInputField(),
+        val showInUnifiedInbox: Boolean = true,
     )
 
     sealed interface Event {
         data class OnAccountNameChanged(val accountName: String) : Event
         data class OnDisplayNameChanged(val displayName: String) : Event
         data class OnEmailSignatureChanged(val emailSignature: String) : Event
+        data class OnShowInUnifiedInboxChanged(val showInUnifiedInbox: Boolean) : Event
 
         data object LoadAccountState : Event
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateMapper.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateMapper.kt
@@ -18,6 +18,7 @@ internal fun AccountState.toDisplayOptionsState(): State {
             accountName = StringInputField(options.accountName),
             displayName = StringInputField(options.displayName),
             emailSignature = StringInputField(options.emailSignature ?: ""),
+            showInUnifiedInbox = options.showInUnifiedInbox,
         )
     }
 }
@@ -27,5 +28,6 @@ internal fun State.toAccountDisplayOptions(): AccountDisplayOptions {
         accountName = accountName.value,
         displayName = displayName.value,
         emailSignature = emailSignature.value.takeIf { it.isNotEmpty() },
+        showInUnifiedInbox =showInUnifiedInbox,
     )
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsViewModel.kt
@@ -45,6 +45,12 @@ internal class DisplayOptionsViewModel(
                 )
             }
 
+            is Event.OnShowInUnifiedInboxChanged -> updateState { state ->
+                state.copy(
+                    showInUnifiedInbox = event.showInUnifiedInbox,
+                )
+            }
+
             Event.OnNextClicked -> submit()
             Event.OnBackClicked -> navigateBack()
         }

--- a/feature/account/setup/src/main/res/values/strings.xml
+++ b/feature/account/setup/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     </plurals>
     <string name="account_setup_options_email_display_count_label">Number of messages to display</string>
     <string name="account_setup_options_show_notifications_label">Show notifications</string>
+    <string name="account_setup_options_show_in_unified_inbox_label">Show in unfied Inbox</string>
 
     <string name="account_setup_create_account_creating">Creating account…</string>
     <string name="account_setup_create_account_error">An error occurred while trying to create the account</string>

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/CreateAccountTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/CreateAccountTest.kt
@@ -111,12 +111,14 @@ class CreateAccountTest {
             checkFrequencyInMinutes = 15,
             messageDisplayCount = 25,
             showNotification = true,
+            showInUnifiedInbox = true,
         )
 
         val DISPLAY_OPTIONS = AccountDisplayOptions(
             accountName = "accountName",
             displayName = "displayName",
             emailSignature = null,
+            showInUnifiedInbox = true,
         )
 
         val SYNC_OPTIONS = AccountSyncOptions(

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountViewModelTest.kt
@@ -193,6 +193,7 @@ class CreateAccountViewModelTest {
             accountName = "account name",
             displayName = "display name",
             emailSignature = null,
+            showInUnifiedInbox = true,
         )
 
         val ACCOUNT_SYNC_OPTIONS = AccountSyncOptions(

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateMapperKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateMapperKtTest.kt
@@ -15,6 +15,7 @@ class DisplayOptionsStateMapperKtTest {
             accountName = StringInputField("accountName"),
             displayName = StringInputField("displayName"),
             emailSignature = StringInputField("emailSignature"),
+            showInUnifiedInbox = true,
         )
 
         val result = state.toAccountDisplayOptions()
@@ -24,6 +25,7 @@ class DisplayOptionsStateMapperKtTest {
                 accountName = "accountName",
                 displayName = "displayName",
                 emailSignature = "emailSignature",
+                showInUnifiedInbox = true,
             ),
         )
     }

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/BaseMessageListWidgetProvider.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/BaseMessageListWidgetProvider.kt
@@ -9,6 +9,7 @@ import android.widget.RemoteViews
 import androidx.core.app.PendingIntentCompat
 import app.k9mail.legacy.search.SearchAccount.Companion.createUnifiedInboxAccount
 import com.fsck.k9.CoreResourceProvider
+import com.fsck.k9.Preferences
 import com.fsck.k9.activity.MessageCompose
 import com.fsck.k9.activity.MessageList
 import com.fsck.k9.activity.MessageList.Companion.intentDisplaySearch
@@ -66,6 +67,7 @@ abstract class BaseMessageListWidgetProvider : AppWidgetProvider(), KoinComponen
         val unifiedInboxAccount = createUnifiedInboxAccount(
             unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
             unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+            accounts = Preferences.getPreferences().getAccounts(),
         )
         val intent = intentDisplaySearch(
             context = context,

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
@@ -13,6 +13,7 @@ import app.k9mail.legacy.search.LocalSearch
 import app.k9mail.legacy.search.SearchAccount
 import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.K9
+import com.fsck.k9.Preferences
 import com.fsck.k9.activity.MessageList
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -33,6 +34,7 @@ internal class MessageListRemoteViewFactory(private val context: Context) : Remo
         unifiedInboxSearch = SearchAccount.createUnifiedInboxAccount(
             unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
             unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+            accounts = Preferences.getPreferences().getAccounts(),
         ).relatedSearch
 
         senderAboveSubject = K9.isMessageListSenderAboveSubject

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
@@ -46,6 +46,7 @@ class UnreadWidgetDataProvider(
         SearchAccount.UNIFIED_INBOX -> SearchAccount.createUnifiedInboxAccount(
             unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
             unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+            accounts = Preferences.getPreferences().getAccounts(),
         )
         else -> throw AssertionError("SearchAccount expected")
     }

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -80,6 +80,10 @@ class Account(
 
     @get:Synchronized
     @set:Synchronized
+    var isShowInUnifiedInbox = true
+
+    @get:Synchronized
+    @set:Synchronized
     var isNotifyNewMail = false
 
     @get:Synchronized

--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
@@ -65,6 +65,7 @@ class AccountCreator(
             newAccount.signatureUse = true
             newAccount.signature = account.options.emailSignature
         }
+        newAccount.isShowInUnifiedInbox = account.options.showInUnifiedInbox
         newAccount.isNotifyNewMail = account.options.showNotification
         newAccount.automaticCheckIntervalMinutes = account.options.checkFrequencyInMinutes
         newAccount.displayCount = account.options.messageDisplayCount

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -53,6 +53,7 @@ class AccountPreferenceSerializer(
                 displayCount = K9.DEFAULT_VISIBLE_LIMIT
             }
             isNotifyNewMail = storage.getBoolean("$accountUuid.notifyNewMail", false)
+            isShowInUnifiedInbox = storage.getBoolean("$accountUuid.showInUnifiedInbox", true)
 
             folderNotifyNewMailMode = getEnumStringPref<FolderMode>(
                 storage,
@@ -277,6 +278,7 @@ class AccountPreferenceSerializer(
             editor.putInt("$accountUuid.automaticCheckIntervalMinutes", automaticCheckIntervalMinutes)
             editor.putInt("$accountUuid.idleRefreshMinutes", idleRefreshMinutes)
             editor.putInt("$accountUuid.displayCount", displayCount)
+            editor.putBoolean("$accountUuid.showInUnifiedInbox", isShowInUnifiedInbox)
             editor.putBoolean("$accountUuid.notifyNewMail", isNotifyNewMail)
             editor.putString("$accountUuid.folderNotifyNewMailMode", folderNotifyNewMailMode.name)
             editor.putBoolean("$accountUuid.notifySelfNewMail", isNotifySelfNewMail)
@@ -566,6 +568,7 @@ class AccountPreferenceSerializer(
             idleRefreshMinutes = 24
             displayCount = K9.DEFAULT_VISIBLE_LIMIT
             accountNumber = UNASSIGNED_ACCOUNT_NUMBER
+            isShowInUnifiedInbox = true
             isNotifyNewMail = true
             folderNotifyNewMailMode = FolderMode.ALL
             isNotifySync = false

--- a/legacy/search/src/main/java/app/k9mail/legacy/search/SearchAccount.kt
+++ b/legacy/search/src/main/java/app/k9mail/legacy/search/SearchAccount.kt
@@ -1,5 +1,6 @@
 package app.k9mail.legacy.search
 
+import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.BaseAccount
 import app.k9mail.legacy.search.api.SearchAttribute
 import app.k9mail.legacy.search.api.SearchField
@@ -35,9 +36,11 @@ class SearchAccount(
         fun createUnifiedInboxAccount(
             unifiedInboxTitle: String,
             unifiedInboxDetail: String,
+            accounts: List<Account>,
         ): SearchAccount {
             val tmpSearch = LocalSearch().apply {
                 id = UNIFIED_INBOX
+                addAccountUuids(accounts.filter { it.isShowInUnifiedInbox }.map { it.uuid }.toTypedArray())
                 and(SearchField.INTEGRATE, "1", SearchAttribute.EQUALS)
             }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.kt
@@ -78,6 +78,7 @@ abstract class AccountList : K9ListActivity(), OnItemClickListener {
             val unifiedInboxAccount: BaseAccount = createUnifiedInboxAccount(
                 unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
                 unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+                accounts = getPreferences().getAccounts(),
             )
             accounts.add(unifiedInboxAccount)
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -47,6 +47,7 @@ import com.fsck.k9.K9.PostMarkAsUnreadNavigation
 import com.fsck.k9.K9.PostRemoveNavigation
 import com.fsck.k9.K9.SplitViewMode
 import com.fsck.k9.Preferences
+import com.fsck.k9.Preferences.Companion.getPreferences
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.activity.compose.MessageActions
 import com.fsck.k9.controller.MessagingController
@@ -1407,6 +1408,7 @@ open class MessageList :
         return SearchAccount.createUnifiedInboxAccount(
             unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
             unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+            accounts = getPreferences().getAccounts()
         )
     }
 
@@ -1491,6 +1493,7 @@ open class MessageList :
                 val search = SearchAccount.createUnifiedInboxAccount(
                     unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
                     unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+                    accounts = getPreferences().getAccounts(),
                 ).relatedSearch
 
                 putExtra(EXTRA_ACCOUNT, account.uuid)
@@ -1558,6 +1561,7 @@ open class MessageList :
                     val search = SearchAccount.createUnifiedInboxAccount(
                         unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
                         unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+                        accounts = getPreferences().getAccounts(),
                     ).relatedSearch
                     putExtra(EXTRA_SEARCH, ParcelableUtil.marshall(search))
                 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -33,6 +33,7 @@ class AccountSettingsDataStore(
             "default_quoted_text_shown" -> account.isDefaultQuotedTextShown
             "reply_after_quote" -> account.isReplyAfterQuote
             "strip_signature" -> account.isStripSignature
+            "show_in_unified_inbox" -> account.isShowInUnifiedInbox
             "account_notify" -> account.isNotifyNewMail
             "account_notify_self" -> account.isNotifySelfNewMail
             "account_notify_contacts_mail_only" -> account.isNotifyContactsMailOnly
@@ -58,6 +59,7 @@ class AccountSettingsDataStore(
             "default_quoted_text_shown" -> account.isDefaultQuotedTextShown = value
             "reply_after_quote" -> account.isReplyAfterQuote = value
             "strip_signature" -> account.isStripSignature = value
+            "show_in_unified_inbox" -> account.isShowInUnifiedInbox = value
             "account_notify" -> account.isNotifyNewMail = value
             "account_notify_self" -> account.isNotifySelfNewMail = value
             "account_notify_contacts_mail_only" -> account.isNotifyContactsMailOnly = value

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -449,6 +449,9 @@
     <string name="account_settings_color_label">Account color</string>
     <string name="account_settings_color_summary">The accent color of this account used in folder and account list</string>
 
+    <string name="account_settings_show_in_unified_inbox_label">Show in unified inbox</string>
+    <string name="account_settings_show_in_unified_inbox_summary">Display messages of this account in the unified inbox</string>
+
     <string name="account_settings_mail_display_count_label">Local folder size</string>
 
     <string name="account_settings_autodownload_message_size_label">Fetch messages up to</string>

--- a/legacy/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/account_settings.xml
@@ -27,6 +27,13 @@
             app:pref_colors="@array/account_colors"
             />
 
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="show_in_unified_inbox"
+            android:summary="@string/account_settings_show_in_unified_inbox_summary"
+            android:title="@string/account_settings_show_in_unified_inbox_label"
+        />
+
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
https://connect.mozilla.org/t5/ideas/ability-to-select-which-account-appear-in-the-unified-inbox/idi-p/82621#M44535
> There is currently no way to select which account appear in the unified inbox.
> 
> This means that if you have many account you always have them all shown in the unified inbox.

This PR proposes a new option on accounts to allow hiding an account from the unified inbox.