### PR TITLE
Account name should be single line if email and display name are identical

### DIFF
--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/account/AccountView.kt
@@ -22,6 +22,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 
+@Suppress("LongMethod")
 @Composable
 internal fun AccountView(
     account: DisplayAccount,
@@ -78,10 +79,12 @@ internal fun AccountView(
                     text = account.name,
                     color = MainTheme.colors.onSurface,
                 )
-                TextBodyMedium(
-                    text = account.email,
-                    color = MainTheme.colors.onSurfaceVariant,
-                )
+                if (account.name != account.email) {
+                    TextBodyMedium(
+                        text = account.email,
+                        color = MainTheme.colors.onSurfaceVariant,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
- Show only  account name among account name and account email in `AccountView `if account name and account email is identical
- Fixes #8739 