### PR TITLE
Add a github action to set the milestone for merged PRs

### DIFF
--- a/.github/workflows/pulls-merged.yml
+++ b/.github/workflows/pulls-merged.yml
@@ -1,0 +1,61 @@
+---
+name: PR Merged Actions
+
+# Warning, this job is running on pull_request_target and therefore has access to issue content.
+# Don't add any steps that act on external code.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  pull-request-merged:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get active milestone
+        id: milestone
+        env:
+          PR_NUMBER: ${{  github.event.pull_request.number  }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The furthest open milestone in the future should be current main
+          gh api repos/$GITHUB_REPOSITORY/milestones --jq '
+                map(select(.state == "open" and .due_on != null))
+                | sort_by(.due_on) | reverse
+                | .[0] | { number, title }
+                | to_entries
+                | map(.key + "=" + (.value|tostring)) | join("\n")' | tee -a $GITHUB_OUTPUT
+
+      - name: Thank you
+        if: |
+          github.event.pull_request.merged == true &&
+          github.event.pull_request.author_association != 'OWNER' &&
+          github.event.pull_request.author_association != 'MEMBER' &&
+          github.event.pull_request.author_association != 'COLLABORATOR'
+        env:
+          PR_NUMBER: ${{  github.event.pull_request.number  }}
+          GH_TOKEN: ${{ github.token }}
+          MILESTONE: ${{ steps.milestone.outputs.title }}
+          MESSAGE: >-
+            Thanks for your contribution! Your pull request has been merged and will be part of
+            ${{ steps.milestone.outputs.title }}. We appreciate the time and effort you put into
+            improving Thunderbird. If you haven’t already, you’re welcome to join our Matrix chat
+            for contributors. It’s where we discuss development and help each other out.
+            https://matrix.to/#/#tb-android-dev:mozilla.org
+
+            Hope to see you there! 🚀📱🐦
+        run: |
+          gh pr comment $PR_NUMBER --repo $GITHUB_REPOSITORY --body "$MESSAGE"
+
+      - name: Set active milestone on PR
+        env:
+          PR_NUMBER: ${{  github.event.pull_request.number  }}
+          GH_TOKEN: ${{ github.token }}
+          MILESTONE: ${{ steps.milestone.outputs.number }}
+        run: |
+          gh api --method PATCH /repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER -f milestone=$MILESTONE


### PR DESCRIPTION
Fixes #8916

@coreycb Here is a first stab at setting the milestone for merged PRs. As a nice side effect, I also added a message for contributors to let them know what version of Thunderbird it will be in, and point them to our matrix dev channel.

I imagine we would always have 3 milestones open:
* The furthest in the future is the one that is active, e.g. the current version of the `main` branch
* The middle one is the beta branch
* The closest one is the release branch.


A few things left to decide:
* For the release branch, would we have one milestone per dot release? Or simply one that we keep on filling as long as it is part of the release?
* Same question for betas
* I'm assuming we should put the pull requests on the milestone, not the issues that are connected to the pull request. Correct?

A few things left to do:
* ~~The uplift merge script should automatically adjust the milestone~~
* ~~Consider using an app user instead of github-actions for commenting - we already do this for releases, but I believe this is on @jfx2006's personal repository. Let's create an app called "botmobile" to match with the Matrix bot, and use this for both releases and the contributor message.~~ https://github.com/thunderbird/cloudops/issues/30
