### PR TITLE
Update SettingsImporter::getImportStreamContents  

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.kt
@@ -30,7 +30,7 @@ class SettingsImporter internal constructor(
      *
      * @throws SettingsImportExportException In case of an error.
      */
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "ThrowsCount")
     @Throws(SettingsImportExportException::class)
     fun getImportStreamContents(inputStream: InputStream): ImportContents {
         try {
@@ -46,7 +46,10 @@ class SettingsImporter internal constructor(
                 )
             }
 
-            // TODO: throw exception if neither global settings nor account settings could be found
+            if (!globalSettings && accounts.isEmpty()) {
+                throw SettingsImportExportException("Neither global settings nor account settings could be found")
+            }
+
             return ImportContents(globalSettings, accounts)
         } catch (e: SettingsImportExportException) {
             throw e

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.kt
@@ -320,4 +320,19 @@ class SettingsImporterTest : K9RobolectricTest() {
             }
         }
     }
+
+    @Test
+    fun `getImportStreamContents() should throw when no setting is present in inputStream`() {
+        val inputStream =
+            """
+            <k9settings format="1" version="1">
+              <accounts>
+              </accounts>
+            </k9settings>
+            """.trimIndent().byteInputStream()
+
+        assertFailure {
+            settingsImporter.getImportStreamContents(inputStream)
+        }.isInstanceOf<SettingsImportExportException>()
+    }
 }


### PR DESCRIPTION
- In **com.fsck.k9.preferences.SettingsImporter** , in `getImportStreamContents ` method, added case to throw exception when no settings is present(global & account) 
- Also added relevant test  in **com.fsck.k9.preferences.SettingsImporterTest** for validating added case.
-  Updated impacted tests due to this change.