### PR TITLE
Add TFA beta changelog

### DIFF
--- a/app-thunderbird/src/beta/res/raw/changelog_master.xml
+++ b/app-thunderbird/src/beta/res/raw/changelog_master.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="changelog_style.xsl"?>
-<!--
-     The master change log is kept in res/raw/changelog_master.xml.
-     Locale-specific versions are kept in res/raw-<locale qualifier>/changelog.xml.
--->
 <changelog>
     <release version="9.0b3" versioncode="11" date="2024-12-11">
         <change>Hyperlink added to Thunderbird website on funding page</change>

--- a/scripts/render-notes.py
+++ b/scripts/render-notes.py
@@ -30,6 +30,18 @@ def render_notes(
         tb_notes_filename = f"{version[0:-1]}eta.yml"
         tb_notes_directory = "android_beta"
 
+    if application == "k9mail":
+        build_type = "main"
+    else:
+        if applicationid == "net.thunderbird.android":
+            build_type = "release"
+        elif applicationid == "net.thunderbird.android.beta":
+            build_type = "beta"
+        else:
+            # // throw error
+            print("Error: Unsupported applicationid")
+            sys.exit(1)
+
     if os.path.isdir(os.path.expanduser(notesrepo)):
         notes_path = os.path.join(
             os.path.expanduser(notesrepo), tb_notes_directory, tb_notes_filename
@@ -85,7 +97,7 @@ def render_notes(
     render_files = {
         "changelog_master": {
             "template": "changelog_master.xml",
-            "outfile": f"./app-{application}/src/main/res/raw/changelog_master.xml",
+            "outfile": f"./app-{application}/src/{build_type}/res/raw/changelog_master.xml",
             "render_data": render_data["releases"][version],
         },
         "changelog": {


### PR DESCRIPTION
This changes the `render_notes` script to generate the `changelog_master.xml` in the beta build type directory for TfA.

This is part of #8802