### PR TITLE
Add navigation to new settings page

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -144,6 +144,8 @@ dependencies {
 
     implementation(projects.core.featureflags)
 
+    implementation(projects.feature.account.settings.impl)
+
     "fossImplementation"(projects.feature.funding.noop)
     "fullImplementation"(projects.feature.funding.googleplay)
     implementation(projects.feature.migration.launcher.noop)

--- a/app-k9mail/src/debug/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
@@ -7,7 +7,8 @@ import app.k9mail.core.featureflag.toFeatureFlagKey
 class K9FeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
-            FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = false),
+            FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = true),
+            FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = true),
         )
     }
 }

--- a/app-k9mail/src/main/kotlin/app/k9mail/feature/FeatureModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/feature/FeatureModule.kt
@@ -6,10 +6,13 @@ import app.k9mail.feature.migration.launcher.featureMigrationModule
 import app.k9mail.feature.onboarding.migration.onboardingMigrationModule
 import app.k9mail.feature.telemetry.telemetryModule
 import com.fsck.k9.feature.featureLauncherModule
+import net.thunderbird.feature.account.settings.featureAccountSettingsModule
 import org.koin.dsl.module
 
 val featureModule = module {
     includes(featureLauncherModule)
+
+    includes(featureAccountSettingsModule)
     includes(telemetryModule)
     includes(featureFundingModule)
     includes(onboardingMigrationModule)

--- a/app-k9mail/src/release/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
+++ b/app-k9mail/src/release/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
@@ -1,16 +1,13 @@
-package net.thunderbird.android.featureflag
+package app.k9mail.featureflag
 
 import app.k9mail.core.featureflag.FeatureFlag
 import app.k9mail.core.featureflag.FeatureFlagFactory
 import app.k9mail.core.featureflag.toFeatureFlagKey
 
-/**
- * Feature flags for Thunderbird Beta
- */
-class TbFeatureFlagFactory : FeatureFlagFactory {
+class K9FeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
-            FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = true),
+            FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = false),
             FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = false),
         )
     }

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -211,6 +211,8 @@ dependencies {
 
     implementation(projects.core.featureflags)
 
+    implementation(projects.feature.account.settings.impl)
+
     implementation(projects.feature.widget.messageList)
     implementation(projects.feature.widget.shortcut)
     implementation(projects.feature.widget.unread)

--- a/app-thunderbird/src/daily/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/daily/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -11,6 +11,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
             FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = true),
+            FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = false),
         )
     }
 }

--- a/app-thunderbird/src/debug/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/debug/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -11,6 +11,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
             FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = true),
+            FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = true),
         )
     }
 }

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/feature/FeatureModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/feature/FeatureModule.kt
@@ -6,10 +6,13 @@ import app.k9mail.feature.migration.launcher.featureMigrationModule
 import app.k9mail.feature.onboarding.migration.onboardingMigrationModule
 import app.k9mail.feature.telemetry.telemetryModule
 import com.fsck.k9.feature.featureLauncherModule
+import net.thunderbird.feature.account.settings.featureAccountSettingsModule
 import org.koin.dsl.module
 
 val featureModule = module {
     includes(featureLauncherModule)
+
+    includes(featureAccountSettingsModule)
     includes(telemetryModule)
     includes(featureFundingModule)
     includes(onboardingMigrationModule)

--- a/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -11,6 +11,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
             FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = false),
+            FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = false),
         )
     }
 }

--- a/feature/account/settings/api/build.gradle.kts
+++ b/feature/account/settings/api/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "net.thunderbird.feature.account.settings.api"
+    resourcePrefix = "account_settings_api_"
+}
+
+dependencies {
+    implementation(projects.core.ui.compose.navigation)
+}

--- a/feature/account/settings/api/src/main/kotlin/net/thunderbird/feature/account/settings/api/AccountSettingsNavigation.kt
+++ b/feature/account/settings/api/src/main/kotlin/net/thunderbird/feature/account/settings/api/AccountSettingsNavigation.kt
@@ -1,0 +1,5 @@
+package net.thunderbird.feature.account.settings.api
+
+import app.k9mail.core.ui.compose.navigation.Navigation
+
+interface AccountSettingsNavigation : Navigation<AccountSettingsRoute>

