### PR TITLE
Change app common to thunderbird

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -2,11 +2,14 @@ plugins {
     id(ThunderbirdPlugins.Library.android)
 }
 
-dependencies {
-    api(projects.legacy.common)
-    implementation(projects.feature.migration.provider)
+android {
+    namespace = "net.thunderbird.app.common"
 }
 
-android {
-    namespace = "app.k9mail.common"
+dependencies {
+    api(projects.legacy.common)
+
+    implementation(projects.legacy.account)
+
+    implementation(projects.feature.migration.provider)
 }

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/AppCommonModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/AppCommonModule.kt
@@ -1,0 +1,8 @@
+package net.thunderbird.app.common
+
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val appCommonModule: Module = module {
+    // add common dependencies here
+}

--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -21,12 +21,14 @@ import com.fsck.k9.preferences.FilePrefixProvider
 import com.fsck.k9.provider.K9ThemeProvider
 import com.fsck.k9.provider.UnreadWidgetProvider
 import com.fsck.k9.widget.list.MessageListWidgetProvider
+import net.thunderbird.app.common.appCommonModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
 import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val appModule = module {
+    includes(appCommonModule)
     includes(appWidgetModule)
     includes(featureModule)
 

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdKoinModule.kt
@@ -20,12 +20,14 @@ import net.thunderbird.android.provider.TbThemeProvider
 import net.thunderbird.android.widget.appWidgetModule
 import net.thunderbird.android.widget.provider.MessageListWidgetProvider
 import net.thunderbird.android.widget.provider.UnreadWidgetProvider
+import net.thunderbird.app.common.appCommonModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
 import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val appModule = module {
+    includes(appCommonModule)
     includes(appWidgetModule)
     includes(featureModule)
 


### PR DESCRIPTION
This is the new home for shared functionality between TfA and K9.

We should move code from `:legacy:common` here in the future.
