### PR TITLE
Add gradle-remote to execute gradle builds on a build server

### DIFF
--- a/gradle-remote
+++ b/gradle-remote
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# This script serves as a drop-in replacement for running Gradle tasks locally.
+# It automates the process of building a Gradle project on a remote server by synchronizing local files,
+# executing specified Gradle tasks remotely, and copying all build outputs back to your local machine.
+
+# Disclaimer
+echo "Please note that this script is quite basic and not recommended for use with public build servers."
+echo "Since rsync transfers all files from the developer's machine, including potentially sensitive information"
+echo "like secrets or configuration files, it should be used with care."
+
+if ! [ -f build.gradle.kts ]; then
+  echo "No build.gradle.kts found"
+  exit 1
+fi
+
+remote=$GRADLE_REMOTE_SSH
+if [ -z "$remote" ]; then
+  echo "\$GRADLE_REMOTE_SSH is not set, please set it to a valid SSH login on your build server"
+  exit 1
+fi
+
+remote_dir=$GRADLE_REMOTE_DIR
+if [ -z "$remote_dir" ]; then
+  echo "\$GRADLE_REMOTE_DIR is not set, please set it to the directory where the project should be copied on the remote server"
+  exit 1
+fi
+
+remote_project_dir="$remote_dir/$(basename "$(dirname "$PWD")")_$(basename "$PWD")"
+
+set -e
+
+# Define rsync exclusions
+exclusions=(
+  --exclude .git/
+  --exclude .github/
+  --exclude .gradle/
+  --exclude .idea/
+  --exclude .kotlin/
+  --exclude .signing/
+  --exclude metadata
+  --exclude build/
+)
+
+# Define rsync inclusions
+inclusions=(
+  --include .gradle/gradle.properties
+)
+
+# Copy the project to the remote server, excluding specified paths but including gradle properties
+rsync -irc "${exclusions[@]}" "${inclusions[@]}" --delete . "$remote:$remote_project_dir"
+
+# Run the gradle command on the remote
+ssh -t "$remote" "cd $remote_project_dir && ./gradlew $*"
+
+# Copy the build directory back
+rsync --delete -ircuq "$remote:$remote_project_dir/build" . | (grep -v '/$' || true)


### PR DESCRIPTION
This adds a `gradle-remote` script that executes Gradle commands on a remote build server. It uses `rsync` to transfer the project files to the server and then connects via SSH to run the Gradle command remotely. Once the execution is complete, the contents of the build folder are synced back to the local machine.

Please note that this script is quite basic and not recommended for use with public build servers. Since `rsync` transfers all project files from the developer's machine, including potentially sensitive information like secrets or configuration files, it should be used with care.