### PR TITLE
Add support for RFCs 5530 and 6855.

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
@@ -19,4 +19,6 @@ class Capabilities {
     public static final String UID_PLUS = "UIDPLUS";
     public static final String LIST_EXTENDED = "LIST-EXTENDED";
     public static final String MOVE = "MOVE";
+    public static final String ENABLE = "ENABLE";
+    public static final String UTF8_ACCEPT = "UTF8=ACCEPT";
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
@@ -21,4 +21,5 @@ class Commands {
     public static final String UID_COPY = "UID COPY";
     public static final String UID_MOVE = "UID MOVE";
     public static final String UID_EXPUNGE = "UID EXPUNGE";
+    public static final String ENABLE = "ENABLE UTF8=ACCEPT";
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/EnabledResponse.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/EnabledResponse.java
@@ -1,0 +1,52 @@
+package com.fsck.k9.mail.store.imap;
+
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import static com.fsck.k9.mail.store.imap.ImapResponseParser.equalsIgnoreCase;
+
+
+class EnabledResponse {
+    private final Set<String> capabilities;
+
+
+    private EnabledResponse(Set<String> capabilities) {
+        this.capabilities = Collections.unmodifiableSet(capabilities);
+    }
+
+    public static EnabledResponse parse(List<ImapResponse> responses) {
+        EnabledResponse result = null;
+        for (ImapResponse response : responses)
+            if (result == null && response.getTag() == null)
+                result = parse(response);
+        return result;
+    }
+
+    static EnabledResponse parse(ImapList capabilityList) {
+        if (capabilityList.isEmpty() || !equalsIgnoreCase(capabilityList.get(0), Responses.ENABLED)) {
+            return null;
+        }
+
+        int size = capabilityList.size();
+        HashSet<String> capabilities = new HashSet<>(size - 1);
+
+        for (int i = 1; i < size; i++) {
+            if (!capabilityList.isString(i)) {
+                return null;
+            }
+
+            String uppercaseCapability = capabilityList.getString(i).toUpperCase(Locale.US);
+            capabilities.add(uppercaseCapability);
+        }
+
+        return new EnabledResponse(capabilities);
+    }
+
+    public Set<String> getCapabilities() {
+        return capabilities;
+    }
+}

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.kt
@@ -11,6 +11,7 @@ internal interface ImapConnection {
     val isConnected: Boolean
     val outputStream: OutputStream
     val isUidPlusCapable: Boolean
+    val isUtf8AcceptCapable: Boolean
     val isIdleCapable: Boolean
 
     @Throws(IOException::class, MessagingException::class)

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Responses.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Responses.java
@@ -17,4 +17,5 @@ class Responses {
     public static final String COPYUID = "COPYUID";
     public static final String SEARCH = "SEARCH";
     public static final String UIDVALIDITY = "UIDVALIDITY";
+    public static final String ENABLED = "ENABLED";
 }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.kt
@@ -435,6 +435,17 @@ class ImapResponseParserTest {
     }
 
     @Test
+    fun `readResponse() with LIST response containing folder name with UTF8`() {
+        val parser = createParserWithResponses("""* LIST (\HasNoChildren) "." "萬里長城"""")
+
+        val response = parser.readResponse()
+
+        assertThat(response).hasSize(4)
+        assertThat(response).index(3).isEqualTo("萬里長城")
+        assertThatAllInputWasConsumed()
+    }
+
+    @Test
     fun `readResponse() with LIST response containing folder name with parentheses should throw`() {
         val parser = createParserWithResponses("""* LIST (\NoInferiors) "/" Root/Folder/Subfolder()""")
 

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
@@ -775,6 +775,42 @@ class RealImapConnectionTest {
     }
 
     @Test
+    fun `open() with ENABLE capability should try to enable UTF8=ACCEPT`() {
+        val server = MockImapServer().apply {
+            simplePreAuthAndLoginDialog(postAuthCapabilities = "ENABLE")
+            expect("3 ENABLE UTF8=ACCEPT")
+            output("* ENABLED")
+            output("3 OK")
+            simplePostAuthenticationDialog(tag = 4)
+        }
+        val imapConnection = startServerAndCreateImapConnection(server, useCompression = true)
+
+        imapConnection.open()
+        assertThat(imapConnection.isUtf8AcceptCapable).isFalse()
+
+        server.verifyConnectionStillOpen()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
+    fun `open() with ENABLE and UTF8=ACCEPT capabilities should enable UTF8=ACCEPT`() {
+        val server = MockImapServer().apply {
+            simplePreAuthAndLoginDialog(postAuthCapabilities = "ENABLE UTF8=ACCEPT")
+            expect("3 ENABLE UTF8=ACCEPT")
+            output("* ENABLED UTF8=ACCEPT")
+            output("3 OK")
+            simplePostAuthenticationDialog(tag = 4)
+        }
+        val imapConnection = startServerAndCreateImapConnection(server, useCompression = true)
+
+        imapConnection.open()
+        assertThat(imapConnection.isUtf8AcceptCapable).isTrue()
+
+        server.verifyConnectionStillOpen()
+        server.verifyInteractionCompleted()
+    }
+
+    @Test
     fun `open() with COMPRESS=DEFLATE capability should enable compression`() {
         val server = MockImapServer().apply {
             simplePreAuthAndLoginDialog(postAuthCapabilities = "COMPRESS=DEFLATE")

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapConnection.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapConnection.kt
@@ -13,6 +13,7 @@ internal open class TestImapConnection(val timeout: Long, override val connectio
     override val outputStream: OutputStream
         get() = TODO("Not yet implemented")
     override val isUidPlusCapable: Boolean = true
+    override val isUtf8AcceptCapable: Boolean = false
     override var isIdleCapable: Boolean = true
         protected set
 


### PR DESCRIPTION
5530 (ENABLE) lets a client tell the server which extensions it would like to use, and lets the server tell the client which extensions is has enabled. Most IMAP extensions don't need to be enabled, but UTF8=ACCEPT does.

6855 (UTF8=ACCEPT) requires three things of clients:
1. The client uses ENABLE (added with tests)
2. The client accepts UTF8 strings (worked already, this adds testing)
3. The client cannot use certain SEARCH syntax (tb already did not)

6855 also allows some optimisations that this change does not contain:
1. A client can send UTF8 quoted-strings instead of some literals
2. A client can send UTF8 folder names instead of mUTF7

This change doesn't do either of those, because they add complexity (and unit tests) but no functionality. Some IMAP commands become three or seven or even ten bytes smaller. Who cares?

RFC 6855 differs modestly from its replacement, currently in the RFC-editor's queue. This implementation sides with the newer RFC when there's any difference.

This commit contains a couple of unit tests that do nothing right now, they merely guard against possible future breakage.