### PR TITLE
Remove tailrec as this is not a tailrec function

### DIFF
--- a/core/android/common/src/main/kotlin/app/k9mail/core/android/common/activity/ContextExtensions.kt
+++ b/core/android/common/src/main/kotlin/app/k9mail/core/android/common/activity/ContextExtensions.kt
@@ -6,6 +6,10 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 
-// Source: https://stackoverflow.com/a/58249983
-tailrec fun Context.findActivity(): Activity? = this as? Activity
-    ?: (this as? ContextWrapper)?.baseContext?.findActivity()
+tailrec fun Context.findActivity(): Activity? {
+    return if (this is Activity) {
+        this
+    } else {
+        (this as? ContextWrapper)?.baseContext?.findActivity()
+    }
+}


### PR DESCRIPTION
Fixes a warning that: A function is marked as tail-recursive but no tail calls are found.