### PR TITLE
Fix Thunderbird not respecting PROCESS_TEXT action in the text selection toolbar

### DIFF
--- a/app-common/src/main/AndroidManifest.xml
+++ b/app-common/src/main/AndroidManifest.xml
@@ -11,4 +11,12 @@
         android:usesCleartextTraffic="true"
         />
 
+    <queries>
+        <!-- Allow access to external text processing actions so they can be displayed in the text selection toolbar -->
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+
 </manifest>


### PR DESCRIPTION
### Description
This PR addresses the issue where Thunderbird was not respecting the `PROCESS_TEXT` action in the text selection toolbar. I added the required `<queries>` section to the `AndroidManifest.xml` to ensure that the app properly handles the `PROCESS_TEXT` intent.

### Changes:
- Added the `<queries>` section in `AndroidManifest.xml` to allow processing of text through the `PROCESS_TEXT` action.
- This change will allow Thunderbird to be recognized as a valid app for text selection and processing, enabling actions like translation to show in the system text selection toolbar.

### Testing:
- I tested the changes by selecting text within Thunderbird and confirming that the text selection toolbar now includes relevant actions.
- - There are some failing tests in the `legacy:storage` module, but they are unrelated to the changes in this PR. Please refer to issue #8778 for further investigation.

### Notes:
- Ensure that your app can handle the `PROCESS_TEXT` action appropriately if additional handling is needed.
![translate](https://github.com/user-attachments/assets/74780b23-69a8-4942-a5d2-8a7ad4f4ffb5)

Fixes #8778
