### PR TITLE
Fix `TokenCompleteTextView`'s "prevent free-form text" behavior

### DIFF
--- a/library/TokenAutoComplete/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/TokenAutoComplete/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -146,10 +146,8 @@ public abstract class TokenCompleteTextView<T> extends AppCompatAutoCompleteText
 
                 //Detect split characters, remove them and complete the current token instead
                 if (tokenizer.containsTokenTerminator(source)) {
-                    if (currentCompletionText().length() > 0) {
-                        performCompletion();
-                        return "";
-                    }
+                    performCompletion();
+                    return "";
                 }
 
                 return null;


### PR DESCRIPTION
Fixes a bug that was introduced in 11b989ec632a9f0c949834af3df0548b3f99b3dc.

The code

```kotlin
if (preventFreeFormText || currentCompletionText().length() > 0) {
    // do thing
}
```

was replaced with

```kotlin
if (currentCompletionText().length() > 0) {
    // do thing
}
```

when it should have been

```kotlin
// do thing
```

because `preventFreeFormText` was always `true`.

Fixes #8732 (issue also contains instructions on how to reproduce)