### PR TITLE
Change CI to use build command

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,8 +46,5 @@ jobs:
       - name: Quality - Dependency Guard
         run: ./gradlew dependencyGuard
 
-      - name: Build
-        run: ./gradlew assembleDebug
-
-      - name: Test
-        run: ./gradlew testsOnCi
+      - name: Build (run full build and tests)
+        run: ./gradlew build

--- a/.github/workflows/gradle-cache.yml
+++ b/.github/workflows/gradle-cache.yml
@@ -31,4 +31,5 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
 
-      - run: ./gradlew assemble
+      - name: Build (run full build and tests)
+        run: ./gradlew build


### PR DESCRIPTION
Change CI to use build instead of assemble to fully cover all app variants and catch errors early.

Reason: Last translation update broke the build for K-9 Mail due to changes to the app name.

This requires #8887 to be merged first to run successfully.

Fixes #8937
