### PR TITLE
Fix GH Action token permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,9 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 10 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   codeql-scan:
 

--- a/.github/workflows/daily_builds.yml
+++ b/.github/workflows/daily_builds.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '8 20 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   trigger_daily_build:
     if: ${{ github.repository_owner == 'thunderbird' }}

--- a/.github/workflows/fluidscan.yml
+++ b/.github/workflows/fluidscan.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 10 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   fluidattacks-scan:
 

--- a/.github/workflows/gradle-cache.yml
+++ b/.github/workflows/gradle-cache.yml
@@ -14,6 +14,9 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -6,6 +6,9 @@ on:
       - '**.md'
       - '.github/workflows/markdown.yml'
 
+permissions:
+  contents: read
+
 jobs:
   markdown_quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/needinfo-remove.yml
+++ b/.github/workflows/needinfo-remove.yml
@@ -6,6 +6,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/needinfo-stale.yml
+++ b/.github/workflows/needinfo-stale.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -29,6 +29,9 @@ on:
         type: boolean
         description: Upload to FTP stage instead of prod
 
+permissions:
+  contents: read
+
 jobs:
   get_environment:
     name: Determine Release Environment

--- a/.github/workflows/uplift-merges.yml
+++ b/.github/workflows/uplift-merges.yml
@@ -8,6 +8,9 @@ on:
         description: Dry run
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   uplift:
     name: Uplift

--- a/.github/workflows/validate-gradle.yml
+++ b/.github/workflows/validate-gradle.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate-gradle:
     name: "validate-gradle"

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -14,6 +14,9 @@ on:
         description: Debug mode
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   validate-workflows:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This resolves the token permission reports by setting the minimal permission `contents: read` for all workflows. This is sufficient as the repository is setup with restrictive GH Action permissions.