### PR TITLE
Keep `<s>` tags when sanitizing HTML

### DIFF
--- a/library/html-cleaner/src/main/kotlin/app/k9mail/html/cleaner/BodyCleaner.kt
+++ b/library/html-cleaner/src/main/kotlin/app/k9mail/html/cleaner/BodyCleaner.kt
@@ -13,7 +13,22 @@ internal class BodyCleaner {
 
     init {
         val allowList = Safelist.relaxed()
-            .addTags("font", "hr", "ins", "del", "center", "map", "area", "title", "tt", "kbd", "samp", "var", "style")
+            .addTags(
+                "font",
+                "hr",
+                "ins",
+                "del",
+                "center",
+                "map",
+                "area",
+                "title",
+                "tt",
+                "kbd",
+                "samp",
+                "var",
+                "style",
+                "s",
+            )
             .addAttributes("font", "color", "face", "size")
             .addAttributes("a", "name")
             .addAttributes("div", "align")

--- a/library/html-cleaner/src/test/kotlin/app/k9mail/html/cleaner/HtmlSanitizerTest.kt
+++ b/library/html-cleaner/src/test/kotlin/app/k9mail/html/cleaner/HtmlSanitizerTest.kt
@@ -468,6 +468,11 @@ class HtmlSanitizerTest {
     }
 
     @Test
+    fun `should keep 's' element`() {
+        assertTagsNotStripped("s")
+    }
+
+    @Test
     fun `should keep 'base' element`() {
         val html =
             """


### PR DESCRIPTION
I received an email that wasn't displayed properly and tracked it down to [`<s>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s) tags being removed.