### PR TITLE
Add list detail pane to design system

### DIFF
--- a/app-k9mail/dependencies/fossReleaseRuntimeClasspath.txt
+++ b/app-k9mail/dependencies/fossReleaseRuntimeClasspath.txt
@@ -23,6 +23,12 @@ androidx.compose.foundation:foundation-android:1.7.8
 androidx.compose.foundation:foundation-layout-android:1.7.8
 androidx.compose.foundation:foundation-layout:1.7.8
 androidx.compose.foundation:foundation:1.7.8
+androidx.compose.material3.adaptive:adaptive-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation:1.0.0
+androidx.compose.material3.adaptive:adaptive:1.0.0
 androidx.compose.material3:material3-android:1.3.1
 androidx.compose.material3:material3:1.3.1
 androidx.compose.material:material-icons-core-android:1.7.8
@@ -137,7 +143,10 @@ androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1
 androidx.viewpager2:viewpager2:1.1.0-beta02
 androidx.viewpager:viewpager:1.0.0
-androidx.window:window:1.0.0
+androidx.window.extensions.core:core:1.0.0
+androidx.window:window-core-android:1.3.0
+androidx.window:window-core:1.3.0
+androidx.window:window:1.3.0
 androidx.work:work-runtime-ktx:2.10.0
 androidx.work:work-runtime:2.10.0
 co.touchlab:stately-concurrency-jvm:2.0.6

--- a/app-k9mail/dependencies/fullReleaseRuntimeClasspath.txt
+++ b/app-k9mail/dependencies/fullReleaseRuntimeClasspath.txt
@@ -23,6 +23,12 @@ androidx.compose.foundation:foundation-android:1.7.8
 androidx.compose.foundation:foundation-layout-android:1.7.8
 androidx.compose.foundation:foundation-layout:1.7.8
 androidx.compose.foundation:foundation:1.7.8
+androidx.compose.material3.adaptive:adaptive-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation:1.0.0
+androidx.compose.material3.adaptive:adaptive:1.0.0
 androidx.compose.material3:material3-android:1.3.1
 androidx.compose.material3:material3:1.3.1
 androidx.compose.material:material-icons-core-android:1.7.8
@@ -137,7 +143,10 @@ androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1
 androidx.viewpager2:viewpager2:1.1.0-beta02
 androidx.viewpager:viewpager:1.0.0
-androidx.window:window:1.0.0
+androidx.window.extensions.core:core:1.0.0
+androidx.window:window-core-android:1.3.0
+androidx.window:window-core:1.3.0
+androidx.window:window:1.3.0
 androidx.work:work-runtime-ktx:2.10.0
 androidx.work:work-runtime:2.10.0
 co.touchlab:stately-concurrency-jvm:2.0.6

--- a/app-thunderbird/dependencies/fossBetaRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fossBetaRuntimeClasspath.txt
@@ -28,6 +28,12 @@ androidx.compose.foundation:foundation-android:1.7.8
 androidx.compose.foundation:foundation-layout-android:1.7.8
 androidx.compose.foundation:foundation-layout:1.7.8
 androidx.compose.foundation:foundation:1.7.8
+androidx.compose.material3.adaptive:adaptive-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation:1.0.0
+androidx.compose.material3.adaptive:adaptive:1.0.0
 androidx.compose.material3:material3-android:1.3.1
 androidx.compose.material3:material3:1.3.1
 androidx.compose.material:material-icons-core-android:1.7.8
@@ -142,7 +148,10 @@ androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1
 androidx.viewpager2:viewpager2:1.1.0-beta02
 androidx.viewpager:viewpager:1.0.0
-androidx.window:window:1.0.0
+androidx.window.extensions.core:core:1.0.0
+androidx.window:window-core-android:1.3.0
+androidx.window:window-core:1.3.0
+androidx.window:window:1.3.0
 androidx.work:work-runtime-ktx:2.10.0
 androidx.work:work-runtime:2.10.0
 co.touchlab:stately-concurrency-jvm:2.0.6

--- a/app-thunderbird/dependencies/fossDailyRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fossDailyRuntimeClasspath.txt
@@ -28,6 +28,12 @@ androidx.compose.foundation:foundation-android:1.7.8
 androidx.compose.foundation:foundation-layout-android:1.7.8
 androidx.compose.foundation:foundation-layout:1.7.8
 androidx.compose.foundation:foundation:1.7.8
