### PR TITLE
Basic EAI support

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/Address.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Address.java
@@ -74,7 +74,7 @@ public class Address implements Serializable {
                 Timber.e("Invalid address: %s", address);
             }
         } else {
-            mAddress = address;
+            mAddress = Rfc822Token.withULabelDomain(address);
             mPersonal = personal;
         }
     }

--- a/mail/common/src/main/java/com/fsck/k9/mail/Address.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Address.java
@@ -309,4 +309,24 @@ public class Address implements Serializable {
             return s;
         }
     }
+
+    /**
+     *  Returns true if either the localpart or the domain of this
+     *  address contains any non-ASCII characters, and false if all
+     *  characters used are within ASCII.
+     *
+     *  Note that this returns false for an address such as "Naïve
+     *  Assumption &lt;naive.assumption@example.com&gt;", because both
+     *  localpart and domain are all-ASCII. There's an ï there, but
+     *  it's not in either localpart or domain.
+     */
+
+    public boolean needsUnicode() {
+        if (mAddress == null)
+            return false;
+        int i = mAddress.length()-1;
+        while (i >= 0 && mAddress.charAt(i) < 128)
+            i--;
+        return i >= 0;
+    }
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/Message.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Message.java
@@ -168,4 +168,21 @@ public abstract class Message implements Part, Body {
         }
         return 0;
     }
+
+    /*
+     * Returns true if any address in this message uses a non-ASCII
+     * character in either the localpart or the domain, and false if
+     * all addresses use only ASCII.
+     */
+
+    public boolean usesAnyUnicodeAddresses() {
+        for (final Address a : getFrom())
+            if (a.needsUnicode())
+                return true;
+        for (RecipientType t : RecipientType.values())
+            for (final Address r : getRecipients(t))
+                if (r.needsUnicode())
+                    return true;
+        return false;
+    }
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/helper/Rfc822Token.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/helper/Rfc822Token.java
@@ -17,6 +17,7 @@
 package com.fsck.k9.mail.helper;
 
 
+import java.net.IDN;
 import org.jetbrains.annotations.Nullable;
 
 