--- a/feature/account/settings/api/src/main/kotlin/net/thunderbird/feature/account/settings/api/AccountSettingsRoute.kt
+++ b/feature/account/settings/api/src/main/kotlin/net/thunderbird/feature/account/settings/api/AccountSettingsRoute.kt
@@ -1,0 +1,22 @@
+package net.thunderbird.feature.account.settings.api
+
+import app.k9mail.core.ui.compose.navigation.Route
+import kotlinx.serialization.Serializable
+
+sealed interface AccountSettingsRoute : Route {
+
+    @Serializable
+    data class GeneralSettings(val accountId: String) : AccountSettingsRoute {
+        override val basePath: String = BASE_PATH
+
+        override fun route(): String = "$basePath/$accountId"
+
+        companion object {
+            const val BASE_PATH = "$ACCOUNT_SETTINGS_BASE_PATH/general"
+        }
+    }
+
+    companion object {
+        const val ACCOUNT_SETTINGS_BASE_PATH = "app://account/settings"
+    }
+}

--- a/feature/account/settings/impl/build.gradle.kts
+++ b/feature/account/settings/impl/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "net.thunderbird.feature.account.settings"
+    resourcePrefix = "account_settings_"
+}
+
+dependencies {
+    api(projects.feature.account.settings.api)
+
+    implementation(projects.core.ui.compose.designsystem)
+    implementation(projects.core.ui.compose.navigation)
+
+    testImplementation(projects.core.ui.compose.testing)
+}

--- a/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/AccountSettingsModule.kt
+++ b/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/AccountSettingsModule.kt
@@ -1,0 +1,9 @@
+package net.thunderbird.feature.account.settings
+
+import net.thunderbird.feature.account.settings.api.AccountSettingsNavigation
+import net.thunderbird.feature.account.settings.impl.DefaultAccountSettingsNavigation
+import org.koin.dsl.module
+
+val featureAccountSettingsModule = module {
+    single<AccountSettingsNavigation> { DefaultAccountSettingsNavigation() }
+}

--- a/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/DefaultAccountSettingsNavigation.kt
+++ b/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/DefaultAccountSettingsNavigation.kt
@@ -1,0 +1,30 @@
+package net.thunderbird.feature.account.settings.impl
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.toRoute
+import app.k9mail.core.ui.compose.navigation.deepLinkComposable
+import net.thunderbird.feature.account.settings.api.AccountSettingsNavigation
+import net.thunderbird.feature.account.settings.api.AccountSettingsRoute
+import net.thunderbird.feature.account.settings.impl.ui.AccountSettingsScreen
+
+class DefaultAccountSettingsNavigation : AccountSettingsNavigation {
+
+    override fun registerRoutes(
+        navGraphBuilder: NavGraphBuilder,
+        onBack: () -> Unit,
+        onFinish: (AccountSettingsRoute) -> Unit,
+    ) {
+        with(navGraphBuilder) {
+            deepLinkComposable<AccountSettingsRoute.GeneralSettings>(
+                basePath = AccountSettingsRoute.GeneralSettings.Companion.BASE_PATH,
+            ) { backStackEntry ->
+                val generalSettingsRoute = backStackEntry.toRoute<AccountSettingsRoute.GeneralSettings>()
+
+                AccountSettingsScreen(
+                    accountId = generalSettingsRoute.accountId,
+                    onBack = onBack,
+                )
+            }
+        }
+    }
+}

--- a/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/ui/AccountSettingsScreen.kt
+++ b/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/ui/AccountSettingsScreen.kt
@@ -1,0 +1,36 @@
+package net.thunderbird.feature.account.settings.impl.ui
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
+import app.k9mail.core.ui.compose.designsystem.organism.SubtitleTopAppBarWithBackButton
+import app.k9mail.core.ui.compose.designsystem.template.Scaffold
+
+@Composable
+fun AccountSettingsScreen(
+    accountId: String,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BackHandler(onBack = onBack)
+
+    Scaffold(
+        topBar = {
+            SubtitleTopAppBarWithBackButton(
+                title = "Account settings",
+                subtitle = accountId,
+                onBackClick = onBack,
+            )
+        },
+        modifier = modifier,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier.padding(innerPadding),
+        ) {
+            TextBodyLarge(text = "accountId: $accountId")
+        }
+    }
+}

