### PR TITLE
Fix drawer message count updates

### DIFF
--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -43,8 +43,8 @@ val navigationDrawerModule: Module = module {
 
     single<UseCase.GetDisplayFoldersForAccount> {
         GetDisplayFoldersForAccount(
-            repository = get(),
-            messageCountsProvider = get(),
+            displayFolderRepository = get(),
+            unifiedFolderRepository = get(),
         )
     }
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -1,5 +1,7 @@
 package app.k9mail.feature.navigation.drawer
 
+import app.k9mail.feature.navigation.drawer.data.UnifiedFolderRepository
+import app.k9mail.feature.navigation.drawer.domain.DomainContract
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDisplayAccounts
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDisplayFoldersForAccount
@@ -13,6 +15,12 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 val navigationDrawerModule: Module = module {
+
+    single<DomainContract.UnifiedFolderRepository> {
+        UnifiedFolderRepository(
+            messageCountsProvider = get(),
+        )
+    }
 
     single<UseCase.GetDrawerConfig> {
         GetDrawerConfig(

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/data/UnifiedFolderRepository.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/data/UnifiedFolderRepository.kt
@@ -1,0 +1,44 @@
+package app.k9mail.feature.navigation.drawer.data
+
+import app.k9mail.feature.navigation.drawer.domain.DomainContract
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
+import app.k9mail.legacy.message.controller.MessageCountsProvider
+import app.k9mail.legacy.search.LocalSearch
+import app.k9mail.legacy.search.api.SearchAttribute
+import app.k9mail.legacy.search.api.SearchField
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+internal class UnifiedFolderRepository(
+    private val messageCountsProvider: MessageCountsProvider,
+) : DomainContract.UnifiedFolderRepository {
+
+    override fun getDisplayUnifiedFolderFlow(unifiedFolderType: DisplayUnifiedFolderType): Flow<DisplayUnifiedFolder> {
+        return messageCountsProvider.getMessageCountsFlow(createUnifiedFolderSearch(unifiedFolderType)).map {
+            DisplayUnifiedFolder(
+                id = UNIFIED_INBOX_ID,
+                unifiedType = DisplayUnifiedFolderType.INBOX,
+                unreadMessageCount = it.unread,
+                starredMessageCount = it.starred,
+            )
+        }
+    }
+
+    private fun createUnifiedFolderSearch(unifiedFolderType: DisplayUnifiedFolderType): LocalSearch {
+        return when (unifiedFolderType) {
+            DisplayUnifiedFolderType.INBOX -> return createUnifiedInboxSearch()
+        }
+    }
+
+    private fun createUnifiedInboxSearch(): LocalSearch {
+        return LocalSearch().apply {
+            id = UNIFIED_INBOX_ID
+            and(SearchField.INTEGRATE, "1", SearchAttribute.EQUALS)
+        }
+    }
+
+    companion object {
+        const val UNIFIED_INBOX_ID = "unified_inbox"
+    }
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -3,6 +3,8 @@ package app.k9mail.feature.navigation.drawer.domain
 import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
 import kotlinx.coroutines.flow.Flow
 
 internal interface DomainContract {
@@ -37,5 +39,9 @@ internal interface DomainContract {
         fun interface SyncAllAccounts {
             operator fun invoke(): Flow<Result<Unit>>
         }
+    }
+
+    interface UnifiedFolderRepository {
+        fun getDisplayUnifiedFolderFlow(unifiedFolderType: DisplayUnifiedFolderType): Flow<DisplayUnifiedFolder>
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccount.kt
@@ -1,68 +1,49 @@
 package app.k9mail.feature.navigation.drawer.domain.usecase
 
+import app.k9mail.feature.navigation.drawer.domain.DomainContract.UnifiedFolderRepository
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
-import app.k9mail.legacy.message.controller.MessageCountsProvider
-import app.k9mail.legacy.search.LocalSearch
-import app.k9mail.legacy.search.api.SearchAttribute
-import app.k9mail.legacy.search.api.SearchField
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 internal class GetDisplayFoldersForAccount(
-    private val repository: DisplayFolderRepository,
-    private val messageCountsProvider: MessageCountsProvider,
+    private val displayFolderRepository: DisplayFolderRepository,
+    private val unifiedFolderRepository: UnifiedFolderRepository,
 ) : UseCase.GetDisplayFoldersForAccount {
     override fun invoke(accountId: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>> {
-        return repository.getDisplayFoldersFlow(accountId).map { displayFolders ->
-            displayFolders.map { displayFolder ->
-                DisplayAccountFolder(
-                    accountId = accountId,
-                    folder = displayFolder.folder,
-                    isInTopGroup = displayFolder.isInTopGroup,
-                    unreadMessageCount = displayFolder.unreadMessageCount,
-                    starredMessageCount = displayFolder.starredMessageCount,
-                )
+        val accountFoldersFlow: Flow<List<DisplayFolder>> =
+            displayFolderRepository.getDisplayFoldersFlow(accountId).map { displayFolders ->
+                displayFolders.map { displayFolder ->
+                    DisplayAccountFolder(
+                        accountId = accountId,
+                        folder = displayFolder.folder,
+                        isInTopGroup = displayFolder.isInTopGroup,
+                        unreadMessageCount = displayFolder.unreadMessageCount,
+                        starredMessageCount = displayFolder.starredMessageCount,
+                    )
+                }
             }
-        }.map { displayFolders ->
-            if (includeUnifiedFolders) {
-                createDisplayUnifiedFolders() + displayFolders
-            } else {
-                displayFolders
-            }
+
+        val unifiedFoldersFlow: Flow<List<DisplayFolder>> = if (includeUnifiedFolders) {
+            unifiedFolderRepository.getDisplayUnifiedFolderFlow(DisplayUnifiedFolderType.INBOX)
+                .map { displayUnifiedFolder ->
+                    listOf(displayUnifiedFolder)
+                }
+        } else {
+            flowOf(emptyList<DisplayUnifiedFolder>())
         }
-    }
 
-    private fun createDisplayUnifiedFolders(): List<DisplayUnifiedFolder> {
-        return listOf(
-            createUnifiedInboxFolder(),
-        )
-    }
-
-    private fun createUnifiedInboxFolder(): DisplayUnifiedFolder {
-        val search = getUnifiedInboxSearch()
-        val messageCounts = messageCountsProvider.getMessageCounts(search)
-
-        return DisplayUnifiedFolder(
-            id = UNIFIED_INBOX_ID,
-            unifiedType = DisplayUnifiedFolderType.INBOX,
-            unreadMessageCount = messageCounts.unread,
-            starredMessageCount = messageCounts.starred,
-        )
-    }
-
-    private fun getUnifiedInboxSearch(): LocalSearch {
-        return LocalSearch().apply {
-            id = UNIFIED_INBOX_ID
-            and(SearchField.INTEGRATE, "1", SearchAttribute.EQUALS)
+        return combine(
+            accountFoldersFlow,
+            unifiedFoldersFlow,
+        ) { accountFolders, unifiedFolders ->
+            unifiedFolders + accountFolders
         }
-    }
-
-    companion object {
-        private const val UNIFIED_INBOX_ID = "unified_inbox"
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -84,7 +84,7 @@ internal class DrawerViewModel(
             .distinctUntilChanged()
             .flatMapLatest { (accountId, showUnifiedInbox) ->
                 getDisplayFoldersForAccount(accountId, showUnifiedInbox)
-            }.collectLatest { folders ->
+            }.collect { folders ->
                 updateFolders(folders)
             }
     }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/data/FakeMessageCountsProvider.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/data/FakeMessageCountsProvider.kt
@@ -1,0 +1,36 @@
+package app.k9mail.feature.navigation.drawer.data
+
+import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.message.controller.MessageCounts
+import app.k9mail.legacy.message.controller.MessageCountsProvider
+import app.k9mail.legacy.search.LocalSearch
+import app.k9mail.legacy.search.SearchAccount
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+internal class FakeMessageCountsProvider(
+    private val messageCounts: MessageCounts,
+) : MessageCountsProvider {
+    var recordedSearch: LocalSearch = LocalSearch()
+
+    override fun getMessageCounts(account: Account): MessageCounts {
+        TODO("Not yet implemented")
+    }
+
+    override fun getMessageCounts(searchAccount: SearchAccount): MessageCounts {
+        TODO("Not yet implemented")
+    }
+
+    override fun getMessageCounts(search: LocalSearch): MessageCounts {
+        TODO("Not yet implemented")
+    }
+
+    override fun getMessageCountsFlow(search: LocalSearch): Flow<MessageCounts> {
+        recordedSearch = search
+        return flowOf(messageCounts)
+    }
+
+    override fun getUnreadMessageCount(account: Account, folderId: Long): Int {
+        TODO("Not yet implemented")
+    }
+}

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/data/UnifiedFolderRepositoryTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/data/UnifiedFolderRepositoryTest.kt
@@ -1,0 +1,47 @@
+package app.k9mail.feature.navigation.drawer.data
+
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
+import app.k9mail.legacy.message.controller.MessageCounts
+import app.k9mail.legacy.search.api.SearchAttribute
+import app.k9mail.legacy.search.api.SearchField
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+internal class UnifiedFolderRepositoryTest {
+
+    @Test
+    fun `should return DisplayUnifiedFolder for unified inbox`() = runTest {
+        val messageCountsProvider = FakeMessageCountsProvider(
+            messageCounts = MessageCounts(
+                unread = 2,
+                starred = 2,
+            ),
+        )
+        val testSubject = UnifiedFolderRepository(
+            messageCountsProvider = messageCountsProvider,
+        )
+        val folderType = DisplayUnifiedFolderType.INBOX
+
+        val result = testSubject.getDisplayUnifiedFolderFlow(folderType).first()
+
+        assertThat(result).isEqualTo(
+            DisplayUnifiedFolder(
+                id = "unified_inbox",
+                unifiedType = folderType,
+                unreadMessageCount = 2,
+                starredMessageCount = 2,
+            ),
+        )
+
+        val search = messageCountsProvider.recordedSearch
+        assertThat(search.id).isEqualTo("unified_inbox")
+        val condition = search.conditions.condition
+        assertThat(condition.value).isEqualTo("1")
+        assertThat(condition.attribute).isEqualTo(SearchAttribute.EQUALS)
+        assertThat(condition.field).isEqualTo(SearchField.INTEGRATE)
+    }
+}

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeDisplayFolderRepository.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeDisplayFolderRepository.kt
@@ -1,0 +1,21 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.ui.folder.DisplayFolder
+import app.k9mail.legacy.ui.folder.DisplayFolderRepository
+import kotlinx.coroutines.flow.Flow
+
+internal class FakeDisplayFolderRepository(
+    private val foldersFlow: Flow<List<DisplayFolder>>,
+) : DisplayFolderRepository {
+    override fun getDisplayFoldersFlow(
+        account: Account,
+        includeHiddenFolders: Boolean,
+    ): Flow<List<DisplayFolder>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>> {
+        return foldersFlow
+    }
+}

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeUnifiedFolderRepository.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeUnifiedFolderRepository.kt
@@ -1,0 +1,14 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import app.k9mail.feature.navigation.drawer.domain.DomainContract.UnifiedFolderRepository
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
+import kotlinx.coroutines.flow.Flow
+
+internal class FakeUnifiedFolderRepository(
+    private val displayUnifiedFolderFlow: Flow<DisplayUnifiedFolder>,
+) : UnifiedFolderRepository {
+    override fun getDisplayUnifiedFolderFlow(unifiedFolderType: DisplayUnifiedFolderType): Flow<DisplayUnifiedFolder> {
+        return displayUnifiedFolderFlow
+    }
+}

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccountTest.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayFoldersForAccountTest.kt
@@ -1,0 +1,154 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import app.cash.turbine.test
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
+import app.k9mail.feature.navigation.drawer.ui.FakeData
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import app.k9mail.legacy.ui.folder.DisplayFolder as LegacyDisplayFolder
+
+internal class GetDisplayFoldersForAccountTest {
+
+    @Test
+    fun `should return only account folders when includeUnifiedFolders is false`() = runTest {
+        val accountId = "account_id"
+        val legacyDisplayFolderFlow = MutableStateFlow(LEGACY_DISPLAY_FOLDERS)
+        val displayFolderRepository = FakeDisplayFolderRepository(legacyDisplayFolderFlow)
+        val unifiedFolderFlow = MutableStateFlow(DISPLAY_UNIFIED_FOLDER)
+        val unifiedFolderRepository = FakeUnifiedFolderRepository(unifiedFolderFlow)
+        val testSubject = GetDisplayFoldersForAccount(
+            displayFolderRepository = displayFolderRepository,
+            unifiedFolderRepository = unifiedFolderRepository,
+        )
+
+        val result = testSubject(accountId, includeUnifiedFolders = false).first()
+
+        assertThat(result).isEqualTo(DISPLAY_ACCOUNT_FOLDERS)
+    }
+
+    @Test
+    fun `should return account folders and unified folders when includeUnifiedFolders is true`() = runTest {
+        val accountId = "account_id"
+        val legacyDisplayFolderFlow = MutableStateFlow(LEGACY_DISPLAY_FOLDERS)
+        val displayFolderRepository = FakeDisplayFolderRepository(legacyDisplayFolderFlow)
+        val unifiedFolderFlow = MutableStateFlow(DISPLAY_UNIFIED_FOLDER)
+        val unifiedFolderRepository = FakeUnifiedFolderRepository(unifiedFolderFlow)
+        val testSubject = GetDisplayFoldersForAccount(
+            displayFolderRepository = displayFolderRepository,
+            unifiedFolderRepository = unifiedFolderRepository,
+        )
+
+        val result = testSubject(accountId, includeUnifiedFolders = true).first()
+
+        assertThat(result).isEqualTo(DISPLAY_UNIFIED_FOLDERS + DISPLAY_ACCOUNT_FOLDERS)
+    }
+
+    @Test
+    fun `should emit new list when account folders or unified folders emit new items`() = runTest {
+        val accountId = "account_id"
+        val legacyDisplayFolderFlow = MutableStateFlow(LEGACY_DISPLAY_FOLDERS)
+        val displayFolderRepository = FakeDisplayFolderRepository(legacyDisplayFolderFlow)
+        val unifiedFolderFlow = MutableStateFlow(DISPLAY_UNIFIED_FOLDER)
+        val unifiedFolderRepository = FakeUnifiedFolderRepository(unifiedFolderFlow)
+        val testSubject = GetDisplayFoldersForAccount(
+            displayFolderRepository = displayFolderRepository,
+            unifiedFolderRepository = unifiedFolderRepository,
+        )
+
+        testSubject(accountId, includeUnifiedFolders = true).test {
+            assertThat(awaitItem()).isEqualTo(DISPLAY_UNIFIED_FOLDERS + DISPLAY_ACCOUNT_FOLDERS)
+
+            legacyDisplayFolderFlow.emit(LEGACY_DISPLAY_FOLDERS_2)
+
+            assertThat(awaitItem()).isEqualTo(DISPLAY_UNIFIED_FOLDERS + DISPLAY_ACCOUNT_FOLDERS_2)
+
+            unifiedFolderFlow.emit(DISPLAY_UNIFIED_FOLDER_2)
+
+            assertThat(awaitItem()).isEqualTo(listOf(DISPLAY_UNIFIED_FOLDER_2) + DISPLAY_ACCOUNT_FOLDERS_2)
+        }
+    }
+
+    private companion object {
+        val LEGACY_DISPLAY_FOLDERS = listOf(
+            LegacyDisplayFolder(
+                folder = FakeData.FOLDER,
+                isInTopGroup = false,
+                unreadMessageCount = 0,
+                starredMessageCount = 0,
+            ),
+            LegacyDisplayFolder(
+                folder = FakeData.FOLDER.copy(
+                    id = 2,
+                    name = "Folder 2",
+                ),
+                isInTopGroup = false,
+                unreadMessageCount = 1,
+                starredMessageCount = 0,
+            ),
+        )
+
+        val LEGACY_DISPLAY_FOLDERS_2 = LEGACY_DISPLAY_FOLDERS + LegacyDisplayFolder(
+            folder = FakeData.FOLDER.copy(
+                id = 3,
+                name = "Folder 3",
+            ),
+            isInTopGroup = false,
+            unreadMessageCount = 0,
+            starredMessageCount = 0,
+        )
+
+        val DISPLAY_UNIFIED_FOLDER = DisplayUnifiedFolder(
+            id = "unified_inbox",
+            unifiedType = DisplayUnifiedFolderType.INBOX,
+            unreadMessageCount = 2,
+            starredMessageCount = 2,
+        )
+
+        val DISPLAY_UNIFIED_FOLDER_2 = DisplayUnifiedFolder(
+            id = "unified_inbox",
+            unifiedType = DisplayUnifiedFolderType.INBOX,
+            unreadMessageCount = 3,
+            starredMessageCount = 3,
+        )
+
+        val DISPLAY_UNIFIED_FOLDERS = listOf(DISPLAY_UNIFIED_FOLDER)
+
+        val DISPLAY_ACCOUNT_FOLDERS = listOf<DisplayFolder>(
+            DisplayAccountFolder(
+                accountId = "account_id",
+                folder = FakeData.FOLDER,
+                isInTopGroup = false,
+                unreadMessageCount = 0,
+                starredMessageCount = 0,
+            ),
+            DisplayAccountFolder(
+                accountId = "account_id",
+                folder = FakeData.FOLDER.copy(
+                    id = 2,
+                    name = "Folder 2",
+                ),
+                isInTopGroup = false,
+                unreadMessageCount = 1,
+                starredMessageCount = 0,
+            ),
+        )
+
+        val DISPLAY_ACCOUNT_FOLDERS_2 = DISPLAY_ACCOUNT_FOLDERS + DisplayAccountFolder(
+            accountId = "account_id",
+            folder = FakeData.FOLDER.copy(
+                id = 3,
+                name = "Folder 3",
+            ),
+            isInTopGroup = false,
+            unreadMessageCount = 0,
+            starredMessageCount = 0,
+        )
+    }
+}

--- a/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -16,6 +16,7 @@ import assertk.assertions.isNull
 import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.Preferences
 import com.fsck.k9.ui.messagelist.DefaultFolderProvider
+import kotlinx.coroutines.flow.Flow
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -138,6 +139,10 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
         }
 
         override fun getMessageCounts(search: LocalSearch): MessageCounts {
+            throw UnsupportedOperationException()
+        }
+
+        override fun getMessageCountsFlow(search: LocalSearch): Flow<MessageCounts> {
             throw UnsupportedOperationException()
         }
 

--- a/legacy/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -39,6 +39,7 @@ val controllerModule = module {
         DefaultMessageCountsProvider(
             accountManager = get(),
             messageStoreManager = get(),
+            messagingControllerRegistry = get(),
         )
     }
 

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessageCountsProvider.kt
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessageCountsProvider.kt
@@ -3,11 +3,13 @@ package app.k9mail.legacy.message.controller
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.search.LocalSearch
 import app.k9mail.legacy.search.SearchAccount
+import kotlinx.coroutines.flow.Flow
 
 interface MessageCountsProvider {
     fun getMessageCounts(account: Account): MessageCounts
     fun getMessageCounts(searchAccount: SearchAccount): MessageCounts
     fun getMessageCounts(search: LocalSearch): MessageCounts
+    fun getMessageCountsFlow(search: LocalSearch): Flow<MessageCounts>
     fun getUnreadMessageCount(account: Account, folderId: Long): Int
 }
 

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 
-class DisplayFolderRepository(
+class DefaultDisplayFolderRepository(
     private val accountManager: AccountManager,
     private val messagingController: MessagingControllerRegistry,
     private val messageStoreManager: MessageStoreManager,

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
@@ -25,7 +25,7 @@ class DefaultDisplayFolderRepository(
     private val messagingController: MessagingControllerRegistry,
     private val messageStoreManager: MessageStoreManager,
     private val coroutineContext: CoroutineContext = Dispatchers.IO,
-) {
+) : DisplayFolderRepository {
     private val sortForDisplay =
         compareByDescending<DisplayFolder> { it.folder.type == FolderType.INBOX }
             .thenByDescending { it.folder.type == FolderType.OUTBOX }
@@ -53,7 +53,7 @@ class DefaultDisplayFolderRepository(
         }.sortedWith(sortForDisplay)
     }
 
-    fun getDisplayFoldersFlow(account: Account, includeHiddenFolders: Boolean): Flow<List<DisplayFolder>> {
+    override fun getDisplayFoldersFlow(account: Account, includeHiddenFolders: Boolean): Flow<List<DisplayFolder>> {
         val messageStore = messageStoreManager.getMessageStore(account.uuid)
 
         return callbackFlow {
@@ -82,7 +82,7 @@ class DefaultDisplayFolderRepository(
             .flowOn(coroutineContext)
     }
 
-    fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>> {
+    override fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>> {
         val account = accountManager.getAccount(accountUuid) ?: error("Account not found: $accountUuid")
         return getDisplayFoldersFlow(account, includeHiddenFolders = false)
     }

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
@@ -1,0 +1,11 @@
+package app.k9mail.legacy.ui.folder
+
+import app.k9mail.legacy.account.Account
+import kotlinx.coroutines.flow.Flow
+
+interface DisplayFolderRepository {
+
+    fun getDisplayFoldersFlow(account: Account, includeHiddenFolders: Boolean): Flow<List<DisplayFolder>>
+
+    fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>>
+}

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/KoinModule.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/KoinModule.kt
@@ -3,8 +3,8 @@ package app.k9mail.legacy.ui.folder
 import org.koin.dsl.module
 
 val uiFolderModule = module {
-    single {
-        DisplayFolderRepository(
+    single<DisplayFolderRepository> {
+        DefaultDisplayFolderRepository(
             accountManager = get(),
             messagingController = get(),
             messageStoreManager = get(),


### PR DESCRIPTION
This pull request fixes the update of unread and stared messages counts in the drawer.

It introduces a new `UnifiedFolderRepository` to the navigation drawer feature, along with several related changes to support updating the unread count reliably.

Fixes #8800, #7865
