### PR TITLE
Change AutoDiscoveryResultView click behaviour

### DIFF
--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultView.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultView.kt
@@ -43,8 +43,15 @@ internal fun AutoDiscoveryResultView(
                     width = 1.dp,
                     color = Color.Gray.copy(alpha = 0.5f),
                     shape = MainTheme.shapes.small,
-                )
-                .clickable(enabled = discoveryResultHeaderState.isExpandable) { expanded.value = !expanded.value },
+                ).let {
+                    if (discoveryResultHeaderState.isExpandable) {
+                        it.clickable(enabled = true) { expanded.value = !expanded.value }
+                    } else if (discoveryResultHeaderState == AutoDiscoveryResultHeaderState.NoSettings) {
+                        it.clickable(enabled = true) { onEditConfigurationClick() }
+                    } else {
+                        it.clickable(enabled = false) {}
+                    }
+                },
         ) {
             Column(
                 modifier = Modifier.padding(MainTheme.spacings.default),


### PR DESCRIPTION
Change `AutoDiscoveryResultView` to open edit manually when no settings found.

Fixes [#8980](https://github.com/thunderbird/thunderbird-android/issues/8980)