+androidx.compose.material3.adaptive:adaptive-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation:1.0.0
+androidx.compose.material3.adaptive:adaptive:1.0.0
 androidx.compose.material3:material3-android:1.3.1
 androidx.compose.material3:material3:1.3.1
 androidx.compose.material:material-icons-core-android:1.7.8
@@ -142,7 +148,10 @@ androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1
 androidx.viewpager2:viewpager2:1.1.0-beta02
 androidx.viewpager:viewpager:1.0.0
-androidx.window:window:1.0.0
+androidx.window.extensions.core:core:1.0.0
+androidx.window:window-core-android:1.3.0
+androidx.window:window-core:1.3.0
+androidx.window:window:1.3.0
 androidx.work:work-runtime-ktx:2.10.0
 androidx.work:work-runtime:2.10.0
 co.touchlab:stately-concurrency-jvm:2.0.6

--- a/app-thunderbird/dependencies/fossReleaseRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fossReleaseRuntimeClasspath.txt
@@ -28,6 +28,12 @@ androidx.compose.foundation:foundation-android:1.7.8
 androidx.compose.foundation:foundation-layout-android:1.7.8
 androidx.compose.foundation:foundation-layout:1.7.8
 androidx.compose.foundation:foundation:1.7.8
+androidx.compose.material3.adaptive:adaptive-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation:1.0.0
+androidx.compose.material3.adaptive:adaptive:1.0.0
 androidx.compose.material3:material3-android:1.3.1
 androidx.compose.material3:material3:1.3.1
 androidx.compose.material:material-icons-core-android:1.7.8
@@ -142,7 +148,10 @@ androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1
 androidx.viewpager2:viewpager2:1.1.0-beta02
 androidx.viewpager:viewpager:1.0.0
-androidx.window:window:1.0.0
+androidx.window.extensions.core:core:1.0.0
+androidx.window:window-core-android:1.3.0
+androidx.window:window-core:1.3.0
+androidx.window:window:1.3.0
 androidx.work:work-runtime-ktx:2.10.0
 androidx.work:work-runtime:2.10.0
 co.touchlab:stately-concurrency-jvm:2.0.6

--- a/app-thunderbird/dependencies/fullBetaRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fullBetaRuntimeClasspath.txt
@@ -28,6 +28,12 @@ androidx.compose.foundation:foundation-android:1.7.8
 androidx.compose.foundation:foundation-layout-android:1.7.8
 androidx.compose.foundation:foundation-layout:1.7.8
 androidx.compose.foundation:foundation:1.7.8
+androidx.compose.material3.adaptive:adaptive-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation:1.0.0
+androidx.compose.material3.adaptive:adaptive:1.0.0
 androidx.compose.material3:material3-android:1.3.1
 androidx.compose.material3:material3:1.3.1
 androidx.compose.material:material-icons-core-android:1.7.8
@@ -142,7 +148,10 @@ androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1
 androidx.viewpager2:viewpager2:1.1.0-beta02
 androidx.viewpager:viewpager:1.0.0
-androidx.window:window:1.0.0
+androidx.window.extensions.core:core:1.0.0
+androidx.window:window-core-android:1.3.0
+androidx.window:window-core:1.3.0
+androidx.window:window:1.3.0
 androidx.work:work-runtime-ktx:2.10.0
 androidx.work:work-runtime:2.10.0
 co.touchlab:stately-concurrency-jvm:2.0.6

--- a/app-thunderbird/dependencies/fullDailyRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fullDailyRuntimeClasspath.txt
@@ -28,6 +28,12 @@ androidx.compose.foundation:foundation-android:1.7.8
 androidx.compose.foundation:foundation-layout-android:1.7.8
 androidx.compose.foundation:foundation-layout:1.7.8
 androidx.compose.foundation:foundation:1.7.8
+androidx.compose.material3.adaptive:adaptive-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation:1.0.0
+androidx.compose.material3.adaptive:adaptive:1.0.0
 androidx.compose.material3:material3-android:1.3.1
 androidx.compose.material3:material3:1.3.1
 androidx.compose.material:material-icons-core-android:1.7.8
