### PR TITLE
Set maxLines and ellipsis on drawer folder labels

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextLabelLarge.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/text/TextLabelLarge.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import androidx.compose.material3.Text as Material3Text
 
@@ -14,12 +15,16 @@ fun TextLabelLarge(
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
     textAlign: TextAlign? = null,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
+    maxLines: Int = Int.MAX_VALUE,
 ) {
     Material3Text(
         text = text,
         modifier = modifier,
         color = color,
         textAlign = textAlign,
+        maxLines = maxLines,
+        overflow = overflow,
         style = MainTheme.typography.labelLarge,
     )
 }
@@ -30,12 +35,16 @@ fun TextLabelLarge(
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
     textAlign: TextAlign? = null,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
+    maxLines: Int = Int.MAX_VALUE,
 ) {
     Material3Text(
         text = text,
         modifier = modifier,
         color = color,
         textAlign = textAlign,
+        maxLines = maxLines,
+        overflow = overflow,
         style = MainTheme.typography.labelLarge,
     )
 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerItem.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerItem.kt
@@ -18,7 +18,7 @@ fun NavigationDrawerItem(
     badge: (@Composable () -> Unit)? = null,
 ) {
     Material3NavigationDrawerItem(
-        label = { TextLabelLarge(text = label) },
+        label = { TextLabelLarge(text = label, maxLines = 2) },
         selected = selected,
         onClick = onClick,
         modifier = Modifier
@@ -39,7 +39,7 @@ fun NavigationDrawerItem(
     badge: (@Composable () -> Unit)? = null,
 ) {
     Material3NavigationDrawerItem(
-        label = { TextLabelLarge(text = label) },
+        label = { TextLabelLarge(text = label, maxLines = 2) },
         selected = selected,
         onClick = onClick,
         modifier = Modifier


### PR DESCRIPTION
Fixes #8738

 - Add overflow and maxLines arguments to `TextLabelLarge` composables.
 - Set 2 max lines and ellipsis overflow on `NavigationDrawerItem`.