### PR TITLE
Run daily builds at 8am EST / 2pm CET

### DIFF
--- a/.github/workflows/daily_builds.yml
+++ b/.github/workflows/daily_builds.yml
@@ -3,7 +3,7 @@ name: Daily Builds
 on:
   workflow_dispatch:
   schedule:
-    - cron: '8 20 * * *'
+    - cron: '8 13 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
I'm currently getting daily notifications on my phone at about 10pm. I think we should move the daily builds into the EST morning, so in case there is an issue it is more actionable.

Another option would be CET morning, which would give more time in case engineering action is needed.