### PR TITLE
Add basic support for subfolders in Thunderbird Android

### DIFF
--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListPreview.kt
@@ -3,6 +3,7 @@ package app.k9mail.feature.navigation.drawer.ui.folder
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.feature.navigation.drawer.domain.entity.TreeFolder
 import app.k9mail.feature.navigation.drawer.ui.FakeData.DISPLAY_FOLDER
 import app.k9mail.feature.navigation.drawer.ui.FakeData.UNIFIED_FOLDER
 import kotlinx.collections.immutable.persistentListOf
@@ -12,8 +13,8 @@ import kotlinx.collections.immutable.persistentListOf
 internal fun FolderListPreview() {
     PreviewWithTheme {
         FolderList(
-            folders = persistentListOf(
-                DISPLAY_FOLDER,
+            rootFolder = TreeFolder.createFromFolders(
+                persistentListOf(DISPLAY_FOLDER)
             ),
             selectedFolder = null,
             onFolderClick = {},
@@ -27,8 +28,8 @@ internal fun FolderListPreview() {
 internal fun FolderListPreviewSelected() {
     PreviewWithTheme {
         FolderList(
-            folders = persistentListOf(
-                DISPLAY_FOLDER,
+            rootFolder = TreeFolder.createFromFolders(
+                persistentListOf(DISPLAY_FOLDER)
             ),
             selectedFolder = DISPLAY_FOLDER,
             onFolderClick = {},
@@ -42,10 +43,10 @@ internal fun FolderListPreviewSelected() {
 internal fun FolderListWithUnifiedFolderPreview() {
     PreviewWithTheme {
         FolderList(
-            folders = persistentListOf(
+            rootFolder = TreeFolder.createFromFolders(persistentListOf(
                 UNIFIED_FOLDER,
                 DISPLAY_FOLDER,
-            ),
+            )),
             selectedFolder = DISPLAY_FOLDER,
             onFolderClick = {},
             showStarredCount = false,

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListPreview.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListPreview.kt
@@ -14,7 +14,7 @@ internal fun FolderListPreview() {
     PreviewWithTheme {
         FolderList(
             rootFolder = TreeFolder.createFromFolders(
-                persistentListOf(DISPLAY_FOLDER)
+                persistentListOf(DISPLAY_FOLDER),
             ),
             selectedFolder = null,
             onFolderClick = {},
@@ -29,7 +29,7 @@ internal fun FolderListPreviewSelected() {
     PreviewWithTheme {
         FolderList(
             rootFolder = TreeFolder.createFromFolders(
-                persistentListOf(DISPLAY_FOLDER)
+                persistentListOf(DISPLAY_FOLDER),
             ),
             selectedFolder = DISPLAY_FOLDER,
             onFolderClick = {},
@@ -43,10 +43,12 @@ internal fun FolderListPreviewSelected() {
 internal fun FolderListWithUnifiedFolderPreview() {
     PreviewWithTheme {
         FolderList(
-            rootFolder = TreeFolder.createFromFolders(persistentListOf(
-                UNIFIED_FOLDER,
-                DISPLAY_FOLDER,
-            )),
+            rootFolder = TreeFolder.createFromFolders(
+                persistentListOf(
+                    UNIFIED_FOLDER,
+                    DISPLAY_FOLDER,
+                ),
+            ),
             selectedFolder = DISPLAY_FOLDER,
             onFolderClick = {},
             showStarredCount = false,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawerModule.kt
@@ -6,6 +6,7 @@ import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDisplayAccounts
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDisplayFoldersForAccount
 import app.k9mail.feature.navigation.drawer.domain.usecase.GetDrawerConfig
+import app.k9mail.feature.navigation.drawer.domain.usecase.GetTreeFolders
 import app.k9mail.feature.navigation.drawer.domain.usecase.SaveDrawerConfig
 import app.k9mail.feature.navigation.drawer.domain.usecase.SyncAccount
 import app.k9mail.feature.navigation.drawer.domain.usecase.SyncAllAccounts
@@ -48,6 +49,10 @@ val navigationDrawerModule: Module = module {
         )
     }
 
+    single<UseCase.GetTreeFolders> {
+        GetTreeFolders()
+    }
+
     single<UseCase.SyncAccount> {
         SyncAccount(
             accountManager = get(),
@@ -67,6 +72,7 @@ val navigationDrawerModule: Module = module {
             saveDrawerConfig = get(),
             getDisplayAccounts = get(),
             getDisplayFoldersForAccount = get(),
+            getTreeFolders = get(),
             syncAccount = get(),
             syncAllAccounts = get(),
         )

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/DomainContract.kt
@@ -5,6 +5,7 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
+import app.k9mail.feature.navigation.drawer.domain.entity.TreeFolder
 import kotlinx.coroutines.flow.Flow
 
 internal interface DomainContract {
@@ -24,6 +25,10 @@ internal interface DomainContract {
 
         fun interface GetDisplayFoldersForAccount {
             operator fun invoke(accountId: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>>
+        }
+
+        fun interface GetTreeFolders {
+            operator fun invoke(folders: List<DisplayFolder>, maxDepth: Int): TreeFolder
         }
 
         /**

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
@@ -1,8 +1,67 @@
 package app.k9mail.feature.navigation.drawer.domain.entity
 
+import app.k9mail.core.mail.folder.api.Folder
+import app.k9mail.core.mail.folder.api.FolderType
+
 internal data class TreeFolder(
     var value: DisplayFolder? = null,
 ) {
+    companion object {
+        fun createFromFolders(folders: List<DisplayFolder>, maxDepth: Int = 3): TreeFolder {
+            // Converting folders to TreeFolder
+            val rootFolder = TreeFolder()
+            var currentTree = rootFolder
+
+            for (displayFolder in folders) {
+                if (displayFolder is DisplayUnifiedFolder) {
+                    currentTree.children.add(TreeFolder(displayFolder))
+                }
+                if (displayFolder !is DisplayAccountFolder) continue
+                val splittedFolderName = displayFolder.folder.name.split("/", limit = maxDepth + 1)
+                var subFolderEntireName = ""
+                for (subFolderName in splittedFolderName) {
+                    subFolderEntireName += subFolderName
+                    var foundInChildren = false
+                    for (children in currentTree.children) {
+                        var childDisplayFolder = children.value
+                        if (childDisplayFolder !is DisplayAccountFolder) continue
+                        if (childDisplayFolder.folder.name == subFolderEntireName) {
+                            currentTree = children
+                            foundInChildren = true
+                            break
+                        }
+                    }
+                    if (!foundInChildren) {
+                        var newChildren = TreeFolder()
+                        if (subFolderEntireName == displayFolder.folder.name) {
+                            newChildren = TreeFolder(displayFolder)
+                        } else {
+                            newChildren = TreeFolder(
+                                DisplayAccountFolder(
+                                    displayFolder.accountId,
+                                    Folder(0, subFolderEntireName, FolderType.REGULAR, displayFolder.folder.isLocalOnly),
+                                    displayFolder.isInTopGroup,
+                                    0,
+                                    0,
+                                ),
+                            )
+                        }
+                        currentTree.children.add(newChildren)
+                        currentTree = newChildren
+                    } else {
+                        if (subFolderEntireName == displayFolder.folder.name) {
+                            currentTree.value = displayFolder
+                        }
+                    }
+                    subFolderEntireName += "/"
+                }
+                currentTree = rootFolder
+            }
+
+            return rootFolder
+        }
+    }
+
     val children: ArrayList<TreeFolder> = ArrayList()
 
     fun getAllUnreadMessageCount(): Int {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
@@ -3,72 +3,76 @@ package app.k9mail.feature.navigation.drawer.domain.entity
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
 
-internal data class TreeFolder(
-    var value: DisplayFolder? = null,
+internal class TreeFolder(
+    var displayFolder: DisplayFolder? = null,
 ) {
     companion object {
         fun createFromFolders(folders: List<DisplayFolder>, maxDepth: Int = 3): TreeFolder {
             // Preparing root
             val rootFolder = TreeFolder()
-            var currentTree = rootFolder
 
             for (displayFolder in folders) {
                 // Managing exceptions
                 if (displayFolder is DisplayUnifiedFolder) {
-                    currentTree.children.add(TreeFolder(displayFolder))
+                    rootFolder.children.add(TreeFolder(displayFolder))
                 }
                 if (displayFolder !is DisplayAccountFolder) continue
 
-                val splittedFolderName = displayFolder.folder.name.split("/", limit = maxDepth + 1)
-                var currentWorkingPath = ""
-
-                for (subFolderName in splittedFolderName) {
-                    currentWorkingPath += subFolderName
-                    var foundInChildren = false
-
-                    // finding subFolderEntireName (current working path) into currentTree children
-                    for (children in currentTree.children) {
-                        var childDisplayFolder = children.value
-                        if (childDisplayFolder !is DisplayAccountFolder) continue
-                        if (childDisplayFolder.folder.name == currentWorkingPath) {
-                            currentTree = children
-                            foundInChildren = true
-                            break
-                        }
-                    }
-
-                    // if not found in children, creating a new one
-                    if (!foundInChildren) {
-                        var newChildren = TreeFolder()
-                        if (currentWorkingPath == displayFolder.folder.name) {
-                            // if it is the final subfolder, adding displayFolder in it
-                            newChildren = TreeFolder(displayFolder)
-                        } else {
-                            // if just an intermediate, adding a fake subFolder
-                            newChildren = TreeFolder(
-                                DisplayAccountFolder(
-                                    displayFolder.accountId,
-                                    Folder(0, currentWorkingPath, FolderType.REGULAR, displayFolder.folder.isLocalOnly),
-                                    displayFolder.isInTopGroup,
-                                    0,
-                                    0,
-                                ),
-                            )
-                        }
-                        currentTree.children.add(newChildren)
-                        currentTree = newChildren
-                    } else {
-                        // if found, association the value to manage fake created subFolders
-                        if (currentWorkingPath == displayFolder.folder.name) {
-                            currentTree.value = displayFolder
-                        }
-                    }
-                    currentWorkingPath += "/"
-                }
-                currentTree = rootFolder
+                // Inserting folder in tree
+                insertFolderInCurrentTree(rootFolder, displayFolder, maxDepth)
             }
 
             return rootFolder
+        }
+
+        private fun insertFolderInCurrentTree(
+            rootTree: TreeFolder,
+            displayFolder: DisplayAccountFolder,
+            maxDepth: Int,
+        ) {
+            val splittedFolderName = displayFolder.folder.name.split("/", limit = maxDepth + 1)
+            var currentWorkingPath = ""
+            var currentTree = rootTree
+
+            for (subFolderName in splittedFolderName) {
+                currentWorkingPath += subFolderName
+
+                // finding subFolderEntireName (current working path) into currentTree children
+                val foundChild = currentTree.children.find { child ->
+                    val childDisplayFolder = child.displayFolder
+                    childDisplayFolder is DisplayAccountFolder && childDisplayFolder.folder.name == currentWorkingPath
+                }
+
+                if (foundChild != null) {
+                    // if found, association the value to manage fake created subFolders
+                    currentTree = foundChild
+                    if (currentWorkingPath == displayFolder.folder.name) {
+                        currentTree.displayFolder = displayFolder
+                    }
+                } else {
+                    // if not found in children, creating a new one
+                    var newChildren = TreeFolder()
+                    if (currentWorkingPath == displayFolder.folder.name) {
+                        // if it is the final subfolder, adding displayFolder in it
+                        newChildren = TreeFolder(displayFolder)
+                    } else {
+                        // if just an intermediate, adding a fake subFolder
+                        newChildren = TreeFolder(
+                            DisplayAccountFolder(
+                                displayFolder.accountId,
+                                Folder(0, currentWorkingPath, FolderType.REGULAR, displayFolder.folder.isLocalOnly),
+                                displayFolder.isInTopGroup,
+                                0,
+                                0,
+                            ),
+                        )
+                    }
+                    currentTree.children.add(newChildren)
+                    currentTree = newChildren
+                }
+
+                currentWorkingPath += "/"
+            }
         }
     }
 
@@ -79,7 +83,7 @@ internal data class TreeFolder(
         for (child in children) {
             allUnreadMessageCount += child.getAllUnreadMessageCount()
         }
-        return allUnreadMessageCount + (value?.unreadMessageCount ?: 0)
+        return allUnreadMessageCount + (displayFolder?.unreadMessageCount ?: 0)
     }
 
     fun getAllStarredMessageCount(): Int {
@@ -87,6 +91,6 @@ internal data class TreeFolder(
         for (child in children) {
             allStarredMessageCount += child.getAllStarredMessageCount()
         }
-        return allStarredMessageCount + (value?.starredMessageCount ?: 0)
+        return allStarredMessageCount + (displayFolder?.starredMessageCount ?: 0)
     }
 }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
@@ -4,7 +4,7 @@ import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
 
 internal data class TreeFolder(
-    var value: DisplayFolder? = null
+    var value: DisplayFolder? = null,
 ) {
     companion object {
         fun createFromFolders(folders: List<DisplayFolder>, maxDepth: Int = 3): TreeFolder {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
@@ -1,0 +1,24 @@
+package app.k9mail.feature.navigation.drawer.domain.entity
+
+internal data class TreeFolder(
+    var value: DisplayFolder
+) {
+    val children: ArrayList<TreeFolder> = ArrayList()
+
+    fun getAllUnreadMessageCount(): Int {
+        var allUnreadMessageCount = 0
+        for (child in children) {
+            allUnreadMessageCount += child.getAllUnreadMessageCount()
+        }
+        return allUnreadMessageCount + value.unreadMessageCount
+    }
+
+    fun getAllStarredMessageCount(): Int {
+        var allStarredMessageCount = 0
+        for (child in children) {
+            allStarredMessageCount += child.getAllStarredMessageCount()
+        }
+        return allStarredMessageCount + value.starredMessageCount
+    }
+}
+

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
@@ -1,7 +1,7 @@
 package app.k9mail.feature.navigation.drawer.domain.entity
 
 internal data class TreeFolder(
-    var value: DisplayFolder
+    var value: DisplayFolder? = null
 ) {
     val children: ArrayList<TreeFolder> = ArrayList()
 
@@ -10,7 +10,7 @@ internal data class TreeFolder(
         for (child in children) {
             allUnreadMessageCount += child.getAllUnreadMessageCount()
         }
-        return allUnreadMessageCount + value.unreadMessageCount
+        return allUnreadMessageCount + (value?.unreadMessageCount ?: 0)
     }
 
     fun getAllStarredMessageCount(): Int {
@@ -18,7 +18,7 @@ internal data class TreeFolder(
         for (child in children) {
             allStarredMessageCount += child.getAllStarredMessageCount()
         }
-        return allStarredMessageCount + value.starredMessageCount
+        return allStarredMessageCount + (value?.starredMessageCount ?: 0)
     }
 }
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/entity/TreeFolder.kt
@@ -1,7 +1,7 @@
 package app.k9mail.feature.navigation.drawer.domain.entity
 
 internal data class TreeFolder(
-    var value: DisplayFolder? = null
+    var value: DisplayFolder? = null,
 ) {
     val children: ArrayList<TreeFolder> = ArrayList()
 
@@ -21,4 +21,3 @@ internal data class TreeFolder(
         return allStarredMessageCount + (value?.starredMessageCount ?: 0)
     }
 }
-

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetTreeFolders.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetTreeFolders.kt
@@ -4,7 +4,7 @@ import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.TreeFolder
 
-internal class GetTreeFolders() : UseCase.GetTreeFolders {
+internal class GetTreeFolders : UseCase.GetTreeFolders {
     override fun invoke(folders: List<DisplayFolder>, maxDepth: Int): TreeFolder {
         return TreeFolder.createFromFolders(folders, maxDepth)
     }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetTreeFolders.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetTreeFolders.kt
@@ -1,0 +1,11 @@
+package app.k9mail.feature.navigation.drawer.domain.usecase
+
+import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.TreeFolder
+
+internal class GetTreeFolders() : UseCase.GetTreeFolders {
+    override fun invoke(folders: List<DisplayFolder>, maxDepth: Int): TreeFolder {
+        return TreeFolder.createFromFolders(folders, maxDepth)
+    }
+}

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContent.kt
@@ -64,7 +64,7 @@ internal fun DrawerContent(
                         .fillMaxSize(),
                 ) {
                     FolderList(
-                        folders = state.folders,
+                        rootFolder = state.rootFolder,
                         selectedFolder = state.folders.firstOrNull { it.id == state.selectedFolderId },
                         onFolderClick = { folder ->
                             onEvent(Event.OnFolderClick(folder))

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerContract.kt
@@ -5,6 +5,7 @@ import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.navigation.drawer.NavigationDrawerExternalContract.DrawerConfig
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.TreeFolder
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -21,6 +22,7 @@ internal interface DrawerContract {
         ),
         val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
         val selectedAccountId: String? = null,
+        val rootFolder: TreeFolder = TreeFolder(),
         val folders: ImmutableList<DisplayFolder> = persistentListOf(),
         val selectedFolderId: String? = null,
         val isLoading: Boolean = false,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/DrawerViewModel.kt
@@ -7,6 +7,7 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.TreeFolder
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Effect
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.Event
 import app.k9mail.feature.navigation.drawer.ui.DrawerContract.State
@@ -30,6 +31,7 @@ internal class DrawerViewModel(
     private val saveDrawerConfig: UseCase.SaveDrawerConfig,
     private val getDisplayAccounts: UseCase.GetDisplayAccounts,
     private val getDisplayFoldersForAccount: UseCase.GetDisplayFoldersForAccount,
+    private val getTreeFolders: UseCase.GetTreeFolders,
     private val syncAccount: UseCase.SyncAccount,
     private val syncAllAccounts: UseCase.SyncAllAccounts,
     initialState: State = State(),
@@ -85,17 +87,18 @@ internal class DrawerViewModel(
             .flatMapLatest { (accountId, showUnifiedInbox) ->
                 getDisplayFoldersForAccount(accountId, showUnifiedInbox)
             }.collect { folders ->
-                updateFolders(folders)
+                updateFolders(folders, getTreeFolders(folders, 3))
             }
     }
 
-    private fun updateFolders(displayFolders: List<DisplayFolder>) {
+    private fun updateFolders(displayFolders: List<DisplayFolder>, rootFolder: TreeFolder) {
         val selectedFolder = displayFolders.find {
             it.id == state.value.selectedFolderId
         } ?: displayFolders.firstOrNull()
 
         updateState {
             it.copy(
+                rootFolder = rootFolder,
                 folders = displayFolders.toImmutableList(),
                 selectedFolderId = selectedFolder?.id,
             )

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -10,8 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import app.k9mail.core.mail.folder.api.Folder
-import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
@@ -19,11 +17,10 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.TreeFolder
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
-import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 internal fun FolderList(
-    folders: ImmutableList<DisplayFolder>,
+    rootFolder: TreeFolder,
     selectedFolder: DisplayFolder?,
     onFolderClick: (DisplayFolder) -> Unit,
     showStarredCount: Boolean,
@@ -32,57 +29,6 @@ internal fun FolderList(
     val resources = LocalContext.current.resources
     val folderNameFormatter = remember { FolderNameFormatter(resources) }
     val listState = rememberLazyListState()
-
-    // Converting folders to TreeFolder
-    val rootFolder = TreeFolder()
-    val maxDepth = 2
-    var currentTree = rootFolder
-
-    for (displayFolder in folders) {
-        if (displayFolder is DisplayUnifiedFolder) {
-            currentTree.children.add(TreeFolder(displayFolder))
-        }
-        if (displayFolder !is DisplayAccountFolder) continue
-        val splittedFolderName = displayFolder.folder.name.split("/", limit = maxDepth + 1)
-        var subFolderEntireName = ""
-        for (subFolderName in splittedFolderName) {
-            subFolderEntireName += subFolderName
-            var foundInChildren = false
-            for (children in currentTree.children) {
-                var childDisplayFolder = children.value
-                if (childDisplayFolder !is DisplayAccountFolder) continue
-                if (childDisplayFolder.folder.name == subFolderEntireName) {
-                    currentTree = children
-                    foundInChildren = true
-                    break
-                }
-            }
-            if (!foundInChildren) {
-                var newChildren = TreeFolder()
-                if (subFolderEntireName == displayFolder.folder.name) {
-                    newChildren = TreeFolder(displayFolder)
-                } else {
-                    newChildren = TreeFolder(
-                        DisplayAccountFolder(
-                            displayFolder.accountId,
-                            Folder(0, subFolderEntireName, FolderType.REGULAR, displayFolder.folder.isLocalOnly),
-                            displayFolder.isInTopGroup,
-                            0,
-                            0,
-                        ),
-                    )
-                }
-                currentTree.children.add(newChildren)
-                currentTree = newChildren
-            } else {
-                if (subFolderEntireName == displayFolder.folder.name) {
-                    currentTree.value = displayFolder
-                }
-            }
-            subFolderEntireName += "/"
-        }
-        currentTree = rootFolder
-    }
 
     LazyColumn(
         state = listState,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -47,7 +47,7 @@ internal fun FolderList(
         var subFolderEntireName = ""
         for (subFolderName in splittedFolderName) {
             subFolderEntireName += subFolderName
-            var foundInChildren = false;
+            var foundInChildren = false
             for (children in currentTree.children) {
                 var childDisplayFolder = children.value
                 if (childDisplayFolder !is DisplayAccountFolder) continue
@@ -62,7 +62,15 @@ internal fun FolderList(
                 if (subFolderEntireName == displayFolder.folder.name) {
                     newChildren = TreeFolder(displayFolder)
                 } else {
-                    newChildren = TreeFolder(DisplayAccountFolder(displayFolder.accountId, Folder(0, subFolderEntireName, FolderType.REGULAR, displayFolder.folder.isLocalOnly), displayFolder.isInTopGroup, 0, 0))
+                    newChildren = TreeFolder(
+                        DisplayAccountFolder(
+                            displayFolder.accountId,
+                            Folder(0, subFolderEntireName, FolderType.REGULAR, displayFolder.folder.isLocalOnly),
+                            displayFolder.isInTopGroup,
+                            0,
+                            0,
+                        ),
+                    )
                 }
                 currentTree.children.add(newChildren)
                 currentTree = newChildren
@@ -84,7 +92,7 @@ internal fun FolderList(
     ) {
         items(
             items = rootFolder.children,
-            key = { it.value?.id ?: '0' }
+            key = { it.value?.id ?: '0' },
         ) { folder ->
             val currentDisplayFolder = folder.value
             if (currentDisplayFolder is DisplayAccountFolder) {

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -10,10 +10,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import app.k9mail.core.mail.folder.api.Folder
+import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.theme2.MainTheme
+import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
+import app.k9mail.feature.navigation.drawer.domain.entity.TreeFolder
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import kotlinx.collections.immutable.ImmutableList
 
@@ -29,6 +33,49 @@ internal fun FolderList(
     val folderNameFormatter = remember { FolderNameFormatter(resources) }
     val listState = rememberLazyListState()
 
+    // Converting folders to TreeFolder
+    val rootFolder = TreeFolder()
+    val maxDepth = 2
+    var currentTree = rootFolder
+
+    for (displayFolder in folders) {
+        if (displayFolder is DisplayUnifiedFolder) {
+            currentTree.children.add(TreeFolder(displayFolder))
+        }
+        if (displayFolder !is DisplayAccountFolder) continue
+        val splittedFolderName = displayFolder.folder.name.split("/", limit = maxDepth + 1)
+        var subFolderEntireName = ""
+        for (subFolderName in splittedFolderName) {
+            subFolderEntireName += subFolderName
+            var foundInChildren = false;
+            for (children in currentTree.children) {
+                var childDisplayFolder = children.value
+                if (childDisplayFolder !is DisplayAccountFolder) continue
+                if (childDisplayFolder.folder.name == subFolderEntireName) {
+                    currentTree = children
+                    foundInChildren = true
+                    break
+                }
+            }
+            if (!foundInChildren) {
+                var newChildren = TreeFolder()
+                if (subFolderEntireName == displayFolder.folder.name) {
+                    newChildren = TreeFolder(displayFolder)
+                } else {
+                    newChildren = TreeFolder(DisplayAccountFolder(displayFolder.accountId, Folder(0, subFolderEntireName, FolderType.REGULAR, displayFolder.folder.isLocalOnly), displayFolder.isInTopGroup, 0, 0))
+                }
+                currentTree.children.add(newChildren)
+                currentTree = newChildren
+            } else {
+                if (subFolderEntireName == displayFolder.folder.name) {
+                    currentTree.value = displayFolder
+                }
+            }
+            subFolderEntireName += "/"
+        }
+        currentTree = rootFolder
+    }
+
     LazyColumn(
         state = listState,
         modifier = modifier
@@ -36,17 +83,21 @@ internal fun FolderList(
         contentPadding = PaddingValues(vertical = MainTheme.spacings.default),
     ) {
         items(
-            items = folders,
-            key = { it.id },
+            items = rootFolder.children,
+            key = { it.value?.id ?: '0' }
         ) { folder ->
-            FolderListItem(
-                displayFolder = folder,
-                selected = folder == selectedFolder,
-                showStarredCount = showStarredCount,
-                onClick = onFolderClick,
-                folderNameFormatter = folderNameFormatter,
-            )
-            if (folder is DisplayUnifiedFolder) {
+            val currentDisplayFolder = folder.value
+            if (currentDisplayFolder is DisplayAccountFolder) {
+                FolderListItem(
+                    displayFolder = currentDisplayFolder,
+                    selected = currentDisplayFolder.folder == selectedFolder,
+                    showStarredCount = showStarredCount,
+                    onClick = onFolderClick,
+                    folderNameFormatter = folderNameFormatter,
+                    treeFolder = folder,
+                )
+            }
+            if (currentDisplayFolder is DisplayUnifiedFolder) {
                 DividerHorizontal(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderList.kt
@@ -38,9 +38,9 @@ internal fun FolderList(
     ) {
         items(
             items = rootFolder.children,
-            key = { it.value?.id ?: '0' },
+            key = { it.displayFolder?.id ?: '0' },
         ) { folder ->
-            val currentDisplayFolder = folder.value
+            val currentDisplayFolder = folder.displayFolder
             if (currentDisplayFolder is DisplayAccountFolder) {
                 FolderListItem(
                     displayFolder = currentDisplayFolder,

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -33,6 +33,7 @@ internal fun FolderListItem(
     modifier: Modifier = Modifier,
     treeFolder: TreeFolder? = null,
     parentPrefix: String? = "",
+    indentationLevel: Int = 1,
 ) {
     var isExpanded = remember { mutableStateOf(false) }
 
@@ -44,33 +45,33 @@ internal fun FolderListItem(
         starredCount = treeFolder.getAllStarredMessageCount()
     }
 
-    NavigationDrawerItem(
-        label = mapFolderName(displayFolder, folderNameFormatter, parentPrefix),
-        selected = selected,
-        onClick = { onClick(displayFolder) },
-        modifier = modifier,
-        icon = {
-            Icon(
-                imageVector = mapFolderIcon(displayFolder),
-            )
-        },
-        badge = {
-            FolderListItemBadge(
-                unreadCount = unreadCount,
-                starredCount = starredCount,
-                showStarredCount = showStarredCount,
-                expandableState = if (treeFolder !== null && treeFolder.children.isNotEmpty()) isExpanded else null,
-            )
-        },
-    )
-
-    // Managing children
     Column(modifier = Modifier.fillMaxWidth().animateContentSize()) {
+        NavigationDrawerItem(
+            label = mapFolderName(displayFolder, folderNameFormatter, parentPrefix),
+            selected = selected,
+            onClick = { onClick(displayFolder) },
+            modifier = modifier,
+            icon = {
+                Icon(
+                    imageVector = mapFolderIcon(displayFolder),
+                )
+            },
+            badge = {
+                FolderListItemBadge(
+                    unreadCount = unreadCount,
+                    starredCount = starredCount,
+                    showStarredCount = showStarredCount,
+                    expandableState = if (treeFolder !== null && treeFolder.children.isNotEmpty()) isExpanded else null,
+                )
+            },
+        )
+
+        // Managing children
         if (!isExpanded.value) return
         if (treeFolder === null) return
         for (child in treeFolder.children) {
-            var displayParent = treeFolder.value
-            var displayChild = child.value
+            var displayParent = treeFolder.displayFolder
+            var displayChild = child.displayFolder
             if (displayChild === null) continue
             FolderListItem(
                 displayFolder = displayChild,
@@ -78,9 +79,10 @@ internal fun FolderListItem(
                 showStarredCount = showStarredCount,
                 onClick = { onClick(displayChild) },
                 folderNameFormatter = folderNameFormatter,
-                modifier = modifier.then(Modifier.padding(start = MainTheme.spacings.triple)),
+                modifier = Modifier.padding(start = MainTheme.spacings.triple * indentationLevel),
                 treeFolder = child,
                 parentPrefix = if (displayParent is DisplayAccountFolder) displayParent.folder.name else null,
+                indentationLevel = indentationLevel + 1,
             )
         }
     }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -32,9 +32,17 @@ internal fun FolderListItem(
     folderNameFormatter: FolderNameFormatter,
     modifier: Modifier = Modifier,
     treeFolder: TreeFolder? = null,
-    parentPrefix: String? = ""
+    parentPrefix: String? = "",
 ) {
     var isExpanded = remember { mutableStateOf(false) }
+
+    var unreadCount = displayFolder.unreadMessageCount
+    var starredCount = displayFolder.starredMessageCount
+
+    if (treeFolder !== null && !isExpanded.value) {
+        unreadCount = treeFolder.getAllUnreadMessageCount()
+        starredCount = treeFolder.getAllStarredMessageCount()
+    }
 
     NavigationDrawerItem(
         label = mapFolderName(displayFolder, folderNameFormatter, parentPrefix),
@@ -48,16 +56,16 @@ internal fun FolderListItem(
         },
         badge = {
             FolderListItemBadge(
-                unreadCount = if (treeFolder !== null && !isExpanded.value) treeFolder.getAllUnreadMessageCount() else displayFolder.unreadMessageCount,
-                starredCount = if (treeFolder !== null && !isExpanded.value) treeFolder.getAllStarredMessageCount() else displayFolder.starredMessageCount,
+                unreadCount = unreadCount,
+                starredCount = starredCount,
                 showStarredCount = showStarredCount,
-                expandableState = if (treeFolder !== null && treeFolder.children.isNotEmpty()) isExpanded else null
+                expandableState = if (treeFolder !== null && treeFolder.children.isNotEmpty()) isExpanded else null,
             )
         },
     )
 
     // Managing children
-    Column (modifier = Modifier.fillMaxWidth().animateContentSize()) {
+    Column(modifier = Modifier.fillMaxWidth().animateContentSize()) {
         if (!isExpanded.value) return
         if (treeFolder === null) return
         for (child in treeFolder.children) {
@@ -72,7 +80,7 @@ internal fun FolderListItem(
                 folderNameFormatter = folderNameFormatter,
                 modifier = modifier.then(Modifier.padding(start = MainTheme.spacings.triple)),
                 treeFolder = child,
-                parentPrefix = if (displayParent is DisplayAccountFolder) displayParent.folder.name else null
+                parentPrefix = if (displayParent is DisplayAccountFolder) displayParent.folder.name else null,
             )
         }
     }
@@ -82,7 +90,7 @@ internal fun FolderListItem(
 private fun mapFolderName(
     displayFolder: DisplayFolder,
     folderNameFormatter: FolderNameFormatter,
-    parentPrefix: String? = ""
+    parentPrefix: String? = "",
 ): String {
     return when (displayFolder) {
         is DisplayAccountFolder -> folderNameFormatter.displayName(displayFolder.folder).removePrefix("$parentPrefix/")

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -2,6 +2,7 @@ package app.k9mail.feature.navigation.drawer.ui.folder
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -31,11 +32,12 @@ internal fun FolderListItem(
     folderNameFormatter: FolderNameFormatter,
     modifier: Modifier = Modifier,
     treeFolder: TreeFolder? = null,
+    parentPrefix: String? = ""
 ) {
     var isExpanded = remember { mutableStateOf(false) }
 
     NavigationDrawerItem(
-        label = mapFolderName(displayFolder, folderNameFormatter),
+        label = mapFolderName(displayFolder, folderNameFormatter, parentPrefix),
         selected = selected,
         onClick = { onClick(displayFolder) },
         modifier = modifier,
@@ -55,10 +57,11 @@ internal fun FolderListItem(
     )
 
     // Managing children
-    Column (modifier = Modifier.animateContentSize()) {
+    Column (modifier = Modifier.fillMaxWidth().animateContentSize()) {
         if (!isExpanded.value) return
         if (treeFolder === null) return
         for (child in treeFolder.children) {
+            var displayParent = treeFolder.value
             var displayChild = child.value
             if (displayChild === null) continue
             FolderListItem(
@@ -67,8 +70,9 @@ internal fun FolderListItem(
                 showStarredCount = showStarredCount,
                 onClick = { onClick(displayChild) },
                 folderNameFormatter = folderNameFormatter,
-                modifier = modifier.then(Modifier.padding(horizontal = MainTheme.spacings.triple)),
+                modifier = modifier.then(Modifier.padding(start = MainTheme.spacings.triple)),
                 treeFolder = child,
+                parentPrefix = if (displayParent is DisplayAccountFolder) displayParent.folder.name else null
             )
         }
     }
@@ -78,9 +82,10 @@ internal fun FolderListItem(
 private fun mapFolderName(
     displayFolder: DisplayFolder,
     folderNameFormatter: FolderNameFormatter,
+    parentPrefix: String? = ""
 ): String {
     return when (displayFolder) {
-        is DisplayAccountFolder -> folderNameFormatter.displayName(displayFolder.folder)
+        is DisplayAccountFolder -> folderNameFormatter.displayName(displayFolder.folder).removePrefix("$parentPrefix/")
         is DisplayUnifiedFolder -> mapUnifiedFolderName(displayFolder)
         else -> throw IllegalArgumentException("Unknown display folder: $displayFolder")
     }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItem.kt
@@ -1,6 +1,11 @@
 package app.k9mail.feature.navigation.drawer.ui.folder
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -8,11 +13,13 @@ import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItem
+import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.feature.navigation.drawer.R
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
+import app.k9mail.feature.navigation.drawer.domain.entity.TreeFolder
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 
 @Composable
@@ -23,7 +30,10 @@ internal fun FolderListItem(
     showStarredCount: Boolean,
     folderNameFormatter: FolderNameFormatter,
     modifier: Modifier = Modifier,
+    treeFolder: TreeFolder? = null,
 ) {
+    var isExpanded = remember { mutableStateOf(false) }
+
     NavigationDrawerItem(
         label = mapFolderName(displayFolder, folderNameFormatter),
         selected = selected,
@@ -36,12 +46,32 @@ internal fun FolderListItem(
         },
         badge = {
             FolderListItemBadge(
-                unreadCount = displayFolder.unreadMessageCount,
-                starredCount = displayFolder.starredMessageCount,
+                unreadCount = if (treeFolder !== null && !isExpanded.value) treeFolder.getAllUnreadMessageCount() else displayFolder.unreadMessageCount,
+                starredCount = if (treeFolder !== null && !isExpanded.value) treeFolder.getAllStarredMessageCount() else displayFolder.starredMessageCount,
                 showStarredCount = showStarredCount,
+                expandableState = if (treeFolder !== null && treeFolder.children.isNotEmpty()) isExpanded else null
             )
         },
     )
+
+    // Managing children
+    Column (modifier = Modifier.animateContentSize()) {
+        if (!isExpanded.value) return
+        if (treeFolder === null) return
+        for (child in treeFolder.children) {
+            var displayChild = child.value
+            if (displayChild === null) continue
+            FolderListItem(
+                displayFolder = displayChild,
+                selected = false,
+                showStarredCount = showStarredCount,
+                onClick = { onClick(displayChild) },
+                folderNameFormatter = folderNameFormatter,
+                modifier = modifier.then(Modifier.padding(horizontal = MainTheme.spacings.triple)),
+                treeFolder = child,
+            )
+        }
+    }
 }
 
 @Composable

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemBadge.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemBadge.kt
@@ -40,7 +40,7 @@ internal fun FolderListItemBadge(
     if (expandableState !== null) {
         FolderExpandableBadge(
             isExpanded = expandableState.value,
-            onClick = { expandableState.value = !expandableState.value }
+            onClick = { expandableState.value = !expandableState.value },
         )
     }
 }
@@ -48,14 +48,14 @@ internal fun FolderListItemBadge(
 @Composable
 private fun FolderExpandableBadge(
     isExpanded: Boolean = false,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     Icon(
         imageVector = if (isExpanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
         modifier = Modifier
             .size(MainTheme.sizes.iconLarge)
             .padding(end = MainTheme.spacings.quarter)
-            .clickable(onClick = onClick)
+            .clickable(onClick = onClick),
     )
 }
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemBadge.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/ui/folder/FolderListItemBadge.kt
@@ -1,11 +1,16 @@
 package app.k9mail.feature.navigation.drawer.ui.folder
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItemBadge
 import app.k9mail.core.ui.compose.theme2.MainTheme
@@ -17,6 +22,7 @@ internal fun FolderListItemBadge(
     starredCount: Int,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
+    expandableState: MutableState<Boolean>? = null,
 ) {
     if (showStarredCount) {
         FolderCountAndStarredBadge(
@@ -30,6 +36,27 @@ internal fun FolderListItemBadge(
             modifier = modifier,
         )
     }
+
+    if (expandableState !== null) {
+        FolderExpandableBadge(
+            isExpanded = expandableState.value,
+            onClick = { expandableState.value = !expandableState.value }
+        )
+    }
+}
+
+@Composable
+private fun FolderExpandableBadge(
+    isExpanded: Boolean = false,
+    onClick: () -> Unit
+) {
+    Icon(
+        imageVector = if (isExpanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+        modifier = Modifier
+            .size(MainTheme.sizes.iconLarge)
+            .padding(end = MainTheme.spacings.quarter)
+            .clickable(onClick = onClick)
+    )
 }
 
 @Composable


### PR DESCRIPTION
**Description**

This PR introduces basic support for email subfolders in Thunderbird Android (#630). Currently, subfolders can be managed up to a depth of 2 levels, which is hardcoded in the implementation. Feedback on a more flexible approach to handling deeper folder structures would be greatly appreciated.

Since this is my first contribution to the project, I would love to get some feedback on the approach taken. This PR is likely not a final version, and I'm open to suggestions for improvements.

**Changes**

- Added support for email subfolders.
- Implemented a basic hierarchy with a maximum depth of 2 levels (hardcoded).
- UI adjustments to display subfolders appropriately.

**Visual Example**

![image](https://github.com/user-attachments/assets/a7b3545c-fbd4-4baa-bd92-df225e9c0e37)

**Feedback Requested**

- Is there a preferred way to handle unlimited or more flexible folder depths in this project?
- Any recommendations on code structure or performance improvements?
- General feedback on the implementation is welcome!

Looking forward to your feedback!