@@ -142,7 +148,10 @@ androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1
 androidx.viewpager2:viewpager2:1.1.0-beta02
 androidx.viewpager:viewpager:1.0.0
-androidx.window:window:1.0.0
+androidx.window.extensions.core:core:1.0.0
+androidx.window:window-core-android:1.3.0
+androidx.window:window-core:1.3.0
+androidx.window:window:1.3.0
 androidx.work:work-runtime-ktx:2.10.0
 androidx.work:work-runtime:2.10.0
 co.touchlab:stately-concurrency-jvm:2.0.6

--- a/app-thunderbird/dependencies/fullReleaseRuntimeClasspath.txt
+++ b/app-thunderbird/dependencies/fullReleaseRuntimeClasspath.txt
@@ -28,6 +28,12 @@ androidx.compose.foundation:foundation-android:1.7.8
 androidx.compose.foundation:foundation-layout-android:1.7.8
 androidx.compose.foundation:foundation-layout:1.7.8
 androidx.compose.foundation:foundation:1.7.8
+androidx.compose.material3.adaptive:adaptive-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-layout:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation-android:1.0.0
+androidx.compose.material3.adaptive:adaptive-navigation:1.0.0
+androidx.compose.material3.adaptive:adaptive:1.0.0
 androidx.compose.material3:material3-android:1.3.1
 androidx.compose.material3:material3:1.3.1
 androidx.compose.material:material-icons-core-android:1.7.8
@@ -142,7 +148,10 @@ androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1
 androidx.viewpager2:viewpager2:1.1.0-beta02
 androidx.viewpager:viewpager:1.0.0
-androidx.window:window:1.0.0
+androidx.window.extensions.core:core:1.0.0
+androidx.window:window-core-android:1.3.0
+androidx.window:window-core:1.3.0
+androidx.window:window:1.3.0
 androidx.work:work-runtime-ktx:2.10.0
 androidx.work:work-runtime:2.10.0
 co.touchlab:stately-concurrency-jvm:2.0.6

