### PR TITLE
Add preference UI with text entry support

### DIFF
--- a/core/ui/compose/preference/build.gradle.kts
+++ b/core/ui/compose/preference/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+    alias(libs.plugins.kotlin.parcelize)
+}
+
+android {
+    namespace = "net.thunderbird.core.ui.compose.preference"
+    resourcePrefix = "core_ui_preference_"
+}
+
+dependencies {
+    implementation(projects.core.ui.compose.designsystem)
+
+    testImplementation(projects.core.ui.compose.testing)
+}

--- a/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewPreview.kt
+++ b/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewPreview.kt
@@ -3,7 +3,7 @@ package net.thunderbird.core.ui.compose.preference.ui
 import androidx.compose.runtime.Composable
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevicesWithBackground
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
-import kotlinx.collections.immutable.persistentListOf
+import net.thunderbird.core.ui.compose.preference.ui.fake.FakePreferenceData
 
 @Composable
 @PreviewDevicesWithBackground
@@ -12,7 +12,7 @@ fun PreferenceViewPreview() {
         PreferenceView(
             title = "Title",
             subtitle = "Subtitle",
-            preferences = persistentListOf(),
+            preferences = FakePreferenceData.preferences,
             onPreferenceChange = {},
             onBack = {},
         )

--- a/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewPreview.kt
+++ b/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewPreview.kt
@@ -1,0 +1,20 @@
+package net.thunderbird.core.ui.compose.preference.ui
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.common.annotation.PreviewDevicesWithBackground
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+@PreviewDevicesWithBackground
+fun PreferenceViewPreview() {
+    PreviewWithTheme {
+        PreferenceView(
+            title = "Title",
+            subtitle = "Subtitle",
+            preferences = persistentListOf(),
+            onPreferenceChange = {},
+            onBack = {},
+        )
+    }
+}

--- a/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/PreferenceTopBarPreview.kt
+++ b/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/PreferenceTopBarPreview.kt
@@ -1,0 +1,29 @@
+package net.thunderbird.core.ui.compose.preference.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
+
+@Composable
+@Preview(showBackground = true)
+internal fun PreferenceTopBarPreview() {
+    PreviewWithThemes {
+        PreferenceTopBar(
+            title = "Title",
+            subtitle = null,
+            onBack = {},
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun PreferenceTopBarWithSubtitlePreview() {
+    PreviewWithThemes {
+        PreferenceTopBar(
+            title = "Title",
+            subtitle = "Subtitle",
+            onBack = {},
+        )
+    }
+}

--- a/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialogLayoutPreview.kt
+++ b/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialogLayoutPreview.kt
@@ -1,0 +1,22 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+
+@Composable
+@Preview(showBackground = true)
+internal fun PreferenceDialogLayoutPreview() {
+    PreviewWithTheme {
+        PreferenceDialogLayout(
+            title = "Dialog",
+            icon = null,
+            onConfirmClick = {},
+            onDismissClick = {},
+            onDismissRequest = {},
+        ) {
+            TextBodyMedium("PreferenceDialogLayoutContent")
+        }
+    }
+}

--- a/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialogTextViewPreview.kt
+++ b/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialogTextViewPreview.kt
@@ -1,0 +1,19 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+import net.thunderbird.core.ui.compose.preference.ui.fake.FakePreferenceData
+
+@Composable
+@Preview(showBackground = true)
+internal fun PreferenceDialogTextViewPreview() {
+    PreviewWithTheme {
+        PreferenceDialogTextView(
+            preference = FakePreferenceData.textPreference,
+            onConfirmClick = {},
+            onDismissClick = {},
+            onDismissRequest = {},
+        )
+    }
+}

--- a/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItemLayoutPreview.kt
+++ b/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItemLayoutPreview.kt
@@ -1,0 +1,37 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.list
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
+
+@Composable
+@Preview(showBackground = true)
+internal fun PreferenceItemLayoutPreview() {
+    PreviewWithThemes {
+        PreferenceItemLayout(
+            onClick = {},
+            icon = null,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            TextTitleLarge(text = "PreferenceItemLayoutContent")
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun PreferenceItemLayoutWithIconPreview() {
+    PreviewWithThemes {
+        PreferenceItemLayout(
+            onClick = {},
+            icon = Icons.Outlined.Info,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            TextTitleLarge(text = "PreferenceItemLayoutContent")
+        }
+    }
+}

--- a/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItemTextViewPreview.kt
+++ b/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItemTextViewPreview.kt
@@ -1,0 +1,17 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.list
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
+import net.thunderbird.core.ui.compose.preference.ui.fake.FakePreferenceData
+
+@Composable
+@Preview(showBackground = true)
+internal fun PreferenceItemTextViewPreview() {
+    PreviewWithThemes {
+        PreferenceItemTextView(
+            preference = FakePreferenceData.textPreference,
+            onClick = {},
+        )
+    }
+}

--- a/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/fake/FakePreferenceData.kt
+++ b/core/ui/compose/preference/src/debug/kotlin/net/thunderbird/core/ui/compose/preference/ui/fake/FakePreferenceData.kt
@@ -1,0 +1,20 @@
+package net.thunderbird.core.ui.compose.preference.ui.fake
+
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import kotlinx.collections.immutable.persistentListOf
+import net.thunderbird.core.ui.compose.preference.api.PreferenceSetting
+
+object FakePreferenceData {
+
+    val textPreference = PreferenceSetting.Text(
+        id = "text",
+        icon = Icons.Outlined.Delete,
+        title = "Title",
+        description = "Description",
+        value = "Value",
+    )
+
+    val preferences = persistentListOf(
+        textPreference,
+    )
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/api/Preference.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/api/Preference.kt
@@ -1,0 +1,33 @@
+package net.thunderbird.core.ui.compose.preference.api
+
+import android.os.Parcelable
+import androidx.compose.ui.graphics.vector.ImageVector
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
+
+/**
+ * A preference that can be displayed in a preference screen.
+ */
+sealed interface Preference : Parcelable
+
+/**
+ * A preference that holds a value of type [T].
+ */
+sealed interface PreferenceSetting<T> : Preference {
+    val id: String
+    val value: T
+    val requiresEditView: Boolean
+
+    @Parcelize
+    data class Text(
+        override val id: String,
+        val title: String,
+        val description: String? = null,
+        val icon: @RawValue ImageVector? = null,
+        override val value: String,
+    ) : PreferenceSetting<String> {
+        @IgnoredOnParcel
+        override val requiresEditView: Boolean = true
+    }
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceView.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceView.kt
@@ -33,3 +33,4 @@ fun PreferenceView(
         onBack = onBack,
         modifier = modifier,
     )
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceView.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceView.kt
@@ -1,0 +1,35 @@
+package net.thunderbird.core.ui.compose.preference.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import kotlinx.collections.immutable.ImmutableList
+import net.thunderbird.core.ui.compose.preference.api.Preference
+import net.thunderbird.core.ui.compose.preference.api.PreferenceSetting
+
+/**
+ * A view that displays a list of preferences.
+ *
+ * @param title The title of the view.
+ * @param subtitle The subtitle of the view (optional).
+ * @param preferences The list of preferences to display.
+ * @param onPreferenceChange The callback to be invoked when a preference is changed.
+ * @param onBack The callback to be invoked when the back button is clicked.
+ * @param modifier The modifier to be applied to the view.
+ */
+@Composable
+fun PreferenceView(
+    title: String,
+    preferences: ImmutableList<Preference>,
+    onPreferenceChange: (PreferenceSetting<*>) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+) {
+    PreferenceViewWithDialog(
+        title = title,
+        subtitle = subtitle,
+        preferences = preferences,
+        onPreferenceChange = onPreferenceChange,
+        onBack = onBack,
+        modifier = modifier,
+    )

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
@@ -56,11 +56,11 @@ internal fun PreferenceViewWithDialog(
 
         PreferenceDialog(
             preference = preference,
-            onConfirm = { preference ->
+            onConfirmClick = { preference ->
                 onPreferenceChange(preference)
                 showDialog = false
             },
-            onDismiss = { showDialog = false },
+            onDismissClick = { showDialog = false },
             onDismissRequest = { showDialog = false },
         )
     }

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
@@ -1,0 +1,67 @@
+package net.thunderbird.core.ui.compose.preference.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
+import app.k9mail.core.ui.compose.designsystem.template.Scaffold
+import kotlinx.collections.immutable.ImmutableList
+import net.thunderbird.core.ui.compose.preference.api.Preference
+import net.thunderbird.core.ui.compose.preference.api.PreferenceSetting
+import net.thunderbird.core.ui.compose.preference.ui.components.PreferenceTopBar
+import net.thunderbird.core.ui.compose.preference.ui.components.dialog.PreferenceDialog
+import net.thunderbird.core.ui.compose.preference.ui.components.list.PreferenceList
+
+@Composable
+internal fun PreferenceViewWithDialog(
+    title: String,
+    preferences: ImmutableList<Preference>,
+    onPreferenceChange: (PreferenceSetting<*>) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+) {
+    var showDialog by remember { mutableStateOf(false) }
+    var selectedIndex by remember(0) { mutableIntStateOf(0) }
+
+    Scaffold(
+        topBar = {
+            PreferenceTopBar(
+                title = title,
+                subtitle = subtitle,
+                onBack = onBack,
+            )
+        },
+        modifier = modifier,
+    ) { innerPadding ->
+        ResponsiveWidthContainer {
+            PreferenceList(
+                preferences = preferences,
+                onItemClick = { index, _ ->
+                    selectedIndex = index
+                    showDialog = true
+                },
+                modifier = Modifier.padding(innerPadding),
+            )
+        }
+    }
+
+    if (showDialog) {
+        val preference = preferences[selectedIndex]
+
+        PreferenceDialog(
+            preference = preference,
+            onConfirm = { preference ->
+                onPreferenceChange(preference)
+                showDialog = false
+            },
+            onDismiss = { showDialog = false },
+            onDismissRequest = { showDialog = false },
+        )
+    }
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.designsystem.template.ResponsiveWidthContainer
@@ -26,8 +26,8 @@ internal fun PreferenceViewWithDialog(
     modifier: Modifier = Modifier,
     subtitle: String? = null,
 ) {
-    var showDialog by remember { mutableStateOf(false) }
-    var selectedIndex by remember(0) { mutableIntStateOf(0) }
+    var showDialog by rememberSaveable { mutableStateOf(false) }
+    var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
 
     Scaffold(
         topBar = {

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/PreferenceTopBar.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/PreferenceTopBar.kt
@@ -1,0 +1,25 @@
+package net.thunderbird.core.ui.compose.preference.ui.components
+
+import androidx.compose.runtime.Composable
+import app.k9mail.core.ui.compose.designsystem.organism.SubtitleTopAppBarWithBackButton
+import app.k9mail.core.ui.compose.designsystem.organism.TopAppBarWithBackButton
+
+@Composable
+internal fun PreferenceTopBar(
+    title: String,
+    subtitle: String?,
+    onBack: () -> Unit,
+) {
+    if (subtitle != null) {
+        SubtitleTopAppBarWithBackButton(
+            title = title,
+            subtitle = subtitle,
+            onBackClick = onBack,
+        )
+    } else {
+        TopAppBarWithBackButton(
+            title = title,
+            onBackClick = onBack,
+        )
+    }
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialog.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialog.kt
@@ -8,8 +8,8 @@ import net.thunderbird.core.ui.compose.preference.api.PreferenceSetting
 @Composable
 internal fun PreferenceDialog(
     preference: Preference,
-    onConfirm: (PreferenceSetting<*>) -> Unit,
-    onDismiss: () -> Unit,
+    onConfirmClick: (PreferenceSetting<*>) -> Unit,
+    onDismissClick: () -> Unit,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -17,7 +17,5 @@ internal fun PreferenceDialog(
         "Unsupported preference type: ${preference::class.java.simpleName}"
     }
 
-    when (preference) {
-        // add dialogs
-    }
+    // add dialogs
 }

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialog.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialog.kt
@@ -17,5 +17,15 @@ internal fun PreferenceDialog(
         "Unsupported preference type: ${preference::class.java.simpleName}"
     }
 
-    // add dialogs
+    when (preference) {
+        is PreferenceSetting.Text -> {
+            PreferenceDialogTextView(
+                preference = preference,
+                onConfirmClick = onConfirmClick,
+                onDismissClick = onDismissClick,
+                onDismissRequest = onDismissRequest,
+                modifier = modifier,
+            )
+        }
+    }
 }

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialog.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialog.kt
@@ -1,0 +1,23 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import net.thunderbird.core.ui.compose.preference.api.Preference
+import net.thunderbird.core.ui.compose.preference.api.PreferenceSetting
+
+@Composable
+internal fun PreferenceDialog(
+    preference: Preference,
+    onConfirm: (PreferenceSetting<*>) -> Unit,
+    onDismiss: () -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    require(preference is PreferenceSetting<*>) {
+        "Unsupported preference type: ${preference::class.java.simpleName}"
+    }
+
+    when (preference) {
+        // add dialogs
+    }
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialogLayout.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialogLayout.kt
@@ -1,0 +1,42 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.dialog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.designsystem.organism.AlertDialog
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.core.ui.compose.preference.R
+
+@Composable
+internal fun PreferenceDialogLayout(
+    title: String,
+    icon: ImageVector?,
+    onConfirmClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    AlertDialog(
+        title = title,
+        icon = icon,
+        confirmText = stringResource(id = R.string.core_ui_preference_dialog_button_accept),
+        onConfirmClick = onConfirmClick,
+        dismissText = stringResource(id = R.string.core_ui_preference_dialog_button_cancel),
+        onDismissClick = onDismissClick,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            content()
+        }
+    }
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialogTextView.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/dialog/PreferenceDialogTextView.kt
@@ -1,0 +1,47 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.dialog
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.core.ui.compose.preference.api.PreferenceSetting
+
+@Composable
+internal fun PreferenceDialogTextView(
+    preference: PreferenceSetting.Text,
+    onConfirmClick: (PreferenceSetting<*>) -> Unit,
+    onDismissClick: () -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val currentPreference = remember { mutableStateOf(preference) }
+
+    PreferenceDialogLayout(
+        title = preference.title,
+        icon = preference.icon,
+        onConfirmClick = {
+            onConfirmClick(currentPreference.value)
+        },
+        onDismissClick = onDismissClick,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        preference.description?.let {
+            TextBodyMedium(text = it)
+
+            Spacer(modifier = Modifier.height(MainTheme.spacings.default))
+        }
+
+        TextInput(
+            text = currentPreference.value.value,
+            contentPadding = PaddingValues(),
+            onTextChange = { currentPreference.value = currentPreference.value.copy(value = it) },
+        )
+    }
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItem.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItem.kt
@@ -12,6 +12,12 @@ internal fun PreferenceItem(
     modifier: Modifier = Modifier,
 ) {
     when (preference) {
-        // add items
+        is PreferenceSetting.Text -> {
+            PreferenceItemTextView(
+                preference = preference,
+                onClick = onClick,
+                modifier = modifier,
+            )
+        }
     }
 }

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItem.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItem.kt
@@ -1,0 +1,17 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.list
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import net.thunderbird.core.ui.compose.preference.api.Preference
+import net.thunderbird.core.ui.compose.preference.api.PreferenceSetting
+
+@Composable
+internal fun PreferenceItem(
+    preference: Preference,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (preference) {
+        // add items
+    }
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItemLayout.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItemLayout.kt
@@ -1,0 +1,49 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.list
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+@Composable
+internal fun PreferenceItemLayout(
+    onClick: () -> Unit,
+    icon: ImageVector?,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            icon?.let {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.padding(MainTheme.spacings.double),
+                ) {
+                    Icon(
+                        imageVector = it,
+                    )
+                }
+            }
+            Column(
+                modifier = Modifier.padding(MainTheme.spacings.double),
+                verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+            ) {
+                content()
+            }
+        }
+    }
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItemTextView.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceItemTextView.kt
@@ -1,0 +1,23 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.list
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
+import net.thunderbird.core.ui.compose.preference.api.PreferenceSetting
+
+@Composable
+internal fun PreferenceItemTextView(
+    preference: PreferenceSetting.Text,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    PreferenceItemLayout(
+        onClick = onClick,
+        icon = preference.icon,
+        modifier = modifier,
+    ) {
+        TextTitleMedium(text = preference.title)
+        TextBodyMedium(text = preference.value)
+    }
+}

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceList.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/components/list/PreferenceList.kt
@@ -1,0 +1,30 @@
+package net.thunderbird.core.ui.compose.preference.ui.components.list
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import kotlinx.collections.immutable.ImmutableList
+import net.thunderbird.core.ui.compose.preference.api.Preference
+
+@Composable
+internal fun PreferenceList(
+    preferences: ImmutableList<Preference>,
+    onItemClick: (index: Int, item: Preference) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+    ) {
+        itemsIndexed(preferences) { index, item ->
+            PreferenceItem(
+                preference = item,
+                onClick = {
+                    onItemClick(index, item)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/core/ui/compose/preference/src/main/res/values/strings.xml
+++ b/core/ui/compose/preference/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="core_ui_preference_dialog_button_accept">Accept</string>
+    <string name="core_ui_preference_dialog_button_cancel">Cancel</string>
+</resources>

--- a/feature/account/settings/impl/build.gradle.kts
+++ b/feature/account/settings/impl/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
     implementation(projects.core.ui.compose.designsystem)
     implementation(projects.core.ui.compose.navigation)
+    implementation(projects.core.ui.compose.preference)
 
     testImplementation(projects.core.ui.compose.testing)
 }

--- a/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/ui/AccountSettingsScreen.kt
+++ b/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/ui/AccountSettingsScreen.kt
@@ -1,13 +1,15 @@
 package net.thunderbird.feature.account.settings.impl.ui
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
-import app.k9mail.core.ui.compose.designsystem.organism.SubtitleTopAppBarWithBackButton
-import app.k9mail.core.ui.compose.designsystem.template.Scaffold
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import kotlinx.collections.immutable.toImmutableList
+import net.thunderbird.core.ui.compose.preference.api.Preference
+import net.thunderbird.core.ui.compose.preference.api.PreferenceSetting
+import net.thunderbird.core.ui.compose.preference.ui.PreferenceView
 
 @Composable
 fun AccountSettingsScreen(
@@ -15,22 +17,60 @@ fun AccountSettingsScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val preferences = remember {
+        mutableStateOf(
+            listOf<Preference>(
+                PreferenceSetting.Text(
+                    id = "1",
+                    title = "Title 1",
+                    description = "Description 1",
+                    icon = Icons.Outlined.Delete,
+                    value = "Value 1",
+                ),
+                PreferenceSetting.Text(
+                    id = "2",
+                    title = "Title 2",
+                    description = "Description 2",
+                    icon = Icons.Outlined.Delete,
+                    value = "Value 2",
+                ),
+                PreferenceSetting.Text(
+                    id = "3",
+                    title = "Title 3",
+                    description = "Description 3",
+                    icon = Icons.Outlined.Folder,
+                    value = "Value 3",
+                ),
+            ),
+        )
+    }
+
     BackHandler(onBack = onBack)
 
-    Scaffold(
-        topBar = {
-            SubtitleTopAppBarWithBackButton(
-                title = "Account settings",
-                subtitle = accountId,
-                onBackClick = onBack,
+    PreferenceView(
+        title = "Account settings",
+        subtitle = accountId,
+        preferences = preferences.value.toImmutableList(),
+        onPreferenceChange = { preference ->
+            preferences.value = updatePreference(
+                preferences = preferences.value,
+                preference = preference,
             )
         },
+        onBack = onBack,
         modifier = modifier,
-    ) { innerPadding ->
-        Column(
-            modifier = Modifier.padding(innerPadding),
-        ) {
-            TextBodyLarge(text = "accountId: $accountId")
+    )
+}
+
+private fun updatePreference(
+    preferences: List<Preference>,
+    preference: PreferenceSetting<*>,
+): List<Preference> {
+    return preferences.map {
+        if (it is PreferenceSetting<*> && it.id == preference.id) {
+            preference
+        } else {
+            it
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -134,6 +134,7 @@ include(
     ":core:ui:compose:common",
     ":core:ui:compose:designsystem",
     ":core:ui:compose:navigation",
+    ":core:ui:compose:preference",
     ":core:ui:compose:theme2:common",
     ":core:ui:compose:theme2:k9mail",
     ":core:ui:compose:theme2:thunderbird",


### PR DESCRIPTION
This establishes a new ui system for preferences based on Jetpack Compose. It adds support for text entries that could be edited in a pop up dialog.

Preparation for #8923
