### PR TITLE
Issue #8784 

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
@@ -99,6 +99,11 @@ class ManageFoldersFragment : Fragment() {
         configureFolderSearchView(menu)
     }
 
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        val folderMenuItem = menu.findItem(R.id.filter_folders)
+        folderMenuItem.isVisible = !folderMenuItem.isActionViewExpanded
+    }
+
     private fun configureFolderSearchView(menu: Menu) {
         val folderMenuItem = menu.findItem(R.id.filter_folders)
         val folderSearchView = folderMenuItem.actionView as SearchView
@@ -116,6 +121,16 @@ class ManageFoldersFragment : Fragment() {
                 }
             },
         )
+        folderMenuItem?.setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
+            override fun onMenuItemActionExpand(p0: MenuItem): Boolean {
+                return true
+            }
+
+            override fun onMenuItemActionCollapse(p0: MenuItem): Boolean {
+                requireActivity().invalidateOptionsMenu()
+                return true
+            }
+        })
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {


### PR DESCRIPTION
Fix for Issue #8784: 'Find Folder' option incorrectly appears in the 'Three-dot' menu on the 'Manage Folders' page when 'Find Folder' is already enabled.

This issue was resolved by adding onPrepareOptionsMenu() in **ManageFoldersFragment**. This method dynamically toggles the visibility of folderMenuItem based on whether the search view is expanded or collapsed.

Additionally, an expand listener was added inside configureFolderSearchView() to ensure that folderMenuItem becomes visible again when the search view collapses, preventing it from incorrectly appearing in the overflow menu.

These changes ensure a smoother and more intuitive user experience by maintaining the correct visibility behavior for the Find Folder option.

[tfa_issue_8784.webm](https://github.com/user-attachments/assets/0ec9073b-2c1d-4a38-88bc-35e5c45162f0)