--- a/feature/launcher/build.gradle.kts
+++ b/feature/launcher/build.gradle.kts
@@ -12,8 +12,10 @@ dependencies {
     implementation(projects.legacy.ui.base)
     implementation(projects.feature.onboarding.main)
     implementation(projects.feature.settings.import)
-    implementation(projects.feature.account.setup)
+
     implementation(projects.feature.account.edit)
+    implementation(projects.feature.account.settings.api)
+    implementation(projects.feature.account.setup)
 
     implementation(projects.feature.funding.api)
 

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherTarget.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherTarget.kt
@@ -7,6 +7,7 @@ import app.k9mail.feature.account.edit.navigation.AccountEditRoute
 import app.k9mail.feature.account.setup.navigation.AccountSetupRoute
 import app.k9mail.feature.funding.api.FundingRoute
 import app.k9mail.feature.onboarding.main.navigation.OnboardingRoute
+import net.thunderbird.feature.account.settings.api.AccountSettingsRoute
 
 sealed class FeatureLauncherTarget(
     val deepLinkUri: Uri,
@@ -31,5 +32,9 @@ sealed class FeatureLauncherTarget(
 
     data object Funding : FeatureLauncherTarget(
         deepLinkUri = FundingRoute.Contribution.route().toUri(),
+    )
+
+    data class AccountSettings(val accountUuid: String) : FeatureLauncherTarget(
+        deepLinkUri = AccountSettingsRoute.GeneralSettings(accountUuid).route().toUri(),
     )
 }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
@@ -13,6 +13,7 @@ import app.k9mail.feature.funding.api.FundingNavigation
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract.AccountSetupFinishedLauncher
 import app.k9mail.feature.onboarding.main.navigation.OnboardingNavigation
 import app.k9mail.feature.onboarding.main.navigation.OnboardingRoute
+import net.thunderbird.feature.account.settings.api.AccountSettingsNavigation
 import org.koin.compose.koinInject
 
 @Composable
@@ -22,6 +23,7 @@ fun FeatureLauncherNavHost(
     modifier: Modifier = Modifier,
     accountSetupFinishedLauncher: AccountSetupFinishedLauncher = koinInject(),
     accountEditNavigation: AccountEditNavigation = koinInject(),
+    accountSettingsNavigation: AccountSettingsNavigation = koinInject(),
     accountSetupNavigation: AccountSetupNavigation = koinInject(),
     onboardingNavigation: OnboardingNavigation = koinInject(),
     fundingNavigation: FundingNavigation = koinInject(),
@@ -62,6 +64,12 @@ fun FeatureLauncherNavHost(
             navGraphBuilder = this,
             onBack = onBack,
             onFinish = { activity.finish() },
+        )
+
+        accountSettingsNavigation.registerRoutes(
+            navGraphBuilder = this,
+            onBack = onBack,
+            onFinish = { onBack() },
         )
 
         fundingNavigation.registerRoutes(

--- a/legacy/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/account_settings.xml
@@ -8,6 +8,12 @@
     android:title="@string/account_settings_title_fmt"
     >
 
+    <Preference
+        android:icon="@drawable/ic_settings"
+        android:key="general"
+        android:title="@string/account_settings_general_title"
+        />
+
     <PreferenceScreen
         android:icon="@drawable/ic_settings"
         android:key="account_settings"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -76,10 +76,12 @@ include(
     ":feature:account:common",
     ":feature:account:edit",
     ":feature:account:oauth",
-    ":feature:account:setup",
+    ":feature:account:settings:api",
+    ":feature:account:settings:impl",
     ":feature:account:server:certificate",
     ":feature:account:server:settings",
     ":feature:account:server:validation",
+    ":feature:account:setup",
 )
 
 include(


### PR DESCRIPTION
This adds the entrypoint to the new account general settings page and adds a minimal screen implementation using the SubtitleTopAppBar.

Fixes #8922

Requires merge of #8934 and #8931.