@@ -34,7 +35,7 @@ public class Rfc822Token {
      */
     public Rfc822Token(@Nullable String name, @Nullable String address, @Nullable String comment) {
         mName = name;
-        mAddress = address;
+        mAddress = withULabelDomain(address);
         mComment = comment;
     }
 
@@ -73,7 +74,7 @@ public class Rfc822Token {
      * Changes the address to the specified address.
      */
     public void setAddress(@Nullable String address) {
-        mAddress = address;
+        mAddress = withULabelDomain(address);
     }
 
     /**
@@ -201,5 +202,13 @@ public class Rfc822Token {
         return (stringEquals(mName, other.mName) &&
                 stringEquals(mAddress, other.mAddress) &&
                 stringEquals(mComment, other.mComment));
+    }
+
+    public static String withULabelDomain(final String address) {
+        int at = address.lastIndexOf('@');
+        if (at < 0 || at == address.length()-1)
+            return address;
+        return address.substring(0, at+1) +
+            IDN.toUnicode(address.substring(at+1), IDN.ALLOW_UNASSIGNED);
     }
 }

--- a/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
@@ -62,8 +62,8 @@ public class AddressTest {
         for(String testEmail: testEmails) {
             Address[] addresses = Address.parse("Anonymous <"+testEmail+">");
 
-            assertEquals(1, addresses.length);
-            assertEquals(testEmail, addresses[0].getAddress());
+            assertEquals(testEmail, 1, addresses.length);
+            assertEquals(testEmail, testEmail, addresses[0].getAddress());
         }
     }
 

--- a/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
@@ -78,13 +78,30 @@ public class AddressTest {
     }
 
     @Test
+    public void construction_withALabel_shouldDecode() {
+        // Mutt and Exchange do this, and maybe Plesk too. Best fix it
+        // at the earliest opportinity.
+        Address a = new Address("grå@xn--gr-zia.org", "Grå katt");
+
+        assertEquals("Grå katt", a.getPersonal());
+        assertEquals("grå@grå.org", a.getAddress());
+    }
+
+    @Test
     public void parse_withQuotedEncodedPersonal_shouldDecode() {
         Address[] addresses = Address.parse(
                 "\"=?UTF-8?B?WWFob28h44OA44Kk44Os44Kv44OI44Kq44OV44Kh44O8?= \"<directoffer-master@mail.yahoo.co.jp>");
 
         assertEquals("Yahoo!ダイレクトオファー ", addresses[0].getPersonal());
         assertEquals("directoffer-master@mail.yahoo.co.jp", addresses[0].getAddress());
+    }
 
+
+    @Test
+    public void parse_withALabel_shouldDecode() {
+        Address[] addresses = Address.parse("info@xn--gr-zia.org");
+        assertEquals(1, addresses.length);
+        assertEquals("info@grå.org", addresses[0].getAddress());
     }
 
     /**

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
@@ -19,4 +19,6 @@ class Capabilities {
     public static final String UID_PLUS = "UIDPLUS";
     public static final String LIST_EXTENDED = "LIST-EXTENDED";
     public static final String MOVE = "MOVE";
+    public static final String ENABLE = "ENABLE";
+    public static final String UTF8_ACCEPT = "UTF8=ACCEPT";
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
@@ -21,4 +21,5 @@ class Commands {
     public static final String UID_COPY = "UID COPY";
     public static final String UID_MOVE = "UID MOVE";
     public static final String UID_EXPUNGE = "UID EXPUNGE";
+    public static final String ENABLE = "ENABLE UTF8=ACCEPT";
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/EnabledResponse.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/EnabledResponse.java
@@ -1,0 +1,52 @@
+package com.fsck.k9.mail.store.imap;
+
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import static com.fsck.k9.mail.store.imap.ImapResponseParser.equalsIgnoreCase;
+
+
+class EnabledResponse {
+    private final Set<String> capabilities;
+
+
+    private EnabledResponse(Set<String> capabilities) {
+        this.capabilities = Collections.unmodifiableSet(capabilities);
+    }
+
+    public static EnabledResponse parse(List<ImapResponse> responses) {
+        EnabledResponse result = null;
+        for (ImapResponse response : responses)
+            if (result == null && response.getTag() == null)
+                result = parse(response);
+        return result;
+    }
+
+    static EnabledResponse parse(ImapList capabilityList) {
+        if (capabilityList.isEmpty() || !equalsIgnoreCase(capabilityList.get(0), Responses.ENABLED)) {
+            return null;
+        }
+
+        int size = capabilityList.size();
+        HashSet<String> capabilities = new HashSet<>(size - 1);
+
+        for (int i = 1; i < size; i++) {
+            if (!capabilityList.isString(i)) {
+                return null;
+            }
+
+            String uppercaseCapability = capabilityList.getString(i).toUpperCase(Locale.US);
+            capabilities.add(uppercaseCapability);
+        }
+
+        return new EnabledResponse(capabilities);
+    }
+
+    public Set<String> getCapabilities() {
+        return capabilities;
+    }
+}

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.kt
@@ -11,6 +11,7 @@ internal interface ImapConnection {
     val isConnected: Boolean
     val outputStream: OutputStream
     val isUidPlusCapable: Boolean
+    val isUtf8AcceptCapable: Boolean
     val isIdleCapable: Boolean
 
     @Throws(IOException::class, MessagingException::class)

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
@@ -258,13 +258,13 @@ internal class RealImapConnection(
 
     private fun enableCapabilitiesIfSupported() {
         if (!hasCapability(Capabilities.ENABLE)) {
-	    return;
-	}
+            return
+        }
 
         try {
             val responses = executeSimpleCommand(Commands.ENABLE)
-	    val enabledResponse = EnabledResponse.parse(responses) ?: return
-	    enabled = enabledResponse.capabilities
+            val enabledResponse = EnabledResponse.parse(responses) ?: return
+            enabled = enabledResponse.capabilities
         } catch (e: NegativeImapResponseException) {
             Timber.d(e, "Ignoring negative response to ENABLE command")
         }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Responses.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Responses.java
@@ -17,4 +17,5 @@ class Responses {
     public static final String COPYUID = "COPYUID";
     public static final String SEARCH = "SEARCH";
     public static final String UIDVALIDITY = "UIDVALIDITY";
+    public static final String ENABLED = "ENABLED";
 }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.kt
@@ -435,6 +435,17 @@ class ImapResponseParserTest {
     }
 
     @Test
+    fun `readResponse() with LIST response containing folder name with UTF8`() {
+        val parser = createParserWithResponses("""* LIST (\HasNoChildren) "." "萬里長城"""")
+
+        val response = parser.readResponse()
+
+        assertThat(response).hasSize(4)
+        assertThat(response).index(3).isEqualTo("萬里長城")
+        assertThatAllInputWasConsumed()
+    }
+
+    @Test
     fun `readResponse() with LIST response containing folder name with parentheses should throw`() {
         val parser = createParserWithResponses("""* LIST (\NoInferiors) "/" Root/Folder/Subfolder()""")
 

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
@@ -775,6 +775,42 @@ class RealImapConnectionTest {
     }
 
     @Test
+    fun `open() with ENABLE capability should try to enable UTF8=ACCEPT`() {
+        val server = MockImapServer().apply {
+            simplePreAuthAndLoginDialog(postAuthCapabilities = "ENABLE")
+            expect("3 ENABLE UTF8=ACCEPT")
+            output("* ENABLED")
+            output("3 OK")
+            simplePostAuthenticationDialog(tag = 4)
+        }
+        val imapConnection = startServerAndCreateImapConnection(server, useCompression = true)
+
+        imapConnection.open()
+        assertThat(imapConnection.isUtf8AcceptCapable).isFalse()
+
+        server.verifyConnectionStillOpen()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
+    fun `open() with ENABLE and UTF8=ACCEPT capabilities should enable UTF8=ACCEPT`() {
+        val server = MockImapServer().apply {
+            simplePreAuthAndLoginDialog(postAuthCapabilities = "ENABLE UTF8=ACCEPT")
+            expect("3 ENABLE UTF8=ACCEPT")
+            output("* ENABLED UTF8=ACCEPT")
+            output("3 OK")
+            simplePostAuthenticationDialog(tag = 4)
+        }
+        val imapConnection = startServerAndCreateImapConnection(server, useCompression = true)
+
+        imapConnection.open()
+        assertThat(imapConnection.isUtf8AcceptCapable).isTrue()
+
+        server.verifyConnectionStillOpen()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
     fun `open() with COMPRESS=DEFLATE capability should enable compression`() {
         val server = MockImapServer().apply {
             simplePreAuthAndLoginDialog(postAuthCapabilities = "COMPRESS=DEFLATE")

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapConnection.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapConnection.kt
@@ -13,6 +13,7 @@ internal open class TestImapConnection(val timeout: Long, override val connectio
     override val outputStream: OutputStream
         get() = TODO("Not yet implemented")
     override val isUidPlusCapable: Boolean = true
+    override val isUtf8AcceptCapable: Boolean = false
     override var isIdleCapable: Boolean = true
         protected set
 

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.kt
@@ -64,6 +64,7 @@ class SmtpTransport(
     private var outputStream: OutputStream? = null
     private var responseParser: SmtpResponseParser? = null
     private var is8bitEncodingAllowed = false
+    private var areUnicodeAddressesAllowed = false
     private var isEnhancedStatusCodesProvided = false
     private var largestAcceptableMessage = 0
     private var retryOAuthWithNewToken = false
@@ -104,6 +105,7 @@ class SmtpTransport(
             var extensions = sendHello(helloName)
 
             is8bitEncodingAllowed = extensions.containsKey("8BITMIME")
+            areUnicodeAddressesAllowed = extensions.containsKey("SMTPUTF8")
             isEnhancedStatusCodesProvided = extensions.containsKey("ENHANCEDSTATUSCODES")
             isPipeliningSupported = extensions.containsKey("PIPELINING")
 
@@ -355,7 +357,12 @@ class SmtpTransport(
 
         var entireMessageSent = false
         try {
-            val mailFrom = constructSmtpMailFromCommand(message.from, is8bitEncodingAllowed)
+            val mailFrom =
+                constructSmtpMailFromCommand(
+                    message.from,
+                    is8bitEncodingAllowed,
+                    areUnicodeAddressesAllowed && message.usesAnyUnicodeAddresses(),
+                )
             if (isPipeliningSupported) {
                 val pipelinedCommands = buildList {
                     add(mailFrom)
@@ -404,13 +411,18 @@ class SmtpTransport(
         }
     }
 
-    private fun constructSmtpMailFromCommand(from: Array<Address>, is8bitEncodingAllowed: Boolean): String {
+    private fun constructSmtpMailFromCommand(
+        from: Array<Address>,
+        is8bitEncodingAllowed: Boolean,
+        canUseSmtputf8: Boolean,
+    ): String {
         val fromAddress = from.first().address
+        val smtputf8 = if (canUseSmtputf8) " SMTPUTF8" else ""
         return if (is8bitEncodingAllowed) {
-            String.format("MAIL FROM:<%s> BODY=8BITMIME", fromAddress)
+            String.format("MAIL FROM:<%s>%s BODY=8BITMIME", fromAddress, smtputf8)
         } else {
             Timber.d("Server does not support 8-bit transfer encoding")
-            String.format("MAIL FROM:<%s>", fromAddress)
+            String.format("MAIL FROM:<%s>%s", fromAddress, smtputf8)
         }
     }
 

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.kt
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.kt
@@ -679,6 +679,61 @@ class SmtpTransportTest {
     }
 
     @Test
+    fun `sendMessage() with unicode recipient and supporting server`() {
+        val message = createMessageWithUnicodeRecipient()
+        val server = createServerAndSetupForPlainAuthentication("SMTPUTF8").apply {
+            expect("MAIL FROM:<user@localhost> SMTPUTF8")
+            output("250 OK")
+            expect("RCPT TO:<user2@dømi.example>")
+            output("250 OK")
+            expect("DATA")
+            output("354 End data with <CR><LF>.<CR><LF>")
+            expect("[message data]")
+            expect(".")
+            output("250 OK: queued as 12345")
+            expect("QUIT")
+            output("221 BYE")
+            closeConnection()
+        }
+        val transport = startServerAndCreateSmtpTransport(server)
+
+        transport.sendMessage(message)
+
+        server.verifyConnectionClosed()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
+    fun `sendMessage() with unicode recipient and plain server`() {
+        val message = createMessageWithUnicodeRecipient()
+        val server = createServerAndSetupForPlainAuthentication("8BITMIME").apply {
+            expect("MAIL FROM:<user@localhost> BODY=8BITMIME")
+            output("250 OK")
+            // Many servers reject this as nonstandard, but some
+            // accept it. The purpose of this commit is to change the
+            // behaviour when SMTPUTF8 is supported. Therefore this
+            // test checks that Thunderbird behaves as previously when
+            // the server does not support SMTPUTF8.
+            expect("RCPT TO:<user2@dømi.example>")
+            output("250 OK")
+            expect("DATA")
+            output("354 End data with <CR><LF>.<CR><LF>")
+            expect("[message data]")
+            expect(".")
+            output("250 OK: queued as 12345")
+            expect("QUIT")
+            output("221 BYE")
+            closeConnection()
+        }
+        val transport = startServerAndCreateSmtpTransport(server)
+
+        transport.sendMessage(message)
+
+        server.verifyConnectionClosed()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
     fun `sendMessage() with message too large should throw`() {
         val message = createDefaultMessageBuilder()
             .setHasAttachments(true)
@@ -926,6 +981,13 @@ class SmtpTransportTest {
         return TestMessageBuilder()
             .from("user@localhost")
             .to("user2@localhost", "user3@localhost")
+            .build()
+    }
+
+    private fun createMessageWithUnicodeRecipient(): Message {
+        return TestMessageBuilder()
+            .from("user@localhost")
+            .to("user2@dømi.example")
             .build()
     }
 


### PR DESCRIPTION
This adds basic EAI support for Thunderbird/Android, bringing it to roughly the same level of support as other versions of Thunderbird: Can display messages to/from/cc `grå@grå.org`, cannot use `grå@grå.org` as your own address.

It requires a bit of code in MIME4J that I haven't pushed yet. With the currently released MIME4J and this PR, Thunderbird displays most of an EAI messages, but... it's complicated:
- all messages that could be displayed previously are still displayed
- a few messages are displayed better (no more xn-- display)
- some messages that could not be displayed at all are now displayed without addresses or with incomplete address lists (the upcoming MIME4J PR fixes this)

A later PR to tb will add a little more, but I wanted to get this out the door, because it's an improvement, and big enough that I was annoyed by the 8.2 version when I accidentally used it after getting used to this.

Waiting until all the functionality and dependencies are in place is of course an otion. That reminds me a little too much of [RFC 1925 truth 5](https://datatracker.ietf.org/doc/html/rfc1925).

This doesn't break any unit tests, but two unit tests were failing already when I started this. I didn't investigate those.