### PR TITLE
Use botmobile for commenting

### DIFF
--- a/.github/workflows/daily_builds.yml
+++ b/.github/workflows/daily_builds.yml
@@ -14,5 +14,4 @@ jobs:
     uses: ./.github/workflows/shippable_builds.yml
     secrets: inherit
     permissions:
-      contents: write # For release bumps
       id-token: write # For GCS publishing (ftp.mo)

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,20 +10,30 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
+
+
+environment: botmobile
 
 jobs:
   build-docs:
     if: ${{ github.repository_owner == 'thunderbird' }}
     runs-on: ubuntu-latest
     steps:
+      - name: App token generate
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e  # v1.11.6
+        if: ${{ vars.BOT_CLIENT_ID }}
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Cargo cache
         uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4  # v1.11.0
@@ -44,9 +54,12 @@ jobs:
           rm book/docs/latest/install.sh
 
       - name: Deploy docs to gh-pages
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug || 'github-actions'}}
+          APP_USER_ID: ${{ vars.BOT_USER_ID || '41898282' }}
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "${APP_SLUG}"
+          git config --global user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
           # Fetch the gh-pages branch
           git fetch origin gh-pages || git checkout --orphan gh-pages

--- a/.github/workflows/needinfo-answered.yml
+++ b/.github/workflows/needinfo-answered.yml
@@ -10,6 +10,8 @@ on:
 permissions:
   issues: write
 
+environment: botmobile
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,9 +22,17 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: App token generate
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e  # v1.11.6
+        if: ${{ vars.BOT_CLIENT_ID }}
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - name: Remove answered label if both exist
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
           gh issue edit $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --remove-label "status: answered"

--- a/.github/workflows/needinfo-remove.yml
+++ b/.github/workflows/needinfo-remove.yml
@@ -10,6 +10,8 @@ permissions:
   contents: read
   issues: write
 
+environment: botmobile
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,9 +24,17 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: App token generate
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e  # v1.11.6
+        if: ${{ vars.BOT_CLIENT_ID }}
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - name: Remove needinfo label and add answered label
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
           gh issue edit $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --remove-label "status: needs information" --add-label "status: answered"

--- a/.github/workflows/needinfo-stale.yml
+++ b/.github/workflows/needinfo-stale.yml
@@ -10,6 +10,8 @@ permissions:
   contents: read
   issues: write
 
+environment: botmobile
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,10 +19,18 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Close old issues with the needinfo tag
-        uses: imhoffd/needs-reply@71e8d5144caa0d4a1e292348bfafa3866d08c855 # v2.0.0
+      - name: App token generate
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e  # v1.11.6
+        if: ${{ vars.BOT_CLIENT_ID }}
+        id: app-token
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ vars.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - name: Close old issues with the needinfo tag
+        uses: imhoffd/needs-reply@71e8d5144caa0d4a1e292348bfafa3866d08c855  # v2.0.0
+        with:
+          repo-token: ${{ steps.app-token.outputs.token || github.token }}
           issue-label: "status: needs information"
           days-before-close: 30
           close-message: >

--- a/.github/workflows/pulls-merged.yml
+++ b/.github/workflows/pulls-merged.yml
@@ -12,16 +12,26 @@ permissions:
   pull-requests: write
   issues: write
 
+environment: botmobile
+
 jobs:
   pull-request-merged:
     runs-on: ubuntu-latest
 
     steps:
