### PR TITLE
Remove cketti from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @cketti @kewisch @wmontwe
+* @kewisch @wmontwe
 /.github/ @coreycb @jfx2006 @dandarnell
 


### PR DESCRIPTION
See https://cketti.de/2025/02/26/goodbye-k9mail/