--- a/app-ui-catalog/build.gradle.kts
+++ b/app-ui-catalog/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id(ThunderbirdPlugins.App.androidCompose)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kotlin.parcelize)
 }
 
 android {

--- a/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/CatalogContent.kt
+++ b/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/CatalogContent.kt
@@ -12,6 +12,7 @@ import net.thunderbird.ui.catalog.ui.common.drawer.DrawerContent
 import net.thunderbird.ui.catalog.ui.navigation.CatalogNavHost
 import net.thunderbird.ui.catalog.ui.navigation.CatalogRoute
 
+@Suppress("LongMethod")
 @Composable
 fun CatalogContent(
     state: State,
@@ -48,6 +49,14 @@ fun CatalogContent(
                 onNavigateToOrganisms = {
                     navController.navigate(
                         route = CatalogRoute.Organism,
+                        navOptions = NavOptions.Builder()
+                            .setLaunchSingleTop(true)
+                            .build(),
+                    )
+                },
+                onNavigateToTemplates = {
+                    navController.navigate(
+                        route = CatalogRoute.Template,
                         navOptions = NavOptions.Builder()
                             .setLaunchSingleTop(true)
                             .build(),

--- a/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/common/drawer/DrawerContent.kt
+++ b/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/common/drawer/DrawerContent.kt
@@ -25,6 +25,7 @@ fun DrawerContent(
     onNavigateToAtoms: () -> Unit,
     onNavigateToMolecules: () -> Unit,
     onNavigateToOrganisms: () -> Unit,
+    onNavigateToTemplates: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ModalDrawerSheet(
@@ -55,6 +56,14 @@ fun DrawerContent(
             onClick = {
                 closeDrawer()
                 onNavigateToOrganisms()
+            },
+        )
+        NavigationDrawerItem(
+            label = "Templates",
+            selected = false,
+            onClick = {
+                closeDrawer()
+                onNavigateToTemplates()
             },
         )
 

--- a/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/navigation/DefaultCatalogNavigation.kt
+++ b/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/navigation/DefaultCatalogNavigation.kt
@@ -5,6 +5,7 @@ import app.k9mail.core.ui.compose.navigation.deepLinkComposable
 import net.thunderbird.ui.catalog.ui.atom.CatalogAtomScreen
 import net.thunderbird.ui.catalog.ui.molecule.CatalogMoleculeScreen
 import net.thunderbird.ui.catalog.ui.organism.CatalogOrganismScreen
+import net.thunderbird.ui.catalog.ui.template.CatalogTemplateScreen
 
 class DefaultCatalogNavigation : CatalogNavigation {
 
@@ -30,6 +31,12 @@ class DefaultCatalogNavigation : CatalogNavigation {
                 basePath = CatalogRoute.Organism.BASE_PATH,
             ) { backStackEntry ->
                 CatalogOrganismScreen()
+            }
+
+            deepLinkComposable<CatalogRoute.Template>(
+                basePath = CatalogRoute.Template.BASE_PATH,
+            ) { backStackEntry ->
+                CatalogTemplateScreen()
             }
         }
     }

--- a/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/template/CatalogTemplateContent.kt
+++ b/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/template/CatalogTemplateContent.kt
@@ -1,0 +1,27 @@
+package net.thunderbird.ui.catalog.ui.template
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import kotlinx.collections.immutable.ImmutableList
+import net.thunderbird.ui.catalog.ui.common.PagedContent
+import net.thunderbird.ui.catalog.ui.template.CatalogTemplatePage.LAYOUT
+import net.thunderbird.ui.catalog.ui.template.items.layoutItems
+
+@Composable
+fun CatalogTemplateContent(
+    pages: ImmutableList<CatalogTemplatePage>,
+    initialPage: CatalogTemplatePage,
+    modifier: Modifier = Modifier,
+) {
+    PagedContent(
+        pages = pages,
+        initialPage = initialPage,
+        modifier = modifier,
+        onRenderPage = {
+            when (it) {
+                LAYOUT -> layoutItems()
+            }
+        },
+        onRenderFullScreenPage = {},
+    )
+}

--- a/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/template/CatalogTemplatePage.kt
+++ b/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/template/CatalogTemplatePage.kt
@@ -1,0 +1,20 @@
+package net.thunderbird.ui.catalog.ui.template
+
+import kotlinx.collections.immutable.toImmutableList
+import net.thunderbird.ui.catalog.ui.CatalogPage
+
+enum class CatalogTemplatePage(
+    override val displayName: String,
+    override val isFullScreen: Boolean = false,
+) : CatalogPage {
+    LAYOUT("Layouts"),
+    ;
+
+    override fun toString(): String {
+        return displayName
+    }
+
+    companion object {
+        fun all() = entries.toImmutableList()
+    }
+}

--- a/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/template/CatalogTemplateScreen.kt
+++ b/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/template/CatalogTemplateScreen.kt
@@ -1,0 +1,15 @@
+package net.thunderbird.ui.catalog.ui.template
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun CatalogTemplateScreen(
+    modifier: Modifier = Modifier,
+) {
+    CatalogTemplateContent(
+        pages = CatalogTemplatePage.Companion.all(),
+        initialPage = CatalogTemplatePage.LAYOUT,
+        modifier = modifier,
+    )
+}

--- a/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/template/items/LayoutItems.kt
+++ b/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/template/items/LayoutItems.kt
@@ -1,0 +1,135 @@
+package net.thunderbird.ui.catalog.ui.template.items
+
+import android.os.Parcelable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
+import app.k9mail.core.ui.compose.designsystem.template.ListDetailPane
+import app.k9mail.core.ui.compose.designsystem.template.rememberListDetailNavigationController
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import kotlinx.parcelize.Parcelize
+import net.thunderbird.ui.catalog.ui.common.list.defaultItem
+import net.thunderbird.ui.catalog.ui.common.list.sectionHeaderItem
+
+fun LazyGridScope.layoutItems() {
+    sectionHeaderItem(text = "ListDetailPane")
+    defaultItem {
+        ListDetailPaneItem()
+    }
+}
+
+@Composable
+private fun ListDetailPaneItem() {
+    val navigationController = rememberListDetailNavigationController<ListItem>()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(MainTheme.sizes.huger)
+            .padding(MainTheme.spacings.double),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        ListDetailPane(
+            navigationController = navigationController,
+            listPane = {
+                Surface(
+                    color = MainTheme.colors.primaryContainer,
+                ) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.double),
+                    ) {
+                        TextTitleMedium("List pane")
+                        LazyColumn(
+                            verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
+                        ) {
+                            itemsIndexed(createItems()) { index, item ->
+                                ListItem(
+                                    item = item,
+                                    onClick = {
+                                        navigationController.value.navigateToDetail(item)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            detailPane = { item ->
+                Surface(
+                    color = MainTheme.colors.secondaryContainer,
+                ) {
+                    ListDetail(
+                        item = item,
+                        onClick = { navigationController.value.navigateBack() },
+                    )
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ListItem(
+    item: ListItem,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.clickable(onClick = onClick)
+            .fillMaxWidth()
+            .padding(MainTheme.spacings.default),
+    ) {
+        TextBodyLarge(item.title)
+    }
+}
+
+@Composable
+private fun ListDetail(
+    item: ListItem,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.clickable(onClick = onClick)
+            .fillMaxWidth()
+            .padding(MainTheme.spacings.default),
+    ) {
+        TextTitleMedium("Detail pane")
+        Spacer(modifier = Modifier.height(MainTheme.spacings.default))
+        TextBodyLarge(item.title)
+    }
+}
+
+@Parcelize
+internal data class ListItem(
+    val id: String,
+    val title: String,
+) : Parcelable
+
+private fun createItems(): List<ListItem> {
+    return listOf(
+        ListItem(
+            id = "1",
+            title = "Item 1",
+        ),
+        ListItem(
+            id = "2",
+            title = "Item 2",
+        ),
+        ListItem(
+            id = "3",
+            title = "Item 3",
+        ),
+    )
+}

--- a/core/ui/compose/designsystem/build.gradle.kts
+++ b/core/ui/compose/designsystem/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id(ThunderbirdPlugins.Library.androidCompose)
+    alias(libs.plugins.kotlin.parcelize)
 }
 
 android {
@@ -14,6 +15,9 @@ dependencies {
     debugApi(projects.core.ui.compose.theme2.thunderbird)
 
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material3.adaptive)
+    implementation(libs.androidx.compose.material3.adaptive.layout)
+    implementation(libs.androidx.compose.material3.adaptive.navigation)
     implementation(libs.androidx.compose.material.icons.extended)
 
     // Landscapist imports a lot of dependencies that we don't need. We exclude them here.

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/template/ListDetailPanePreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/template/ListDetailPanePreview.kt
@@ -1,0 +1,93 @@
+package app.k9mail.core.ui.compose.designsystem.template
+
+import android.os.Parcelable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
+import kotlinx.parcelize.Parcelize
+
+@Composable
+@PreviewDevices
+internal fun ListDetailPanePreview() {
+    PreviewWithTheme {
+        val navigationController = rememberListDetailNavigationController<ListItem>()
+
+        ListDetailPane(
+            navigationController = navigationController,
+            listPane = {
+                Surface(
+                    color = Color.Yellow,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    LazyColumn {
+                        itemsIndexed(createItems()) { index, item ->
+                            ListItem(
+                                item = item,
+                                onClick = {
+                                    navigationController.value.navigateToDetail(item)
+                                },
+                            )
+                        }
+                    }
+                }
+            },
+            detailPane = { item ->
+                Surface(
+                    color = Color.Red,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    ListItem(
+                        item = item,
+                        onClick = { navigationController.value.navigateBack() },
+                    )
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ListItem(
+    item: ListItem,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.clickable(onClick = onClick),
+    ) {
+        TextTitleMedium(item.id)
+        TextBodyMedium(item.title)
+    }
+}
+
+@Parcelize
+internal data class ListItem(
+    val id: String,
+    val title: String,
+) : Parcelable
+
+private fun createItems(): List<ListItem> {
+    return listOf(
+        ListItem(
+            id = "1",
+            title = "Item 1",
+        ),
+        ListItem(
+            id = "2",
+            title = "Item 2",
+        ),
+        ListItem(
+            id = "3",
+            title = "Item 3",
+        ),
+    )
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerHeadline.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerHeadline.kt
@@ -17,6 +17,7 @@ fun NavigationDrawerHeadline(
     ) {
         TextTitleSmall(
             text = title,
+            color = MainTheme.colors.primary,
             modifier = Modifier
                 .padding(NavigationDrawerItemDefaults.ItemPadding)
                 .padding(

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ListDetailPane.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ListDetailPane.kt
@@ -1,0 +1,115 @@
+package app.k9mail.core.ui.compose.designsystem.template
+
+import android.os.Parcelable
+import androidx.activity.compose.BackHandler
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
+import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+/**
+ * A list and detail pane layout that can be used to display a list of items and a detail view.
+ *
+ * @param navigationController A [ListDetailNavigationController] that can be used to navigate between list
+ *                             and detail panes.
+ * @param listPane A composable that displays the list of items.
+ * @param detailPane A composable that displays the detail view of an item.
+ * @param modifier The modifier to apply to this layout.
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+fun <T : Parcelable> ListDetailPane(
+    navigationController: MutableState<ListDetailNavigationController<T>>,
+    listPane: @Composable () -> Unit,
+    detailPane: @Composable (T) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val navigator = rememberListDetailPaneScaffoldNavigator<T>()
+
+    LaunchedEffect(navigator) {
+        navigationController.value = DefaultListDetailNavigationController(
+            navigator = navigator,
+        )
+    }
+
+    BackHandler(navigator.canNavigateBack()) {
+        navigator.navigateBack()
+    }
+
+    ListDetailPaneScaffold(
+        directive = navigator.scaffoldDirective,
+        value = navigator.scaffoldValue,
+        listPane = {
+            AnimatedPane {
+                listPane()
+            }
+        },
+        detailPane = {
+            navigator.currentDestination?.content?.let { item ->
+                AnimatedPane {
+                    detailPane(item)
+                }
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+/**
+ * Creates a [ListDetailNavigationController] that can be used to navigate between list and
+ * detail panes in a [ListDetailPane].
+ */
+@Composable
+fun <T : Parcelable> rememberListDetailNavigationController(): MutableState<ListDetailNavigationController<T>> {
+    val defaultController = remember { NoOpListDetailNavigationController<T>() }
+    return remember { mutableStateOf(defaultController) }
+}
+
+/**
+ * A controller that can be used to navigate between list and detail panes in a [ListDetailPane].
+ *
+ * It is recommended to use [rememberListDetailNavigationController] to create an instance of this controller.
+ *
+ * @see rememberListDetailNavigationController
+ */
+interface ListDetailNavigationController<T : Parcelable> {
+    fun canNavigateBack(): Boolean
+    fun navigateBack(): Boolean
+    fun navigateToDetail(item: T)
+
+    fun paneCount(): Int
+}
+
+/**
+ * A [ListDetailNavigationController] that does nothing.
+ */
+internal class NoOpListDetailNavigationController<T : Parcelable> : ListDetailNavigationController<T> {
+    override fun canNavigateBack() = false
+    override fun navigateBack() = false
+    override fun navigateToDetail(item: T) = Unit
+
+    override fun paneCount() = 1
+}
+
+/**
+ * A [ListDetailNavigationController] that wrappes a [ThreePaneScaffoldNavigator] to navigate
+ * between list and detail panes.
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+internal class DefaultListDetailNavigationController<T : Parcelable>(
+    private val navigator: ThreePaneScaffoldNavigator<T>,
+) : ListDetailNavigationController<T> {
+    override fun canNavigateBack() = navigator.canNavigateBack()
+    override fun navigateBack() = navigator.navigateBack()
+    override fun navigateToDetail(item: T) = navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, item)
+
+    override fun paneCount(): Int = navigator.scaffoldDirective.maxHorizontalPartitions
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -137,6 +137,9 @@ androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = 
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive" }
+androidx-compose-material3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout" }
+androidx-compose-material3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation" }
 androidx-compose-material3-windowSizeClass = { module = "androidx.compose.material3:material3-window-size-class" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }


### PR DESCRIPTION
This introduces a new ListDetailPane template to our design system, leveraging the capabilities of Compose Material 3's Adaptive Layouts feature. For more information, see [Compose Material 3 - Adaptive Layouts](https://developer.android.com/jetpack/androidx/releases/compose-material3-adaptive) and [About adaptive layouts](https://developer.android.com/develop/ui/compose/layouts/adaptive).

Preparation for [#8923](https://github.com/thunderbird/thunderbird-android/issues/8923)

Depends on #8973
