### PR TITLE
Add kewisch as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @cketti @wmontwe
+* @cketti @kewisch @wmontwe
 /.github/ @coreycb @jfx2006 @dandarnell
 


### PR DESCRIPTION
With the new branch protection rules, any code change needs to be approved by the codeowners before it could be merged.

This adds @kewisch as Codeowner for the app source code, to allow him to approve pull-requests.
