### PR TITLE
Prefill server text field in manual account setup flow

### DIFF
--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/common/EmailExtensions.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/common/EmailExtensions.kt
@@ -1,0 +1,3 @@
+package app.k9mail.feature.account.server.settings.ui.common
+
+fun String.toInvalidEmailDomain() = ".${this.substringAfter("@")}"

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapper.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapper.kt
@@ -22,7 +22,7 @@ fun AccountState.toIncomingServerSettingsState() = incomingServerSettings?.toInc
         server = StringInputField(value = emailAddress?.toInvalidEmailDomain() ?: ""),
     )
 
-private fun String.toInvalidEmailDomain() = ".${this.substringAfter("@")}"
+fun String.toInvalidEmailDomain() = ".${this.substringAfter("@")}"
 
 private fun ServerSettings.toIncomingServerSettingsState(): State {
     return State(

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapper.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapper.kt
@@ -19,7 +19,10 @@ import com.fsck.k9.mail.store.imap.ImapStoreSettings.pathPrefix
 fun AccountState.toIncomingServerSettingsState() = incomingServerSettings?.toIncomingServerSettingsState()
     ?: State(
         username = StringInputField(value = emailAddress ?: ""),
+        server = StringInputField(value = emailAddress?.toInvalidEmailDomain() ?: ""),
     )
+
+private fun String.toInvalidEmailDomain() = ".${this.substringAfter("@")}"
 
 private fun ServerSettings.toIncomingServerSettingsState(): State {
     return State(

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapper.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapper.kt
@@ -8,6 +8,7 @@ import app.k9mail.feature.account.common.domain.entity.toConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toMailConnectionSecurity
 import app.k9mail.feature.account.common.domain.input.NumberInputField
 import app.k9mail.feature.account.common.domain.input.StringInputField
+import app.k9mail.feature.account.server.settings.ui.common.toInvalidEmailDomain
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings
@@ -21,8 +22,6 @@ fun AccountState.toIncomingServerSettingsState() = incomingServerSettings?.toInc
         username = StringInputField(value = emailAddress ?: ""),
         server = StringInputField(value = emailAddress?.toInvalidEmailDomain() ?: ""),
     )
-
-fun String.toInvalidEmailDomain() = ".${this.substringAfter("@")}"
 
 private fun ServerSettings.toIncomingServerSettingsState(): State {
     return State(

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapper.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapper.kt
@@ -7,7 +7,7 @@ import app.k9mail.feature.account.common.domain.entity.toConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toMailConnectionSecurity
 import app.k9mail.feature.account.common.domain.input.NumberInputField
 import app.k9mail.feature.account.common.domain.input.StringInputField
-import app.k9mail.feature.account.server.settings.ui.incoming.toInvalidEmailDomain
+import app.k9mail.feature.account.server.settings.ui.common.toInvalidEmailDomain
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
 import com.fsck.k9.mail.ServerSettings
 

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapper.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapper.kt
@@ -7,6 +7,7 @@ import app.k9mail.feature.account.common.domain.entity.toConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toMailConnectionSecurity
 import app.k9mail.feature.account.common.domain.input.NumberInputField
 import app.k9mail.feature.account.common.domain.input.StringInputField
+import app.k9mail.feature.account.server.settings.ui.incoming.toInvalidEmailDomain
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
 import com.fsck.k9.mail.ServerSettings
 
@@ -17,6 +18,7 @@ fun AccountState.toOutgoingServerSettingsState(): State {
         ?: State(
             username = StringInputField(value = emailAddress ?: ""),
             password = StringInputField(value = password),
+            server = StringInputField(value = emailAddress?.toInvalidEmailDomain() ?: ""),
         )
 }
 

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapperKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapperKtTest.kt
@@ -7,6 +7,7 @@ import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
 import app.k9mail.feature.account.common.domain.input.NumberInputField
 import app.k9mail.feature.account.common.domain.input.StringInputField
+import app.k9mail.feature.account.server.settings.ui.common.toInvalidEmailDomain
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapperKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapperKtTest.kt
@@ -18,7 +18,8 @@ import org.junit.Test
 class IncomingServerSettingsStateMapperKtTest {
 
     @Test
-    fun `should map to state with email as username when server settings are null`() {
+    fun `should map to state with email as username and emailDomain With dot prefix as server name when server settings are null`() {
+        val email = "test@example.com"
         val accountState = AccountState(
             emailAddress = "test@example.com",
             incomingServerSettings = null,
@@ -28,7 +29,8 @@ class IncomingServerSettingsStateMapperKtTest {
 
         assertThat(result).isEqualTo(
             State(
-                username = StringInputField(value = "test@example.com"),
+                username = StringInputField(value = email),
+                server = StringInputField(value = email.toInvalidEmailDomain()),
             ),
         )
     }

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapperKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapperKtTest.kt
@@ -18,11 +18,12 @@ import org.junit.Test
 
 class IncomingServerSettingsStateMapperKtTest {
 
+    @Suppress("MaxLineLength")
     @Test
     fun `should map to state with email as username and emailDomain With dot prefix as server name when server settings are null`() {
         val email = "test@example.com"
         val accountState = AccountState(
-            emailAddress = "test@example.com",
+            emailAddress = email,
             incomingServerSettings = null,
         )
 

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapperKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapperKtTest.kt
@@ -6,6 +6,7 @@ import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
 import app.k9mail.feature.account.common.domain.input.NumberInputField
 import app.k9mail.feature.account.common.domain.input.StringInputField
+import app.k9mail.feature.account.server.settings.ui.common.toInvalidEmailDomain
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -15,10 +16,12 @@ import org.junit.Test
 
 class OutgoingServerSettingsStateMapperKtTest {
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `should map to state with email as username when server settings are null`() {
+    fun `should map to state with email as username and emailDomain With dot prefix as server name when server settings are null`() {
+        val email = "test@example.com"
         val accountState = AccountState(
-            emailAddress = "test@example.com",
+            emailAddress = email,
             outgoingServerSettings = null,
         )
 
@@ -26,15 +29,18 @@ class OutgoingServerSettingsStateMapperKtTest {
 
         assertThat(result).isEqualTo(
             State(
-                username = StringInputField(value = "test@example.com"),
+                username = StringInputField(value = email),
+                server = StringInputField(value = email.toInvalidEmailDomain()),
             ),
         )
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `should map to state with password from incomingServerSettings when outgoingServerSettings is null`() {
+    fun `should map to state with password from incomingServerSettings and emailDomain With dot prefix as server name when outgoingServerSettings is null`() {
+        val email = "test@domain.example"
         val accountState = AccountState(
-            emailAddress = "test@domain.example",
+            emailAddress = email,
             incomingServerSettings = IMAP_SERVER_SETTINGS,
             outgoingServerSettings = null,
         )
@@ -43,8 +49,9 @@ class OutgoingServerSettingsStateMapperKtTest {
 
         assertThat(result).isEqualTo(
             State(
-                username = StringInputField(value = "test@domain.example"),
+                username = StringInputField(value = email),
                 password = StringInputField(value = INCOMING_SERVER_PASSWORD),
+                server = StringInputField(value = email.toInvalidEmailDomain()),
             ),
         )
     }


### PR DESCRIPTION
Fixes #7552  that includes:

1. Prefill server text value when server settings are null for both incoming & outgoing server.
2. Update relevant unit tests.

