### PR TITLE
Create a separate SECURITY.md and link to vulnerability reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Feature Request
     url: https://connect.mozilla.org/t5/ideas/idb-p/ideas/label-name/thunderbird%20android
     about: Submit your ideas to improve Thunderbird for Android.
+  - name: Security Vulnerability
+    url: https://github.com/thunderbird/thunderbird-android/security/advisories/new
+    about: Report a security vulnerability. Many users could be harmed from this and it should be kept private until resolved.
   - name: Mozilla Support Forum (SUMO)
     url: https://support.mozilla.org/products/thunderbird-android
     about: Most issues are not bugs. Ask the community for help.

--- a/README.md
+++ b/README.md
@@ -64,28 +64,6 @@ For more information about our ADRs, please see the [ADRs README](docs/architect
 We encourage team members and contributors to read through our ADRs to understand the architectural decisions that
 have shaped this project so far. Feel free to propose new ADRs or suggest modifications to existing ones as needed.
 
-## Security
-
-The code in this repository was undergoing an extensive security audit in collaboration with the Open Source Technology
-Improvement Fund ([OSTIF](https://ostif.org/)) and [7ASecurity](https://7asecurity.com/) in the first half of 2023. For
-more details, see
-our [blog post](https://blog.thunderbird.net/2023/07/k-9-mail-collaborates-with-ostif-and-7asecurity-security-audit/).
-
-You can report a security vulnerability [through the respective issues form](https://github.com/thunderbird/thunderbird-android/security/advisories/new).
-
-These are the SHA-256 fingerprints for our signing certificates:
-
-- Thunderbird: `B6:52:47:79:B3:DB:BC:5A:C1:7A:5A:C2:71:DD:B2:9D:CF:BF:72:35:78:C2:38:E0:3C:3C:21:78:11:35:6D:D1`
-- Thunderbird Beta: `05:6B:FA:FB:45:02:49:50:2F:D9:22:62:28:70:4C:25:29:E1:B8:22:DA:06:76:0D:47:A8:5C:95:57:74:1F:BD`
-- K-9 Mail: `55:C8:A5:23:B9:73:35:F5:BF:60:DF:E8:A9:F3:E1:DD:E7:44:51:6D:93:57:E8:0A:92:5B:7B:22:E4:F5:55:24`
-
-You can use the following command to retrieve and [verify](https://developer.android.com/tools/apksigner#usage-verify)
-the certificate before installation:
-
-```bash
-apksigner verify -v --print-certs <path-to-apk>
-```
-
 ## K-9 Mail
 
 In June 2022, [K-9 Mail joined the Thunderbird family](https://k9mail.app/2022/06/13/K-9-Mail-and-Thunderbird.html)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Thunderbird for Android Security
+
+## Security Audit
+
+The code in this repository underwent an extensive security audit in collaboration with the Open Source Technology
+Improvement Fund ([OSTIF](https://ostif.org/)) and [7ASecurity](https://7asecurity.com/) in the first half of 2023. For
+more details, see
+our [blog post](https://blog.thunderbird.net/2023/07/k-9-mail-collaborates-with-ostif-and-7asecurity-security-audit/).
+
+## Verifying Fingerprints
+
+These are the SHA-256 fingerprints for our signing certificates:
+
+- Thunderbird: `B6:52:47:79:B3:DB:BC:5A:C1:7A:5A:C2:71:DD:B2:9D:CF:BF:72:35:78:C2:38:E0:3C:3C:21:78:11:35:6D:D1`
+- Thunderbird Beta: `05:6B:FA:FB:45:02:49:50:2F:D9:22:62:28:70:4C:25:29:E1:B8:22:DA:06:76:0D:47:A8:5C:95:57:74:1F:BD`
+- K-9 Mail: `55:C8:A5:23:B9:73:35:F5:BF:60:DF:E8:A9:F3:E1:DD:E7:44:51:6D:93:57:E8:0A:92:5B:7B:22:E4:F5:55:24`
+
+You can use the following command to retrieve and [verify](https://developer.android.com/tools/apksigner#usage-verify)
+the certificate before installation:
+
+```bash
+apksigner verify -v --print-certs <path-to-apk>
+```
+
+## Reporting Vulnerabilities
+
+You can report a security vulnerability through the [vulnerability reporting form](https://github.com/thunderbird/thunderbird-android/security/advisories/new).
+
+We appreciate your support in making Thunderbird for Android as safe as possible!


### PR DESCRIPTION
Fixes #8972

GitHub will display a tab with Security Information, we can use this to separate the info a bit. I'm also adding a link to the advisories reporting in the issue form so it is easier to find.

@kaie If there is any additional information you think we should include let us know.