### PR TITLE
Message compose: support completion of list of recipients

### DIFF
--- a/library/TokenAutoComplete/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/TokenAutoComplete/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -145,7 +145,8 @@ public abstract class TokenCompleteTextView<T> extends AppCompatAutoCompleteText
                 }
 
                 //Detect split characters, remove them and complete the current token instead
-                if (tokenizer.containsTokenTerminator(source)) {
+                // We only want to handle the case where the user inputs a single split character here
+                if (source.length() == 1 && tokenizer.containsTokenTerminator(source)) {
                     performCompletion();
                     return "";
                 }
@@ -392,16 +393,10 @@ public abstract class TokenCompleteTextView<T> extends AppCompatAutoCompleteText
                 candidateStringEnd = spanStart;
             }
         }
-
-        List<Range> tokenRanges = tokenizer.findTokenRanges(editable, candidateStringStart, candidateStringEnd);
-
-        for (Range range: tokenRanges) {
-            if (range.start <= cursorEndPosition && cursorEndPosition <= range.end) {
-                return range;
-            }
+        if (candidateStringEnd < candidateStringStart) {
+            return new Range(cursorEndPosition, cursorEndPosition);
         }
-
-        return new Range(cursorEndPosition, cursorEndPosition);
+        return new Range(candidateStringStart, candidateStringEnd);
     }
 
     /**


### PR DESCRIPTION
Thank you for creating a wonderful piece of software!
This fixes #5199, which I chose to implement because it was tagged "good first issue".

This PR adds support to the message compose screen for completing entire lists of recipient addresses, rather than just a single address. This way, the user can paste in comma/semicolon delimited address lists. It uses the existing functionality of parsing lists of addresses.

The other way of implementing the feature of pasting in lists of addresses is overriding the paste behavior for the input, and then virtually inserting the pasted characters one by one. However, I considered this method pretty hacky, and I also wanted to use the existing support for parsing lists of addresses.

Unfortunately, this could not be implemented in Kotlin as I was not in the mood to refactor ~2000 lines of Java.

[android_thunderbird_compose_paste_list_demo.webm](https://github.com/user-attachments/assets/514d0110-85c4-4d82-b108-450aac96a1ad)