### PR TITLE
Prevent activity overlap when toggling "Show Unified Inbox"

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -537,7 +537,7 @@ open class MessageList :
         if (messageListActivityConfig == null) {
             messageListActivityConfig = MessageListActivityConfig.create(generalSettingsManager)
         } else if (messageListActivityConfig != MessageListActivityConfig.create(generalSettingsManager)) {
-            recreateCompat()
+            recreateMessageList(this)
         }
 
         if (displayMode != DisplayMode.MESSAGE_VIEW) {
@@ -1604,6 +1604,16 @@ open class MessageList :
          */
         fun launch(context: Context, accountUuid: String) {
             val intent = shortcutIntentForAccount(context, accountUuid)
+            context.startActivity(intent)
+        }
+
+        @JvmStatic
+        fun recreateMessageList(context: Context) {
+            val intent = Intent(context, MessageList::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            }
+
             context.startActivity(intent)
         }
     }


### PR DESCRIPTION
Fixes #8767

Description:
This PR fixes the issue where toggling the "Show Unified Inbox" setting causes activity overlap and inconsistent UI updates. As described in my comment on #8767, the problem occurs because ActivityCompat.recreate() adds a new instance of MessageList to the back stack without clearing the previous one, leading to "ghost" activities when navigating back.

Changes:
Replaced ActivityCompat.recreate() with a new recreateMessageList() function that uses Intent with FLAG_ACTIVITY_NEW_TASK and FLAG_ACTIVITY_CLEAR_TASK to ensure a clean activity launch.

Testing:
Verified both scenarios: enabling and disabling "Show Unified Inbox". 
Confirmed that pressing the back button now closes the app or returns to the previous screen without overlapping activities.