### PR TITLE
Add settings change notifier

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
@@ -1,10 +1,14 @@
 package com.fsck.k9.preferences
 
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.preferences.DefaultSettingsChangeBroker
 import app.k9mail.legacy.preferences.GeneralSettingsManager
+import app.k9mail.legacy.preferences.SettingsChangeBroker
+import app.k9mail.legacy.preferences.SettingsChangePublisher
 import com.fsck.k9.Preferences
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val preferencesModule = module {
@@ -24,6 +28,7 @@ val preferencesModule = module {
         RealGeneralSettingsManager(
             preferences = get(),
             coroutineScope = get(named("AppCoroutineScope")),
+            changePublisher = get(),
         )
     } bind GeneralSettingsManager::class
     single {
@@ -77,4 +82,7 @@ val preferencesModule = module {
             unifiedInboxConfigurator = get(),
         )
     }
+
+    single { DefaultSettingsChangeBroker() }
+        .binds(arrayOf(SettingsChangePublisher::class, SettingsChangeBroker::class))
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
@@ -35,6 +35,7 @@ val preferencesModule = module {
         RealDrawerConfigManager(
             preferences = get(),
             coroutineScope = get(named("AppCoroutineScope")),
+            changeBroker = get(),
         )
     } bind DrawerConfigManager::class
 

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/RealGeneralSettingsManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/RealGeneralSettingsManager.kt
@@ -6,6 +6,7 @@ import app.k9mail.legacy.preferences.AppTheme
 import app.k9mail.legacy.preferences.BackgroundSync
 import app.k9mail.legacy.preferences.GeneralSettings
 import app.k9mail.legacy.preferences.GeneralSettingsManager
+import app.k9mail.legacy.preferences.SettingsChangePublisher
 import app.k9mail.legacy.preferences.SubTheme
 import com.fsck.k9.K9
 import com.fsck.k9.Preferences
@@ -30,6 +31,7 @@ import timber.log.Timber
 internal class RealGeneralSettingsManager(
     private val preferences: Preferences,
     private val coroutineScope: CoroutineScope,
+    private val changePublisher: SettingsChangePublisher,
     private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : GeneralSettingsManager {
     private val settingsFlow = MutableSharedFlow<GeneralSettings>(replay = 1)
@@ -88,6 +90,8 @@ internal class RealGeneralSettingsManager(
         K9.save(editor)
         writeSettings(editor, settings)
         editor.commit()
+
+        changePublisher.publish()
     }
 
     @Synchronized

--- a/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/DefaultSettingsChangeBroker.kt
+++ b/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/DefaultSettingsChangeBroker.kt
@@ -19,7 +19,9 @@ class DefaultSettingsChangeBroker(
     }
 
     override fun publish() {
-        for (subscriber in subscribers) {
+        val currentSubscribers = synchronized(lock) { HashSet(subscribers) }
+
+        for (subscriber in currentSubscribers) {
             subscriber.receive()
         }
     }

--- a/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/DefaultSettingsChangeBroker.kt
+++ b/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/DefaultSettingsChangeBroker.kt
@@ -1,0 +1,26 @@
+package app.k9mail.legacy.preferences
+
+class DefaultSettingsChangeBroker(
+    private val subscribers: MutableSet<SettingsChangeSubscriber> = mutableSetOf(),
+) : SettingsChangeBroker, SettingsChangePublisher {
+
+    private val lock = Any()
+
+    override fun subscribe(subscriber: SettingsChangeSubscriber) {
+        synchronized(lock) {
+            subscribers.add(subscriber)
+        }
+    }
+
+    override fun unsubscribe(subscriber: SettingsChangeSubscriber) {
+        synchronized(lock) {
+            subscribers.remove(subscriber)
+        }
+    }
+
+    override fun publish() {
+        for (subscriber in subscribers) {
+            subscriber.receive()
+        }
+    }
+}

--- a/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/SettingsChangeBroker.kt
+++ b/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/SettingsChangeBroker.kt
@@ -1,0 +1,22 @@
+package app.k9mail.legacy.preferences
+
+/**
+ * Broker to manage subscribers and notify them about changes in the settings, when the
+ * [SettingsChangePublisher] publishes a change.
+ */
+interface SettingsChangeBroker {
+
+    /**
+     * Subscribe to settings changes.
+     *
+     * @param subscriber The subscriber to be notified about settings changes.
+     */
+    fun subscribe(subscriber: SettingsChangeSubscriber)
+
+    /**
+     * Unsubscribe from settings changes.
+     *
+     * @param subscriber The subscriber that no longer wants to be notified about settings changes.
+     */
+    fun unsubscribe(subscriber: SettingsChangeSubscriber)
+}

--- a/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/SettingsChangePublisher.kt
+++ b/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/SettingsChangePublisher.kt
@@ -1,0 +1,12 @@
+package app.k9mail.legacy.preferences
+
+/**
+ * Publishes changes in the settings.
+ */
+interface SettingsChangePublisher {
+
+    /**
+     * Publish a change in the settings.
+     */
+    fun publish()
+}

--- a/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/SettingsChangeSubscriber.kt
+++ b/legacy/preferences/src/main/java/app/k9mail/legacy/preferences/SettingsChangeSubscriber.kt
@@ -1,0 +1,12 @@
+package app.k9mail.legacy.preferences
+
+/**
+ * Subscribe to be notified about changes in the settings.
+ */
+fun interface SettingsChangeSubscriber {
+
+    /**
+     * Called when settings change.
+     */
+    fun receive()
+}

--- a/legacy/preferences/src/test/java/app/k9mail/legacy/preferences/DefaultSettingsChangeBrokerTest.kt
+++ b/legacy/preferences/src/test/java/app/k9mail/legacy/preferences/DefaultSettingsChangeBrokerTest.kt
@@ -1,0 +1,49 @@
+package app.k9mail.legacy.preferences
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class DefaultSettingsChangeBrokerTest {
+
+    @Test
+    fun `subscribe should add subscriber`() {
+        val subscriber = SettingsChangeSubscriber { }
+        val subscribers = mutableSetOf<SettingsChangeSubscriber>()
+        val broker = DefaultSettingsChangeBroker(subscribers)
+
+        broker.subscribe(subscriber)
+
+        assertThat(subscribers.size).isEqualTo(1)
+        assertThat(subscribers).contains(subscriber)
+    }
+
+    @Test
+    fun `unsubscribe should remove subscriber`() {
+        val subscriber = SettingsChangeSubscriber { }
+        val subscribers = mutableSetOf<SettingsChangeSubscriber>(subscriber)
+        val broker = DefaultSettingsChangeBroker(subscribers)
+
+        broker.unsubscribe(subscriber)
+
+        assertThat(subscribers.size).isEqualTo(0)
+        assertThat(subscribers).doesNotContain(subscriber)
+    }
+
+    @Test
+    fun `publish should notify subscribers`() {
+        var received = false
+        val subscriber = SettingsChangeSubscriber { received = true }
+        var receivedOther = false
+        val otherSubscriber = SettingsChangeSubscriber { receivedOther = true }
+        val subscribers = mutableSetOf<SettingsChangeSubscriber>(subscriber, otherSubscriber)
+        val broker = DefaultSettingsChangeBroker(subscribers)
+
+        broker.publish()
+
+        assertThat(received).isEqualTo(true)
+        assertThat(receivedOther).isEqualTo(true)
+    }
+}


### PR DESCRIPTION
This introduces a new settings change notification system to the project. The main changes include adding a publish/subscribe pattern with a broker and publisher for settings changes, updating existing classes to use this new system, and adding tests for the new functionality.

The drawer is now immediatelly updated whenever a setting is changed.

Resolves #8765



