### PR TITLE
Fix deploy-docs job harder

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,6 +43,10 @@ jobs:
           rm book/docs/latest/.gitignore
           rm book/docs/latest/install.sh
 
+          # Restore mermaid.min.js, it has already been copied over to book/docs/latest
+          git restore .
+
+
       - name: Deploy docs to gh-pages
         run: |
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
The actual issue here was that the updated mermaid.min.js has local changes due to executing install.sh, which is a problem when switching branches. The modified version has already been copied over during the mdbook build docs step though, so we can just restore to the branch to get to a clean state.