+      - name: App token generate
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e  # v1.11.6
+        if: ${{ vars.BOT_CLIENT_ID }}
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - name: Get active milestone
         id: milestone
         env:
           PR_NUMBER: ${{  github.event.pull_request.number  }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
           # The furthest open milestone in the future should be current main
           gh api repos/$GITHUB_REPOSITORY/milestones --jq '
@@ -39,7 +49,7 @@ jobs:
           github.event.pull_request.author_association != 'COLLABORATOR'
         env:
           PR_NUMBER: ${{  github.event.pull_request.number  }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           MILESTONE: ${{ steps.milestone.outputs.title }}
           MESSAGE: >-
             Thanks for your contribution! Your pull request has been merged and will be part of
@@ -55,7 +65,7 @@ jobs:
       - name: Set active milestone on PR
         env:
           PR_NUMBER: ${{  github.event.pull_request.number  }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           MILESTONE: ${{ steps.milestone.outputs.number }}
         run: |
           gh api --method PATCH /repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER -f milestone=$MILESTONE

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -197,8 +197,6 @@ jobs:
       max-parallel: 1
       matrix:
         include: "${{ fromJSON(needs.dump_config.outputs.matrixInclude) }}"
-    permissions:
-      contents: write
     outputs:
       k9mail_sha: ${{ steps.commit.outputs.k9mail_sha }}
       thunderbird_sha: ${{ steps.commit.outputs.thunderbird_sha }}
@@ -207,11 +205,20 @@ jobs:
       old_version_code: ${{ steps.new_version_code.outputs.old_version_code }}
       new_version_code: ${{ steps.new_version_code.outputs.new_version_code }}
     steps:
+      - name: App Token Generate
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
+        if: ${{ vars.BOT_CLIENT_ID }}
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - name: Checkout repository
         if: ${{ contains(matrix.releaseTarget, 'github') || needs.dump_config.outputs.releaseType == 'daily' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Copy CI gradle.properties
         if: ${{ contains(matrix.releaseTarget, 'github') || needs.dump_config.outputs.releaseType == 'daily' }}
@@ -369,9 +376,11 @@ jobs:
           APP_NAME: ${{ matrix.appName }}
           FULL_VERSION_NAME: ${{ steps.appinfo.outputs.VERSION_NAME }}${{ steps.bump_version_suffix.outputs.SUFFIX || steps.appinfo.outputs.VERSION_NAME_SUFFIX }}
           RELEASE_TYPE: ${{ vars.RELEASE_TYPE }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug || 'github-actions'}}
+          APP_USER_ID: ${{ vars.BOT_USER_ID || '41898282' }}
         run: |
-          git config --global user.name "GitHub Actions Bot"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "${APP_SLUG}"
+          git config --global user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
           # We need the metadata to point to the right application for the release commit
           set -x
@@ -756,12 +765,12 @@ jobs:
           ls -l uploads/${PKG_FILE_PRETTY}
 
       - name: App Token Generate
-        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
-        if: ${{ contains(matrix.releaseTarget, 'github') && vars.RELEASER_APP_CLIENT_ID }}
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e  # v1.11.6
+        if: ${{ contains(matrix.releaseTarget, 'github') && vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.RELEASER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Publish to GitHub Releases
         id: publish_gh

--- a/.github/workflows/uplift-merges.yml
+++ b/.github/workflows/uplift-merges.yml
@@ -11,28 +11,41 @@ on:
 permissions:
   contents: read
 
+environment: botmobile
+
 jobs:
   uplift:
     name: Uplift
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: write
     steps:
+      - name: App token generate
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
+        if: ${{ !inputs.dryRun && vars.BOT_CLIENT_ID }}
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Configure for push
         if: ${{ !inputs.dryRun }}
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug || 'github-actions'}}
+          APP_USER_ID: ${{ vars.BOT_USER_ID || '41898282' }}
         run: |
-          git config --global user.name "GitHub Actions Bot"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "${APP_SLUG}"
+          git config --global user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       - name: Run uplift script
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           DRYRUN: ${{ !inputs.dryRun && '--no-dry-run' || '' }}
           BRANCH: ${{ github.ref_name }}
           PUSH: ${{ !inputs.dryRun && '--push' || '' }}

--- a/scripts/ci/setup_release_automation
+++ b/scripts/ci/setup_release_automation
@@ -168,7 +168,8 @@ def get_github_public_key(repo, environment_name):
     }
     response = requests.get(url, headers=headers)
     if response.status_code == 200:
-        return response.json()
+        data = response.json()
+        return [data["key_id"], data["key"]]
     else:
         raise Exception(
             f"Failed to fetch public key from GitHub. Response: {response.status_code}, {response.text}"
@@ -424,9 +425,7 @@ def create_signing_environment(repo, environment, branch, props_file):
     create_github_environment(repo, environment, branches=[branch])
 
     # Fetch the public key from GitHub for the specific environment
-    public_key_data = get_github_public_key(repo, environment)
-    public_key = public_key_data["key"]
-    key_id = public_key_data["key_id"]
+    key_id, public_key = get_github_public_key(repo, environment)
 
     # Encrypt the secrets using the public key
     encrypted_signing_key = encrypt_secret(public_key, SIGNING_KEY)
@@ -448,14 +447,41 @@ def create_signing_environment(repo, environment, branch, props_file):
         )
 
 
+def make_bot_environment(repo, environment):
+    key_id, public_key = get_github_public_key(repo, environment)
+
+    with open("botmobile.key.pem") as fp:
+        encrypted_bot_key = encrypt_secret(public_key, fp.read())
+    with open("botmobile.clientid.txt") as fp:
+        bot_client_id = fp.read().strip()
+    with open("botmobile.userid.txt") as fp:
+        bot_user_id = fp.read().strip()
+
+
+    set_github_environment_secret(
+        repo, "BOT_PRIVATE_KEY", encrypted_bot_key, key_id, environment
+    )
+
+    set_github_environment_variable(repo, "BOT_CLIENT_ID", bot_client_id, environment)
+    set_github_environment_variable(repo, "BOT_USER_ID", bot_user_id, environment)
+
+
+def create_channel_environment(repo, environment, branch, variables):
+    create_github_environment(repo, environment, branches=[branch])
+
+    for name, value in variables.items():
+        if isinstance(value, dict) or isinstance(value, list):
+            value = json.dumps(value)
+
+        set_github_environment_variable(repo, name, value, environment)
+
+
 def create_release_environment(repo, branches):
     environment = "publish_release"
 
     create_github_environment(repo, environment, branches=branches)
 
-    public_key_data = get_github_public_key(repo, environment)
-    public_key = public_key_data["key"]
-    key_id = public_key_data["key_id"]
+    key_id, public_key = get_github_public_key(repo, environment)
 
     with open("play-store-account.json") as fp:
         encrypted_play_account = encrypt_secret(public_key, fp.read())
@@ -464,28 +490,13 @@ def create_release_environment(repo, branches):
         repo, "PLAY_STORE_ACCOUNT", encrypted_play_account, key_id, environment
     )
 
-    with open("thunderbird-mobile-gh-releaser-bot.pem") as fp:
-        encrypted_releaser_key = encrypt_secret(public_key, fp.read())
-    with open("thunderbird-mobile-gh-releaser-bot.clientid.txt") as fp:
-        releaser_client_id = fp.read().strip()
-
-    set_github_environment_secret(
-        repo, "RELEASER_APP_PRIVATE_KEY", encrypted_releaser_key, key_id, environment
-    )
-
-    set_github_environment_variable(
-        repo, "RELEASER_APP_CLIENT_ID", releaser_client_id, environment
-    )
-
 
 def create_matrix_environment(repo, branches):
     environment = "notify_matrix"
 
     create_github_environment(repo, environment, branches=branches)
 
-    public_key_data = get_github_public_key(repo, environment)
-    public_key = public_key_data["key"]
-    key_id = public_key_data["key_id"]
+    key_id, public_key = get_github_public_key(repo, environment)
 
     with open("matrix-account.json") as fp:
         mxdata = json.load(fp)
@@ -543,7 +554,7 @@ def main():
     includeset = set(
         list(CHANNEL_ENVIRONMENTS.keys())
         + list(SIGNING_ENVIRONMENTS.keys())
-        + ["publish_hold", "publish_release", "notify_matrix"]
+        + ["publish_hold", "publish_release", "notify_matrix", "botmobile"]
     )
     if args.skip:
         for skip in args.skip:
@@ -570,17 +581,8 @@ def main():
             print(f"Environment {environment_name}")
             print_github_environment_variable(args.repo, environment_name)
         else:
-            create_github_environment(
-                args.repo, environment_name, branches=[data["branch"]]
-            )
-
-            for name, value in data["variables"].items():
-                if isinstance(value, dict) or isinstance(value, list):
-                    value = json.dumps(value)
-
-                set_github_environment_variable(
-                    args.repo, name, value, environment_name
-                )
+            create_channel_environment(args.repo, environment_name, **data)
+            make_bot_environment(args.repo, environment_name)
 
     # Signing environments
     for environment_name, data in SIGNING_ENVIRONMENTS.items():
@@ -604,6 +606,15 @@ def main():
             print_github_environment(args.repo, "publish_release")
         else:
             create_release_environment(args.repo, ["main", "beta", "release"])
+            make_bot_environment(args.repo, "publish_release")
+
+    # Botmobile environment
+    if "botmobile" in includeset:
+        if args.print:
+            print_github_environment(args.repo, "botmobile")
+        else:
+            create_github_environment(args.repo, "botmobile", branches=["main"])
+            make_bot_environment(args.repo, "botmobile")
 
     # Notify
     if "notify_matrix" in includeset:


### PR DESCRIPTION
@coreycb draft pull request to switch over to botmobile for all actions once https://github.com/thunderbird/cloudops/issues/30 is resolved. I need to update the variable names once the following question is answered.

Where do we put the secrets for this? 
- For the release right now they are in the publish_release environment, which makes sense. 
- To be able to use that username for the earlier release bump commit, we'd also need to put it into the respective  `thunderbird_beta` and `thunderbird_release` environments.
- To be able to use the username for commenting and the deploy docs, we'd either need yet another environment.

Or, we put them as repository secrets, which would however make them available to all environments. Contributors in pull requests would still not get the secrets. 

If we're able to lock down the permissions so that all that is available is repository contents, issues, pull requests, then it might be a bit more safe.

Let me know what you recommend in terms of security.