### PR TITLE
Add unidirectional wrapper for account

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,6 +28,7 @@
       <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
           <package name="java" withSubpackages="true" static="false" />
           <emptyLine />
           <package name="android" withSubpackages="true" static="false" />

--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -9,6 +9,8 @@ android {
 dependencies {
     api(projects.legacy.common)
 
+    implementation(projects.feature.account.core)
+
     implementation(projects.legacy.core)
     implementation(projects.legacy.account)
 

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/AppCommonModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/AppCommonModule.kt
@@ -1,11 +1,32 @@
 package net.thunderbird.app.common
 
 import app.k9mail.legacy.account.AccountDefaultsProvider
+import app.k9mail.legacy.account.LegacyAccountWrapperManager
 import net.thunderbird.app.common.account.CommonAccountDefaultsProvider
+import net.thunderbird.app.common.account.data.CommonAccountProfileLocalDataSource
+import net.thunderbird.app.common.account.data.CommonLegacyAccountWrapperManager
+import net.thunderbird.feature.account.core.AccountCoreExternalContract.AccountProfileLocalDataSource
+import net.thunderbird.feature.account.core.featureAccountCoreModule
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 val appCommonModule: Module = module {
+    includes(
+        featureAccountCoreModule,
+    )
+
+    single<LegacyAccountWrapperManager> {
+        CommonLegacyAccountWrapperManager(
+            accountManager = get(),
+        )
+    }
+
+    single<AccountProfileLocalDataSource> {
+        CommonAccountProfileLocalDataSource(
+            accountManager = get(),
+        )
+    }
+
     single<AccountDefaultsProvider> {
         CommonAccountDefaultsProvider(
             resourceProvider = get(),

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/CommonAccountDefaultsProvider.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/CommonAccountDefaultsProvider.kt
@@ -2,11 +2,6 @@ package net.thunderbird.app.common.account
 
 import app.k9mail.core.featureflag.FeatureFlagProvider
 import app.k9mail.core.featureflag.toFeatureFlagKey
-import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.Expunge
-import app.k9mail.legacy.account.Account.FolderMode
-import app.k9mail.legacy.account.Account.ShowPictures
-import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import app.k9mail.legacy.account.AccountDefaultsProvider
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT
@@ -24,7 +19,12 @@ import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_STRIP
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_SYNC_INTERVAL
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.UNASSIGNED_ACCOUNT_NUMBER
+import app.k9mail.legacy.account.Expunge
+import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
+import app.k9mail.legacy.account.ShowPictures
+import app.k9mail.legacy.account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationSettings
 import app.k9mail.legacy.notification.NotificationVibration
@@ -37,13 +37,13 @@ class CommonAccountDefaultsProvider(
     private val featureFlagProvider: FeatureFlagProvider,
 ) : AccountDefaultsProvider {
 
-    override fun applyDefaults(account: Account) = with(account) {
+    override fun applyDefaults(account: LegacyAccount) = with(account) {
         applyLegacyDefaults()
         applyNotificationDefaults()
     }
 
     @Suppress("LongMethod")
-    private fun Account.applyLegacyDefaults() {
+    private fun LegacyAccount.applyLegacyDefaults() {
         automaticCheckIntervalMinutes = DEFAULT_SYNC_INTERVAL
         idleRefreshMinutes = 24
         displayCount = K9.DEFAULT_VISIBLE_LIMIT
@@ -116,7 +116,7 @@ class CommonAccountDefaultsProvider(
         resetChangeMarkers()
     }
 
-    private fun Account.applyNotificationDefaults() {
+    private fun LegacyAccount.applyNotificationDefaults() {
         isNotifyNewMail = featureFlagProvider.provide(
             "email_notification_default".toFeatureFlagKey(),
         ).whenEnabledOrNot(

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/CommonAccountProfileLocalDataSource.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/CommonAccountProfileLocalDataSource.kt
@@ -1,0 +1,41 @@
+package net.thunderbird.app.common.account.data
+
+import app.k9mail.legacy.account.LegacyAccountWrapperManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import net.thunderbird.feature.account.api.AccountId
+import net.thunderbird.feature.account.api.profile.AccountProfile
+import net.thunderbird.feature.account.core.AccountCoreExternalContract.AccountProfileLocalDataSource
+
+class CommonAccountProfileLocalDataSource(
+    private val accountManager: LegacyAccountWrapperManager,
+) : AccountProfileLocalDataSource {
+
+    override fun getById(accountId: AccountId): Flow<AccountProfile?> {
+        return accountManager.getById(accountId.value)
+            .onEach { println("Flow emitted account: $it") }
+            .map { account ->
+                account?.let {
+                    AccountProfile(
+                        accountId = AccountId.from(account.uuid),
+                        name = account.displayName,
+                        color = account.chipColor,
+                    )
+                }
+            }
+    }
+
+    override suspend fun update(accountProfile: AccountProfile) {
+        val currentAccount = accountManager.getById(accountProfile.accountId.value)
+            .firstOrNull() ?: return
+
+        val updatedAccount = currentAccount.copy(
+            displayName = accountProfile.name,
+            chipColor = accountProfile.color,
+        )
+
+        accountManager.update(updatedAccount)
+    }
+}

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/CommonLegacyAccountWrapperManager.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/CommonLegacyAccountWrapperManager.kt
@@ -1,0 +1,31 @@
+package net.thunderbird.app.common.account.data
+
+import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccountWrapper
+import app.k9mail.legacy.account.LegacyAccountWrapperManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class CommonLegacyAccountWrapperManager(
+    private val accountManager: AccountManager,
+) : LegacyAccountWrapperManager {
+
+    override fun getAll(): Flow<List<LegacyAccountWrapper>> {
+        return accountManager.getAccountsFlow()
+            .map { list ->
+                list.map { account ->
+                    LegacyAccountWrapper.from(account)
+                }
+            }
+    }
+
+    override fun getById(id: String): Flow<LegacyAccountWrapper?> {
+        return accountManager.getAccountFlow(id).map { account ->
+            account?.let { LegacyAccountWrapper.from(it) }
+        }
+    }
+
+    override suspend fun update(account: LegacyAccountWrapper) {
+        accountManager.saveAccount(LegacyAccountWrapper.to(account))
+    }
+}

--- a/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/FakeLegacyAccountWrapperManager.kt
+++ b/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/FakeLegacyAccountWrapperManager.kt
@@ -1,0 +1,35 @@
+package net.thunderbird.app.common.account.data
+
+import app.k9mail.legacy.account.LegacyAccountWrapper
+import app.k9mail.legacy.account.LegacyAccountWrapperManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+
+internal class FakeLegacyAccountWrapperManager(
+    initialAccounts: List<LegacyAccountWrapper> = emptyList(),
+) : LegacyAccountWrapperManager {
+
+    private val accountsState = MutableStateFlow<List<LegacyAccountWrapper>>(
+        initialAccounts,
+    )
+    private val accounts: StateFlow<List<LegacyAccountWrapper>> = accountsState
+
+    override fun getAll(): Flow<List<LegacyAccountWrapper>> = accounts
+
+    override fun getById(id: String): Flow<LegacyAccountWrapper?> = accounts
+        .map { list ->
+            list.find { it.uuid == id }
+        }
+
+    override suspend fun update(account: LegacyAccountWrapper) {
+        accountsState.update { currentList ->
+            currentList.toMutableList().apply {
+                removeIf { it.uuid == account.uuid }
+                add(account)
+            }
+        }
+    }
+}

--- a/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/LegacyAccountProfileLocalDataSourceTest.kt
+++ b/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/LegacyAccountProfileLocalDataSourceTest.kt
@@ -1,0 +1,147 @@
+package net.thunderbird.app.common.account.data
+
+import app.cash.turbine.test
+import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccountWrapper
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.feature.account.api.AccountId
+import net.thunderbird.feature.account.api.profile.AccountProfile
+import org.junit.Test
+import app.k9mail.legacy.account.LegacyAccount as LegacyAccount
+
+class LegacyAccountProfileLocalDataSourceTest {
+
+    @Test
+    fun `getById should return account profile`() = runTest {
+        // arrange
+        val accountId = AccountId.create()
+        val legacyAccount = createLegacyAccount(accountId.value)
+        val accountProfile = createAccountProfile(accountId)
+
+        val testSubject = CommonAccountProfileLocalDataSource(
+            accountManager = FakeLegacyAccountWrapperManager(
+                initialAccounts = listOf(
+                    legacyAccount,
+                ),
+            ),
+        )
+
+        // act & assert
+        testSubject.getById(accountId).test {
+            assertThat(awaitItem()).isEqualTo(accountProfile)
+        }
+    }
+
+    @Test
+    fun `getById should return null when account is not found`() = runTest {
+        // arrange
+        val accountId = AccountId.create()
+
+        val testSubject = CommonAccountProfileLocalDataSource(
+            accountManager = FakeLegacyAccountWrapperManager(),
+        )
+
+        // act & assert
+        testSubject.getById(accountId).test {
+            assertThat(awaitItem()).isEqualTo(null)
+        }
+    }
+
+    @Test
+    fun `update should save account profile`() = runTest {
+        // arrange
+        val accountId = AccountId.create()
+        val legacyAccount = createLegacyAccount(accountId.value)
+        val accountProfile = createAccountProfile(accountId)
+
+        val updatedName = "updatedName"
+        val updatedAccountProfile = accountProfile.copy(name = updatedName)
+
+        val accountManager = FakeLegacyAccountWrapperManager(
+            initialAccounts = listOf(
+                legacyAccount,
+            ),
+        )
+
+        val testSubject = CommonAccountProfileLocalDataSource(
+            accountManager = accountManager,
+        )
+
+        // act & assert
+        testSubject.getById(accountId).test {
+            assertThat(awaitItem()).isEqualTo(accountProfile)
+
+            testSubject.update(updatedAccountProfile)
+
+            assertThat(awaitItem()).isEqualTo(updatedAccountProfile)
+        }
+    }
+
+    private companion object {
+        const val NAME = "name"
+        const val COLOR = 0xFF333333.toInt()
+
+        fun createLegacyAccount(
+            accountId: String,
+            displayName: String = NAME,
+            color: Int = COLOR,
+        ): LegacyAccountWrapper {
+            return LegacyAccountWrapper.from(
+                LegacyAccount(
+                    uuid = accountId,
+                    isSensitiveDebugLoggingEnabled = { true },
+                ).apply {
+                    identities = ArrayList()
+
+                    val identity = Identity(
+                        signatureUse = false,
+                        description = "Demo User",
+                    )
+                    identities.add(identity)
+
+                    name = displayName
+                    chipColor = color
+                    email = "demo@example.com"
+
+                    incomingServerSettings = ServerSettings(
+                        type = "imap",
+                        host = "imap.example.com",
+                        port = 993,
+                        connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+                        authenticationType = AuthType.PLAIN,
+                        username = "test",
+                        password = "password",
+                        clientCertificateAlias = null,
+                    )
+                    outgoingServerSettings = ServerSettings(
+                        type = "smtp",
+                        host = "smtp.example.com",
+                        port = 465,
+                        connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+                        authenticationType = AuthType.PLAIN,
+                        username = "test",
+                        password = "password",
+                        clientCertificateAlias = null,
+                    )
+                },
+            )
+        }
+
+        fun createAccountProfile(
+            accountId: AccountId,
+            name: String = NAME,
+            color: Int = COLOR,
+        ): AccountProfile {
+            return AccountProfile(
+                accountId = accountId,
+                name = name,
+                color = color,
+            )
+        }
+    }
+}

--- a/app-k9mail/src/debug/kotlin/app/k9mail/dev/DemoBackendFactory.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/dev/DemoBackendFactory.kt
@@ -1,13 +1,13 @@
 package app.k9mail.dev
 
 import app.k9mail.backend.demo.DemoBackend
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.mailstore.K9BackendStorageFactory
 
 class DemoBackendFactory(private val backendStorageFactory: K9BackendStorageFactory) : BackendFactory {
-    override fun createBackend(account: Account): Backend {
+    override fun createBackend(account: LegacyAccount): Backend {
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         return DemoBackend(backendStorage)
     }

--- a/app-thunderbird/src/debug/kotlin/net/thunderbird/android/dev/DemoBackendFactory.kt
+++ b/app-thunderbird/src/debug/kotlin/net/thunderbird/android/dev/DemoBackendFactory.kt
@@ -1,13 +1,13 @@
 package net.thunderbird.android.dev
 
 import app.k9mail.backend.demo.DemoBackend
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.mailstore.K9BackendStorageFactory
 
 class DemoBackendFactory(private val backendStorageFactory: K9BackendStorageFactory) : BackendFactory {
-    override fun createBackend(account: Account): Backend {
+    override fun createBackend(account: LegacyAccount): Backend {
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         return DemoBackend(backendStorage)
     }

--- a/config/detekt/detekt-baseline-feature-account-setup.xml
+++ b/config/detekt/detekt-baseline-feature-account-setup.xml
@@ -4,6 +4,5 @@
   <CurrentIssues>
     <ID>ViewModelForwarding:AccountAutoDiscoveryContent.kt$AccountOAuthView( onOAuthResult = { result -&gt; onEvent(Event.OnOAuthResult(result)) }, viewModel = oAuthViewModel, isEnabled = isAutoDiscoverySettingsTrusted || isConfigurationApproved, )</ID>
     <ID>ViewModelForwarding:AccountAutoDiscoveryContent.kt$AutoDiscoveryContent( state = state, onEvent = onEvent, oAuthViewModel = oAuthViewModel, )</ID>
-    <ID>ViewModelForwarding:AccountAutoDiscoveryContent.kt$ContentView( state = state, onEvent = onEvent, oAuthViewModel = oAuthViewModel, resources = resources, )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/config/detekt/detekt-baseline-legacy-common.xml
+++ b/config/detekt/detekt-baseline-legacy-common.xml
@@ -2,7 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>ReturnCount:K9NotificationStrategy.kt$K9NotificationStrategy$override fun shouldNotifyForMessage( account: Account, localFolder: LocalFolder, message: LocalMessage, isOldMessage: Boolean, ): Boolean</ID>
     <ID>TooManyFunctions:K9CoreResourceProvider.kt$K9CoreResourceProvider : CoreResourceProvider</ID>
     <ID>TooManyFunctions:K9NotificationActionCreator.kt$K9NotificationActionCreator : NotificationActionCreator</ID>
     <ID>TooManyFunctions:K9NotificationResourceProvider.kt$K9NotificationResourceProvider : NotificationResourceProvider</ID>

--- a/config/detekt/detekt-baseline-legacy-core.xml
+++ b/config/detekt/detekt-baseline-legacy-core.xml
@@ -4,18 +4,10 @@
   <CurrentIssues>
     <ID>CastToNullableType:SettingsExporter.kt$SettingsExporter$as</ID>
     <ID>CyclomaticComplexMethod:HttpUriParser.kt$HttpUriParser$private fun tryMatchIpv6Address(text: CharSequence, startPos: Int): Int</ID>
-    <ID>CyclomaticComplexMethod:SettingsExporter.kt$SettingsExporter$private fun writeAccount( serializer: XmlSerializer, account: Account, prefs: Map&lt;String, Any&gt;, includePasswords: Boolean, )</ID>
     <ID>ForbiddenComment:K9BackendFolderTest.kt$K9BackendFolderTest$// FIXME: This is a hack to get Preferences into a state where it's safe to call newAccount()</ID>
     <ID>ForbiddenComment:K9BackendStorageTest.kt$K9BackendStorageTest$// FIXME: This is a hack to get Preferences into a state where it's safe to call newAccount()</ID>
     <ID>FunctionOnlyReturningConstant:DisplayHtml.kt$DisplayHtml$private fun cssStyleSignature(): String</ID>
-    <ID>LongMethod:AccountPreferenceSerializer.kt$AccountPreferenceSerializer$@Synchronized fun delete(editor: StorageEditor, storage: Storage, account: Account)</ID>
-    <ID>LongMethod:AccountPreferenceSerializer.kt$AccountPreferenceSerializer$@Synchronized fun loadAccount(account: Account, storage: Storage)</ID>
-    <ID>LongMethod:AccountPreferenceSerializer.kt$AccountPreferenceSerializer$@Synchronized fun save(editor: StorageEditor, storage: Storage, account: Account)</ID>
-    <ID>LongMethod:AccountPreferenceSerializer.kt$AccountPreferenceSerializer$fun loadDefaults(account: Account)</ID>
-    <ID>LongMethod:K9.kt$K9$@JvmStatic fun loadPrefs(storage: Storage)</ID>
     <ID>LongMethod:MessageListRepositoryTest.kt$MessageListRepositoryTest$@Test fun `getThread() should use flag values from the cache`()</ID>
-    <ID>LongMethod:NotificationDataStore.kt$NotificationDataStore$@Synchronized fun removeNotifications( account: Account, selector: (List&lt;MessageReference&gt;) -&gt; List&lt;MessageReference&gt;, ): RemoveNotificationsResult?</ID>
-    <ID>LongMethod:SettingsExporter.kt$SettingsExporter$private fun writeAccount( serializer: XmlSerializer, account: Account, prefs: Map&lt;String, Any&gt;, includePasswords: Boolean, )</ID>
     <ID>LongMethod:TextBodyBuilderTest.kt$TextBodyBuilderTest.Companion$@JvmStatic @Parameterized.Parameters(name = "{index}: {0}") fun data(): Collection&lt;TestData&gt;</ID>
     <ID>LoopWithTooManyJumpStatements:HttpUriParser.kt$HttpUriParser$while</ID>
     <ID>LoopWithTooManyJumpStatements:SettingsExporter.kt$SettingsExporter$for</ID>
@@ -24,8 +16,6 @@
     <ID>MagicNumber:AccountPreferenceSerializer.kt$AccountPreferenceSerializer$5</ID>
     <ID>MagicNumber:CollectionExtensions.kt$0.75F</ID>
     <ID>MagicNumber:CollectionExtensions.kt$3</ID>
-    <ID>MagicNumber:ConnectivityManager.kt$23</ID>
-    <ID>MagicNumber:ConnectivityManager.kt$24</ID>
     <ID>MagicNumber:EmailTextToHtml.kt$EmailTextToHtml$3</ID>
     <ID>MagicNumber:EmailTextToHtml.kt$EmailTextToHtml$4</ID>
     <ID>MagicNumber:EmailTextToHtml.kt$EmailTextToHtml$5</ID>
@@ -47,7 +37,6 @@
     <ID>MagicNumber:NotificationLightDecoder.kt$NotificationLightDecoder$0xFF00FF</ID>
     <ID>MagicNumber:NotificationLightDecoder.kt$NotificationLightDecoder$0xFFFF00</ID>
     <ID>MagicNumber:NotificationLightDecoder.kt$NotificationLightDecoder$0xFFFFFF</ID>
-    <ID>MagicNumber:PushService.kt$PushService$29</ID>
     <ID>MagicNumber:ServerSettingsSerializer.kt$ServerSettingsAdapter$3</ID>
     <ID>MagicNumber:ServerSettingsSerializer.kt$ServerSettingsAdapter$4</ID>
     <ID>MagicNumber:ServerSettingsSerializer.kt$ServerSettingsAdapter$5</ID>
@@ -58,10 +47,8 @@
     <ID>MayBeConst:SummaryNotificationDataCreatorTest.kt$private val TIMESTAMP = 0L</ID>
     <ID>MemberNameEqualsClassName:HtmlModification.kt$HtmlModification.Replace$abstract fun replace(textToHtml: TextToHtml)</ID>
     <ID>NestedBlockDepth:HttpUriParser.kt$HttpUriParser$private fun tryMatchIpv6Address(text: CharSequence, startPos: Int): Int</ID>
-    <ID>NestedBlockDepth:SettingsExporter.kt$SettingsExporter$private fun writeAccount( serializer: XmlSerializer, account: Account, prefs: Map&lt;String, Any&gt;, includePasswords: Boolean, )</ID>
     <ID>NestedBlockDepth:SettingsExporter.kt$SettingsExporter$private fun writeIdentity( serializer: XmlSerializer, accountUuid: String, identity: String, prefs: Map&lt;String, Any&gt;, )</ID>
     <ID>NestedBlockDepth:SingleMessageNotificationCreator.kt$SingleMessageNotificationCreator$private fun NotificationBuilder.setWearActions(notificationData: SingleNotificationData)</ID>
-    <ID>NestedBlockDepth:SummaryNotificationCreator.kt$SummaryNotificationCreator$private fun NotificationBuilder.setWearActions( account: Account, notificationData: SummaryInboxNotificationData, )</ID>
     <ID>ReturnCount:AutocryptDraftStateHeaderParser.kt$AutocryptDraftStateHeaderParser$fun parseAutocryptDraftStateHeader(headerValue: String): AutocryptDraftStateHeader?</ID>
     <ID>ReturnCount:EmailSection.kt$EmailSection$override fun subSequence(startIndex: Int, endIndex: Int): CharSequence</ID>
     <ID>ReturnCount:HtmlSignatureRemover.kt$HtmlSignatureRemover.StripSignatureFilter$override fun head(node: Node, depth: Int): HeadFilterDecision</ID>
@@ -77,8 +64,6 @@
     <ID>ReturnCount:MailSyncWorker.kt$MailSyncWorker$override fun doWork(): Result</ID>
     <ID>ReturnCount:MessageHelper.kt$MessageHelper.Companion$@JvmStatic fun toFriendly( address: Address, contactRepository: ContactRepository?, showCorrespondentNames: Boolean, changeContactNameColor: Boolean, contactNameColor: Int, ): CharSequence</ID>
     <ID>ReturnCount:MessageRepository.kt$MessageRepository$private fun List&lt;Header&gt;.parseDate(headerName: String): MessageDate</ID>
-    <ID>ReturnCount:NotificationContentCreator.kt$NotificationContentCreator$private fun getMessageSender(account: Account, message: Message): String?</ID>
-    <ID>ReturnCount:NotificationDataStore.kt$NotificationDataStore$@Synchronized fun removeNotifications( account: Account, selector: (List&lt;MessageReference&gt;) -&gt; List&lt;MessageReference&gt;, ): RemoveNotificationsResult?</ID>
     <ID>ReturnCount:PreviewTextExtractor.kt$PreviewTextExtractor$private fun extractUnquotedText(text: String): String</ID>
     <ID>ReturnCount:TextPartFinder.kt$TextPartFinder$private fun findTextPartInMultipart(multipart: Multipart): Part?</ID>
     <ID>ReturnCount:TextPartFinder.kt$TextPartFinder$private fun findTextPartInMultipartAlternative(multipart: Multipart): Part?</ID>

--- a/config/detekt/detekt-baseline-legacy-ui-legacy.xml
+++ b/config/detekt/detekt-baseline-legacy-ui-legacy.xml
@@ -33,12 +33,10 @@
     <ID>LongMethod:MessageViewFragment.kt$MessageViewFragment$override fun onPrepareOptionsMenu(menu: Menu)</ID>
     <ID>LongMethod:RecipientNamesView.kt$RecipientNamesView$override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int)</ID>
     <ID>LongParameterList:MessageDetailsViewModel.kt$MessageDetailsViewModel$( private val resources: Resources, private val messageRepository: MessageRepository, private val folderRepository: FolderRepository, private val contactSettingsProvider: ContactSettingsProvider, private val contactRepository: ContactRepository, private val contactPermissionResolver: ContactPermissionResolver, private val clipboardManager: ClipboardManager, private val accountManager: AccountManager, private val participantFormatter: MessageDetailsParticipantFormatter, private val folderNameFormatter: FolderNameFormatter, )</ID>
-    <ID>LongParameterList:RecipientPresenter.kt$RecipientPresenter$( private val context: Context, loaderManager: LoaderManager, private val openPgpApiManager: OpenPgpApiManager, private val recipientMvpView: RecipientMvpView, account: Account, private val composePgpInlineDecider: ComposePgpInlineDecider, private val composePgpEnableByDefaultDecider: ComposePgpEnableByDefaultDecider, private val autocryptStatusInteractor: AutocryptStatusInteractor, private val replyToParser: ReplyToParser, private val draftStateHeaderParser: AutocryptDraftStateHeaderParser, )</ID>
     <ID>MagicNumber:AccountItem.kt$AccountItem$200L</ID>
     <ID>MagicNumber:AutocryptSetupTransferLiveEvent.kt$AutocryptSetupTransferLiveEvent$2000</ID>
     <ID>MagicNumber:ContactLetterBitmapCreator.kt$ContactLetterBitmapCreator$0.65f</ID>
     <ID>MagicNumber:ContactLetterBitmapCreator.kt$ContactLetterBitmapCreator$255</ID>
-    <ID>MagicNumber:GeneralSettingsFragment.kt$GeneralSettingsFragment$28</ID>
     <ID>MagicNumber:MessageContainerView.kt$MessageContainerView$29</ID>
     <ID>MagicNumber:MessageListItemAnimator.kt$MessageListItemAnimator$120</ID>
     <ID>MagicNumber:MessageListItemMapper.kt$MessageListItemMapper$52</ID>

--- a/feature/account/api/build.gradle.kts
+++ b/feature/account/api/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id(ThunderbirdPlugins.Library.jvm)
+    alias(libs.plugins.android.lint)
+}

--- a/feature/account/api/src/main/kotlin/net/thunderbird/feature/account/api/Account.kt
+++ b/feature/account/api/src/main/kotlin/net/thunderbird/feature/account/api/Account.kt
@@ -1,0 +1,5 @@
+package net.thunderbird.feature.account.api
+
+interface Account {
+    val accountId: AccountId
+}

--- a/feature/account/api/src/main/kotlin/net/thunderbird/feature/account/api/AccountId.kt
+++ b/feature/account/api/src/main/kotlin/net/thunderbird/feature/account/api/AccountId.kt
@@ -1,0 +1,29 @@
+package net.thunderbird.feature.account.api
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@JvmInline
+value class AccountId private constructor(
+    val value: String,
+) {
+    companion object {
+
+        /**
+         * Create an [AccountId] from a [String].
+         */
+        @OptIn(ExperimentalUuidApi::class)
+        fun from(id: String): AccountId {
+            try {
+                return AccountId(Uuid.parse(id).toString())
+            } catch (exception: IllegalArgumentException) {
+                throw IllegalArgumentException("Invalid AccountId: $id", exception)
+            }
+        }
+
+        @OptIn(ExperimentalUuidApi::class)
+        fun create(): AccountId {
+            return AccountId(Uuid.random().toString())
+        }
+    }
+}

--- a/feature/account/api/src/main/kotlin/net/thunderbird/feature/account/api/profile/AccountProfile.kt
+++ b/feature/account/api/src/main/kotlin/net/thunderbird/feature/account/api/profile/AccountProfile.kt
@@ -1,0 +1,10 @@
+package net.thunderbird.feature.account.api.profile
+
+import net.thunderbird.feature.account.api.Account
+import net.thunderbird.feature.account.api.AccountId
+
+data class AccountProfile(
+    override val accountId: AccountId,
+    val name: String,
+    val color: Int,
+) : Account

--- a/feature/account/api/src/main/kotlin/net/thunderbird/feature/account/api/profile/AccountProfileRepository.kt
+++ b/feature/account/api/src/main/kotlin/net/thunderbird/feature/account/api/profile/AccountProfileRepository.kt
@@ -1,0 +1,11 @@
+package net.thunderbird.feature.account.api.profile
+
+import kotlinx.coroutines.flow.Flow
+import net.thunderbird.feature.account.api.AccountId
+
+interface AccountProfileRepository {
+
+    fun getById(accountId: AccountId): Flow<AccountProfile?>
+
+    suspend fun update(accountProfile: AccountProfile)
+}

--- a/feature/account/api/src/test/kotlin/net/thunderbird/feature/account/api/AccountIdTest.kt
+++ b/feature/account/api/src/test/kotlin/net/thunderbird/feature/account/api/AccountIdTest.kt
@@ -1,0 +1,59 @@
+package net.thunderbird.feature.account.api
+
+import assertk.Assert
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
+import kotlin.test.Test
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class AccountIdTest {
+
+    @Test
+    fun `from should return AccountId with the same id`() {
+        val id = "123e4567-e89b-12d3-a456-426614174000"
+
+        val result = AccountId.from(id)
+
+        assertThat(result.value).isEqualTo(id)
+    }
+
+    @Test
+    fun `from should throw IllegalArgumentException when id is invalid`() {
+        val id = "invalid"
+
+        val result = assertFailure {
+            AccountId.from(id)
+        }
+
+        result.hasMessage("Invalid AccountId: $id")
+        result.isInstanceOf<IllegalArgumentException>()
+    }
+
+    @Test
+    fun `create should return AccountId with a uuid`() {
+        val result = AccountId.create()
+
+        assertThat(result.value).isUuid()
+    }
+
+    @Test
+    fun `create should return AccountId with unique ids`() {
+        val ids = List(10) { AccountId.create().value }
+
+        ids.forEachIndexed { index, id ->
+            ids.drop(index + 1).forEach { otherId ->
+                assertThat(id).isNotEqualTo(otherId)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    private fun Assert<String>.isUuid() = given { actual ->
+        Uuid.parse(actual)
+    }
+}

--- a/feature/account/core/build.gradle.kts
+++ b/feature/account/core/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id(ThunderbirdPlugins.Library.jvm)
+    alias(libs.plugins.android.lint)
+}
+
+dependencies {
+    api(projects.feature.account.api)
+}

--- a/feature/account/core/src/main/kotlin/net/thunderbird/feature/account/core/AccountCoreExternalContract.kt
+++ b/feature/account/core/src/main/kotlin/net/thunderbird/feature/account/core/AccountCoreExternalContract.kt
@@ -1,0 +1,14 @@
+package net.thunderbird.feature.account.core
+
+import kotlinx.coroutines.flow.Flow
+import net.thunderbird.feature.account.api.AccountId
+import net.thunderbird.feature.account.api.profile.AccountProfile
+
+interface AccountCoreExternalContract {
+
+    interface AccountProfileLocalDataSource {
+        fun getById(accountId: AccountId): Flow<AccountProfile?>
+
+        suspend fun update(accountProfile: AccountProfile)
+    }
+}

--- a/feature/account/core/src/main/kotlin/net/thunderbird/feature/account/core/AccountCoreModule.kt
+++ b/feature/account/core/src/main/kotlin/net/thunderbird/feature/account/core/AccountCoreModule.kt
@@ -1,0 +1,10 @@
+package net.thunderbird.feature.account.core
+
+import net.thunderbird.feature.account.api.profile.AccountProfileRepository
+import net.thunderbird.feature.account.core.data.DefaultAccountProfileRepository
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val featureAccountCoreModule: Module = module {
+    single<AccountProfileRepository> { DefaultAccountProfileRepository(get()) }
+}

--- a/feature/account/core/src/main/kotlin/net/thunderbird/feature/account/core/data/DefaultAccountProfileRepository.kt
+++ b/feature/account/core/src/main/kotlin/net/thunderbird/feature/account/core/data/DefaultAccountProfileRepository.kt
@@ -1,0 +1,22 @@
+package net.thunderbird.feature.account.core.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import net.thunderbird.feature.account.api.AccountId
+import net.thunderbird.feature.account.api.profile.AccountProfile
+import net.thunderbird.feature.account.api.profile.AccountProfileRepository
+import net.thunderbird.feature.account.core.AccountCoreExternalContract
+
+class DefaultAccountProfileRepository(
+    private val localStore: AccountCoreExternalContract.AccountProfileLocalDataSource,
+) : AccountProfileRepository {
+
+    override fun getById(accountId: AccountId): Flow<AccountProfile?> {
+        return localStore.getById(accountId)
+            .distinctUntilChanged()
+    }
+
+    override suspend fun update(accountProfile: AccountProfile) {
+        localStore.update(accountProfile)
+    }
+}

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/domain/entity/AccountData.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/domain/entity/AccountData.kt
@@ -3,7 +3,6 @@ package app.k9mail.feature.migration.qrcode.domain.entity
 import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.net.Hostname
 import app.k9mail.core.common.net.Port
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.DeletePolicy
 
 internal data class AccountData(

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/domain/entity/AccountData.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/domain/entity/AccountData.kt
@@ -4,7 +4,7 @@ import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.net.Hostname
 import app.k9mail.core.common.net.Port
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.DeletePolicy
 
 internal data class AccountData(
     val sequenceNumber: Int,

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadMapper.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadMapper.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.common.net.toHostname
 import app.k9mail.core.common.net.toPort
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.IncomingServerProtocol
-import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.DeletePolicy
 import com.fsck.k9.account.DeletePolicyProvider
 
 internal class QrCodePayloadMapper(

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/settings/XmlSettingWriter.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/settings/XmlSettingWriter.kt
@@ -6,7 +6,7 @@ import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.Identity
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.IncomingServer
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.OutgoingServer
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.OutgoingServerGroup
-import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.DeletePolicy
 import java.io.OutputStream
 import org.xmlpull.v1.XmlSerializer
 

--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/domain/usecase/QrCodePayloadReaderTest.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/domain/usecase/QrCodePayloadReaderTest.kt
@@ -9,7 +9,6 @@ import app.k9mail.feature.migration.qrcode.payload.QrCodePayloadAdapter
 import app.k9mail.feature.migration.qrcode.payload.QrCodePayloadMapper
 import app.k9mail.feature.migration.qrcode.payload.QrCodePayloadParser
 import app.k9mail.feature.migration.qrcode.payload.QrCodePayloadValidator
-import app.k9mail.legacy.account.Account
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull

--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/payload/FakeDeletePolicyProvider.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/payload/FakeDeletePolicyProvider.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.migration.qrcode.payload
 
-import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.DeletePolicy
 import com.fsck.k9.account.DeletePolicyProvider
 
 class FakeDeletePolicyProvider : DeletePolicyProvider {

--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadMapperTest.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/payload/QrCodePayloadMapperTest.kt
@@ -5,7 +5,6 @@ import app.k9mail.core.common.net.toHostname
 import app.k9mail.core.common.net.toPort
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.ConnectionSecurity
-import app.k9mail.legacy.account.Account
 import assertk.assertThat
 import assertk.assertions.first
 import assertk.assertions.isEqualTo

--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/settings/XmlSettingWriterTest.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/settings/XmlSettingWriterTest.kt
@@ -5,7 +5,6 @@ import app.k9mail.core.common.net.toHostname
 import app.k9mail.core.common.net.toPort
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.ConnectionSecurity
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.DeletePolicy
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/settings/XmlSettingWriterTest.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/settings/XmlSettingWriterTest.kt
@@ -6,7 +6,7 @@ import app.k9mail.core.common.net.toPort
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData
 import app.k9mail.feature.migration.qrcode.domain.entity.AccountData.ConnectionSecurity
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.DeletePolicy
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test

--- a/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
+++ b/feature/navigation/drawer/src/debug/kotlin/app/k9mail/feature/navigation/drawer/ui/FakeData.kt
@@ -9,8 +9,8 @@ import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccountFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolder
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -24,7 +24,7 @@ internal object FakeData {
     const val LONG_TEXT = "loremipsumdolorsitametconsetetursadipscingelitr" +
         "seddiamnonumyeirmodtemporinviduntutlaboreetdoloremagnaaliquyameratseddiamvoluptua"
 
-    val ACCOUNT = Account(
+    val ACCOUNT = LegacyAccount(
         uuid = ACCOUNT_UUID,
     ).apply {
         identities = ArrayList()

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/FolderDrawer.kt
@@ -9,7 +9,7 @@ import app.k9mail.core.ui.theme.api.FeatureThemeProvider
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayUnifiedFolderType
 import app.k9mail.feature.navigation.drawer.domain.entity.createDisplayAccountFolderId
 import app.k9mail.feature.navigation.drawer.ui.DrawerView
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import org.koin.core.component.KoinComponent
@@ -60,7 +60,7 @@ class FolderDrawer(
     override val isOpen: Boolean
         get() = drawer.isOpen
 
-    override fun updateUserAccountsAndFolders(account: Account?) {
+    override fun updateUserAccountsAndFolders(account: LegacyAccount?) {
         // no-op
     }
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawer.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/NavigationDrawer.kt
@@ -1,14 +1,14 @@
 package app.k9mail.feature.navigation.drawer
 
 import androidx.appcompat.app.AppCompatActivity
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 interface NavigationDrawer {
     val parent: AppCompatActivity
     val isOpen: Boolean
 
     // TODO: remove once LegacyDrawer is removed
-    fun updateUserAccountsAndFolders(account: Account?)
+    fun updateUserAccountsAndFolders(account: LegacyAccount?)
 
     fun selectAccount(accountUuid: String)
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayAccounts.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/GetDisplayAccounts.kt
@@ -2,8 +2,8 @@ package app.k9mail.feature.navigation.drawer.domain.usecase
 
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
 import app.k9mail.feature.navigation.drawer.domain.entity.DisplayAccount
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageListChangedListener
 import app.k9mail.legacy.mailstore.MessageListRepository
 import app.k9mail.legacy.message.controller.MessageCounts
@@ -49,7 +49,7 @@ internal class GetDisplayAccounts(
             }
     }
 
-    private fun getMessageCountsFlow(account: Account): Flow<MessageCounts> {
+    private fun getMessageCountsFlow(account: LegacyAccount): Flow<MessageCounts> {
         return callbackFlow {
             send(messageCountsProvider.getMessageCounts(account))
 

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAccount.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAccount.kt
@@ -2,8 +2,8 @@ package app.k9mail.feature.navigation.drawer.domain.usecase
 
 import android.content.Context
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import kotlin.coroutines.CoroutineContext
@@ -20,7 +20,7 @@ internal class SyncAccount(
 ) : UseCase.SyncAccount {
     override fun invoke(accountUuid: String): Flow<Result<Unit>> = callbackFlow {
         val listener = object : SimpleMessagingListener() {
-            override fun checkMailFinished(context: Context?, account: Account?) {
+            override fun checkMailFinished(context: Context?, account: LegacyAccount?) {
                 trySend(Result.success(Unit))
                 close()
             }

--- a/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAllAccounts.kt
+++ b/feature/navigation/drawer/src/main/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/SyncAllAccounts.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.navigation.drawer.domain.usecase
 
 import android.content.Context
 import app.k9mail.feature.navigation.drawer.domain.DomainContract.UseCase
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import kotlin.coroutines.CoroutineContext
@@ -18,7 +18,7 @@ class SyncAllAccounts(
 ) : UseCase.SyncAllAccounts {
     override fun invoke(): Flow<Result<Unit>> = callbackFlow {
         val listener = object : SimpleMessagingListener() {
-            override fun checkMailFinished(context: Context?, account: Account?) {
+            override fun checkMailFinished(context: Context?, account: LegacyAccount?) {
                 trySend(Result.success(Unit))
                 close()
             }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/data/FakeMessageCountsProvider.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/data/FakeMessageCountsProvider.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.data
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageCounts
 import app.k9mail.legacy.message.controller.MessageCountsProvider
 import app.k9mail.legacy.search.LocalSearch
@@ -13,7 +13,7 @@ internal class FakeMessageCountsProvider(
 ) : MessageCountsProvider {
     var recordedSearch: LocalSearch = LocalSearch()
 
-    override fun getMessageCounts(account: Account): MessageCounts {
+    override fun getMessageCounts(account: LegacyAccount): MessageCounts {
         TODO("Not yet implemented")
     }
 
@@ -30,7 +30,7 @@ internal class FakeMessageCountsProvider(
         return flowOf(messageCounts)
     }
 
-    override fun getUnreadMessageCount(account: Account, folderId: Long): Int {
+    override fun getUnreadMessageCount(account: LegacyAccount, folderId: Long): Int {
         TODO("Not yet implemented")
     }
 }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeAccountManager.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeAccountManager.kt
@@ -1,29 +1,29 @@
 package app.k9mail.feature.navigation.drawer.domain.usecase
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.account.AccountRemovedListener
 import app.k9mail.legacy.account.AccountsChangeListener
+import app.k9mail.legacy.account.LegacyAccount
 import kotlinx.coroutines.flow.Flow
 
 internal class FakeAccountManager(
     val recordedParameters: MutableList<String> = mutableListOf(),
-    private val accounts: List<Account> = emptyList(),
+    private val accounts: List<LegacyAccount> = emptyList(),
 ) : AccountManager {
-    override fun getAccounts(): List<Account> {
+    override fun getAccounts(): List<LegacyAccount> {
         TODO("Not yet implemented")
     }
 
-    override fun getAccountsFlow(): Flow<List<Account>> {
+    override fun getAccountsFlow(): Flow<List<LegacyAccount>> {
         TODO("Not yet implemented")
     }
 
-    override fun getAccount(accountUuid: String): Account? {
+    override fun getAccount(accountUuid: String): LegacyAccount? {
         recordedParameters.add(accountUuid)
         return accounts.find { it.uuid == accountUuid }
     }
 
-    override fun getAccountFlow(accountUuid: String): Flow<Account> {
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccount> {
         TODO("Not yet implemented")
     }
 
@@ -31,7 +31,7 @@ internal class FakeAccountManager(
         TODO("Not yet implemented")
     }
 
-    override fun moveAccount(account: Account, newPosition: Int) {
+    override fun moveAccount(account: LegacyAccount, newPosition: Int) {
         TODO("Not yet implemented")
     }
 
@@ -43,7 +43,7 @@ internal class FakeAccountManager(
         TODO("Not yet implemented")
     }
 
-    override fun saveAccount(account: Account) {
+    override fun saveAccount(account: LegacyAccount) {
         TODO("Not yet implemented")
     }
 }

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeDisplayFolderRepository.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeDisplayFolderRepository.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.domain.usecase
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.flow.Flow
@@ -9,7 +9,7 @@ internal class FakeDisplayFolderRepository(
     private val foldersFlow: Flow<List<DisplayFolder>>,
 ) : DisplayFolderRepository {
     override fun getDisplayFoldersFlow(
-        account: Account,
+        account: LegacyAccount,
         includeHiddenFolders: Boolean,
     ): Flow<List<DisplayFolder>> {
         TODO("Not yet implemented")

--- a/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeMessagingControllerMailChecker.kt
+++ b/feature/navigation/drawer/src/test/kotlin/app/k9mail/feature/navigation/drawer/domain/usecase/FakeMessagingControllerMailChecker.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.navigation.drawer.domain.usecase
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.MessagingListener
 
@@ -9,7 +9,7 @@ internal class FakeMessagingControllerMailChecker(
     private val listenerExecutor: (MessagingListener?) -> Unit = {},
 ) : MessagingControllerMailChecker {
     override fun checkMail(
-        account: Account?,
+        account: LegacyAccount?,
         ignoreLastCheckedTime: Boolean,
         useManualWakeLock: Boolean,
         notify: Boolean,
@@ -22,7 +22,7 @@ internal class FakeMessagingControllerMailChecker(
 }
 
 internal data class CheckMailParameters(
-    val account: Account?,
+    val account: LegacyAccount?,
     val ignoreLastCheckedTime: Boolean,
     val useManualWakeLock: Boolean,
     val notify: Boolean,

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/AuthViewModel.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/AuthViewModel.kt
@@ -15,8 +15,8 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import app.k9mail.feature.account.oauth.domain.AccountOAuthDomainContract.UseCase.GetOAuthRequestIntent
 import app.k9mail.feature.account.oauth.domain.entity.AuthorizationIntentResult
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -41,7 +41,7 @@ internal class AuthViewModel(
     private var authService: AuthorizationService? = null
     private val authState = AuthState()
 
-    private var account: Account? = null
+    private var account: LegacyAccount? = null
 
     private lateinit var resultObserver: AppAuthResultObserver
 
@@ -53,7 +53,7 @@ internal class AuthViewModel(
         return authService ?: AuthorizationService(getApplication<Application>()).also { authService = it }
     }
 
-    fun init(activityResultRegistry: ActivityResultRegistry, lifecycle: Lifecycle, account: Account) {
+    fun init(activityResultRegistry: ActivityResultRegistry, lifecycle: Lifecycle, account: LegacyAccount) {
         this.account = account
         resultObserver = AppAuthResultObserver(activityResultRegistry)
         lifecycle.addObserver(resultObserver)
@@ -63,16 +63,16 @@ internal class AuthViewModel(
         _uiState.update { AuthFlowState.Idle }
     }
 
-    fun isAuthorized(account: Account): Boolean {
+    fun isAuthorized(account: LegacyAccount): Boolean {
         val authState = getOrCreateAuthState(account)
         return authState.isAuthorized
     }
 
-    fun isUsingGoogle(account: Account): Boolean {
+    fun isUsingGoogle(account: LegacyAccount): Boolean {
         return GoogleOAuthHelper.isGoogle(account.incomingServerSettings.host!!)
     }
 
-    private fun getOrCreateAuthState(account: Account): AuthState {
+    private fun getOrCreateAuthState(account: LegacyAccount): AuthState {
         return try {
             account.oAuthState?.let { AuthState.jsonDeserialize(it) } ?: AuthState()
         } catch (e: Exception) {
@@ -93,7 +93,7 @@ internal class AuthViewModel(
         }
     }
 
-    private suspend fun startLogin(account: Account) {
+    private suspend fun startLogin(account: LegacyAccount) {
         val authRequestIntentResult = withContext(Dispatchers.IO) {
             getOAuthRequestIntent.execute(account.incomingServerSettings.host!!, account.email)
         }

--- a/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListConfig.kt
+++ b/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListConfig.kt
@@ -1,6 +1,6 @@
 package net.thunderbird.feature.widget.message.list
 
-import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.search.LocalSearch
 
 internal data class MessageListConfig(

--- a/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListItemMapper.kt
+++ b/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListItemMapper.kt
@@ -1,6 +1,6 @@
 package net.thunderbird.feature.widget.message.list
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageDetailsAccessor
 import app.k9mail.legacy.mailstore.MessageMapper
 import app.k9mail.legacy.message.controller.MessageReference
@@ -11,7 +11,7 @@ import java.util.Locale
 
 internal class MessageListItemMapper(
     private val messageHelper: MessageHelper,
-    private val account: Account,
+    private val account: LegacyAccount,
 ) : MessageMapper<MessageListItem> {
     private val calendar: Calendar = Calendar.getInstance()
 
@@ -57,7 +57,7 @@ internal class MessageListItemMapper(
         return String.format("%d %s", dayOfMonth, month)
     }
 
-    private fun createUniqueId(account: Account, messageId: Long): Long {
+    private fun createUniqueId(account: LegacyAccount, messageId: Long): Long {
         return ((account.accountNumber + 1).toLong() shl ACCOUNT_NUMBER_BIT_SHIFT) + messageId
     }
 

--- a/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListLoader.kt
+++ b/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListLoader.kt
@@ -1,6 +1,6 @@
 package net.thunderbird.feature.widget.message.list
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.mailstore.MessageListRepository
 import com.fsck.k9.Preferences
@@ -39,7 +39,7 @@ internal class MessageListLoader(
         return messageListItems
     }
 
-    private fun loadMessageListForAccount(account: Account, config: MessageListConfig): List<MessageListItem> {
+    private fun loadMessageListForAccount(account: LegacyAccount, config: MessageListConfig): List<MessageListItem> {
         val accountUuid = account.uuid
         val sortOrder = buildSortOrder(config)
         val mapper = MessageListItemMapper(messageHelper, account)

--- a/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListLoader.kt
+++ b/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListLoader.kt
@@ -1,7 +1,7 @@
 package net.thunderbird.feature.widget.message.list
 
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.mailstore.MessageListRepository
 import com.fsck.k9.Preferences
 import com.fsck.k9.helper.MessageHelper

--- a/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListWidget.kt
+++ b/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListWidget.kt
@@ -11,7 +11,7 @@ import androidx.core.app.PendingIntentCompat
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.provideContent
-import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.search.SearchAccount.Companion.createUnifiedInboxAccount
 import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.K9

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListConfig.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListConfig.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.widget.message.list
 
-import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.search.LocalSearch
 
 internal data class MessageListConfig(

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListItemMapper.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListItemMapper.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.widget.message.list
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageDetailsAccessor
 import app.k9mail.legacy.mailstore.MessageMapper
 import app.k9mail.legacy.message.controller.MessageReference
@@ -11,7 +11,7 @@ import java.util.Locale
 
 internal class MessageListItemMapper(
     private val messageHelper: MessageHelper,
-    private val account: Account,
+    private val account: LegacyAccount,
 ) : MessageMapper<MessageListItem> {
     private val calendar: Calendar = Calendar.getInstance()
 
@@ -57,7 +57,7 @@ internal class MessageListItemMapper(
         return String.format("%d %s", dayOfMonth, month)
     }
 
-    private fun createUniqueId(account: Account, messageId: Long): Long {
+    private fun createUniqueId(account: LegacyAccount, messageId: Long): Long {
         return ((account.accountNumber + 1).toLong() shl ACCOUNT_NUMBER_BIT_SHIFT) + messageId
     }
 

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListLoader.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListLoader.kt
@@ -1,6 +1,6 @@
 package app.k9mail.feature.widget.message.list
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.mailstore.MessageListRepository
 import com.fsck.k9.Preferences
@@ -39,7 +39,7 @@ internal class MessageListLoader(
         return messageListItems
     }
 
-    private fun loadMessageListForAccount(account: Account, config: MessageListConfig): List<MessageListItem> {
+    private fun loadMessageListForAccount(account: LegacyAccount, config: MessageListConfig): List<MessageListItem> {
         val accountUuid = account.uuid
         val sortOrder = buildSortOrder(config)
         val mapper = MessageListItemMapper(messageHelper, account)

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListLoader.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListLoader.kt
@@ -1,7 +1,7 @@
 package app.k9mail.feature.widget.message.list
 
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.mailstore.MessageListRepository
 import com.fsck.k9.Preferences
 import com.fsck.k9.helper.MessageHelper

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
@@ -8,7 +8,7 @@ import android.view.View
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService.RemoteViewsFactory
 import androidx.core.content.ContextCompat
-import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.search.LocalSearch
 import app.k9mail.legacy.search.SearchAccount
 import com.fsck.k9.CoreResourceProvider

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.widget.unread
 
 import android.content.Context
 import android.content.Intent
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.message.controller.MessageCountsProvider
 import app.k9mail.legacy.search.LocalSearch
@@ -59,7 +59,7 @@ class UnreadWidgetDataProvider(
         return UnreadWidgetData(configuration, title, unreadCount, clickIntent)
     }
 
-    private fun getClickIntentForAccount(account: Account): Intent {
+    private fun getClickIntentForAccount(account: LegacyAccount): Intent {
         val folderId = defaultFolderProvider.getDefaultFolder(account)
         return getClickIntentForFolder(account, folderId)
     }
@@ -81,7 +81,7 @@ class UnreadWidgetDataProvider(
         return UnreadWidgetData(configuration, title, unreadCount, clickIntent)
     }
 
-    private fun getFolderDisplayName(account: Account, folderId: Long): String {
+    private fun getFolderDisplayName(account: LegacyAccount, folderId: Long): String {
         val folder = folderRepository.getFolder(account, folderId)
         return if (folder != null) {
             folderNameFormatter.displayName(folder)
@@ -91,7 +91,7 @@ class UnreadWidgetDataProvider(
         }
     }
 
-    private fun getClickIntentForFolder(account: Account, folderId: Long): Intent {
+    private fun getClickIntentForFolder(account: LegacyAccount, folderId: Long): Intent {
         val search = LocalSearch()
         search.addAllowedFolder(folderId)
         search.addAccountUuid(account.uuid)

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetUpdateListener.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetUpdateListener.kt
@@ -1,11 +1,13 @@
 package app.k9mail.feature.widget.unread
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import com.fsck.k9.mail.Message
 import timber.log.Timber
 
-class UnreadWidgetUpdateListener(private val unreadWidgetUpdater: UnreadWidgetUpdater) : SimpleMessagingListener() {
+class UnreadWidgetUpdateListener(
+    private val unreadWidgetUpdater: UnreadWidgetUpdater,
+) : SimpleMessagingListener() {
 
     @Suppress("TooGenericExceptionCaught")
     private fun updateUnreadWidget() {
@@ -16,15 +18,19 @@ class UnreadWidgetUpdateListener(private val unreadWidgetUpdater: UnreadWidgetUp
         }
     }
 
-    override fun synchronizeMailboxRemovedMessage(account: Account, folderServerId: String, messageServerId: String) {
+    override fun synchronizeMailboxRemovedMessage(
+        account: LegacyAccount,
+        folderServerId: String,
+        messageServerId: String,
+    ) {
         updateUnreadWidget()
     }
 
-    override fun synchronizeMailboxNewMessage(account: Account, folderServerId: String, message: Message) {
+    override fun synchronizeMailboxNewMessage(account: LegacyAccount, folderServerId: String, message: Message) {
         updateUnreadWidget()
     }
 
-    override fun folderStatusChanged(account: Account, folderId: Long) {
+    override fun folderStatusChanged(account: LegacyAccount, folderId: Long) {
         updateUnreadWidget()
     }
 }

--- a/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.widget.unread
 import android.content.Context
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.message.controller.MessageCounts
 import app.k9mail.legacy.message.controller.MessageCountsProvider
@@ -120,7 +120,7 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
         assertThat(widgetData).isNull()
     }
 
-    private fun createAccount(): Account = mock {
+    private fun createAccount(): LegacyAccount = mock {
         on { uuid } doReturn ACCOUNT_UUID
         on { displayName } doReturn ACCOUNT_NAME
     }
@@ -130,7 +130,7 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
     }
 
     private fun createMessageCountsProvider() = object : MessageCountsProvider {
-        override fun getMessageCounts(account: Account): MessageCounts {
+        override fun getMessageCounts(account: LegacyAccount): MessageCounts {
             return MessageCounts(unread = ACCOUNT_UNREAD_COUNT, starred = 0)
         }
 
@@ -146,7 +146,7 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
             throw UnsupportedOperationException()
         }
 
-        override fun getUnreadMessageCount(account: Account, folderId: Long): Int {
+        override fun getUnreadMessageCount(account: LegacyAccount, folderId: Long): Int {
             return FOLDER_UNREAD_COUNT
         }
     }

--- a/legacy/account/build.gradle.kts
+++ b/legacy/account/build.gradle.kts
@@ -8,7 +8,8 @@ android {
 }
 
 dependencies {
-    implementation(projects.legacy.notification)
-    implementation(projects.mail.common)
+    api(projects.legacy.notification)
+    api(projects.mail.common)
+
     implementation(projects.backend.api)
 }

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -601,14 +601,6 @@ open class Account(
         return uuid.hashCode()
     }
 
-    enum class FolderMode {
-        NONE,
-        ALL,
-        FIRST_CLASS,
-        FIRST_AND_SECOND_CLASS,
-        NOT_SECOND_CLASS,
-    }
-
     enum class SpecialFolderSelection {
         AUTOMATIC,
         MANUAL,

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -636,21 +636,6 @@ open class Account(
         }
     }
 
-    @Suppress("MagicNumber")
-    enum class DeletePolicy(@JvmField val setting: Int) {
-        NEVER(0),
-        SEVEN_DAYS(1),
-        ON_DELETE(2),
-        MARK_AS_READ(3),
-        ;
-
-        companion object {
-            fun fromInt(initialSetting: Int): DeletePolicy {
-                return entries.find { it.setting == initialSetting } ?: error("DeletePolicy $initialSetting unknown")
-            }
-        }
-    }
-
     enum class SortType(val isDefaultAscending: Boolean) {
         SORT_DATE(false),
         SORT_ARRIVAL(false),

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -622,16 +622,6 @@ open class Account(
         AUTO,
     }
 
-    enum class SortType(val isDefaultAscending: Boolean) {
-        SORT_DATE(false),
-        SORT_ARRIVAL(false),
-        SORT_SUBJECT(true),
-        SORT_SENDER(true),
-        SORT_UNREAD(true),
-        SORT_FLAGGED(true),
-        SORT_ATTACHMENT(true),
-    }
-
     companion object {
         /**
          * Fixed name of outbox - not actually displayed.

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -600,11 +600,6 @@ open class Account(
         return uuid.hashCode()
     }
 
-    enum class SpecialFolderSelection {
-        AUTOMATIC,
-        MANUAL,
-    }
-
     enum class ShowPictures {
         NEVER,
         ALWAYS,

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -600,12 +600,6 @@ open class Account(
         return uuid.hashCode()
     }
 
-    enum class ShowPictures {
-        NEVER,
-        ALWAYS,
-        ONLY_FROM_CONTACTS,
-    }
-
     enum class QuoteStyle {
         PREFIX,
         HEADER,

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -14,10 +14,11 @@ const val DEFAULT_VISIBLE_LIMIT = 25
 /**
  * Account stores all of the settings for a single account defined by the user. Each account is defined by a UUID.
  */
+@Deprecated("Use LegacyAccountWrapper instead")
 @Suppress("TooManyFunctions")
-class Account(
+open class Account(
     override val uuid: String,
-    private val isSensitiveDebugLoggingEnabled: () -> Boolean = { false },
+    internal val isSensitiveDebugLoggingEnabled: () -> Boolean = { false },
 ) : BaseAccount {
     @get:Synchronized
     @set:Synchronized
@@ -198,7 +199,7 @@ class Account(
     @set:Synchronized
     var sortType: SortType = SortType.SORT_DATE
 
-    private val sortAscending: MutableMap<SortType, Boolean> = mutableMapOf()
+    internal var sortAscending: MutableMap<SortType, Boolean> = mutableMapOf()
 
     @get:Synchronized
     @set:Synchronized
@@ -343,7 +344,7 @@ class Account(
 
     @get:Synchronized
     var isFinishedSetup = false
-        private set
+        internal set
 
     @get:Synchronized
     @set:Synchronized
@@ -352,7 +353,7 @@ class Account(
     @get:Synchronized
     @set:Synchronized
     var isChangedVisibleLimits = false
-        private set
+        internal set
 
     /**
      * Database ID of the folder that was last selected for a copy or move operation.
@@ -361,7 +362,7 @@ class Account(
      */
     @get:Synchronized
     var lastSelectedFolderId: Long? = null
-        private set
+        internal set
 
     @get:Synchronized
     @set:Synchronized
@@ -372,7 +373,7 @@ class Account(
 
     @get:Synchronized
     var notificationSettings = NotificationSettings()
-        private set
+        internal set
 
     val displayName: String
         get() = name ?: email
@@ -435,6 +436,7 @@ class Account(
         draftsFolderSelection = selection
     }
 
+    @Deprecated("use AccountWrapper instead")
     @Synchronized
     fun hasDraftsFolder(): Boolean {
         return draftsFolderId != null
@@ -446,6 +448,7 @@ class Account(
         sentFolderSelection = selection
     }
 
+    @Deprecated("use AccountWrapper instead")
     @Synchronized
     fun hasSentFolder(): Boolean {
         return sentFolderId != null
@@ -457,6 +460,7 @@ class Account(
         trashFolderSelection = selection
     }
 
+    @Deprecated("use AccountWrapper instead")
     @Synchronized
     fun hasTrashFolder(): Boolean {
         return trashFolderId != null
@@ -468,6 +472,7 @@ class Account(
         archiveFolderSelection = selection
     }
 
+    @Deprecated("use AccountWrapper instead")
     @Synchronized
     fun hasArchiveFolder(): Boolean {
         return archiveFolderId != null
@@ -479,6 +484,7 @@ class Account(
         spamFolderSelection = selection
     }
 
+    @Deprecated("use AccountWrapper instead")
     @Synchronized
     fun hasSpamFolder(): Boolean {
         return spamFolderId != null
@@ -549,9 +555,11 @@ class Account(
             return now.time
         }
 
+    @Deprecated("use AccountWrapper instead")
     val isOpenPgpProviderConfigured: Boolean
         get() = openPgpProvider != null
 
+    @Deprecated("use AccountWrapper instead")
     @Synchronized
     fun hasOpenPgpKey(): Boolean {
         return openPgpKey != NO_OPENPGP_KEY

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -605,12 +605,6 @@ open class Account(
         HEADER,
     }
 
-    enum class MessageFormat {
-        TEXT,
-        HTML,
-        AUTO,
-    }
-
     companion object {
         /**
          * Fixed name of outbox - not actually displayed.

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -2,7 +2,6 @@ package app.k9mail.legacy.account
 
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.notification.NotificationSettings
-import com.fsck.k9.backend.api.SyncConfig.ExpungePolicy
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.ServerSettings
 import java.util.Calendar
@@ -621,19 +620,6 @@ open class Account(
         TEXT,
         HTML,
         AUTO,
-    }
-
-    enum class Expunge {
-        EXPUNGE_IMMEDIATELY,
-        EXPUNGE_MANUALLY,
-        EXPUNGE_ON_POLL,
-        ;
-
-        fun toBackendExpungePolicy(): ExpungePolicy = when (this) {
-            EXPUNGE_IMMEDIATELY -> ExpungePolicy.IMMEDIATELY
-            EXPUNGE_MANUALLY -> ExpungePolicy.MANUALLY
-            EXPUNGE_ON_POLL -> ExpungePolicy.ON_POLL
-        }
     }
 
     enum class SortType(val isDefaultAscending: Boolean) {

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Account.kt
@@ -600,11 +600,6 @@ open class Account(
         return uuid.hashCode()
     }
 
-    enum class QuoteStyle {
-        PREFIX,
-        HEADER,
-    }
-
     companion object {
         /**
          * Fixed name of outbox - not actually displayed.

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/AccountDefaultsProvider.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/AccountDefaultsProvider.kt
@@ -1,11 +1,7 @@
 package app.k9mail.legacy.account
 
-import app.k9mail.legacy.account.Account.MessageFormat
-import app.k9mail.legacy.account.Account.QuoteStyle
-import app.k9mail.legacy.account.Account.SortType
-
 fun interface AccountDefaultsProvider {
-    fun applyDefaults(account: Account)
+    fun applyDefaults(account: LegacyAccount)
 
     companion object {
         const val DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE = 131072

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/AccountManager.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/AccountManager.kt
@@ -3,13 +3,13 @@ package app.k9mail.legacy.account
 import kotlinx.coroutines.flow.Flow
 
 interface AccountManager {
-    fun getAccounts(): List<Account>
-    fun getAccountsFlow(): Flow<List<Account>>
-    fun getAccount(accountUuid: String): Account?
-    fun getAccountFlow(accountUuid: String): Flow<Account?>
+    fun getAccounts(): List<LegacyAccount>
+    fun getAccountsFlow(): Flow<List<LegacyAccount>>
+    fun getAccount(accountUuid: String): LegacyAccount?
+    fun getAccountFlow(accountUuid: String): Flow<LegacyAccount?>
     fun addAccountRemovedListener(listener: AccountRemovedListener)
-    fun moveAccount(account: Account, newPosition: Int)
+    fun moveAccount(account: LegacyAccount, newPosition: Int)
     fun addOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener)
     fun removeOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener)
-    fun saveAccount(account: Account)
+    fun saveAccount(account: LegacyAccount)
 }

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/AccountManager.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/AccountManager.kt
@@ -6,7 +6,7 @@ interface AccountManager {
     fun getAccounts(): List<Account>
     fun getAccountsFlow(): Flow<List<Account>>
     fun getAccount(accountUuid: String): Account?
-    fun getAccountFlow(accountUuid: String): Flow<Account>
+    fun getAccountFlow(accountUuid: String): Flow<Account?>
     fun addAccountRemovedListener(listener: AccountRemovedListener)
     fun moveAccount(account: Account, newPosition: Int)
     fun addOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener)

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/AccountRemovedListener.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/AccountRemovedListener.kt
@@ -1,5 +1,5 @@
 package app.k9mail.legacy.account
 
 fun interface AccountRemovedListener {
-    fun onAccountRemoved(account: Account)
+    fun onAccountRemoved(account: LegacyAccount)
 }

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/DeletePolicy.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/DeletePolicy.kt
@@ -1,0 +1,16 @@
+package app.k9mail.legacy.account
+
+@Suppress("MagicNumber")
+enum class DeletePolicy(@JvmField val setting: Int) {
+    NEVER(0),
+    SEVEN_DAYS(1),
+    ON_DELETE(2),
+    MARK_AS_READ(3),
+    ;
+
+    companion object {
+        fun fromInt(initialSetting: Int): DeletePolicy {
+            return entries.find { it.setting == initialSetting } ?: error("DeletePolicy $initialSetting unknown")
+        }
+    }
+}

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/Expunge.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/Expunge.kt
@@ -1,0 +1,16 @@
+package app.k9mail.legacy.account
+
+import com.fsck.k9.backend.api.SyncConfig.ExpungePolicy
+
+enum class Expunge {
+    EXPUNGE_IMMEDIATELY,
+    EXPUNGE_MANUALLY,
+    EXPUNGE_ON_POLL,
+    ;
+
+    fun toBackendExpungePolicy(): ExpungePolicy = when (this) {
+        EXPUNGE_IMMEDIATELY -> ExpungePolicy.IMMEDIATELY
+        EXPUNGE_MANUALLY -> ExpungePolicy.MANUALLY
+        EXPUNGE_ON_POLL -> ExpungePolicy.ON_POLL
+    }
+}

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/FolderMode.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/FolderMode.kt
@@ -1,0 +1,9 @@
+package app.k9mail.legacy.account
+
+enum class FolderMode {
+    NONE,
+    ALL,
+    FIRST_CLASS,
+    FIRST_AND_SECOND_CLASS,
+    NOT_SECOND_CLASS,
+}

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccount.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccount.kt
@@ -15,7 +15,7 @@ const val DEFAULT_VISIBLE_LIMIT = 25
  */
 @Deprecated("Use LegacyAccountWrapper instead")
 @Suppress("TooManyFunctions")
-open class Account(
+open class LegacyAccount(
     override val uuid: String,
     internal val isSensitiveDebugLoggingEnabled: () -> Boolean = { false },
 ) : BaseAccount {
@@ -589,7 +589,7 @@ open class Account(
     }
 
     override fun equals(other: Any?): Boolean {
-        return if (other is Account) {
+        return if (other is LegacyAccount) {
             other.uuid == uuid
         } else {
             super.equals(other)

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -1,7 +1,6 @@
 package app.k9mail.legacy.account
 
 import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
-import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.notification.NotificationSettings
 import com.fsck.k9.mail.ServerSettings

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -3,7 +3,6 @@ package app.k9mail.legacy.account
 import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
-import app.k9mail.legacy.account.Account.ShowPictures
 import app.k9mail.legacy.notification.NotificationSettings
 import com.fsck.k9.mail.ServerSettings
 

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -4,7 +4,6 @@ import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures
-import app.k9mail.legacy.account.Account.SortType
 import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationSettings
 import com.fsck.k9.mail.ServerSettings

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -1,17 +1,18 @@
 package app.k9mail.legacy.account
 
-import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
+import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.notification.NotificationSettings
 import com.fsck.k9.mail.ServerSettings
 
 /**
- * A immutable wrapper for the [Account] class.
+ * A immutable wrapper for the [LegacyAccount] class.
  *
  * This class is used to store the account data in a way that is safe to pass between threads.
  *
  * Use LegacyAccountWrapper.from(account) to create a wrapper from an account.
  * Use LegacyAccountWrapper.to(wrapper) to create an account from a wrapper.
  */
+@Suppress("LongMethod")
 data class LegacyAccountWrapper(
     override val uuid: String,
     override val name: String?,
@@ -132,7 +133,8 @@ data class LegacyAccountWrapper(
     }
 
     companion object {
-        fun from(account: Account): LegacyAccountWrapper {
+        @Suppress("LongMethod")
+        fun from(account: LegacyAccount): LegacyAccountWrapper {
             return LegacyAccountWrapper(
                 uuid = account.uuid,
                 isSensitiveDebugLoggingEnabled = account.isSensitiveDebugLoggingEnabled,
@@ -225,8 +227,9 @@ data class LegacyAccountWrapper(
             )
         }
 
-        fun to(wrapper: LegacyAccountWrapper): Account {
-            return Account(
+        @Suppress("LongMethod")
+        fun to(wrapper: LegacyAccountWrapper): LegacyAccount {
+            return LegacyAccount(
                 uuid = wrapper.uuid,
                 isSensitiveDebugLoggingEnabled = wrapper.isSensitiveDebugLoggingEnabled,
             ).apply {

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -4,7 +4,6 @@ import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures
-import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationSettings
 import com.fsck.k9.mail.ServerSettings
 

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -1,0 +1,329 @@
+package app.k9mail.legacy.account
+
+import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
+import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.Account.Expunge
+import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.Account.MessageFormat
+import app.k9mail.legacy.account.Account.QuoteStyle
+import app.k9mail.legacy.account.Account.ShowPictures
+import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.Account.SpecialFolderSelection
+import app.k9mail.legacy.notification.NotificationSettings
+import com.fsck.k9.mail.ServerSettings
+
+/**
+ * A immutable wrapper for the [Account] class.
+ *
+ * This class is used to store the account data in a way that is safe to pass between threads.
+ *
+ * Use LegacyAccountWrapper.from(account) to create a wrapper from an account.
+ * Use LegacyAccountWrapper.to(wrapper) to create an account from a wrapper.
+ */
+data class LegacyAccountWrapper(
+    override val uuid: String,
+    override val name: String?,
+    override val email: String,
+    private val isSensitiveDebugLoggingEnabled: () -> Boolean = { false },
+    val deletePolicy: DeletePolicy,
+    val incomingServerSettings: ServerSettings,
+    val outgoingServerSettings: ServerSettings,
+    val oAuthState: String?,
+    val alwaysBcc: String?,
+    val automaticCheckIntervalMinutes: Int,
+    val displayCount: Int,
+    val chipColor: Int,
+    val isNotifyNewMail: Boolean,
+    val folderNotifyNewMailMode: FolderMode,
+    val isNotifySelfNewMail: Boolean,
+    val isNotifyContactsMailOnly: Boolean,
+    val isIgnoreChatMessages: Boolean,
+    val legacyInboxFolder: String?,
+    val importedDraftsFolder: String?,
+    val importedSentFolder: String?,
+    val importedTrashFolder: String?,
+    val importedArchiveFolder: String?,
+    val importedSpamFolder: String?,
+    val inboxFolderId: Long?,
+    val outboxFolderId: Long?,
+    val draftsFolderId: Long?,
+    val sentFolderId: Long?,
+    val trashFolderId: Long?,
+    val archiveFolderId: Long?,
+    val spamFolderId: Long?,
+    val draftsFolderSelection: SpecialFolderSelection,
+    val sentFolderSelection: SpecialFolderSelection,
+    val trashFolderSelection: SpecialFolderSelection,
+    val archiveFolderSelection: SpecialFolderSelection,
+    val spamFolderSelection: SpecialFolderSelection,
+    val importedAutoExpandFolder: String?,
+    val autoExpandFolderId: Long?,
+    val folderDisplayMode: FolderMode,
+    val folderSyncMode: FolderMode,
+    val folderPushMode: FolderMode,
+    val accountNumber: Int,
+    val isNotifySync: Boolean,
+    val sortType: SortType,
+    val sortAscending: Map<SortType, Boolean>,
+    val showPictures: ShowPictures,
+    val isSignatureBeforeQuotedText: Boolean,
+    val expungePolicy: Expunge,
+    val maxPushFolders: Int,
+    val idleRefreshMinutes: Int,
+    val useCompression: Boolean,
+    val isSendClientInfoEnabled: Boolean,
+    val isSubscribedFoldersOnly: Boolean,
+    val maximumPolledMessageAge: Int,
+    val maximumAutoDownloadMessageSize: Int,
+    val messageFormat: MessageFormat,
+    val isMessageFormatAuto: Boolean,
+    val isMessageReadReceipt: Boolean,
+    val quoteStyle: QuoteStyle,
+    val quotePrefix: String?,
+    val isDefaultQuotedTextShown: Boolean,
+    val isReplyAfterQuote: Boolean,
+    val isStripSignature: Boolean,
+    val isSyncRemoteDeletions: Boolean,
+    val openPgpProvider: String?,
+    val openPgpKey: Long,
+    val autocryptPreferEncryptMutual: Boolean,
+    val isOpenPgpHideSignOnly: Boolean,
+    val isOpenPgpEncryptSubject: Boolean,
+    val isOpenPgpEncryptAllDrafts: Boolean,
+    val isMarkMessageAsReadOnView: Boolean,
+    val isMarkMessageAsReadOnDelete: Boolean,
+    val isAlwaysShowCcBcc: Boolean,
+    val isRemoteSearchFullText: Boolean,
+    val remoteSearchNumResults: Int,
+    val isUploadSentMessages: Boolean,
+    val lastSyncTime: Long,
+    val lastFolderListRefreshTime: Long,
+    val isFinishedSetup: Boolean,
+    val messagesNotificationChannelVersion: Int,
+    val isChangedVisibleLimits: Boolean,
+    val lastSelectedFolderId: Long?,
+    val identities: List<Identity>,
+    val notificationSettings: NotificationSettings,
+    val displayName: String,
+    val senderName: String?,
+    val signatureUse: Boolean,
+    val signature: String?,
+    val shouldMigrateToOAuth: Boolean,
+) : BaseAccount {
+
+    fun hasDraftsFolder(): Boolean {
+        return draftsFolderId != null
+    }
+
+    fun hasSentFolder(): Boolean {
+        return sentFolderId != null
+    }
+
+    fun hasTrashFolder(): Boolean {
+        return trashFolderId != null
+    }
+
+    fun hasArchiveFolder(): Boolean {
+        return archiveFolderId != null
+    }
+
+    fun hasSpamFolder(): Boolean {
+        return spamFolderId != null
+    }
+
+    fun isOpenPgpProviderConfigured(): Boolean {
+        return openPgpProvider != null
+    }
+
+    fun hasOpenPgpKey(): Boolean {
+        return openPgpKey != NO_OPENPGP_KEY
+    }
+
+    companion object {
+        fun from(account: Account): LegacyAccountWrapper {
+            return LegacyAccountWrapper(
+                uuid = account.uuid,
+                isSensitiveDebugLoggingEnabled = account.isSensitiveDebugLoggingEnabled,
+                name = account.displayName,
+                identities = account.identities,
+                email = account.email,
+                deletePolicy = account.deletePolicy,
+                incomingServerSettings = account.incomingServerSettings,
+                outgoingServerSettings = account.outgoingServerSettings,
+                oAuthState = account.oAuthState,
+                alwaysBcc = account.alwaysBcc,
+                automaticCheckIntervalMinutes = account.automaticCheckIntervalMinutes,
+                displayCount = account.displayCount,
+                chipColor = account.chipColor,
+                isNotifyNewMail = account.isNotifyNewMail,
+                folderNotifyNewMailMode = account.folderNotifyNewMailMode,
+                isNotifySelfNewMail = account.isNotifySelfNewMail,
+                isNotifyContactsMailOnly = account.isNotifyContactsMailOnly,
+                isIgnoreChatMessages = account.isIgnoreChatMessages,
+                legacyInboxFolder = account.legacyInboxFolder,
+                importedDraftsFolder = account.importedDraftsFolder,
+                importedSentFolder = account.importedSentFolder,
+                importedTrashFolder = account.importedTrashFolder,
+                importedArchiveFolder = account.importedArchiveFolder,
+                importedSpamFolder = account.importedSpamFolder,
+                inboxFolderId = account.inboxFolderId,
+                outboxFolderId = account.outboxFolderId,
+                draftsFolderId = account.draftsFolderId,
+                sentFolderId = account.sentFolderId,
+                trashFolderId = account.trashFolderId,
+                archiveFolderId = account.archiveFolderId,
+                spamFolderId = account.spamFolderId,
+                draftsFolderSelection = account.draftsFolderSelection,
+                sentFolderSelection = account.sentFolderSelection,
+                trashFolderSelection = account.trashFolderSelection,
+                archiveFolderSelection = account.archiveFolderSelection,
+                spamFolderSelection = account.spamFolderSelection,
+                importedAutoExpandFolder = account.importedAutoExpandFolder,
+                autoExpandFolderId = account.autoExpandFolderId,
+                folderDisplayMode = account.folderDisplayMode,
+                folderSyncMode = account.folderSyncMode,
+                folderPushMode = account.folderPushMode,
+                accountNumber = account.accountNumber,
+                isNotifySync = account.isNotifySync,
+                sortType = account.sortType,
+                sortAscending = account.sortAscending,
+                showPictures = account.showPictures,
+                isSignatureBeforeQuotedText = account.isSignatureBeforeQuotedText,
+                expungePolicy = account.expungePolicy,
+                maxPushFolders = account.maxPushFolders,
+                idleRefreshMinutes = account.idleRefreshMinutes,
+                useCompression = account.useCompression,
+                isSendClientInfoEnabled = account.isSendClientInfoEnabled,
+                isSubscribedFoldersOnly = account.isSubscribedFoldersOnly,
+                maximumPolledMessageAge = account.maximumPolledMessageAge,
+                maximumAutoDownloadMessageSize = account.maximumAutoDownloadMessageSize,
+                messageFormat = account.messageFormat,
+                isMessageFormatAuto = account.isMessageFormatAuto,
+                isMessageReadReceipt = account.isMessageReadReceipt,
+                quoteStyle = account.quoteStyle,
+                quotePrefix = account.quotePrefix,
+                isDefaultQuotedTextShown = account.isDefaultQuotedTextShown,
+                isReplyAfterQuote = account.isReplyAfterQuote,
+                isStripSignature = account.isStripSignature,
+                isSyncRemoteDeletions = account.isSyncRemoteDeletions,
+                openPgpProvider = account.openPgpProvider,
+                openPgpKey = account.openPgpKey,
+                autocryptPreferEncryptMutual = account.autocryptPreferEncryptMutual,
+                isOpenPgpHideSignOnly = account.isOpenPgpHideSignOnly,
+                isOpenPgpEncryptSubject = account.isOpenPgpEncryptSubject,
+                isOpenPgpEncryptAllDrafts = account.isOpenPgpEncryptAllDrafts,
+                isMarkMessageAsReadOnView = account.isMarkMessageAsReadOnView,
+                isMarkMessageAsReadOnDelete = account.isMarkMessageAsReadOnDelete,
+                isAlwaysShowCcBcc = account.isAlwaysShowCcBcc,
+                isRemoteSearchFullText = account.isRemoteSearchFullText,
+                remoteSearchNumResults = account.remoteSearchNumResults,
+                isUploadSentMessages = account.isUploadSentMessages,
+                lastSyncTime = account.lastSyncTime,
+                lastFolderListRefreshTime = account.lastFolderListRefreshTime,
+                isFinishedSetup = account.isFinishedSetup,
+                messagesNotificationChannelVersion = account.messagesNotificationChannelVersion,
+                isChangedVisibleLimits = account.isChangedVisibleLimits,
+                lastSelectedFolderId = account.lastSelectedFolderId,
+                notificationSettings = account.notificationSettings,
+                displayName = account.displayName,
+                senderName = account.senderName,
+                signatureUse = account.signatureUse,
+                signature = account.signature,
+                shouldMigrateToOAuth = account.shouldMigrateToOAuth,
+            )
+        }
+
+        fun to(wrapper: LegacyAccountWrapper): Account {
+            return Account(
+                uuid = wrapper.uuid,
+                isSensitiveDebugLoggingEnabled = wrapper.isSensitiveDebugLoggingEnabled,
+            ).apply {
+                identities = wrapper.identities.toMutableList()
+                name = wrapper.displayName
+                email = wrapper.email
+                deletePolicy = wrapper.deletePolicy
+                incomingServerSettings = wrapper.incomingServerSettings
+                outgoingServerSettings = wrapper.outgoingServerSettings
+                oAuthState = wrapper.oAuthState
+                alwaysBcc = wrapper.alwaysBcc
+                automaticCheckIntervalMinutes = wrapper.automaticCheckIntervalMinutes
+                displayCount = wrapper.displayCount
+                chipColor = wrapper.chipColor
+                isNotifyNewMail = wrapper.isNotifyNewMail
+                folderNotifyNewMailMode = wrapper.folderNotifyNewMailMode
+                isNotifySelfNewMail = wrapper.isNotifySelfNewMail
+                isNotifyContactsMailOnly = wrapper.isNotifyContactsMailOnly
+                isIgnoreChatMessages = wrapper.isIgnoreChatMessages
+                legacyInboxFolder = wrapper.legacyInboxFolder
+                importedDraftsFolder = wrapper.importedDraftsFolder
+                importedSentFolder = wrapper.importedSentFolder
+                importedTrashFolder = wrapper.importedTrashFolder
+                importedArchiveFolder = wrapper.importedArchiveFolder
+                importedSpamFolder = wrapper.importedSpamFolder
+                inboxFolderId = wrapper.inboxFolderId
+                outboxFolderId = wrapper.outboxFolderId
+                draftsFolderId = wrapper.draftsFolderId
+                sentFolderId = wrapper.sentFolderId
+                trashFolderId = wrapper.trashFolderId
+                archiveFolderId = wrapper.archiveFolderId
+                spamFolderId = wrapper.spamFolderId
+                draftsFolderSelection = wrapper.draftsFolderSelection
+                sentFolderSelection = wrapper.sentFolderSelection
+                trashFolderSelection = wrapper.trashFolderSelection
+                archiveFolderSelection = wrapper.archiveFolderSelection
+                spamFolderSelection = wrapper.spamFolderSelection
+                importedAutoExpandFolder = wrapper.importedAutoExpandFolder
+                autoExpandFolderId = wrapper.autoExpandFolderId
+                folderDisplayMode = wrapper.folderDisplayMode
+                folderSyncMode = wrapper.folderSyncMode
+                folderPushMode = wrapper.folderPushMode
+                accountNumber = wrapper.accountNumber
+                isNotifySync = wrapper.isNotifySync
+                sortType = wrapper.sortType
+                sortAscending = wrapper.sortAscending.toMutableMap()
+                showPictures = wrapper.showPictures
+                isSignatureBeforeQuotedText = wrapper.isSignatureBeforeQuotedText
+                expungePolicy = wrapper.expungePolicy
+                maxPushFolders = wrapper.maxPushFolders
+                idleRefreshMinutes = wrapper.idleRefreshMinutes
+                useCompression = wrapper.useCompression
+                isSendClientInfoEnabled = wrapper.isSendClientInfoEnabled
+                isSubscribedFoldersOnly = wrapper.isSubscribedFoldersOnly
+                maximumPolledMessageAge = wrapper.maximumPolledMessageAge
+                maximumAutoDownloadMessageSize = wrapper.maximumAutoDownloadMessageSize
+                messageFormat = wrapper.messageFormat
+                isMessageFormatAuto = wrapper.isMessageFormatAuto
+                isMessageReadReceipt = wrapper.isMessageReadReceipt
+                quoteStyle = wrapper.quoteStyle
+                quotePrefix = wrapper.quotePrefix
+                isDefaultQuotedTextShown = wrapper.isDefaultQuotedTextShown
+                isReplyAfterQuote = wrapper.isReplyAfterQuote
+                isStripSignature = wrapper.isStripSignature
+                isSyncRemoteDeletions = wrapper.isSyncRemoteDeletions
+                openPgpProvider = wrapper.openPgpProvider
+                openPgpKey = wrapper.openPgpKey
+                autocryptPreferEncryptMutual = wrapper.autocryptPreferEncryptMutual
+                isOpenPgpHideSignOnly = wrapper.isOpenPgpHideSignOnly
+                isOpenPgpEncryptSubject = wrapper.isOpenPgpEncryptSubject
+                isOpenPgpEncryptAllDrafts = wrapper.isOpenPgpEncryptAllDrafts
+                isMarkMessageAsReadOnView = wrapper.isMarkMessageAsReadOnView
+                isMarkMessageAsReadOnDelete = wrapper.isMarkMessageAsReadOnDelete
+                isAlwaysShowCcBcc = wrapper.isAlwaysShowCcBcc
+                isRemoteSearchFullText = wrapper.isRemoteSearchFullText
+                remoteSearchNumResults = wrapper.remoteSearchNumResults
+                isUploadSentMessages = wrapper.isUploadSentMessages
+                lastSyncTime = wrapper.lastSyncTime
+                lastFolderListRefreshTime = wrapper.lastFolderListRefreshTime
+                isFinishedSetup = wrapper.isFinishedSetup
+                messagesNotificationChannelVersion = wrapper.messagesNotificationChannelVersion
+                isChangedVisibleLimits = wrapper.isChangedVisibleLimits
+                lastSelectedFolderId = wrapper.lastSelectedFolderId
+                notificationSettings = wrapper.notificationSettings
+                senderName = wrapper.senderName
+                signatureUse = wrapper.signatureUse
+                signature = wrapper.signature
+                shouldMigrateToOAuth = wrapper.shouldMigrateToOAuth
+            }
+        }
+    }
+}

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -1,7 +1,6 @@
 package app.k9mail.legacy.account
 
 import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
-import app.k9mail.legacy.account.Account.DeletePolicy
 import app.k9mail.legacy.account.Account.Expunge
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -1,7 +1,6 @@
 package app.k9mail.legacy.account
 
 import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
-import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.notification.NotificationSettings
 import com.fsck.k9.mail.ServerSettings
 

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -3,7 +3,6 @@ package app.k9mail.legacy.account
 import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.account.Account.DeletePolicy
 import app.k9mail.legacy.account.Account.Expunge
-import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapper.kt
@@ -1,7 +1,6 @@
 package app.k9mail.legacy.account
 
 import app.k9mail.legacy.account.Account.Companion.NO_OPENPGP_KEY
-import app.k9mail.legacy.account.Account.Expunge
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapperManager.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/LegacyAccountWrapperManager.kt
@@ -1,0 +1,11 @@
+package app.k9mail.legacy.account
+
+import kotlinx.coroutines.flow.Flow
+
+interface LegacyAccountWrapperManager {
+    fun getAll(): Flow<List<LegacyAccountWrapper>>
+
+    fun getById(id: String): Flow<LegacyAccountWrapper?>
+
+    suspend fun update(account: LegacyAccountWrapper)
+}

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/MessageFormat.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/MessageFormat.kt
@@ -1,0 +1,7 @@
+package app.k9mail.legacy.account
+
+enum class MessageFormat {
+    TEXT,
+    HTML,
+    AUTO,
+}

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/QuoteStyle.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/QuoteStyle.kt
@@ -1,0 +1,6 @@
+package app.k9mail.legacy.account
+
+enum class QuoteStyle {
+    PREFIX,
+    HEADER,
+}

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/ShowPictures.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/ShowPictures.kt
@@ -1,0 +1,7 @@
+package app.k9mail.legacy.account
+
+enum class ShowPictures {
+    NEVER,
+    ALWAYS,
+    ONLY_FROM_CONTACTS,
+}

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/SortType.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/SortType.kt
@@ -1,0 +1,11 @@
+package app.k9mail.legacy.account
+
+enum class SortType(val isDefaultAscending: Boolean) {
+    SORT_DATE(false),
+    SORT_ARRIVAL(false),
+    SORT_SUBJECT(true),
+    SORT_SENDER(true),
+    SORT_UNREAD(true),
+    SORT_FLAGGED(true),
+    SORT_ATTACHMENT(true),
+}

--- a/legacy/account/src/main/java/app/k9mail/legacy/account/SpecialFolderSelection.kt
+++ b/legacy/account/src/main/java/app/k9mail/legacy/account/SpecialFolderSelection.kt
@@ -1,0 +1,6 @@
+package app.k9mail.legacy.account
+
+enum class SpecialFolderSelection {
+    AUTOMATIC,
+    MANUAL,
+}

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -1,6 +1,5 @@
 package app.k9mail.legacy.account
 
-import app.k9mail.legacy.account.Account.DeletePolicy
 import app.k9mail.legacy.account.Account.Expunge
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -163,8 +163,9 @@ class LegacyAccountWrapperTest {
 
         val defaultNotificationSettings = NotificationSettings()
 
-        fun createAccount(): Account {
-            return Account(
+        @Suppress("LongMethod")
+        fun createAccount(): LegacyAccount {
+            return LegacyAccount(
                 uuid = "uuid",
                 isSensitiveDebugLoggingEnabled = defaultIsSensitiveDebugLoggingEnabled,
             ).apply {
@@ -258,6 +259,7 @@ class LegacyAccountWrapperTest {
             }
         }
 
+        @Suppress("LongMethod")
         fun createAccountWrapper(): LegacyAccountWrapper {
             return LegacyAccountWrapper(
                 uuid = "uuid",

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -3,7 +3,6 @@ package app.k9mail.legacy.account
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures
-import app.k9mail.legacy.account.Account.SortType
 import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationSettings
 import assertk.assertThat

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -1,6 +1,5 @@
 package app.k9mail.legacy.account
 
-import app.k9mail.legacy.account.Account.Expunge
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -3,7 +3,6 @@ package app.k9mail.legacy.account
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures
-import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationSettings
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -1,0 +1,364 @@
+package app.k9mail.legacy.account
+
+import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.Account.Expunge
+import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.Account.MessageFormat
+import app.k9mail.legacy.account.Account.QuoteStyle
+import app.k9mail.legacy.account.Account.ShowPictures
+import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.Account.SpecialFolderSelection
+import app.k9mail.legacy.notification.NotificationSettings
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
+import kotlin.test.Test
+
+class LegacyAccountWrapperTest {
+
+    @Test
+    fun `from account should return wrapper`() {
+        // arrange
+        val account = createAccount()
+        val expected = createAccountWrapper()
+
+        // act
+        val result = LegacyAccountWrapper.from(account)
+
+        // assert
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Suppress("LongMethod")
+    @Test
+    fun `to wrapper should return account`() {
+        // arrange
+        val wrapper = createAccountWrapper()
+
+        // act
+        val result = LegacyAccountWrapper.to(wrapper)
+
+        // assert
+        assertThat(result.uuid).isEqualTo("uuid")
+        assertThat(result.isSensitiveDebugLoggingEnabled).isEqualTo(defaultIsSensitiveDebugLoggingEnabled)
+        assertThat(result.identities).isEqualTo(defaultIdentities)
+        assertThat(result.name).isEqualTo("displayName")
+        assertThat(result.email).isEqualTo("demo@example.com")
+        assertThat(result.deletePolicy).isEqualTo(DeletePolicy.SEVEN_DAYS)
+        assertThat(result.incomingServerSettings).isEqualTo(defaultIncomingServerSettings)
+        assertThat(result.outgoingServerSettings).isEqualTo(defaultOutgoingServerSettings)
+        assertThat(result.oAuthState).isEqualTo("oAuthState")
+        assertThat(result.alwaysBcc).isEqualTo("alwaysBcc")
+        assertThat(result.automaticCheckIntervalMinutes).isEqualTo(60)
+        assertThat(result.displayCount).isEqualTo(10)
+        assertThat(result.chipColor).isEqualTo(0xFFFF0000.toInt())
+        assertThat(result.isNotifyNewMail).isEqualTo(true)
+        assertThat(result.folderNotifyNewMailMode).isEqualTo(FolderMode.FIRST_AND_SECOND_CLASS)
+        assertThat(result.isNotifySelfNewMail).isEqualTo(true)
+        assertThat(result.isNotifyContactsMailOnly).isEqualTo(true)
+        assertThat(result.isIgnoreChatMessages).isEqualTo(true)
+        assertThat(result.legacyInboxFolder).isEqualTo("legacyInboxFolder")
+        assertThat(result.importedDraftsFolder).isEqualTo("importedDraftsFolder")
+        assertThat(result.importedSentFolder).isEqualTo("importedSentFolder")
+        assertThat(result.importedTrashFolder).isEqualTo("importedTrashFolder")
+        assertThat(result.importedArchiveFolder).isEqualTo("importedArchiveFolder")
+        assertThat(result.importedSpamFolder).isEqualTo("importedSpamFolder")
+        assertThat(result.inboxFolderId).isEqualTo(1)
+        assertThat(result.outboxFolderId).isEqualTo(2)
+        assertThat(result.draftsFolderId).isEqualTo(3)
+        assertThat(result.sentFolderId).isEqualTo(4)
+        assertThat(result.trashFolderId).isEqualTo(5)
+        assertThat(result.archiveFolderId).isEqualTo(6)
+        assertThat(result.spamFolderId).isEqualTo(7)
+        assertThat(result.draftsFolderSelection).isEqualTo(SpecialFolderSelection.MANUAL)
+        assertThat(result.sentFolderSelection).isEqualTo(SpecialFolderSelection.MANUAL)
+        assertThat(result.trashFolderSelection).isEqualTo(SpecialFolderSelection.MANUAL)
+        assertThat(result.archiveFolderSelection).isEqualTo(SpecialFolderSelection.MANUAL)
+        assertThat(result.spamFolderSelection).isEqualTo(SpecialFolderSelection.MANUAL)
+        assertThat(result.importedAutoExpandFolder).isEqualTo("importedAutoExpandFolder")
+        assertThat(result.autoExpandFolderId).isEqualTo(8)
+        assertThat(result.folderDisplayMode).isEqualTo(FolderMode.FIRST_AND_SECOND_CLASS)
+        assertThat(result.folderSyncMode).isEqualTo(FolderMode.FIRST_AND_SECOND_CLASS)
+        assertThat(result.folderPushMode).isEqualTo(FolderMode.FIRST_AND_SECOND_CLASS)
+        assertThat(result.accountNumber).isEqualTo(11)
+        assertThat(result.isNotifySync).isEqualTo(true)
+        assertThat(result.sortType).isEqualTo(SortType.SORT_SUBJECT)
+        assertThat(result.sortAscending).isEqualTo(
+            mutableMapOf(
+                SortType.SORT_SUBJECT to false,
+            ),
+        )
+        assertThat(result.showPictures).isEqualTo(ShowPictures.ALWAYS)
+        assertThat(result.isSignatureBeforeQuotedText).isEqualTo(true)
+        assertThat(result.expungePolicy).isEqualTo(Expunge.EXPUNGE_MANUALLY)
+        assertThat(result.maxPushFolders).isEqualTo(12)
+        assertThat(result.idleRefreshMinutes).isEqualTo(13)
+        assertThat(result.useCompression).isEqualTo(false)
+        assertThat(result.isSendClientInfoEnabled).isEqualTo(false)
+        assertThat(result.isSubscribedFoldersOnly).isEqualTo(false)
+        assertThat(result.maximumPolledMessageAge).isEqualTo(14)
+        assertThat(result.maximumAutoDownloadMessageSize).isEqualTo(15)
+        assertThat(result.messageFormat).isEqualTo(MessageFormat.TEXT)
+        assertThat(result.isMessageFormatAuto).isEqualTo(true)
+        assertThat(result.isMessageReadReceipt).isEqualTo(true)
+        assertThat(result.quoteStyle).isEqualTo(QuoteStyle.HEADER)
+        assertThat(result.quotePrefix).isEqualTo("quotePrefix")
+        assertThat(result.isDefaultQuotedTextShown).isEqualTo(true)
+        assertThat(result.isReplyAfterQuote).isEqualTo(true)
+        assertThat(result.isStripSignature).isEqualTo(true)
+        assertThat(result.isSyncRemoteDeletions).isEqualTo(true)
+        assertThat(result.openPgpProvider).isEqualTo("openPgpProvider")
+        assertThat(result.openPgpKey).isEqualTo(16)
+        assertThat(result.autocryptPreferEncryptMutual).isEqualTo(true)
+        assertThat(result.isOpenPgpHideSignOnly).isEqualTo(true)
+        assertThat(result.isOpenPgpEncryptSubject).isEqualTo(true)
+        assertThat(result.isOpenPgpEncryptAllDrafts).isEqualTo(true)
+        assertThat(result.isMarkMessageAsReadOnView).isEqualTo(true)
+        assertThat(result.isMarkMessageAsReadOnDelete).isEqualTo(true)
+        assertThat(result.isAlwaysShowCcBcc).isEqualTo(true)
+        assertThat(result.isRemoteSearchFullText).isEqualTo(false)
+        assertThat(result.remoteSearchNumResults).isEqualTo(17)
+        assertThat(result.isUploadSentMessages).isEqualTo(true)
+        assertThat(result.lastSyncTime).isEqualTo(18)
+        assertThat(result.lastFolderListRefreshTime).isEqualTo(19)
+        assertThat(result.isFinishedSetup).isEqualTo(true)
+        assertThat(result.messagesNotificationChannelVersion).isEqualTo(20)
+        assertThat(result.isChangedVisibleLimits).isEqualTo(true)
+        assertThat(result.lastSelectedFolderId).isEqualTo(21)
+        assertThat(result.notificationSettings).isEqualTo(defaultNotificationSettings)
+        assertThat(result.senderName).isEqualTo(defaultIdentities[0].name)
+        assertThat(result.signatureUse).isEqualTo(defaultIdentities[0].signatureUse)
+        assertThat(result.signature).isEqualTo(defaultIdentities[0].signature)
+        assertThat(result.shouldMigrateToOAuth).isEqualTo(true)
+    }
+
+    private companion object {
+        val defaultIsSensitiveDebugLoggingEnabled = { true }
+
+        val defaultIncomingServerSettings = ServerSettings(
+            type = "imap",
+            host = "imap.example.com",
+            port = 993,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "test",
+            password = "password",
+            clientCertificateAlias = null,
+        )
+
+        val defaultOutgoingServerSettings = ServerSettings(
+            type = "smtp",
+            host = "smtp.example.com",
+            port = 465,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "test",
+            password = "password",
+            clientCertificateAlias = null,
+        )
+
+        val defaultIdentities = mutableListOf(
+            Identity(
+                email = "demo@example.com",
+                name = "identityName",
+                signatureUse = true,
+                signature = "signature",
+                description = "Demo User",
+            ),
+        )
+
+        val defaultNotificationSettings = NotificationSettings()
+
+        fun createAccount(): Account {
+            return Account(
+                uuid = "uuid",
+                isSensitiveDebugLoggingEnabled = defaultIsSensitiveDebugLoggingEnabled,
+            ).apply {
+                identities = defaultIdentities
+                name = "displayName"
+                email = "demo@example.com"
+                deletePolicy = DeletePolicy.SEVEN_DAYS
+                incomingServerSettings = defaultIncomingServerSettings
+                outgoingServerSettings = defaultOutgoingServerSettings
+                oAuthState = "oAuthState"
+                alwaysBcc = "alwaysBcc"
+                automaticCheckIntervalMinutes = 60
+                displayCount = 10
+                chipColor = 0xFFFF0000.toInt()
+                isNotifyNewMail = true
+                folderNotifyNewMailMode = FolderMode.FIRST_AND_SECOND_CLASS
+                isNotifySelfNewMail = true
+                isNotifyContactsMailOnly = true
+                isIgnoreChatMessages = true
+                legacyInboxFolder = "legacyInboxFolder"
+                importedDraftsFolder = "importedDraftsFolder"
+                importedSentFolder = "importedSentFolder"
+                importedTrashFolder = "importedTrashFolder"
+                importedArchiveFolder = "importedArchiveFolder"
+                importedSpamFolder = "importedSpamFolder"
+                inboxFolderId = 1
+                outboxFolderId = 2
+                draftsFolderId = 3
+                sentFolderId = 4
+                trashFolderId = 5
+                archiveFolderId = 6
+                spamFolderId = 7
+                draftsFolderSelection = SpecialFolderSelection.MANUAL
+                sentFolderSelection = SpecialFolderSelection.MANUAL
+                trashFolderSelection = SpecialFolderSelection.MANUAL
+                archiveFolderSelection = SpecialFolderSelection.MANUAL
+                spamFolderSelection = SpecialFolderSelection.MANUAL
+                importedAutoExpandFolder = "importedAutoExpandFolder"
+                autoExpandFolderId = 8
+                folderDisplayMode = FolderMode.FIRST_AND_SECOND_CLASS
+                folderSyncMode = FolderMode.FIRST_AND_SECOND_CLASS
+                folderPushMode = FolderMode.FIRST_AND_SECOND_CLASS
+                accountNumber = 11
+                isNotifySync = true
+                sortType = SortType.SORT_SUBJECT
+                sortAscending = mutableMapOf(
+                    SortType.SORT_SUBJECT to false,
+                )
+                showPictures = ShowPictures.ALWAYS
+                isSignatureBeforeQuotedText = true
+                expungePolicy = Expunge.EXPUNGE_MANUALLY
+                maxPushFolders = 12
+                idleRefreshMinutes = 13
+                useCompression = false
+                isSendClientInfoEnabled = false
+                isSubscribedFoldersOnly = false
+                maximumPolledMessageAge = 14
+                maximumAutoDownloadMessageSize = 15
+                messageFormat = MessageFormat.TEXT
+                isMessageFormatAuto = true
+                isMessageReadReceipt = true
+                quoteStyle = QuoteStyle.HEADER
+                quotePrefix = "quotePrefix"
+                isDefaultQuotedTextShown = true
+                isReplyAfterQuote = true
+                isStripSignature = true
+                isSyncRemoteDeletions = true
+                openPgpProvider = "openPgpProvider"
+                openPgpKey = 16
+                autocryptPreferEncryptMutual = true
+                isOpenPgpHideSignOnly = true
+                isOpenPgpEncryptSubject = true
+                isOpenPgpEncryptAllDrafts = true
+                isMarkMessageAsReadOnView = true
+                isMarkMessageAsReadOnDelete = true
+                isAlwaysShowCcBcc = true
+                isRemoteSearchFullText = false
+                remoteSearchNumResults = 17
+                isUploadSentMessages = true
+                lastSyncTime = 18
+                lastFolderListRefreshTime = 19
+                isFinishedSetup = true
+                messagesNotificationChannelVersion = 20
+                isChangedVisibleLimits = true
+                lastSelectedFolderId = 21
+                notificationSettings = defaultNotificationSettings
+                senderName = defaultIdentities[0].name
+                signatureUse = defaultIdentities[0].signatureUse
+                signature = defaultIdentities[0].signature
+                shouldMigrateToOAuth = true
+            }
+        }
+
+        fun createAccountWrapper(): LegacyAccountWrapper {
+            return LegacyAccountWrapper(
+                uuid = "uuid",
+                isSensitiveDebugLoggingEnabled = defaultIsSensitiveDebugLoggingEnabled,
+                name = "displayName",
+                email = "demo@example.com",
+                deletePolicy = DeletePolicy.SEVEN_DAYS,
+                incomingServerSettings = defaultIncomingServerSettings,
+                outgoingServerSettings = defaultOutgoingServerSettings,
+                oAuthState = "oAuthState",
+                alwaysBcc = "alwaysBcc",
+                automaticCheckIntervalMinutes = 60,
+                displayCount = 10,
+                chipColor = 0xFFFF0000.toInt(),
+                isNotifyNewMail = true,
+                folderNotifyNewMailMode = FolderMode.FIRST_AND_SECOND_CLASS,
+                isNotifySelfNewMail = true,
+                isNotifyContactsMailOnly = true,
+                isIgnoreChatMessages = true,
+                legacyInboxFolder = "legacyInboxFolder",
+                importedDraftsFolder = "importedDraftsFolder",
+                importedSentFolder = "importedSentFolder",
+                importedTrashFolder = "importedTrashFolder",
+                importedArchiveFolder = "importedArchiveFolder",
+                importedSpamFolder = "importedSpamFolder",
+                inboxFolderId = 1,
+                outboxFolderId = 2,
+                draftsFolderId = 3,
+                sentFolderId = 4,
+                trashFolderId = 5,
+                archiveFolderId = 6,
+                spamFolderId = 7,
+                draftsFolderSelection = SpecialFolderSelection.MANUAL,
+                sentFolderSelection = SpecialFolderSelection.MANUAL,
+                trashFolderSelection = SpecialFolderSelection.MANUAL,
+                archiveFolderSelection = SpecialFolderSelection.MANUAL,
+                spamFolderSelection = SpecialFolderSelection.MANUAL,
+                importedAutoExpandFolder = "importedAutoExpandFolder",
+                autoExpandFolderId = 8,
+                folderDisplayMode = FolderMode.FIRST_AND_SECOND_CLASS,
+                folderSyncMode = FolderMode.FIRST_AND_SECOND_CLASS,
+                folderPushMode = FolderMode.FIRST_AND_SECOND_CLASS,
+                accountNumber = 11,
+                isNotifySync = true,
+                sortType = SortType.SORT_SUBJECT,
+                sortAscending = mutableMapOf(
+                    SortType.SORT_SUBJECT to false,
+                ),
+                showPictures = ShowPictures.ALWAYS,
+                isSignatureBeforeQuotedText = true,
+                expungePolicy = Expunge.EXPUNGE_MANUALLY,
+                maxPushFolders = 12,
+                idleRefreshMinutes = 13,
+                useCompression = false,
+                isSendClientInfoEnabled = false,
+                isSubscribedFoldersOnly = false,
+                maximumPolledMessageAge = 14,
+                maximumAutoDownloadMessageSize = 15,
+                messageFormat = MessageFormat.TEXT,
+                isMessageFormatAuto = true,
+                isMessageReadReceipt = true,
+                quoteStyle = QuoteStyle.HEADER,
+                quotePrefix = "quotePrefix",
+                isDefaultQuotedTextShown = true,
+                isReplyAfterQuote = true,
+                isStripSignature = true,
+                isSyncRemoteDeletions = true,
+                openPgpProvider = "openPgpProvider",
+                openPgpKey = 16,
+                autocryptPreferEncryptMutual = true,
+                isOpenPgpHideSignOnly = true,
+                isOpenPgpEncryptSubject = true,
+                isOpenPgpEncryptAllDrafts = true,
+                isMarkMessageAsReadOnView = true,
+                isMarkMessageAsReadOnDelete = true,
+                isAlwaysShowCcBcc = true,
+                isRemoteSearchFullText = false,
+                remoteSearchNumResults = 17,
+                isUploadSentMessages = true,
+                lastSyncTime = 18,
+                lastFolderListRefreshTime = 19,
+                isFinishedSetup = true,
+                messagesNotificationChannelVersion = 20,
+                isChangedVisibleLimits = true,
+                lastSelectedFolderId = 21,
+                identities = defaultIdentities,
+                notificationSettings = defaultNotificationSettings,
+                senderName = defaultIdentities[0].name,
+                signatureUse = defaultIdentities[0].signatureUse,
+                signature = defaultIdentities[0].signature,
+                shouldMigrateToOAuth = true,
+                displayName = "displayName",
+            )
+        }
+    }
+}

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -2,7 +2,6 @@ package app.k9mail.legacy.account
 
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
-import app.k9mail.legacy.account.Account.ShowPictures
 import app.k9mail.legacy.notification.NotificationSettings
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -2,7 +2,6 @@ package app.k9mail.legacy.account
 
 import app.k9mail.legacy.account.Account.DeletePolicy
 import app.k9mail.legacy.account.Account.Expunge
-import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -1,6 +1,5 @@
 package app.k9mail.legacy.account
 
-import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.notification.NotificationSettings
 import assertk.assertThat

--- a/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
+++ b/legacy/account/src/test/kotlin/app/k9mail/legacy/account/LegacyAccountWrapperTest.kt
@@ -1,6 +1,5 @@
 package app.k9mail.legacy.account
 
-import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.notification.NotificationSettings
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountActivator.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountActivator.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.account
 
 import android.content.Context
 import app.k9mail.feature.settings.import.SettingsImportExternalContract
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.Core
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
@@ -28,7 +28,7 @@ class AccountActivator(
         enableAccount(account)
     }
 
-    private fun enableAccount(account: Account) {
+    private fun enableAccount(account: LegacyAccount) {
         // Start services if necessary
         Core.setServicesEnabled(context)
 
@@ -37,7 +37,7 @@ class AccountActivator(
     }
 
     private fun setAccountPasswords(
-        account: Account,
+        account: LegacyAccount,
         incomingServerPassword: String?,
         outgoingServerPassword: String?,
     ) {

--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
@@ -7,7 +7,7 @@ import app.k9mail.feature.account.common.domain.entity.SpecialFolderOption
 import app.k9mail.feature.account.common.domain.entity.SpecialFolderSettings
 import app.k9mail.feature.account.setup.AccountSetupExternalContract
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
-import app.k9mail.legacy.account.Account.SpecialFolderSelection
+import app.k9mail.legacy.account.SpecialFolderSelection
 import com.fsck.k9.Core
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController

--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountCreator.kt
@@ -24,7 +24,7 @@ import com.fsck.k9.preferences.UnifiedInboxConfigurator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import app.k9mail.legacy.account.Account as K9Account
+import app.k9mail.legacy.account.LegacyAccount as K9Account
 
 // TODO Move to feature/account/setup
 class AccountCreator(

--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountStateLoader.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountStateLoader.kt
@@ -4,15 +4,15 @@ import app.k9mail.core.common.mail.Protocols
 import app.k9mail.feature.account.common.AccountCommonExternalContract
 import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.AuthorizationState
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.backends.toImapServerSettings
 import com.fsck.k9.logging.Timber
 import com.fsck.k9.mail.ServerSettings
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import app.k9mail.legacy.account.Account as K9Account
+import app.k9mail.legacy.account.LegacyAccount as K9Account
 
 class AccountStateLoader(
     private val accountManager: AccountManager,
@@ -47,7 +47,7 @@ class AccountStateLoader(
     }
 }
 
-private val Account.incomingServerSettingsExtra: ServerSettings
+private val LegacyAccount.incomingServerSettingsExtra: ServerSettings
     get() = when (incomingServerSettings.type) {
         Protocols.IMAP -> toImapServerSettings()
         else -> incomingServerSettings

--- a/legacy/common/src/main/java/com/fsck/k9/account/DefaultDeletePolicyProvider.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/DefaultDeletePolicyProvider.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.account
 
 import app.k9mail.core.common.mail.Protocols
-import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.DeletePolicy
 
 class DefaultDeletePolicyProvider : DeletePolicyProvider {
     override fun getDeletePolicy(accountType: String): DeletePolicy {

--- a/legacy/common/src/main/java/com/fsck/k9/account/DeletePolicyProvider.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/DeletePolicyProvider.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.account
 
 import app.k9mail.core.common.mail.Protocols
-import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.DeletePolicy
 
 /**
  * Decides which [DeletePolicy] an account uses by default.

--- a/legacy/common/src/main/java/com/fsck/k9/backends/AccountAuthStateStorage.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/AccountAuthStateStorage.kt
@@ -1,12 +1,12 @@
 package com.fsck.k9.backends
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mail.oauth.AuthStateStorage
 
 class AccountAuthStateStorage(
     private val accountManager: AccountManager,
-    private val account: Account,
+    private val account: LegacyAccount,
 ) : AuthStateStorage {
     override fun getAuthorizationState(): String? {
         return account.oAuthState

--- a/legacy/common/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -2,8 +2,8 @@ package com.fsck.k9.backends
 
 import android.content.Context
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.Expunge
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.Expunge
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.backend.imap.ImapBackend

--- a/legacy/common/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -19,6 +19,7 @@ import com.fsck.k9.mail.transport.smtp.SmtpTransport
 import com.fsck.k9.mailstore.K9BackendStorageFactory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 
 @Suppress("LongParameterList")
@@ -100,11 +101,13 @@ class ImapBackendFactory(
     private fun createPushConfigProvider(account: Account) = object : ImapPushConfigProvider {
         override val maxPushFoldersFlow: Flow<Int>
             get() = accountManager.getAccountFlow(account.uuid)
+                .filterNotNull()
                 .map { it.maxPushFolders }
                 .distinctUntilChanged()
 
         override val idleRefreshMinutesFlow: Flow<Int>
             get() = accountManager.getAccountFlow(account.uuid)
+                .filterNotNull()
                 .map { it.idleRefreshMinutes }
                 .distinctUntilChanged()
     }

--- a/legacy/common/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -1,9 +1,9 @@
 package com.fsck.k9.backends
 
 import android.content.Context
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.account.Expunge
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.backend.imap.ImapBackend
@@ -33,7 +33,7 @@ class ImapBackendFactory(
     private val clientInfoAppName: String,
     private val clientInfoAppVersion: String,
 ) : BackendFactory {
-    override fun createBackend(account: Account): Backend {
+    override fun createBackend(account: LegacyAccount): Backend {
         val accountName = account.displayName
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         val imapStore = createImapStore(account)
@@ -51,7 +51,7 @@ class ImapBackendFactory(
         )
     }
 
-    private fun createImapStore(account: Account): ImapStore {
+    private fun createImapStore(account: LegacyAccount): ImapStore {
         val serverSettings = account.toImapServerSettings()
 
         val oAuth2TokenProvider = if (serverSettings.authenticationType == AuthType.XOAUTH2) {
@@ -69,7 +69,7 @@ class ImapBackendFactory(
         )
     }
 
-    private fun createImapStoreConfig(account: Account): ImapStoreConfig {
+    private fun createImapStoreConfig(account: LegacyAccount): ImapStoreConfig {
         return object : ImapStoreConfig {
             override val logLabel
                 get() = account.uuid
@@ -82,7 +82,7 @@ class ImapBackendFactory(
         }
     }
 
-    private fun createSmtpTransport(account: Account): SmtpTransport {
+    private fun createSmtpTransport(account: LegacyAccount): SmtpTransport {
         val serverSettings = account.outgoingServerSettings
         val oauth2TokenProvider = if (serverSettings.authenticationType == AuthType.XOAUTH2) {
             createOAuth2TokenProvider(account)
@@ -93,12 +93,12 @@ class ImapBackendFactory(
         return SmtpTransport(serverSettings, trustedSocketFactory, oauth2TokenProvider)
     }
 
-    private fun createOAuth2TokenProvider(account: Account): RealOAuth2TokenProvider {
+    private fun createOAuth2TokenProvider(account: LegacyAccount): RealOAuth2TokenProvider {
         val authStateStorage = AccountAuthStateStorage(accountManager, account)
         return RealOAuth2TokenProvider(context, authStateStorage)
     }
 
-    private fun createPushConfigProvider(account: Account) = object : ImapPushConfigProvider {
+    private fun createPushConfigProvider(account: LegacyAccount) = object : ImapPushConfigProvider {
         override val maxPushFoldersFlow: Flow<Int>
             get() = accountManager.getAccountFlow(account.uuid)
                 .filterNotNull()

--- a/legacy/common/src/main/java/com/fsck/k9/backends/ImapServerSettingsExtensions.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/ImapServerSettingsExtensions.kt
@@ -1,12 +1,12 @@
 package com.fsck.k9.backends
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.autoDetectNamespace
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.pathPrefix
 
-fun Account.toImapServerSettings(): ServerSettings {
+fun LegacyAccount.toImapServerSettings(): ServerSettings {
     val serverSettings = incomingServerSettings
     return serverSettings.copy(
         extra = ImapStoreSettings.createExtra(

--- a/legacy/common/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.backends
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.backend.pop3.Pop3Backend
@@ -14,7 +14,7 @@ class Pop3BackendFactory(
     private val backendStorageFactory: K9BackendStorageFactory,
     private val trustedSocketFactory: TrustedSocketFactory,
 ) : BackendFactory {
-    override fun createBackend(account: Account): Backend {
+    override fun createBackend(account: LegacyAccount): Backend {
         val accountName = account.displayName
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         val pop3Store = createPop3Store(account)
@@ -22,12 +22,12 @@ class Pop3BackendFactory(
         return Pop3Backend(accountName, backendStorage, pop3Store, smtpTransport)
     }
 
-    private fun createPop3Store(account: Account): Pop3Store {
+    private fun createPop3Store(account: LegacyAccount): Pop3Store {
         val serverSettings = account.incomingServerSettings
         return Pop3Store(serverSettings, trustedSocketFactory)
     }
 
-    private fun createSmtpTransport(account: Account): SmtpTransport {
+    private fun createSmtpTransport(account: LegacyAccount): SmtpTransport {
         val serverSettings = account.outgoingServerSettings
         val oauth2TokenProvider: OAuth2TokenProvider? = null
         return SmtpTransport(serverSettings, trustedSocketFactory, oauth2TokenProvider)

--- a/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.kt
@@ -9,7 +9,7 @@ import android.net.Uri
 import androidx.core.app.PendingIntentCompat
 import app.k9mail.feature.launcher.FeatureLauncherActivity
 import app.k9mail.feature.launcher.FeatureLauncherTarget
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.search.LocalSearch
@@ -44,13 +44,13 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun createViewFolderPendingIntent(account: Account, folderId: Long): PendingIntent {
+    override fun createViewFolderPendingIntent(account: LegacyAccount, folderId: Long): PendingIntent {
         val intent = createMessageListIntent(account, folderId)
         return PendingIntentCompat.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
     override fun createViewMessagesPendingIntent(
-        account: Account,
+        account: LegacyAccount,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         val folderIds = extractFolderIds(messageReferences)
@@ -65,12 +65,12 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun createViewFolderListPendingIntent(account: Account): PendingIntent {
+    override fun createViewFolderListPendingIntent(account: LegacyAccount): PendingIntent {
         val intent = createMessageListIntent(account)
         return PendingIntentCompat.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun createDismissAllMessagesPendingIntent(account: Account): PendingIntent {
+    override fun createDismissAllMessagesPendingIntent(account: LegacyAccount): PendingIntent {
         val intent = NotificationActionService.createDismissAllMessagesIntent(context, account).apply {
             data = Uri.parse("data:,dismissAll/${account.uuid}/${System.currentTimeMillis()}")
         }
@@ -99,7 +99,7 @@ internal class K9NotificationActionCreator(
     }
 
     override fun createMarkAllAsReadPendingIntent(
-        account: Account,
+        account: LegacyAccount,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         val accountUuid = account.uuid
@@ -110,7 +110,7 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getService(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun getEditIncomingServerSettingsIntent(account: Account): PendingIntent {
+    override fun getEditIncomingServerSettingsIntent(account: LegacyAccount): PendingIntent {
         val intent = FeatureLauncherActivity.getIntent(
             context = context,
             target = FeatureLauncherTarget.AccountEditIncomingSettings(account.uuid),
@@ -118,7 +118,7 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getActivity(context, account.accountNumber, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun getEditOutgoingServerSettingsIntent(account: Account): PendingIntent {
+    override fun getEditOutgoingServerSettingsIntent(account: LegacyAccount): PendingIntent {
         val intent = FeatureLauncherActivity.getIntent(
             context = context,
             target = FeatureLauncherTarget.AccountEditOutgoingSettings(account.uuid),
@@ -149,7 +149,7 @@ internal class K9NotificationActionCreator(
     }
 
     override fun createDeleteAllPendingIntent(
-        account: Account,
+        account: LegacyAccount,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         return if (K9.isConfirmDeleteFromNotification) {
@@ -167,7 +167,7 @@ internal class K9NotificationActionCreator(
     }
 
     private fun getDeleteAllServicePendingIntent(
-        account: Account,
+        account: LegacyAccount,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         val accountUuid = account.uuid
@@ -186,7 +186,7 @@ internal class K9NotificationActionCreator(
     }
 
     override fun createArchiveAllPendingIntent(
-        account: Account,
+        account: LegacyAccount,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         val intent = NotificationActionService.createArchiveAllIntent(context, account, messageReferences).apply {
@@ -202,7 +202,7 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getService(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    private fun createMessageListIntent(account: Account): Intent {
+    private fun createMessageListIntent(account: LegacyAccount): Intent {
         val folderId = defaultFolderProvider.getDefaultFolder(account)
         val search = LocalSearch().apply {
             addAllowedFolder(folderId)
@@ -220,7 +220,7 @@ internal class K9NotificationActionCreator(
         }
     }
 
-    private fun createMessageListIntent(account: Account, folderId: Long): Intent {
+    private fun createMessageListIntent(account: LegacyAccount, folderId: Long): Intent {
         val search = LocalSearch().apply {
             addAllowedFolder(folderId)
             addAccountUuid(account.uuid)
@@ -243,13 +243,13 @@ internal class K9NotificationActionCreator(
         }
     }
 
-    private fun createUnifiedInboxIntent(account: Account): Intent {
+    private fun createUnifiedInboxIntent(account: LegacyAccount): Intent {
         return MessageList.createUnifiedInboxIntent(context, account).apply {
             data = Uri.parse("data:,unifiedInbox/${account.uuid}")
         }
     }
 
-    private fun createNewMessagesIntent(account: Account): Intent {
+    private fun createNewMessagesIntent(account: LegacyAccount): Intent {
         return MessageList.createNewMessagesIntent(context, account).apply {
             data = Uri.parse("data:,newMessages/${account.uuid}")
         }
@@ -259,7 +259,7 @@ internal class K9NotificationActionCreator(
         return messageReferences.asSequence().map { it.folderId }.toSet()
     }
 
-    private fun areAllIncludedInUnifiedInbox(account: Account, folderIds: Collection<Long>): Boolean {
+    private fun areAllIncludedInUnifiedInbox(account: LegacyAccount, folderIds: Collection<Long>): Boolean {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.areAllIncludedInUnifiedInbox(folderIds)
     }

--- a/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.notification
 
 import app.k9mail.core.android.common.contact.ContactRepository
 import app.k9mail.core.common.mail.toEmailAddressOrNull
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.K9MailLib
@@ -15,8 +15,9 @@ class K9NotificationStrategy(
     private val contactRepository: ContactRepository,
 ) : NotificationStrategy {
 
+    @Suppress("ReturnCount")
     override fun shouldNotifyForMessage(
-        account: Account,
+        account: LegacyAccount,
         localFolder: LocalFolder,
         message: LocalMessage,
         isOldMessage: Boolean,

--- a/legacy/common/src/test/java/com/fsck/k9/account/AccountServerSettingsUpdaterTest.kt
+++ b/legacy/common/src/test/java/com/fsck/k9/account/AccountServerSettingsUpdaterTest.kt
@@ -14,7 +14,7 @@ import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.mail.ServerSettings
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import app.k9mail.legacy.account.Account as K9Account
+import app.k9mail.legacy.account.LegacyAccount as K9Account
 
 class AccountServerSettingsUpdaterTest {
 

--- a/legacy/common/src/test/java/com/fsck/k9/account/AccountStateLoaderTest.kt
+++ b/legacy/common/src/test/java/com/fsck/k9/account/AccountStateLoaderTest.kt
@@ -2,8 +2,8 @@ package com.fsck.k9.account
 
 import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.AuthorizationState
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
@@ -28,7 +28,7 @@ class AccountStateLoaderTest {
     @Test
     fun `loadAccountState() SHOULD return account when present in accountManager`() = runTest {
         val accounts = mutableMapOf(
-            "accountUuid" to Account(uuid = "accountUuid").apply {
+            "accountUuid" to LegacyAccount(uuid = "accountUuid").apply {
                 identities = mutableListOf(Identity())
                 email = "emailAddress"
                 incomingServerSettings = INCOMING_SERVER_SETTINGS

--- a/legacy/common/src/test/java/com/fsck/k9/account/DefaultDeletePolicyProviderTest.kt
+++ b/legacy/common/src/test/java/com/fsck/k9/account/DefaultDeletePolicyProviderTest.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.account
 
 import app.k9mail.core.common.mail.Protocols
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.DeletePolicy
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -15,21 +15,21 @@ class DefaultDeletePolicyProviderTest {
     fun `getDeletePolicy with IMAP should return ON_DELETE`() {
         val result = deletePolicyProvider.getDeletePolicy(Protocols.IMAP)
 
-        assertThat(result).isEqualTo(Account.DeletePolicy.ON_DELETE)
+        assertThat(result).isEqualTo(DeletePolicy.ON_DELETE)
     }
 
     @Test
     fun `getDeletePolicy with POP3 should return NEVER`() {
         val result = deletePolicyProvider.getDeletePolicy(Protocols.POP3)
 
-        assertThat(result).isEqualTo(Account.DeletePolicy.NEVER)
+        assertThat(result).isEqualTo(DeletePolicy.NEVER)
     }
 
     @Test
     fun `getDeletePolicy with demo should return ON_DELETE`() {
         val result = deletePolicyProvider.getDeletePolicy("demo")
 
-        assertThat(result).isEqualTo(Account.DeletePolicy.ON_DELETE)
+        assertThat(result).isEqualTo(DeletePolicy.ON_DELETE)
     }
 
     @Test

--- a/legacy/common/src/test/java/com/fsck/k9/account/FakeAccountManager.kt
+++ b/legacy/common/src/test/java/com/fsck/k9/account/FakeAccountManager.kt
@@ -1,25 +1,25 @@
 package com.fsck.k9.account
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.account.AccountRemovedListener
 import app.k9mail.legacy.account.AccountsChangeListener
+import app.k9mail.legacy.account.LegacyAccount
 import kotlinx.coroutines.flow.Flow
 
 class FakeAccountManager(
-    private val accounts: MutableMap<String, Account> = mutableMapOf(),
+    private val accounts: MutableMap<String, LegacyAccount> = mutableMapOf(),
     private val isFailureOnSave: Boolean = false,
 ) : AccountManager {
 
-    override fun getAccounts(): List<Account> = accounts.values.toList()
+    override fun getAccounts(): List<LegacyAccount> = accounts.values.toList()
 
-    override fun getAccountsFlow(): Flow<List<Account>> {
+    override fun getAccountsFlow(): Flow<List<LegacyAccount>> {
         TODO("Not yet implemented")
     }
 
-    override fun getAccount(accountUuid: String): Account? = accounts[accountUuid]
+    override fun getAccount(accountUuid: String): LegacyAccount? = accounts[accountUuid]
 
-    override fun getAccountFlow(accountUuid: String): Flow<Account> {
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccount> {
         TODO("Not yet implemented")
     }
 
@@ -27,7 +27,7 @@ class FakeAccountManager(
         TODO("Not yet implemented")
     }
 
-    override fun moveAccount(account: Account, newPosition: Int) {
+    override fun moveAccount(account: LegacyAccount, newPosition: Int) {
         TODO("Not yet implemented")
     }
 
@@ -40,7 +40,7 @@ class FakeAccountManager(
     }
 
     @Suppress("TooGenericExceptionThrown")
-    override fun saveAccount(account: Account) {
+    override fun saveAccount(account: LegacyAccount) {
         if (isFailureOnSave) {
             throw Exception("FakeAccountManager.saveAccount() failed")
         }

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -3,7 +3,6 @@ package com.fsck.k9
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
-import app.k9mail.legacy.account.Account.ShowPictures
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT_AUTO
@@ -22,6 +21,7 @@ import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.Expunge
 import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.ShowPictures
 import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationLight

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -3,7 +3,6 @@ package com.fsck.k9
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.DeletePolicy
 import app.k9mail.legacy.account.Account.Expunge
-import app.k9mail.legacy.account.Account.FolderMode
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures
@@ -23,6 +22,7 @@ import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_STRIP
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_SYNC_INTERVAL
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.UNASSIGNED_ACCOUNT_NUMBER
+import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationSettings

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT_AUTO
@@ -19,6 +18,7 @@ import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.Expunge
 import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.MessageFormat
 import app.k9mail.legacy.account.QuoteStyle
 import app.k9mail.legacy.account.ShowPictures
@@ -37,8 +37,9 @@ class AccountPreferenceSerializer(
     private val serverSettingsSerializer: ServerSettingsSerializer,
 ) {
 
+    @Suppress("LongMethod")
     @Synchronized
-    fun loadAccount(account: Account, storage: Storage) {
+    fun loadAccount(account: LegacyAccount, storage: Storage) {
         val accountUuid = account.uuid
         with(account) {
             incomingServerSettings = serverSettingsSerializer.deserialize(
@@ -259,8 +260,9 @@ class AccountPreferenceSerializer(
         return newIdentities
     }
 
+    @Suppress("LongMethod")
     @Synchronized
-    fun save(editor: StorageEditor, storage: Storage, account: Account) {
+    fun save(editor: StorageEditor, storage: Storage, account: LegacyAccount) {
         val accountUuid = account.uuid
 
         if (!storage.getString("accountUuids", "").contains(account.uuid)) {
@@ -373,8 +375,9 @@ class AccountPreferenceSerializer(
         saveIdentities(account, storage, editor)
     }
 
+    @Suppress("LongMethod")
     @Synchronized
-    fun delete(editor: StorageEditor, storage: Storage, account: Account) {
+    fun delete(editor: StorageEditor, storage: Storage, account: LegacyAccount) {
         val accountUuid = account.uuid
 
         // Get the list of account UUIDs
@@ -491,7 +494,7 @@ class AccountPreferenceSerializer(
     }
 
     @Synchronized
-    private fun saveIdentities(account: Account, storage: Storage, editor: StorageEditor) {
+    private fun saveIdentities(account: LegacyAccount, storage: Storage, editor: StorageEditor) {
         deleteIdentities(account, storage, editor)
         var ident = 0
 
@@ -509,7 +512,7 @@ class AccountPreferenceSerializer(
     }
 
     @Synchronized
-    private fun deleteIdentities(account: Account, storage: Storage, editor: StorageEditor) {
+    private fun deleteIdentities(account: LegacyAccount, storage: Storage, editor: StorageEditor) {
         val accountUuid = account.uuid
 
         var identityIndex = 0
@@ -530,7 +533,7 @@ class AccountPreferenceSerializer(
         } while (gotOne)
     }
 
-    fun move(editor: StorageEditor, account: Account, storage: Storage, newPosition: Int) {
+    fun move(editor: StorageEditor, account: LegacyAccount, storage: Storage, newPosition: Int) {
         val accountUuids = storage.getString("accountUuids", "").split(",").filter { it.isNotEmpty() }
         val oldPosition = accountUuids.indexOf(account.uuid)
         if (oldPosition == -1 || oldPosition == newPosition) return

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9
 
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.Expunge
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures
@@ -22,6 +21,7 @@ import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_SYNC_
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.UNASSIGNED_ACCOUNT_NUMBER
 import app.k9mail.legacy.account.DeletePolicy
+import app.k9mail.legacy.account.Expunge
 import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
 import app.k9mail.legacy.notification.NotificationLight

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9
 
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT
@@ -21,6 +20,7 @@ import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.Expunge
 import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.MessageFormat
 import app.k9mail.legacy.account.ShowPictures
 import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.account.SpecialFolderSelection

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9
 
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.DeletePolicy
 import app.k9mail.legacy.account.Account.Expunge
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
@@ -22,6 +21,7 @@ import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_STRIP
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_SYNC_INTERVAL
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.UNASSIGNED_ACCOUNT_NUMBER
+import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
 import app.k9mail.legacy.notification.NotificationLight

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -4,7 +4,6 @@ import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures
-import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT_AUTO
@@ -24,6 +23,7 @@ import app.k9mail.legacy.account.Expunge
 import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
 import app.k9mail.legacy.account.SortType
+import app.k9mail.legacy.account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationSettings
 import app.k9mail.legacy.notification.NotificationVibration

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9
 
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT_AUTO
@@ -21,6 +20,7 @@ import app.k9mail.legacy.account.Expunge
 import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
 import app.k9mail.legacy.account.MessageFormat
+import app.k9mail.legacy.account.QuoteStyle
 import app.k9mail.legacy.account.ShowPictures
 import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.account.SpecialFolderSelection

--- a/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -4,7 +4,6 @@ import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.MessageFormat
 import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Account.ShowPictures
-import app.k9mail.legacy.account.Account.SortType
 import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_FORMAT
@@ -24,6 +23,7 @@ import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.Expunge
 import app.k9mail.legacy.account.FolderMode
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationSettings
 import app.k9mail.legacy.notification.NotificationVibration

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -5,8 +5,8 @@ import android.content.SharedPreferences
 import app.k9mail.core.featureflag.FeatureFlagProvider
 import app.k9mail.core.featureflag.toFeatureFlagKey
 import app.k9mail.feature.telemetry.api.TelemetryManager
-import app.k9mail.legacy.account.Account.SortType
 import app.k9mail.legacy.account.AccountDefaultsProvider
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.di.DI
 import com.fsck.k9.core.BuildConfig
 import com.fsck.k9.mail.K9MailLib

--- a/legacy/core/src/main/java/com/fsck/k9/LocalKeyStoreManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/LocalKeyStoreManager.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mail.ssl.LocalKeyStore
 import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
@@ -13,7 +13,7 @@ class LocalKeyStoreManager(
      * Add a new certificate for the incoming or outgoing server to the local key store.
      */
     @Throws(CertificateException::class)
-    fun addCertificate(account: Account, direction: MailServerDirection, certificate: X509Certificate) {
+    fun addCertificate(account: LegacyAccount, direction: MailServerDirection, certificate: X509Certificate) {
         val serverSettings = if (direction === MailServerDirection.INCOMING) {
             account.incomingServerSettings
         } else {
@@ -27,7 +27,7 @@ class LocalKeyStoreManager(
      * new host/port, then try and delete any (possibly non-existent) certificate stored for the
      * old host/port.
      */
-    fun deleteCertificate(account: Account, newHost: String, newPort: Int, direction: MailServerDirection) {
+    fun deleteCertificate(account: LegacyAccount, newHost: String, newPort: Int, direction: MailServerDirection) {
         val serverSettings = if (direction === MailServerDirection.INCOMING) {
             account.incomingServerSettings
         } else {
@@ -48,7 +48,7 @@ class LocalKeyStoreManager(
      * Examine the settings for the account and attempt to delete (possibly non-existent)
      * certificates for the incoming and outgoing servers.
      */
-    fun deleteCertificates(account: Account) {
+    fun deleteCertificates(account: LegacyAccount) {
         account.incomingServerSettings.let { serverSettings ->
             localKeyStore.deleteCertificate(serverSettings.host!!, serverSettings.port)
         }

--- a/legacy/core/src/main/java/com/fsck/k9/backend/BackendFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/backend/BackendFactory.kt
@@ -1,8 +1,8 @@
 package com.fsck.k9.backend
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.backend.api.Backend
 
 interface BackendFactory {
-    fun createBackend(account: Account): Backend
+    fun createBackend(account: LegacyAccount): Backend
 }

--- a/legacy/core/src/main/java/com/fsck/k9/backend/BackendManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/backend/BackendManager.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.backend
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.mail.ServerSettings
 import java.util.concurrent.CopyOnWriteArraySet
@@ -9,7 +9,7 @@ class BackendManager(private val backendFactories: Map<String, BackendFactory>) 
     private val backendCache = mutableMapOf<String, BackendContainer>()
     private val listeners = CopyOnWriteArraySet<BackendChangedListener>()
 
-    fun getBackend(account: Account): Backend {
+    fun getBackend(account: LegacyAccount): Backend {
         val newBackend = synchronized(backendCache) {
             val container = backendCache[account.uuid]
             if (container != null && isBackendStillValid(container, account)) {
@@ -30,12 +30,12 @@ class BackendManager(private val backendFactories: Map<String, BackendFactory>) 
         return newBackend
     }
 
-    private fun isBackendStillValid(container: BackendContainer, account: Account): Boolean {
+    private fun isBackendStillValid(container: BackendContainer, account: LegacyAccount): Boolean {
         return container.incomingServerSettings == account.incomingServerSettings &&
             container.outgoingServerSettings == account.outgoingServerSettings
     }
 
-    fun removeBackend(account: Account) {
+    fun removeBackend(account: LegacyAccount) {
         synchronized(backendCache) {
             backendCache.remove(account.uuid)
         }
@@ -43,7 +43,7 @@ class BackendManager(private val backendFactories: Map<String, BackendFactory>) 
         notifyListeners(account)
     }
 
-    private fun createBackend(account: Account): Backend {
+    private fun createBackend(account: LegacyAccount): Backend {
         val serverType = account.incomingServerSettings.type
         val backendFactory = backendFactories[serverType] ?: error("Unsupported account type")
         return backendFactory.createBackend(account)
@@ -57,7 +57,7 @@ class BackendManager(private val backendFactories: Map<String, BackendFactory>) 
         listeners.remove(listener)
     }
 
-    private fun notifyListeners(account: Account) {
+    private fun notifyListeners(account: LegacyAccount) {
         for (listener in listeners) {
             listener.onBackendChanged(account)
         }
@@ -71,5 +71,5 @@ private data class BackendContainer(
 )
 
 fun interface BackendChangedListener {
-    fun onBackendChanged(account: Account)
+    fun onBackendChanged(account: LegacyAccount)
 }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.controller
 
 import app.k9mail.core.featureflag.FeatureFlagProvider
 import app.k9mail.core.featureflag.toFeatureFlagKey
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.controller.MessagingController.MessageActor
 import com.fsck.k9.controller.MessagingController.MoveOrCopyFlavor
@@ -33,7 +33,12 @@ internal class ArchiveOperations(
     private fun archiveByFolder(
         description: String,
         messages: List<MessageReference>,
-        action: (account: Account, folderId: Long, messagesInFolder: List<LocalMessage>, archiveFolderId: Long) -> Unit,
+        action: (
+            account: LegacyAccount,
+            folderId: Long,
+            messagesInFolder: List<LocalMessage>,
+            archiveFolderId: Long,
+        ) -> Unit,
     ) {
         actOnMessagesGroupedByAccountAndFolder(messages) { account, messageFolder, messagesInFolder ->
             val sourceFolderId = messageFolder.databaseId
@@ -57,7 +62,7 @@ internal class ArchiveOperations(
     }
 
     private fun archiveThreads(
-        account: Account,
+        account: LegacyAccount,
         sourceFolderId: Long,
         messages: List<LocalMessage>,
         archiveFolderId: Long,
@@ -67,7 +72,7 @@ internal class ArchiveOperations(
     }
 
     private fun archiveMessages(
-        account: Account,
+        account: LegacyAccount,
         sourceFolderId: Long,
         messages: List<LocalMessage>,
         archiveFolderId: Long,
@@ -88,7 +93,7 @@ internal class ArchiveOperations(
 
     private fun actOnMessagesGroupedByAccountAndFolder(
         messages: List<MessageReference>,
-        block: (account: Account, messageFolder: LocalFolder, messages: List<LocalMessage>) -> Unit,
+        block: (account: LegacyAccount, messageFolder: LocalFolder, messages: List<LocalMessage>) -> Unit,
     ) {
         val actor = MessageActor { account, messageFolder, messagesInFolder ->
             block(account, messageFolder, messagesInFolder)

--- a/legacy/core/src/main/java/com/fsck/k9/controller/DefaultMessageCountsProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/DefaultMessageCountsProvider.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.controller
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.message.controller.MessageCounts
 import app.k9mail.legacy.message.controller.MessageCountsProvider
@@ -31,7 +31,7 @@ internal class DefaultMessageCountsProvider(
     private val messagingControllerRegistry: MessagingControllerRegistry,
     private val coroutineContext: CoroutineContext = Dispatchers.IO,
 ) : MessageCountsProvider {
-    override fun getMessageCounts(account: Account): MessageCounts {
+    override fun getMessageCounts(account: LegacyAccount): MessageCounts {
         val search = LocalSearch().apply {
             excludeSpecialFolders(account)
             limitToDisplayableFolders()
@@ -59,7 +59,7 @@ internal class DefaultMessageCountsProvider(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    override fun getUnreadMessageCount(account: Account, folderId: Long): Int {
+    override fun getUnreadMessageCount(account: LegacyAccount, folderId: Long): Int {
         return try {
             val messageStore = messageStoreManager.getMessageStore(account)
             return if (folderId == account.outboxFolderId) {
@@ -78,7 +78,7 @@ internal class DefaultMessageCountsProvider(
             send(getMessageCounts(search))
 
             val folderStatusChangedListener = object : SimpleMessagingListener() {
-                override fun folderStatusChanged(account: Account, folderId: Long) {
+                override fun folderStatusChanged(account: LegacyAccount, folderId: Long) {
                     trySendBlocking(getMessageCounts(search))
                 }
             }
@@ -93,7 +93,7 @@ internal class DefaultMessageCountsProvider(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun getMessageCounts(account: Account, conditions: ConditionsTreeNode?): MessageCounts {
+    private fun getMessageCounts(account: LegacyAccount, conditions: ConditionsTreeNode?): MessageCounts {
         return try {
             val messageStore = messageStoreManager.getMessageStore(account)
             return MessageCounts(

--- a/legacy/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.controller
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.mailstore.SaveMessageData
 import com.fsck.k9.K9
@@ -24,7 +24,7 @@ internal class DraftOperations(
 ) {
 
     fun saveDraft(
-        account: Account,
+        account: LegacyAccount,
         message: Message,
         existingDraftId: Long?,
         plaintextSubject: String?,
@@ -46,7 +46,7 @@ internal class DraftOperations(
     }
 
     private fun saveAndUploadDraft(
-        account: Account,
+        account: LegacyAccount,
         message: Message,
         folderId: Long,
         existingDraftId: Long?,
@@ -84,7 +84,7 @@ internal class DraftOperations(
     }
 
     private fun saveDraftLocally(
-        account: Account,
+        account: LegacyAccount,
         message: Message,
         folderId: Long,
         existingDraftId: Long?,
@@ -96,7 +96,7 @@ internal class DraftOperations(
         return messageStore.saveLocalMessage(folderId, messageData, existingDraftId)
     }
 
-    fun processPendingReplace(command: PendingReplace, account: Account) {
+    fun processPendingReplace(command: PendingReplace, account: LegacyAccount) {
         val localStore = messagingController.getLocalStoreOrThrow(account)
         val localFolder = localStore.getFolder(command.folderId)
         localFolder.open()
@@ -119,7 +119,7 @@ internal class DraftOperations(
 
     private fun uploadMessage(
         backend: Backend,
-        account: Account,
+        account: LegacyAccount,
         localFolder: LocalFolder,
         localMessage: LocalMessage,
     ) {

--- a/legacy/core/src/main/java/com/fsck/k9/controller/LocalDeleteOperationDecider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/LocalDeleteOperationDecider.kt
@@ -1,15 +1,15 @@
 package com.fsck.k9.controller
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 /**
  * Decides whether deleting a message in the app moves it to the trash folder or deletes it immediately.
  *
  * Note: This only applies to local messages. What remote operation is performed when deleting a message is controlled
- * by [Account.deletePolicy].
+ * by [LegacyAccount.deletePolicy].
  */
 internal class LocalDeleteOperationDecider {
-    fun isDeleteImmediately(account: Account, folderId: Long): Boolean {
+    fun isDeleteImmediately(account: LegacyAccount, folderId: Long): Boolean {
         // If there's no trash folder configured, all messages are deleted immediately.
         if (!account.hasTrashFolder()) {
             return true

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
@@ -6,7 +6,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.message.controller.MessagingListener;
 import app.k9mail.legacy.message.controller.SimpleMessagingListener;
 
@@ -14,7 +14,7 @@ import app.k9mail.legacy.message.controller.SimpleMessagingListener;
 class MemorizingMessagingListener extends SimpleMessagingListener {
     Map<String, Memory> memories = new HashMap<>(31);
 
-    synchronized void removeAccount(Account account) {
+    synchronized void removeAccount(LegacyAccount account) {
         Iterator<Entry<String, Memory>> memIt = memories.entrySet().iterator();
 
         while (memIt.hasNext()) {
@@ -64,7 +64,7 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     }
 
     @Override
-    public synchronized void synchronizeMailboxStarted(Account account, long folderId) {
+    public synchronized void synchronizeMailboxStarted(LegacyAccount account, long folderId) {
         Memory memory = getMemory(account, folderId);
         memory.syncingState = MemorizingState.STARTED;
         memory.folderCompleted = 0;
@@ -72,13 +72,13 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     }
 
     @Override
-    public synchronized void synchronizeMailboxFinished(Account account, long folderId) {
+    public synchronized void synchronizeMailboxFinished(LegacyAccount account, long folderId) {
         Memory memory = getMemory(account, folderId);
         memory.syncingState = MemorizingState.FINISHED;
     }
 
     @Override
-    public synchronized void synchronizeMailboxFailed(Account account, long folderId,
+    public synchronized void synchronizeMailboxFailed(LegacyAccount account, long folderId,
             String message) {
 
         Memory memory = getMemory(account, folderId);
@@ -87,14 +87,14 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     }
 
     @Override
-    public synchronized void synchronizeMailboxProgress(Account account, long folderId, int completed,
+    public synchronized void synchronizeMailboxProgress(LegacyAccount account, long folderId, int completed,
             int total) {
         Memory memory = getMemory(account, folderId);
         memory.folderCompleted = completed;
         memory.folderTotal = total;
     }
 
-    private Memory getMemory(Account account, long folderId) {
+    private Memory getMemory(LegacyAccount account, long folderId) {
         Memory memory = memories.get(getMemoryKey(account, folderId));
         if (memory == null) {
             memory = new Memory(account, folderId);
@@ -103,14 +103,14 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
         return memory;
     }
 
-    private static String getMemoryKey(Account account, long folderId) {
+    private static String getMemoryKey(LegacyAccount account, long folderId) {
         return account.getUuid() + ":" + folderId;
     }
 
     private enum MemorizingState { STARTED, FINISHED, FAILED }
 
     private static class Memory {
-        Account account;
+        LegacyAccount account;
         long folderId;
         MemorizingState syncingState = null;
         String failureMessage = null;
@@ -118,7 +118,7 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
         int folderCompleted = 0;
         int folderTotal = 0;
 
-        Memory(Account account, long folderId) {
+        Memory(LegacyAccount account, long folderId) {
             this.account = account;
             this.folderId = folderId;
         }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -28,7 +28,7 @@ import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import app.k9mail.core.featureflag.FeatureFlagProvider;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.account.DeletePolicy;
 import app.k9mail.legacy.di.DI;
 import app.k9mail.legacy.message.controller.MessageReference;
@@ -270,11 +270,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         throw new Error(e);
     }
 
-    Backend getBackend(Account account) {
+    Backend getBackend(LegacyAccount account) {
         return backendManager.getBackend(account);
     }
 
-    LocalStore getLocalStoreOrThrow(Account account) {
+    LocalStore getLocalStoreOrThrow(LegacyAccount account) {
         try {
             return localStoreProvider.getInstance(account);
         } catch (MessagingException e) {
@@ -282,7 +282,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private String getFolderServerId(Account account, long folderId) {
+    private String getFolderServerId(LegacyAccount account, long folderId) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         String folderServerId = messageStore.getFolderServerId(folderId);
         if (folderServerId == null) {
@@ -291,7 +291,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return folderServerId;
     }
 
-    private long getFolderId(Account account, String folderServerId) {
+    private long getFolderId(LegacyAccount account, String folderServerId) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         Long folderId = messageStore.getFolderId(folderServerId);
         if (folderId == null) {
@@ -332,12 +332,12 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
 
-    void suppressMessages(Account account, List<LocalMessage> messages) {
+    void suppressMessages(LegacyAccount account, List<LocalMessage> messages) {
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.hideMessages(messages);
     }
 
-    private void unsuppressMessages(Account account, List<LocalMessage> messages) {
+    private void unsuppressMessages(LegacyAccount account, List<LocalMessage> messages) {
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.unhideMessages(messages);
     }
@@ -350,39 +350,39 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return cache.isMessageHidden(messageId, folderId);
     }
 
-    private void setFlagInCache(final Account account, final List<Long> messageIds,
+    private void setFlagInCache(final LegacyAccount account, final List<Long> messageIds,
             final Flag flag, final boolean newState) {
 
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.setFlagForMessages(messageIds, flag, newState);
     }
 
-    private void removeFlagFromCache(final Account account, final List<Long> messageIds,
+    private void removeFlagFromCache(final LegacyAccount account, final List<Long> messageIds,
             final Flag flag) {
 
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.removeFlagForMessages(messageIds, flag);
     }
 
-    private void setFlagForThreadsInCache(final Account account, final List<Long> threadRootIds,
+    private void setFlagForThreadsInCache(final LegacyAccount account, final List<Long> threadRootIds,
             final Flag flag, final boolean newState) {
 
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.setValueForThreads(threadRootIds, flag, newState);
     }
 
-    private void removeFlagForThreadsFromCache(final Account account, final List<Long> messageIds,
+    private void removeFlagForThreadsFromCache(final LegacyAccount account, final List<Long> messageIds,
             final Flag flag) {
 
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.removeFlagForThreads(messageIds, flag);
     }
 
-    public void refreshFolderList(final Account account) {
+    public void refreshFolderList(final LegacyAccount account) {
         put("refreshFolderList", null, () -> refreshFolderListSynchronous(account));
     }
 
-    public void refreshFolderListBlocking(Account account) {
+    public void refreshFolderListBlocking(LegacyAccount account) {
         final CountDownLatch latch = new CountDownLatch(1);
         putBackground("refreshFolderListBlocking", null, () -> {
             try {
@@ -399,7 +399,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    void refreshFolderListSynchronous(Account account) {
+    void refreshFolderListSynchronous(LegacyAccount account) {
         try {
             if (isAuthenticationProblem(account, true)) {
                 Timber.d("Authentication will fail. Skip refreshing the folder list.");
@@ -434,7 +434,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     void searchRemoteMessagesSynchronous(String acctUuid, long folderId, String query, Set<Flag> requiredFlags,
             Set<Flag> forbiddenFlags, MessagingListener listener) {
 
-        Account account = preferences.getAccount(acctUuid);
+        LegacyAccount account = preferences.getAccount(acctUuid);
 
         if (listener != null) {
             listener.remoteSearchStarted(folderId);
@@ -493,7 +493,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
 
     }
 
-    public void loadSearchResults(Account account, long folderId, List<String> messageServerIds,
+    public void loadSearchResults(LegacyAccount account, long folderId, List<String> messageServerIds,
             MessagingListener listener) {
         threadPool.execute(() -> {
             if (listener != null) {
@@ -520,7 +520,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void loadSearchResultsSynchronous(Account account, List<String> messageServerIds, LocalFolder localFolder)
+    private void loadSearchResultsSynchronous(LegacyAccount account, List<String> messageServerIds, LocalFolder localFolder)
             throws MessagingException {
 
         Backend backend = getBackend(account);
@@ -535,11 +535,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void loadMoreMessages(Account account, long folderId) {
+    public void loadMoreMessages(LegacyAccount account, long folderId) {
         putBackground("loadMoreMessages", null, () -> loadMoreMessagesSynchronous(account, folderId));
     }
 
-    public void loadMoreMessagesSynchronous(Account account, long folderId) {
+    public void loadMoreMessagesSynchronous(LegacyAccount account, long folderId) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         Integer visibleLimit = messageStore.getFolder(folderId, FolderDetailsAccessor::getVisibleLimit);
         if (visibleLimit == null) {
@@ -558,13 +558,13 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Start background synchronization of the specified folder.
      */
-    public void synchronizeMailbox(Account account, long folderId, boolean notify, MessagingListener listener) {
+    public void synchronizeMailbox(LegacyAccount account, long folderId, boolean notify, MessagingListener listener) {
         putBackground("synchronizeMailbox", listener, () ->
                 synchronizeMailboxSynchronous(account, folderId, notify, listener, new NotificationState())
         );
     }
 
-    public void synchronizeMailboxBlocking(Account account, String folderServerId) {
+    public void synchronizeMailboxBlocking(LegacyAccount account, String folderServerId) {
         long folderId = getFolderId(account, folderServerId);
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -583,7 +583,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void synchronizeMailboxSynchronous(Account account, long folderId, boolean notify,
+    private void synchronizeMailboxSynchronous(LegacyAccount account, long folderId, boolean notify,
             MessagingListener listener, NotificationState notificationState) {
         refreshFolderListIfStale(account);
 
@@ -591,7 +591,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         syncFolder(account, folderId, notify, listener, backend, notificationState);
     }
 
-    private void refreshFolderListIfStale(Account account) {
+    private void refreshFolderListIfStale(LegacyAccount account) {
         long lastFolderListRefresh = account.getLastFolderListRefreshTime();
         long now = System.currentTimeMillis();
 
@@ -603,7 +603,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void syncFolder(Account account, long folderId, boolean notify, MessagingListener listener, Backend backend,
+    private void syncFolder(LegacyAccount account, long folderId, boolean notify, MessagingListener listener, Backend backend,
             NotificationState notificationState) {
         if (isAuthenticationProblem(account, true)) {
             Timber.d("Authentication will fail. Skip synchronizing folder %d.", folderId);
@@ -658,7 +658,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private SyncConfig createSyncConfig(Account account) {
+    private SyncConfig createSyncConfig(LegacyAccount account) {
         return new SyncConfig(
                     account.getExpungePolicy().toBackendExpungePolicy(),
                     account.getEarliestPollDate(),
@@ -668,12 +668,12 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
                     SYNC_FLAGS);
     }
 
-    private void updateFolderStatus(Account account, long folderId, String status) {
+    private void updateFolderStatus(LegacyAccount account, long folderId, String status) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         messageStore.setStatus(folderId, status);
     }
 
-    public void handleAuthenticationFailure(Account account, boolean incoming) {
+    public void handleAuthenticationFailure(LegacyAccount account, boolean incoming) {
         if (account.shouldMigrateToOAuth()) {
             migrateAccountToOAuth(account);
         }
@@ -681,7 +681,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         notificationController.showAuthenticationErrorNotification(account, incoming);
     }
 
-    private void migrateAccountToOAuth(Account account) {
+    private void migrateAccountToOAuth(LegacyAccount account) {
         account.setIncomingServerSettings(account.getIncomingServerSettings().newAuthenticationType(AuthType.XOAUTH2));
         account.setOutgoingServerSettings(account.getOutgoingServerSettings().newAuthenticationType(AuthType.XOAUTH2));
         account.setShouldMigrateToOAuth(false);
@@ -689,7 +689,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         preferences.saveAccount(account);
     }
 
-    public void handleException(Account account, Exception exception) {
+    public void handleException(LegacyAccount account, Exception exception) {
         if (exception instanceof AuthenticationFailedException) {
             handleAuthenticationFailure(account, true);
         } else {
@@ -697,7 +697,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    void queuePendingCommand(Account account, PendingCommand command) {
+    void queuePendingCommand(LegacyAccount account, PendingCommand command) {
         try {
             LocalStore localStore = localStoreProvider.getInstance(account);
             localStore.addPendingCommand(command);
@@ -706,7 +706,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    void processPendingCommands(final Account account) {
+    void processPendingCommands(final LegacyAccount account) {
         putBackground("processPendingCommands", null, new Runnable() {
             @Override
             public void run() {
@@ -724,7 +724,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void processPendingCommandsSynchronous(Account account) throws MessagingException {
+    public void processPendingCommandsSynchronous(LegacyAccount account) throws MessagingException {
         LocalStore localStore = localStoreProvider.getInstance(account);
         List<PendingCommand> commands = localStore.getPendingCommands();
 
@@ -780,7 +780,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * that the server message will be synchronized down without an additional copy being
      * created.
      */
-    void processPendingAppend(PendingAppend command, Account account) throws MessagingException {
+    void processPendingAppend(PendingAppend command, LegacyAccount account) throws MessagingException {
         LocalStore localStore = localStoreProvider.getInstance(account);
         long folderId = command.folderId;
         LocalFolder localFolder = localStore.getFolder(folderId);
@@ -851,11 +851,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    void processPendingReplace(PendingReplace pendingReplace, Account account) {
+    void processPendingReplace(PendingReplace pendingReplace, LegacyAccount account) {
         draftOperations.processPendingReplace(pendingReplace, account);
     }
 
-    private void queueMoveOrCopy(Account account, long srcFolderId, long destFolderId, MoveOrCopyFlavor operation,
+    private void queueMoveOrCopy(LegacyAccount account, long srcFolderId, long destFolderId, MoveOrCopyFlavor operation,
             Map<String, String> uidMap) {
         PendingCommand command;
         switch (operation) {
@@ -874,7 +874,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         queuePendingCommand(account, command);
     }
 
-    void processPendingMoveOrCopy(PendingMoveOrCopy command, Account account) throws MessagingException {
+    void processPendingMoveOrCopy(PendingMoveOrCopy command, LegacyAccount account) throws MessagingException {
         long srcFolder = command.srcFolderId;
         long destFolder = command.destFolderId;
         MoveOrCopyFlavor operation = command.isCopy ? MoveOrCopyFlavor.COPY : MoveOrCopyFlavor.MOVE;
@@ -885,7 +885,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         processPendingMoveOrCopy(account, srcFolder, destFolder, uids, operation, newUidMap);
     }
 
-    void processPendingMoveAndRead(PendingMoveAndMarkAsRead command, Account account) throws MessagingException {
+    void processPendingMoveAndRead(PendingMoveAndMarkAsRead command, LegacyAccount account) throws MessagingException {
         long srcFolder = command.srcFolderId;
         long destFolder = command.destFolderId;
         Map<String, String> newUidMap = command.newUidMap;
@@ -896,7 +896,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
     @VisibleForTesting
-    void processPendingMoveOrCopy(Account account, long srcFolderId, long destFolderId, List<String> uids,
+    void processPendingMoveOrCopy(LegacyAccount account, long srcFolderId, long destFolderId, List<String> uids,
                                   MoveOrCopyFlavor operation, Map<String, String> newUidMap) throws MessagingException {
         requireNotNull(newUidMap);
 
@@ -981,7 +981,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void queueSetFlag(Account account, long folderId, boolean newState, Flag flag, List<String> uids) {
+    private void queueSetFlag(LegacyAccount account, long folderId, boolean newState, Flag flag, List<String> uids) {
         PendingCommand command = PendingSetFlag.create(folderId, newState, flag, uids);
         queuePendingCommand(account, command);
     }
@@ -989,18 +989,18 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Processes a pending mark read or unread command.
      */
-    void processPendingSetFlag(PendingSetFlag command, Account account) throws MessagingException {
+    void processPendingSetFlag(PendingSetFlag command, LegacyAccount account) throws MessagingException {
         Backend backend = getBackend(account);
         String folderServerId = getFolderServerId(account, command.folderId);
         backend.setFlag(folderServerId, command.uids, command.flag, command.newState);
     }
 
-    private void queueDelete(Account account, long folderId, List<String> uids) {
+    private void queueDelete(LegacyAccount account, long folderId, List<String> uids) {
         PendingCommand command = PendingDelete.create(folderId, uids);
         queuePendingCommand(account, command);
     }
 
-    void processPendingDelete(PendingDelete command, Account account) throws MessagingException {
+    void processPendingDelete(PendingDelete command, LegacyAccount account) throws MessagingException {
         long folderId = command.folderId;
         List<String> uids = command.uids;
 
@@ -1014,18 +1014,18 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         destroyPlaceholderMessages(localFolder, uids);
     }
 
-    private void queueExpunge(Account account, long folderId) {
+    private void queueExpunge(LegacyAccount account, long folderId) {
         PendingCommand command = PendingExpunge.create(folderId);
         queuePendingCommand(account, command);
     }
 
-    void processPendingExpunge(PendingExpunge command, Account account) throws MessagingException {
+    void processPendingExpunge(PendingExpunge command, LegacyAccount account) throws MessagingException {
         Backend backend = getBackend(account);
         String folderServerId = getFolderServerId(account, command.folderId);
         backend.expunge(folderServerId);
     }
 
-    void processPendingMarkAllAsRead(PendingMarkAllAsRead command, Account account) throws MessagingException {
+    void processPendingMarkAllAsRead(PendingMarkAllAsRead command, LegacyAccount account) throws MessagingException {
         long folderId = command.folderId;
         LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);
@@ -1053,13 +1053,13 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void markAllMessagesRead(Account account, long folderId) {
+    public void markAllMessagesRead(LegacyAccount account, long folderId) {
         PendingCommand command = PendingMarkAllAsRead.create(folderId);
         queuePendingCommand(account, command);
         processPendingCommands(account);
     }
 
-    public void setFlag(final Account account, final List<Long> messageIds, final Flag flag,
+    public void setFlag(final LegacyAccount account, final List<Long> messageIds, final Flag flag,
             final boolean newState) {
 
         setFlagInCache(account, messageIds, flag, newState);
@@ -1069,7 +1069,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         );
     }
 
-    public void setFlagForThreads(final Account account, final List<Long> threadRootIds,
+    public void setFlagForThreads(final LegacyAccount account, final List<Long> threadRootIds,
             final Flag flag, final boolean newState) {
 
         setFlagForThreadsInCache(account, threadRootIds, flag, newState);
@@ -1079,7 +1079,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         );
     }
 
-    private void setFlagSynchronous(final Account account, final List<Long> ids,
+    private void setFlagSynchronous(final LegacyAccount account, final List<Long> ids,
             final Flag flag, final boolean newState, final boolean threadedList) {
 
         LocalStore localStore;
@@ -1145,7 +1145,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void cancelNotificationsForMessages(Account account, long folderId, List<String> uids) {
+    private void cancelNotificationsForMessages(LegacyAccount account, long folderId, List<String> uids) {
         for (String uid : uids) {
             MessageReference messageReference = new MessageReference(account.getUuid(), folderId, uid);
             notificationController.removeNewMailNotification(account, messageReference);
@@ -1158,7 +1158,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * The {@link Message} objects passed in are updated to reflect the new flag state.
      * </p>
      */
-    public void setFlag(Account account, long folderId, List<LocalMessage> messages, Flag flag, boolean newState) {
+    public void setFlag(LegacyAccount account, long folderId, List<LocalMessage> messages, Flag flag, boolean newState) {
         // TODO: Put this into the background, but right now some callers depend on the message
         //       objects being modified right after this method returns.
         try {
@@ -1187,7 +1187,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Set or remove a flag for a message referenced by message UID.
      */
-    public void setFlag(Account account, long folderId, String uid, Flag flag, boolean newState) {
+    public void setFlag(LegacyAccount account, long folderId, String uid, Flag flag, boolean newState) {
         try {
             LocalStore localStore = localStoreProvider.getInstance(account);
             LocalFolder localFolder = localStore.getFolder(folderId);
@@ -1202,20 +1202,20 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void loadMessageRemotePartial(Account account, long folderId, String uid, MessagingListener listener) {
+    public void loadMessageRemotePartial(LegacyAccount account, long folderId, String uid, MessagingListener listener) {
         put("loadMessageRemotePartial", listener, () ->
             loadMessageRemoteSynchronous(account, folderId, uid, listener, true)
         );
     }
 
     //TODO: Fix the callback mess. See GH-782
-    public void loadMessageRemote(Account account, long folderId, String uid, MessagingListener listener) {
+    public void loadMessageRemote(LegacyAccount account, long folderId, String uid, MessagingListener listener) {
         put("loadMessageRemote", listener, () ->
             loadMessageRemoteSynchronous(account, folderId, uid, listener, false)
         );
     }
 
-    private void loadMessageRemoteSynchronous(Account account, long folderId, String messageServerId,
+    private void loadMessageRemoteSynchronous(LegacyAccount account, long folderId, String messageServerId,
             MessagingListener listener, boolean loadPartialFromSearch) {
         try {
             if (messageServerId.startsWith(K9.LOCAL_UID_PREFIX)) {
@@ -1251,7 +1251,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public LocalMessage loadMessage(Account account, long folderId, String uid) throws MessagingException {
+    public LocalMessage loadMessage(LegacyAccount account, long folderId, String uid) throws MessagingException {
         LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);
         localFolder.open();
@@ -1269,7 +1269,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return message;
     }
 
-    public LocalMessage loadMessageMetadata(Account account, long folderId, String uid) throws MessagingException {
+    public LocalMessage loadMessageMetadata(LegacyAccount account, long folderId, String uid) throws MessagingException {
         LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);
         localFolder.open();
@@ -1287,7 +1287,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return message;
     }
 
-    public void markMessageAsOpened(Account account, LocalMessage message) {
+    public void markMessageAsOpened(LegacyAccount account, LocalMessage message) {
         threadPool.execute(() ->
             notificationController.removeNewMailNotification(account, message.makeMessageReference())
         );
@@ -1316,7 +1316,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void markMessageAsOpenedBlocking(Account account, LocalMessage message, boolean markMessageAsRead) {
+    private void markMessageAsOpenedBlocking(LegacyAccount account, LocalMessage message, boolean markMessageAsRead) {
         if (markMessageAsRead) {
             markMessageAsRead(account, message);
         } else {
@@ -1326,28 +1326,28 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void markMessageAsRead(Account account, LocalMessage message) {
+    private void markMessageAsRead(LegacyAccount account, LocalMessage message) {
         List<Long> messageIds = Collections.singletonList(message.getDatabaseId());
         setFlagSynchronous(account, messageIds, Flag.SEEN, true, false);
     }
 
-    private void markMessageAsNotNew(Account account, LocalMessage message) {
+    private void markMessageAsNotNew(LegacyAccount account, LocalMessage message) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         long folderId = message.getFolder().getDatabaseId();
         String messageServerId = message.getUid();
         messageStore.setNewMessageState(folderId, messageServerId, false);
     }
 
-    public void clearNewMessages(Account account) {
+    public void clearNewMessages(LegacyAccount account) {
         put("clearNewMessages", null, () -> clearNewMessagesBlocking(account));
     }
 
-    private void clearNewMessagesBlocking(Account account) {
+    private void clearNewMessagesBlocking(LegacyAccount account) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         messageStore.clearNewMessageState();
     }
 
-    public void loadAttachment(final Account account, final LocalMessage message, final Part part,
+    public void loadAttachment(final LegacyAccount account, final LocalMessage message, final Part part,
             final MessagingListener listener) {
 
         put("loadAttachment", listener, new Runnable() {
@@ -1391,7 +1391,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Stores the given message in the Outbox and starts a sendPendingMessages command to attempt to send the message.
      */
-    public void sendMessage(Account account, Message message, String plaintextSubject, MessagingListener listener) {
+    public void sendMessage(LegacyAccount account, Message message, String plaintextSubject, MessagingListener listener) {
         try {
             Long outboxFolderId = account.getOutboxFolderId();
             if (outboxFolderId == null) {
@@ -1421,7 +1421,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void sendMessageBlocking(Account account, Message message) throws MessagingException {
+    public void sendMessageBlocking(LegacyAccount account, Message message) throws MessagingException {
         Backend backend = getBackend(account);
         backend.sendMessage(message);
     }
@@ -1429,7 +1429,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Attempt to send any messages that are sitting in the Outbox.
      */
-    public void sendPendingMessages(final Account account,
+    public void sendPendingMessages(final LegacyAccount account,
             MessagingListener listener) {
         putBackground("sendPendingMessages", listener, new Runnable() {
             @Override
@@ -1448,19 +1448,19 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void showSendingNotificationIfNecessary(Account account) {
+    private void showSendingNotificationIfNecessary(LegacyAccount account) {
         if (account.isNotifySync()) {
             notificationController.showSendingNotification(account);
         }
     }
 
-    private void clearSendingNotificationIfNecessary(Account account) {
+    private void clearSendingNotificationIfNecessary(LegacyAccount account) {
         if (account.isNotifySync()) {
             notificationController.clearSendingNotification(account);
         }
     }
 
-    private boolean messagesPendingSend(final Account account) {
+    private boolean messagesPendingSend(final LegacyAccount account) {
         Long outboxFolderId = account.getOutboxFolderId();
         if (outboxFolderId == null) {
             Timber.w("Could not get Outbox folder ID from Account");
@@ -1475,7 +1475,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * Attempt to send any messages that are sitting in the Outbox.
      */
     @VisibleForTesting
-    protected void sendPendingMessagesSynchronous(final Account account) {
+    protected void sendPendingMessagesSynchronous(final LegacyAccount account) {
         Exception lastFailure = null;
         try {
             if (isAuthenticationProblem(account, false)) {
@@ -1613,7 +1613,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void moveOrDeleteSentMessage(Account account, LocalStore localStore, LocalMessage message)
+    private void moveOrDeleteSentMessage(LegacyAccount account, LocalStore localStore, LocalMessage message)
             throws MessagingException {
         if (!account.hasSentFolder() || !account.isUploadSentMessages()) {
             Timber.i("Not uploading sent message; deleting local message");
@@ -1645,7 +1645,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void handleSendFailure(Account account, LocalFolder localFolder, Message message, Exception exception)
+    private void handleSendFailure(LegacyAccount account, LocalFolder localFolder, Message message, Exception exception)
             throws MessagingException {
 
         Timber.e(exception, "Failed to send message");
@@ -1654,7 +1654,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         notifySynchronizeMailboxFailed(account, localFolder, exception);
     }
 
-    private void notifySynchronizeMailboxFailed(Account account, LocalFolder localFolder, Exception exception) {
+    private void notifySynchronizeMailboxFailed(LegacyAccount account, LocalFolder localFolder, Exception exception) {
         long folderId = localFolder.getDatabaseId();
         String errorMessage = getRootCauseMessage(exception);
         for (MessagingListener listener : getListeners()) {
@@ -1670,39 +1670,39 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return isMoveCapable(message);
     }
 
-    public boolean isMoveCapable(final Account account) {
+    public boolean isMoveCapable(final LegacyAccount account) {
         return getBackend(account).getSupportsMove();
     }
 
-    public boolean isCopyCapable(final Account account) {
+    public boolean isCopyCapable(final LegacyAccount account) {
         return getBackend(account).getSupportsCopy();
     }
 
-    public boolean isPushCapable(Account account) {
+    public boolean isPushCapable(LegacyAccount account) {
         return getBackend(account).isPushCapable();
     }
 
-    public boolean supportsFlags(Account account) {
+    public boolean supportsFlags(LegacyAccount account) {
         return getBackend(account).getSupportsFlags();
     }
 
-    public boolean supportsExpunge(Account account) {
+    public boolean supportsExpunge(LegacyAccount account) {
         return getBackend(account).getSupportsExpunge();
     }
 
-    public boolean supportsSearchByDate(Account account) {
+    public boolean supportsSearchByDate(LegacyAccount account) {
         return getBackend(account).getSupportsSearchByDate();
     }
 
-    public boolean supportsUpload(Account account) {
+    public boolean supportsUpload(LegacyAccount account) {
         return getBackend(account).getSupportsUpload();
     }
 
-    public boolean supportsFolderSubscriptions(Account account) {
+    public boolean supportsFolderSubscriptions(LegacyAccount account) {
         return getBackend(account).getSupportsFolderSubscriptions();
     }
 
-    public void moveMessages(Account srcAccount, long srcFolderId,
+    public void moveMessages(LegacyAccount srcAccount, long srcFolderId,
             List<MessageReference> messageReferences, long destFolderId) {
         actOnMessageGroup(srcAccount, srcFolderId, messageReferences, (account, messageFolder, messages) -> {
             suppressMessages(account, messages);
@@ -1713,7 +1713,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void moveMessagesInThread(Account srcAccount, long srcFolderId,
+    public void moveMessagesInThread(LegacyAccount srcAccount, long srcFolderId,
             List<MessageReference> messageReferences, long destFolderId) {
         actOnMessageGroup(srcAccount, srcFolderId, messageReferences, (account, messageFolder, messages) -> {
             suppressMessages(account, messages);
@@ -1730,11 +1730,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void moveMessage(Account account, long srcFolderId, MessageReference message, long destFolderId) {
+    public void moveMessage(LegacyAccount account, long srcFolderId, MessageReference message, long destFolderId) {
         moveMessages(account, srcFolderId, Collections.singletonList(message), destFolderId);
     }
 
-    public void copyMessages(Account srcAccount, long srcFolderId,
+    public void copyMessages(LegacyAccount srcAccount, long srcFolderId,
             List<MessageReference> messageReferences, long destFolderId) {
         actOnMessageGroup(srcAccount, srcFolderId, messageReferences, (account, messageFolder, messages) -> {
             putBackground("copyMessages", null, () ->
@@ -1743,7 +1743,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void copyMessagesInThread(Account srcAccount, long srcFolderId,
+    public void copyMessagesInThread(LegacyAccount srcAccount, long srcFolderId,
             final List<MessageReference> messageReferences, long destFolderId) {
         actOnMessageGroup(srcAccount, srcFolderId, messageReferences, (account, messageFolder, messages) -> {
             putBackground("copyMessagesInThread", null, () -> {
@@ -1758,11 +1758,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void copyMessage(Account account, long srcFolderId, MessageReference message, long destFolderId) {
+    public void copyMessage(LegacyAccount account, long srcFolderId, MessageReference message, long destFolderId) {
         copyMessages(account, srcFolderId, Collections.singletonList(message), destFolderId);
     }
 
-    void moveOrCopyMessageSynchronous(Account account, long srcFolderId, List<LocalMessage> inMessages,
+    void moveOrCopyMessageSynchronous(LegacyAccount account, long srcFolderId, List<LocalMessage> inMessages,
             long destFolderId, MoveOrCopyFlavor operation) {
 
         try {
@@ -1863,11 +1863,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void moveToDraftsFolder(Account account, long folderId, List<MessageReference> messages){
+    public void moveToDraftsFolder(LegacyAccount account, long folderId, List<MessageReference> messages){
         putBackground("moveToDrafts", null, () -> moveToDraftsFolderInBackground(account, folderId, messages));
     }
 
-    private void moveToDraftsFolderInBackground(Account account, long folderId, List<MessageReference> messages) {
+    private void moveToDraftsFolderInBackground(LegacyAccount account, long folderId, List<MessageReference> messages) {
         for (MessageReference messageReference : messages) {
             try {
                 Message message = loadMessage(account, folderId, messageReference.getUid());
@@ -1899,22 +1899,22 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         archiveOperations.archiveMessage(message);
     }
 
-    public void expunge(Account account, long folderId) {
+    public void expunge(LegacyAccount account, long folderId) {
         putBackground("expunge", null, () -> {
             queueExpunge(account, folderId);
             processPendingCommands(account);
         });
     }
 
-    public void deleteDraftSkippingTrashFolder(Account account, long messageId) {
+    public void deleteDraftSkippingTrashFolder(LegacyAccount account, long messageId) {
         deleteDraft(account, messageId, true);
     }
 
-    public void deleteDraft(Account account, long messageId) {
+    public void deleteDraft(LegacyAccount account, long messageId) {
         deleteDraft(account, messageId, false);
     }
 
-    private void deleteDraft(Account account, long messageId, boolean skipTrashFolder) {
+    private void deleteDraft(LegacyAccount account, long messageId, boolean skipTrashFolder) {
         Long folderId = account.getDraftsFolderId();
         if (folderId == null) {
             Timber.w("No Drafts folder configured. Can't delete draft.");
@@ -1938,7 +1938,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void deleteThreadsSynchronous(Account account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
+    private void deleteThreadsSynchronous(LegacyAccount account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
         try {
             List<LocalMessage> messagesToDelete = collectMessagesInThreads(account, messages);
             deleteMessagesSynchronous(account, folderId, messagesToDelete, skipTrashFolder);
@@ -1947,7 +1947,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    List<LocalMessage> collectMessagesInThreads(Account account, List<LocalMessage> messages)
+    List<LocalMessage> collectMessagesInThreads(LegacyAccount account, List<LocalMessage> messages)
             throws MessagingException {
 
         LocalStore localStore = localStoreProvider.getInstance(account);
@@ -1982,7 +1982,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void deleteMessagesSynchronous(Account account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
+    private void deleteMessagesSynchronous(LegacyAccount account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
         try {
             List<LocalMessage> localOnlyMessages = new ArrayList<>();
             List<LocalMessage> syncedMessages = new ArrayList<>();
@@ -2107,7 +2107,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return uids;
     }
 
-    void processPendingEmptySpam(Account account) throws MessagingException {
+    void processPendingEmptySpam(LegacyAccount account) throws MessagingException {
         if (!account.hasSpamFolder()) {
             return;
         }
@@ -2127,7 +2127,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         compact(account);
     }
 
-    public void emptySpam(final Account account, MessagingListener listener) {
+    public void emptySpam(final LegacyAccount account, MessagingListener listener) {
         putBackground("emptySpam", listener, new Runnable() {
             @Override
             public void run() {
@@ -2159,7 +2159,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    void processPendingEmptyTrash(Account account) throws MessagingException {
+    void processPendingEmptyTrash(LegacyAccount account) throws MessagingException {
         if (!account.hasTrashFolder()) {
             return;
         }
@@ -2179,7 +2179,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         compact(account);
     }
 
-    public void emptyTrash(final Account account, MessagingListener listener) {
+    public void emptyTrash(final LegacyAccount account, MessagingListener listener) {
         putBackground("emptyTrash", listener, new Runnable() {
             @Override
             public void run() {
@@ -2218,14 +2218,14 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void clearFolder(Account account, long folderId) {
+    public void clearFolder(LegacyAccount account, long folderId) {
         putBackground("clearFolder", null, () ->
                 clearFolderSynchronous(account, folderId)
         );
     }
 
     @VisibleForTesting
-    protected void clearFolderSynchronous(Account account, long folderId) {
+    protected void clearFolderSynchronous(LegacyAccount account, long folderId) {
         try {
             LocalFolder localFolder = localStoreProvider.getInstance(account).getFolder(folderId);
             localFolder.open();
@@ -2247,22 +2247,22 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * @return {@code true} if the account only has a local Trash folder that is not synchronized
      * with a folder on the server. {@code false} otherwise.
      */
-    private boolean isTrashLocalOnly(Account account) {
+    private boolean isTrashLocalOnly(LegacyAccount account) {
         Backend backend = getBackend(account);
         return !backend.getSupportsTrashFolder();
     }
 
-    public boolean performPeriodicMailSync(Account account) {
+    public boolean performPeriodicMailSync(LegacyAccount account) {
         final CountDownLatch latch = new CountDownLatch(1);
         MutableBoolean syncError = new MutableBoolean(false);
         checkMail(account, false, false, true, new SimpleMessagingListener() {
             @Override
-            public void checkMailFinished(Context context, Account account) {
+            public void checkMailFinished(Context context, LegacyAccount account) {
                 latch.countDown();
             }
 
             @Override
-            public void synchronizeMailboxFailed(Account account, long folderId, String message) {
+            public void synchronizeMailboxFailed(LegacyAccount account, long folderId, String message) {
                 syncError.setValue(true);
             }
         });
@@ -2291,7 +2291,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * Checks mail for one or multiple accounts. If account is null all accounts
      * are checked.
      */
-    public void checkMail(Account account, boolean ignoreLastCheckedTime, boolean useManualWakeLock, boolean notify,
+    public void checkMail(LegacyAccount account, boolean ignoreLastCheckedTime, boolean useManualWakeLock, boolean notify,
             MessagingListener listener) {
 
         final WakeLock wakeLock;
@@ -2315,7 +2315,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
                 try {
                     Timber.i("Starting mail check");
 
-                    Collection<Account> accounts;
+                    Collection<LegacyAccount> accounts;
                     if (account != null) {
                         accounts = new ArrayList<>(1);
                         accounts.add(account);
@@ -2323,7 +2323,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
                         accounts = preferences.getAccounts();
                     }
 
-                    for (final Account account : accounts) {
+                    for (final LegacyAccount account : accounts) {
                         checkMailForAccount(account, ignoreLastCheckedTime, notify, listener);
                     }
 
@@ -2351,7 +2351,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
 
-    private void checkMailForAccount(Account account, boolean ignoreLastCheckedTime, boolean notify,
+    private void checkMailForAccount(LegacyAccount account, boolean ignoreLastCheckedTime, boolean notify,
             MessagingListener listener) {
         Timber.i("Synchronizing account %s", account);
 
@@ -2394,14 +2394,14 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
 
     }
 
-    private void synchronizeFolder(Account account, LocalFolder folder, boolean ignoreLastCheckedTime,
+    private void synchronizeFolder(LegacyAccount account, LocalFolder folder, boolean ignoreLastCheckedTime,
             boolean notify, MessagingListener listener, NotificationState notificationState) {
         putBackground("sync" + folder.getServerId(), null, () -> {
             synchronizeFolderInBackground(account, folder, ignoreLastCheckedTime, notify, listener, notificationState);
         });
     }
 
-    private void synchronizeFolderInBackground(Account account, LocalFolder folder, boolean ignoreLastCheckedTime,
+    private void synchronizeFolderInBackground(LegacyAccount account, LocalFolder folder, boolean ignoreLastCheckedTime,
             boolean notify, MessagingListener listener, NotificationState notificationState) {
         Timber.v("Folder %s was last synced @ %tc", folder.getServerId(), folder.getLastChecked());
 
@@ -2434,23 +2434,23 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void showFetchingMailNotificationIfNecessary(Account account, LocalFolder folder) {
+    private void showFetchingMailNotificationIfNecessary(LegacyAccount account, LocalFolder folder) {
         if (account.isNotifySync()) {
             notificationController.showFetchingMailNotification(account, folder);
         }
     }
 
-    private void showEmptyFetchingMailNotificationIfNecessary(Account account) {
+    private void showEmptyFetchingMailNotificationIfNecessary(LegacyAccount account) {
         if (account.isNotifySync()) {
             notificationController.showEmptyFetchingMailNotification(account);
         }
     }
 
-    private void clearFetchingMailNotification(Account account) {
+    private void clearFetchingMailNotification(LegacyAccount account) {
         notificationController.clearFetchingMailNotification(account);
     }
 
-    public void compact(Account account) {
+    public void compact(LegacyAccount account) {
         putBackground("compact:" + account, null, () -> {
             try {
                 MessageStore messageStore = messageStoreManager.getMessageStore(account);
@@ -2461,7 +2461,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void deleteAccount(Account account) {
+    public void deleteAccount(LegacyAccount account) {
         notificationController.clearNewMailNotifications(account, false);
         memorizingMessagingListener.removeAccount(account);
     }
@@ -2469,7 +2469,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Save a draft message.
      */
-    public Long saveDraft(Account account, Message message, Long existingDraftId, String plaintextSubject) {
+    public Long saveDraft(LegacyAccount account, Message message, Long existingDraftId, String plaintextSubject) {
         return draftOperations.saveDraft(account, message, existingDraftId, plaintextSubject);
     }
 
@@ -2510,26 +2510,26 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void cancelNotificationsForAccount(Account account) {
+    public void cancelNotificationsForAccount(LegacyAccount account) {
         notificationController.clearNewMailNotifications(account, true);
     }
 
-    public void cancelNotificationForMessage(Account account, MessageReference messageReference) {
+    public void cancelNotificationForMessage(LegacyAccount account, MessageReference messageReference) {
         notificationController.removeNewMailNotification(account, messageReference);
     }
 
     @Deprecated
-    public void clearCertificateErrorNotifications(Account account, boolean incoming) {
+    public void clearCertificateErrorNotifications(LegacyAccount account, boolean incoming) {
         notificationController.clearCertificateErrorNotifications(account, incoming);
     }
 
-    public void notifyUserIfCertificateProblem(Account account, Exception exception, boolean incoming) {
+    public void notifyUserIfCertificateProblem(LegacyAccount account, Exception exception, boolean incoming) {
         if (exception instanceof CertificateValidationException) {
             notificationController.showCertificateErrorNotification(account, incoming);
         }
     }
 
-    private boolean isAuthenticationProblem(Account account, boolean incoming) {
+    private boolean isAuthenticationProblem(LegacyAccount account, boolean incoming) {
         ServerSettings serverSettings = incoming ?
                 account.getIncomingServerSettings() : account.getOutgoingServerSettings();
 
@@ -2542,7 +2542,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
 
         for (Map.Entry<String, Map<Long, List<MessageReference>>> entry : accountMap.entrySet()) {
             String accountUuid = entry.getKey();
-            Account account = preferences.getAccount(accountUuid);
+            LegacyAccount account = preferences.getAccount(accountUuid);
 
             Map<Long, List<MessageReference>> folderMap = entry.getValue();
             for (Map.Entry<Long, List<MessageReference>> folderEntry : folderMap.entrySet()) {
@@ -2582,7 +2582,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
     private void actOnMessageGroup(
-            Account account, long folderId, List<MessageReference> messageReferences, MessageActor actor) {
+            LegacyAccount account, long folderId, List<MessageReference> messageReferences, MessageActor actor) {
         try {
             LocalFolder messageFolder = localStoreProvider.getInstance(account).getFolder(folderId);
             List<LocalMessage> localMessages = messageFolder.getMessagesByReference(messageReferences);
@@ -2594,11 +2594,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
     interface MessageActor {
-        void act(Account account, LocalFolder messageFolder, List<LocalMessage> messages);
+        void act(LegacyAccount account, LocalFolder messageFolder, List<LocalMessage> messages);
     }
 
     class ControllerSyncListener implements SyncListener {
-        private final Account account;
+        private final LegacyAccount account;
         private final MessagingListener listener;
         private final LocalStore localStore;
         private final boolean suppressNotifications;
@@ -2606,7 +2606,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         boolean syncFailed = false;
 
 
-        ControllerSyncListener(Account account, MessagingListener listener, boolean suppressNotifications,
+        ControllerSyncListener(LegacyAccount account, MessagingListener listener, boolean suppressNotifications,
                 NotificationState notificationState) {
             this.account = account;
             this.listener = listener;

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -29,7 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import app.k9mail.core.featureflag.FeatureFlagProvider;
 import app.k9mail.legacy.account.Account;
-import app.k9mail.legacy.account.Account.DeletePolicy;
+import app.k9mail.legacy.account.DeletePolicy;
 import app.k9mail.legacy.di.DI;
 import app.k9mail.legacy.message.controller.MessageReference;
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker;

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -4,7 +4,7 @@ package com.fsck.k9.controller;
 import java.util.List;
 import java.util.Map;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.MessagingException;
 
@@ -31,7 +31,7 @@ public class MessagingControllerCommands {
         PendingCommand() { }
 
         public abstract String getCommandName();
-        public abstract void execute(MessagingController controller, Account account) throws MessagingException;
+        public abstract void execute(MessagingController controller, LegacyAccount account) throws MessagingException;
     }
 
     public static class PendingMoveOrCopy extends PendingCommand {
@@ -63,7 +63,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingMoveOrCopy(this, account);
         }
     }
@@ -91,7 +91,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingMoveAndRead(this, account);
         }
     }
@@ -107,7 +107,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingEmptySpam(account);
         }
     }
@@ -123,7 +123,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingEmptyTrash(account);
         }
     }
@@ -154,7 +154,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingSetFlag(this, account);
         }
     }
@@ -180,7 +180,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingAppend(this, account);
         }
     }
@@ -207,7 +207,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingReplace(this, account);
         }
     }
@@ -230,7 +230,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingMarkAllAsRead(this, account);
         }
     }
@@ -256,7 +256,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingDelete(this, account);
         }
     }
@@ -279,7 +279,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, Account account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
             controller.processPendingExpunge(this, account);
         }
     }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/NotificationOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/NotificationOperations.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.controller
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.search.LocalSearch
 import com.fsck.k9.notification.NotificationController
@@ -51,13 +51,13 @@ internal class NotificationOperations(
         }
     }
 
-    private fun clearNotifications(account: Account, folderId: Long) {
+    private fun clearNotifications(account: LegacyAccount, folderId: Long) {
         notificationController.clearNewMailNotifications(account) { messageReferences ->
             messageReferences.filter { messageReference -> messageReference.folderId == folderId }
         }
     }
 
-    private fun LocalSearch.firstAccount(): Account? {
+    private fun LocalSearch.firstAccount(): LegacyAccount? {
         return accountManager.getAccount(accountUuids.first())
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.controller.push
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.backend.api.BackendPusher
@@ -18,7 +18,7 @@ internal class AccountPushController(
     private val messagingController: MessagingController,
     private val folderRepository: FolderRepository,
     backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val account: Account,
+    private val account: LegacyAccount,
 ) {
     private val coroutineScope = CoroutineScope(backgroundDispatcher)
 

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushControllerFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushControllerFactory.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.controller.push
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.controller.MessagingController
@@ -10,7 +10,7 @@ internal class AccountPushControllerFactory(
     private val messagingController: MessagingController,
     private val folderRepository: FolderRepository,
 ) {
-    fun create(account: Account): AccountPushController {
+    fun create(account: LegacyAccount): AccountPushController {
         return AccountPushController(
             backendManager,
             messagingController,

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.controller.push
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.preferences.BackgroundSync
 import app.k9mail.legacy.preferences.GeneralSettingsManager
@@ -137,7 +137,7 @@ class PushController internal constructor(
         launchUpdatePushers()
     }
 
-    private fun onBackendChanged(account: Account) {
+    private fun onBackendChanged(account: LegacyAccount) {
         coroutineScope.launch(coroutineDispatcher) {
             val accountPushController = synchronized(lock) {
                 pushers.remove(account.uuid)
@@ -239,14 +239,14 @@ class PushController internal constructor(
         }
     }
 
-    private fun getPushCapableAccounts(): Set<Account> {
+    private fun getPushCapableAccounts(): Set<LegacyAccount> {
         return accountManager.getAccounts()
             .asSequence()
             .filter { account -> backendManager.getBackend(account).isPushCapable }
             .toSet()
     }
 
-    private fun getPushAccounts(): Set<Account> {
+    private fun getPushAccounts(): Set<LegacyAccount> {
         return getPushCapableAccounts()
             .asSequence()
             .filter { account -> folderRepository.hasPushEnabledFolder(account) }
@@ -297,7 +297,7 @@ class PushController internal constructor(
         }
     }
 
-    private fun updatePushEnabledListeners(accounts: Set<Account>) {
+    private fun updatePushEnabledListeners(accounts: Set<LegacyAccount>) {
         synchronized(lock) {
             // Stop listening to push enabled changes in accounts we no longer monitor
             val accountUuids = accounts.mapToSet { it.uuid }

--- a/legacy/core/src/main/java/com/fsck/k9/helper/IdentityHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/helper/IdentityHelper.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.helper
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.Message.RecipientType
 
@@ -25,10 +25,10 @@ object IdentityHelper {
      * @return The identity the message was sent to, or the account's default identity if it
      * couldn't be determined which identity this message was sent to.
      *
-     * @see Account.findIdentity
+     * @see LegacyAccount.findIdentity
      */
     @JvmStatic
-    fun getRecipientIdentityFromMessage(account: Account, message: Message): Identity {
+    fun getRecipientIdentityFromMessage(account: LegacyAccount, message: Message): Identity {
         val recipient: Identity? = RECIPIENT_TYPES.asSequence()
             .flatMap { recipientType -> message.getRecipients(recipientType).asSequence() }
             .map { address -> account.findIdentity(address) }

--- a/legacy/core/src/main/java/com/fsck/k9/helper/ReplyToParser.java
+++ b/legacy/core/src/main/java/com/fsck/k9/helper/ReplyToParser.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import androidx.annotation.VisibleForTesting;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Message.RecipientType;
@@ -16,7 +16,7 @@ import com.fsck.k9.mail.Message.RecipientType;
 
 public class ReplyToParser {
 
-    public ReplyToAddresses getRecipientsToReplyTo(Message message, Account account) {
+    public ReplyToAddresses getRecipientsToReplyTo(Message message, LegacyAccount account) {
         Address[] candidateAddress;
 
         Address[] replyToAddresses = message.getReplyTo();
@@ -39,7 +39,7 @@ public class ReplyToParser {
         return new ReplyToAddresses(candidateAddress);
     }
 
-    public ReplyToAddresses getRecipientsToReplyAllTo(Message message, Account account) {
+    public ReplyToAddresses getRecipientsToReplyAllTo(Message message, LegacyAccount account) {
         List<Address> replyToAddresses = Arrays.asList(getRecipientsToReplyTo(message, account).to);
 
         HashSet<Address> alreadyAddedAddresses = new HashSet<>(replyToAddresses);

--- a/legacy/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
@@ -1,8 +1,8 @@
 package com.fsck.k9.job
 
 import androidx.work.WorkManager
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import timber.log.Timber
 
 class K9JobManager(
@@ -15,7 +15,7 @@ class K9JobManager(
         scheduleMailSync()
     }
 
-    fun scheduleMailSync(account: Account) {
+    fun scheduleMailSync(account: LegacyAccount) {
         mailSyncWorkerManager.cancelMailSync(account)
         mailSyncWorkerManager.scheduleMailSync(account)
     }

--- a/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
@@ -4,7 +4,7 @@ import android.content.ContentResolver
 import android.content.Context
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
@@ -64,7 +64,7 @@ class MailSyncWorker(
         }
     }
 
-    private val Account.isPeriodicMailSyncDisabled
+    private val LegacyAccount.isPeriodicMailSyncDisabled
         get() = automaticCheckIntervalMinutes <= 0
 
     companion object {

--- a/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
@@ -7,7 +7,7 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 import java.util.concurrent.TimeUnit
 import kotlinx.datetime.Clock
@@ -18,13 +18,13 @@ class MailSyncWorkerManager(
     val clock: Clock,
 ) {
 
-    fun cancelMailSync(account: Account) {
+    fun cancelMailSync(account: LegacyAccount) {
         Timber.v("Canceling mail sync worker for %s", account)
         val uniqueWorkName = createUniqueWorkName(account.uuid)
         workManager.cancelUniqueWork(uniqueWorkName)
     }
 
-    fun scheduleMailSync(account: Account) {
+    fun scheduleMailSync(account: LegacyAccount) {
         if (isNeverSyncInBackground()) return
 
         getSyncIntervalIfEnabled(account)?.let { syncIntervalMinutes ->
@@ -59,9 +59,9 @@ class MailSyncWorkerManager(
 
     private fun isNeverSyncInBackground() = K9.backgroundOps == K9.BACKGROUND_OPS.NEVER
 
-    private fun getSyncIntervalIfEnabled(account: Account): Long? {
+    private fun getSyncIntervalIfEnabled(account: LegacyAccount): Long? {
         val intervalMinutes = account.automaticCheckIntervalMinutes
-        if (intervalMinutes <= Account.INTERVAL_MINUTES_NEVER) {
+        if (intervalMinutes <= LegacyAccount.INTERVAL_MINUTES_NEVER) {
             return null
         }
 

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/AutoExpandFolderBackendFoldersRefreshListener.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/AutoExpandFolderBackendFoldersRefreshListener.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.mailstore
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.Preferences
 
@@ -9,7 +9,7 @@ import com.fsck.k9.Preferences
  */
 class AutoExpandFolderBackendFoldersRefreshListener(
     private val preferences: Preferences,
-    private val account: Account,
+    private val account: LegacyAccount,
     private val folderRepository: FolderRepository,
 ) : BackendFoldersRefreshListener {
     private var isFirstSync = false

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/FolderSettingsProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/FolderSettingsProvider.kt
@@ -1,13 +1,13 @@
 package com.fsck.k9.mailstore
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderSettings
 import com.fsck.k9.Preferences
 
 /**
  * Provides imported folder settings if available, otherwise default values.
  */
-class FolderSettingsProvider(val preferences: Preferences, val account: Account) {
+class FolderSettingsProvider(val preferences: Preferences, val account: LegacyAccount) {
     fun getFolderSettings(folderServerId: String): FolderSettings {
         val storage = preferences.storage
         val prefix = "${account.uuid}.$folderServerId"

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.mailstore
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import com.fsck.k9.Preferences
@@ -12,7 +12,7 @@ class K9BackendStorageFactory(
     private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
     private val saveMessageDataCreator: SaveMessageDataCreator,
 ) {
-    fun createBackendStorage(account: Account): K9BackendStorage {
+    fun createBackendStorage(account: LegacyAccount): K9BackendStorage {
         val messageStore = messageStoreManager.getMessageStore(account)
         val folderSettingsProvider = FolderSettingsProvider(preferences, account)
         val specialFolderUpdater = SpecialFolderUpdater(

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -8,7 +8,7 @@ import android.database.sqlite.SQLiteDatabase;
 import androidx.annotation.NonNull;
 
 import androidx.annotation.Nullable;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.mailstore.MoreMessages;
 import com.fsck.k9.K9;
 import app.k9mail.legacy.message.controller.MessageReference;
@@ -1192,7 +1192,7 @@ public class LocalFolder {
         });
     }
 
-    private Account getAccount() {
+    private LegacyAccount getAccount() {
         return localStore.getAccount();
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -12,7 +12,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import androidx.annotation.VisibleForTesting;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.K9;
 import app.k9mail.legacy.message.controller.MessageReference;
 import com.fsck.k9.mail.Address;
@@ -367,7 +367,7 @@ public class LocalMessage extends MimeMessage {
         return rootId;
     }
 
-    public Account getAccount() {
+    public LegacyAccount getAccount() {
         return localStore.getAccount();
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -26,7 +26,7 @@ import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import androidx.core.database.CursorKt;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.di.DI;
 import app.k9mail.legacy.mailstore.MessageListRepository;
 import app.k9mail.legacy.mailstore.MoreMessages;
@@ -163,19 +163,19 @@ public class LocalStore {
     private final AttachmentInfoExtractor attachmentInfoExtractor;
     private final StorageFilesProvider storageFilesProvider;
 
-    private final Account account;
+    private final LegacyAccount account;
     private final LockableDatabase database;
     private final OutboxStateRepository outboxStateRepository;
 
-    static LocalStore createInstance(Account account, Context context) throws MessagingException {
+    static LocalStore createInstance(LegacyAccount account, Context context) throws MessagingException {
         return new LocalStore(account, context);
     }
 
     /**
      * local://localhost/path/to/database/uuid.db
-     * This constructor is only used by {@link LocalStoreProvider#getInstance(Account)}
+     * This constructor is only used by {@link LocalStoreProvider#getInstance(LegacyAccount)}
      */
-    private LocalStore(final Account account, final Context context) throws MessagingException {
+    private LocalStore(final LegacyAccount account, final Context context) throws MessagingException {
         pendingCommandSerializer = PendingCommandSerializer.getInstance();
         attachmentInfoExtractor = DI.get(AttachmentInfoExtractor.class);
         StorageFilesProviderFactory storageFilesProviderFactory = DI.get(StorageFilesProviderFactory.class);
@@ -199,7 +199,7 @@ public class LocalStore {
         return schemaDefinitionFactory.getDatabaseVersion();
     }
 
-    Account getAccount() {
+    LegacyAccount getAccount() {
         return account;
     }
 
@@ -1037,7 +1037,7 @@ public class LocalStore {
 
     class RealMigrationsHelper implements MigrationsHelper {
         @Override
-        public Account getAccount() {
+        public LegacyAccount getAccount() {
             return LocalStore.this.getAccount();
         }
 

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStoreProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStoreProvider.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.mailstore
 
 import android.content.Context
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.di.DI
 import com.fsck.k9.mail.MessagingException
 import java.util.concurrent.ConcurrentHashMap
@@ -11,7 +11,7 @@ class LocalStoreProvider {
     private val accountLocks = ConcurrentHashMap<String, Any>()
 
     @Throws(MessagingException::class)
-    fun getInstance(account: Account): LocalStore {
+    fun getInstance(account: LegacyAccount): LocalStore {
         val context = DI.get(Context::class.java)
         val accountUuid = account.uuid
 
@@ -23,7 +23,7 @@ class LocalStoreProvider {
         }
     }
 
-    fun removeInstance(account: Account) {
+    fun removeInstance(account: LegacyAccount) {
         val accountUuid = account.uuid
         localStores.remove(accountUuid)
     }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/MigrationsHelper.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/MigrationsHelper.java
@@ -1,13 +1,13 @@
 package com.fsck.k9.mailstore;
 
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 
 
 /**
  * Helper to allow accessing classes and methods that aren't visible or accessible to the 'migrations' package
  */
 public interface MigrationsHelper {
-    Account getAccount();
+    LegacyAccount getAccount();
     void saveAccount();
 }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.mailstore
 import app.k9mail.core.common.mail.Protocols
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.SpecialFolderSelection
+import app.k9mail.legacy.account.SpecialFolderSelection
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.Preferences
 import net.thunderbird.feature.folder.api.RemoteFolder

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
@@ -2,22 +2,22 @@ package com.fsck.k9.mailstore
 
 import app.k9mail.core.common.mail.Protocols
 import app.k9mail.core.mail.folder.api.FolderType
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.SpecialFolderSelection
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.Preferences
 import net.thunderbird.feature.folder.api.RemoteFolder
 
 /**
- * Updates special folders in [Account] if they are marked as [SpecialFolderSelection.AUTOMATIC] or if they are marked
- * as [SpecialFolderSelection.MANUAL] but have been deleted from the server.
+ * Updates special folders in [LegacyAccount] if they are marked as [SpecialFolderSelection.AUTOMATIC] or if they
+ * are marked as [SpecialFolderSelection.MANUAL] but have been deleted from the server.
  */
 // TODO: Find a better way to deal with local-only special folders
 class SpecialFolderUpdater(
     private val preferences: Preferences,
     private val folderRepository: FolderRepository,
     private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
-    private val account: Account,
+    private val account: LegacyAccount,
 ) {
     fun updateSpecialFolders() {
         val folders = folderRepository.getRemoteFolders(account)
@@ -134,5 +134,5 @@ class SpecialFolderUpdater(
         preferences.saveAccount(account)
     }
 
-    private fun Account.isPop3() = incomingServerSettings.type == Protocols.POP3
+    private fun LegacyAccount.isPop3() = incomingServerSettings.type == Protocols.POP3
 }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialLocalFoldersCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialLocalFoldersCreator.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.mailstore
 
 import app.k9mail.core.common.mail.Protocols
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.SpecialFolderSelection
 import com.fsck.k9.Preferences
 import com.fsck.k9.mail.FolderType
@@ -13,7 +13,7 @@ class SpecialLocalFoldersCreator(
 ) {
     // TODO: When rewriting the account setup code make sure this method is only called once. Until then this can be
     //  called multiple times and we have to make sure folders are only created once.
-    fun createSpecialLocalFolders(account: Account) {
+    fun createSpecialLocalFolders(account: LegacyAccount) {
         Timber.d("Creating special local folders")
 
         val localStore = localStoreProvider.getInstance(account)
@@ -50,7 +50,7 @@ class SpecialLocalFoldersCreator(
         preferences.saveAccount(account)
     }
 
-    fun createOutbox(account: Account): Long {
+    fun createOutbox(account: LegacyAccount): Long {
         Timber.d("Creating Outbox folder")
 
         val localStore = localStoreProvider.getInstance(account)
@@ -62,10 +62,10 @@ class SpecialLocalFoldersCreator(
         return outboxFolderId
     }
 
-    private fun Account.isPop3() = incomingServerSettings.type == Protocols.POP3
+    private fun LegacyAccount.isPop3() = incomingServerSettings.type == Protocols.POP3
 
     companion object {
-        private const val OUTBOX_FOLDER_NAME = Account.OUTBOX_NAME
+        private const val OUTBOX_FOLDER_NAME = LegacyAccount.OUTBOX_NAME
         private const val DRAFTS_FOLDER_NAME = "Drafts"
         private const val SENT_FOLDER_NAME = "Sent"
         private const val TRASH_FOLDER_NAME = "Trash"

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialLocalFoldersCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialLocalFoldersCreator.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.mailstore
 
 import app.k9mail.core.common.mail.Protocols
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.SpecialFolderSelection
+import app.k9mail.legacy.account.SpecialFolderSelection
 import com.fsck.k9.Preferences
 import com.fsck.k9.mail.FolderType
 import timber.log.Timber

--- a/legacy/core/src/main/java/com/fsck/k9/message/IdentityHeaderBuilder.java
+++ b/legacy/core/src/main/java/com/fsck/k9/message/IdentityHeaderBuilder.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import android.net.Uri;
 import android.net.Uri.Builder;
 
-import app.k9mail.legacy.account.Account.QuoteStyle;
+import app.k9mail.legacy.account.QuoteStyle;
 import app.k9mail.legacy.account.Identity;
 import com.fsck.k9.K9;
 import app.k9mail.legacy.message.controller.MessageReference;

--- a/legacy/core/src/main/java/com/fsck/k9/message/MessageBuilder.java
+++ b/legacy/core/src/main/java/com/fsck/k9/message/MessageBuilder.java
@@ -15,7 +15,7 @@ import com.fsck.k9.mail.internet.AddressHeaderBuilder;
 import com.fsck.k9.mail.internet.Headers;
 import timber.log.Timber;
 
-import app.k9mail.legacy.account.Account.QuoteStyle;
+import app.k9mail.legacy.account.QuoteStyle;
 import app.k9mail.legacy.account.Identity;
 import com.fsck.k9.K9;
 import app.k9mail.legacy.message.controller.MessageReference;

--- a/legacy/core/src/main/java/com/fsck/k9/message/ReplyActionStrategy.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/ReplyActionStrategy.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.message
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.helper.ReplyToParser
 import com.fsck.k9.mail.Message
 
@@ -8,7 +8,7 @@ import com.fsck.k9.mail.Message
  * Figures out which reply actions are available to the user.
  */
 class ReplyActionStrategy(private val replyRoParser: ReplyToParser) {
-    fun getReplyActions(account: Account, message: Message): ReplyActions {
+    fun getReplyActions(account: LegacyAccount, message: Message): ReplyActions {
         val recipientsToReplyTo = replyRoParser.getRecipientsToReplyTo(message, account)
         val recipientsToReplyAllTo = replyRoParser.getRecipientsToReplyAllTo(message, account)
 

--- a/legacy/core/src/main/java/com/fsck/k9/message/quote/HtmlQuoteCreator.java
+++ b/legacy/core/src/main/java/com/fsck/k9/message/quote/HtmlQuoteCreator.java
@@ -8,7 +8,7 @@ import com.fsck.k9.CoreResourceProvider;
 import app.k9mail.legacy.di.DI;
 import timber.log.Timber;
 
-import app.k9mail.legacy.account.Account.QuoteStyle;
+import app.k9mail.legacy.account.QuoteStyle;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Message.RecipientType;

--- a/legacy/core/src/main/java/com/fsck/k9/message/quote/TextQuoteCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/quote/TextQuoteCreator.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.message.quote
 
-import app.k9mail.legacy.account.Account.QuoteStyle
+import app.k9mail.legacy.account.QuoteStyle
 import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.Message

--- a/legacy/core/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotificationController.kt
@@ -4,14 +4,14 @@ import android.app.Notification
 import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 internal open class AuthenticationErrorNotificationController(
     private val notificationHelper: NotificationHelper,
     private val actionCreator: NotificationActionCreator,
     private val resourceProvider: NotificationResourceProvider,
 ) {
-    fun showAuthenticationErrorNotification(account: Account, incoming: Boolean) {
+    fun showAuthenticationErrorNotification(account: LegacyAccount, incoming: Boolean) {
         val notificationId = NotificationIds.getAuthenticationErrorNotificationId(account, incoming)
         val editServerSettingsPendingIntent = createContentIntent(account, incoming)
         val title = resourceProvider.authenticationErrorTitle()
@@ -35,12 +35,12 @@ internal open class AuthenticationErrorNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearAuthenticationErrorNotification(account: Account, incoming: Boolean) {
+    fun clearAuthenticationErrorNotification(account: LegacyAccount, incoming: Boolean) {
         val notificationId = NotificationIds.getAuthenticationErrorNotificationId(account, incoming)
         notificationManager.cancel(notificationId)
     }
 
-    protected open fun createContentIntent(account: Account, incoming: Boolean): PendingIntent {
+    protected open fun createContentIntent(account: LegacyAccount, incoming: Boolean): PendingIntent {
         return if (incoming) {
             actionCreator.getEditIncomingServerSettingsIntent(account)
         } else {
@@ -48,7 +48,7 @@ internal open class AuthenticationErrorNotificationController(
         }
     }
 
-    private fun createLockScreenNotification(account: Account): Notification {
+    private fun createLockScreenNotification(account: LegacyAccount): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconWarning)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/BaseNotificationDataCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/BaseNotificationDataCreator.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 import com.fsck.k9.K9.LockScreenNotificationVisibility
 
@@ -39,7 +39,7 @@ internal class BaseNotificationDataCreator {
             .joinToString()
     }
 
-    private fun createNotificationAppearance(account: Account): NotificationAppearance {
+    private fun createNotificationAppearance(account: LegacyAccount): NotificationAppearance {
         return with(account.notificationSettings) {
             val vibrationPattern = vibration.systemPattern.takeIf { vibration.isEnabled }
             NotificationAppearance(

--- a/legacy/core/src/main/java/com/fsck/k9/notification/CertificateErrorNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/CertificateErrorNotificationController.kt
@@ -4,14 +4,14 @@ import android.app.Notification
 import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 internal open class CertificateErrorNotificationController(
     private val notificationHelper: NotificationHelper,
     private val actionCreator: NotificationActionCreator,
     private val resourceProvider: NotificationResourceProvider,
 ) {
-    fun showCertificateErrorNotification(account: Account, incoming: Boolean) {
+    fun showCertificateErrorNotification(account: LegacyAccount, incoming: Boolean) {
         val notificationId = NotificationIds.getCertificateErrorNotificationId(account, incoming)
         val editServerSettingsPendingIntent = createContentIntent(account, incoming)
         val title = resourceProvider.certificateErrorTitle(account.displayName)
@@ -35,12 +35,12 @@ internal open class CertificateErrorNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearCertificateErrorNotifications(account: Account, incoming: Boolean) {
+    fun clearCertificateErrorNotifications(account: LegacyAccount, incoming: Boolean) {
         val notificationId = NotificationIds.getCertificateErrorNotificationId(account, incoming)
         notificationManager.cancel(notificationId)
     }
 
-    protected open fun createContentIntent(account: Account, incoming: Boolean): PendingIntent {
+    protected open fun createContentIntent(account: LegacyAccount, incoming: Boolean): PendingIntent {
         return if (incoming) {
             actionCreator.getEditIncomingServerSettingsIntent(account)
         } else {
@@ -48,7 +48,7 @@ internal open class CertificateErrorNotificationController(
         }
     }
 
-    private fun createLockScreenNotification(account: Account): Notification {
+    private fun createLockScreenNotification(account: LegacyAccount): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconWarning)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationController.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
 import androidx.core.app.NotificationManagerCompat
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mailstore.LocalMessage
 
@@ -15,7 +15,7 @@ internal class NewMailNotificationController(
     private val singleMessageNotificationCreator: SingleMessageNotificationCreator,
 ) {
     @Synchronized
-    fun restoreNewMailNotifications(accounts: List<Account>) {
+    fun restoreNewMailNotifications(accounts: List<LegacyAccount>) {
         for (account in accounts) {
             val notificationData = newMailNotificationManager.restoreNewMailNotifications(account)
 
@@ -26,7 +26,7 @@ internal class NewMailNotificationController(
     }
 
     @Synchronized
-    fun addNewMailNotification(account: Account, message: LocalMessage, silent: Boolean) {
+    fun addNewMailNotification(account: LegacyAccount, message: LocalMessage, silent: Boolean) {
         val notificationData = newMailNotificationManager.addNewMailNotification(account, message, silent)
 
         if (notificationData != null) {
@@ -36,7 +36,7 @@ internal class NewMailNotificationController(
 
     @Synchronized
     fun removeNewMailNotifications(
-        account: Account,
+        account: LegacyAccount,
         clearNewMessageState: Boolean,
         selector: (List<MessageReference>) -> List<MessageReference>,
     ) {
@@ -52,7 +52,7 @@ internal class NewMailNotificationController(
     }
 
     @Synchronized
-    fun clearNewMailNotifications(account: Account, clearNewMessageState: Boolean) {
+    fun clearNewMailNotifications(account: LegacyAccount, clearNewMessageState: Boolean) {
         val cancelNotificationIds = newMailNotificationManager.clearNewMailNotifications(account, clearNewMessageState)
 
         cancelNotifications(cancelNotificationIds)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationData.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationData.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 
 internal data class NewMailNotificationData(
@@ -11,7 +11,7 @@ internal data class NewMailNotificationData(
 )
 
 internal data class BaseNotificationData(
-    val account: Account,
+    val account: LegacyAccount,
     val accountName: String,
     val groupKey: String,
     val color: Int,

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationManager.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mailstore.LocalMessage
 import kotlinx.datetime.Clock
@@ -16,7 +16,7 @@ internal class NewMailNotificationManager(
     private val summaryNotificationDataCreator: SummaryNotificationDataCreator,
     private val clock: Clock,
 ) {
-    fun restoreNewMailNotifications(account: Account): NewMailNotificationData? {
+    fun restoreNewMailNotifications(account: LegacyAccount): NewMailNotificationData? {
         val notificationData = notificationRepository.restoreNotifications(account) ?: return null
 
         val addLockScreenNotification = notificationData.isSingleMessageNotification
@@ -38,7 +38,11 @@ internal class NewMailNotificationManager(
         )
     }
 
-    fun addNewMailNotification(account: Account, message: LocalMessage, silent: Boolean): NewMailNotificationData? {
+    fun addNewMailNotification(
+        account: LegacyAccount,
+        message: LocalMessage,
+        silent: Boolean,
+    ): NewMailNotificationData? {
         val content = contentCreator.createFromMessage(account, message)
 
         val result = notificationRepository.addNotification(account, content, timestamp = now()) ?: return null
@@ -64,7 +68,7 @@ internal class NewMailNotificationManager(
     }
 
     fun removeNewMailNotifications(
-        account: Account,
+        account: LegacyAccount,
         clearNewMessageState: Boolean,
         selector: (List<MessageReference>) -> List<MessageReference>,
     ): NewMailNotificationData? {
@@ -97,7 +101,7 @@ internal class NewMailNotificationManager(
         )
     }
 
-    fun clearNewMailNotifications(account: Account, clearNewMessageState: Boolean): List<Int> {
+    fun clearNewMailNotifications(account: LegacyAccount, clearNewMessageState: Boolean): List<Int> {
         notificationRepository.clearNotifications(account, clearNewMessageState)
         return NotificationIds.getAllMessageNotificationIds(account)
     }
@@ -107,7 +111,7 @@ internal class NewMailNotificationManager(
     }
 
     private fun createSingleNotificationData(
-        account: Account,
+        account: LegacyAccount,
         notificationId: Int,
         content: NotificationContent,
         timestamp: Long,

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionCreator.kt
@@ -1,19 +1,22 @@
 package com.fsck.k9.notification
 
 import android.app.PendingIntent
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 
 interface NotificationActionCreator {
     fun createViewMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createViewFolderPendingIntent(account: Account, folderId: Long): PendingIntent
+    fun createViewFolderPendingIntent(account: LegacyAccount, folderId: Long): PendingIntent
 
-    fun createViewMessagesPendingIntent(account: Account, messageReferences: List<MessageReference>): PendingIntent
+    fun createViewMessagesPendingIntent(
+        account: LegacyAccount,
+        messageReferences: List<MessageReference>,
+    ): PendingIntent
 
-    fun createViewFolderListPendingIntent(account: Account): PendingIntent
+    fun createViewFolderListPendingIntent(account: LegacyAccount): PendingIntent
 
-    fun createDismissAllMessagesPendingIntent(account: Account): PendingIntent
+    fun createDismissAllMessagesPendingIntent(account: LegacyAccount): PendingIntent
 
     fun createDismissMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
@@ -21,19 +24,22 @@ interface NotificationActionCreator {
 
     fun createMarkMessageAsReadPendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createMarkAllAsReadPendingIntent(account: Account, messageReferences: List<MessageReference>): PendingIntent
+    fun createMarkAllAsReadPendingIntent(
+        account: LegacyAccount,
+        messageReferences: List<MessageReference>,
+    ): PendingIntent
 
-    fun getEditIncomingServerSettingsIntent(account: Account): PendingIntent
+    fun getEditIncomingServerSettingsIntent(account: LegacyAccount): PendingIntent
 
-    fun getEditOutgoingServerSettingsIntent(account: Account): PendingIntent
+    fun getEditOutgoingServerSettingsIntent(account: LegacyAccount): PendingIntent
 
     fun createDeleteMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createDeleteAllPendingIntent(account: Account, messageReferences: List<MessageReference>): PendingIntent
+    fun createDeleteAllPendingIntent(account: LegacyAccount, messageReferences: List<MessageReference>): PendingIntent
 
     fun createArchiveMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createArchiveAllPendingIntent(account: Account, messageReferences: List<MessageReference>): PendingIntent
+    fun createArchiveAllPendingIntent(account: LegacyAccount, messageReferences: List<MessageReference>): PendingIntent
 
     fun createMarkMessageAsSpamPendingIntent(messageReference: MessageReference): PendingIntent
 }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionService.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionService.kt
@@ -4,7 +4,7 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.K9
 import com.fsck.k9.Preferences
@@ -66,7 +66,7 @@ class NotificationActionService : Service() {
         return null
     }
 
-    private fun markMessagesAsRead(intent: Intent, account: Account) {
+    private fun markMessagesAsRead(intent: Intent, account: LegacyAccount) {
         Timber.i("NotificationActionService marking messages as read")
 
         val messageReferenceStrings = intent.getStringArrayListExtra(EXTRA_MESSAGE_REFERENCES)
@@ -97,7 +97,7 @@ class NotificationActionService : Service() {
         messagingController.archiveMessages(messageReferences)
     }
 
-    private fun markMessageAsSpam(intent: Intent, account: Account) {
+    private fun markMessageAsSpam(intent: Intent, account: LegacyAccount) {
         Timber.i("NotificationActionService moving messages to spam")
 
         val messageReferenceString = intent.getStringExtra(EXTRA_MESSAGE_REFERENCE)
@@ -120,7 +120,7 @@ class NotificationActionService : Service() {
         }
     }
 
-    private fun cancelNotifications(intent: Intent, account: Account) {
+    private fun cancelNotifications(intent: Intent, account: LegacyAccount) {
         if (intent.hasExtra(EXTRA_MESSAGE_REFERENCE)) {
             val messageReferenceString = intent.getStringExtra(EXTRA_MESSAGE_REFERENCE)
             val messageReference = MessageReference.parse(messageReferenceString)
@@ -183,7 +183,7 @@ class NotificationActionService : Service() {
             }
         }
 
-        fun createDismissAllMessagesIntent(context: Context, account: Account): Intent {
+        fun createDismissAllMessagesIntent(context: Context, account: LegacyAccount): Intent {
             return Intent(context, NotificationActionService::class.java).apply {
                 action = ACTION_DISMISS
                 putExtra(EXTRA_ACCOUNT_UUID, account.uuid)
@@ -223,7 +223,7 @@ class NotificationActionService : Service() {
 
         fun createArchiveAllIntent(
             context: Context,
-            account: Account,
+            account: LegacyAccount,
             messageReferences: List<MessageReference>,
         ): Intent {
             return Intent(context, NotificationActionService::class.java).apply {

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
@@ -8,8 +8,8 @@ import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationSettings
 import java.util.concurrent.Executor
@@ -58,7 +58,7 @@ class NotificationChannelManager(
     @RequiresApi(api = Build.VERSION_CODES.O)
     private fun addChannelsForAccounts(
         notificationManager: NotificationManager,
-        accounts: List<Account>,
+        accounts: List<LegacyAccount>,
     ) {
         for (account in accounts) {
             val groupId = account.notificationChannelGroupId
@@ -76,7 +76,7 @@ class NotificationChannelManager(
     @RequiresApi(api = Build.VERSION_CODES.O)
     private fun removeChannelsForNonExistingOrChangedAccounts(
         notificationManager: NotificationManager,
-        accounts: List<Account>,
+        accounts: List<LegacyAccount>,
     ) {
         val accountUuids = accounts.map { it.uuid }.toSet()
 
@@ -120,7 +120,7 @@ class NotificationChannelManager(
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
-    private fun getChannelMessages(account: Account): NotificationChannel {
+    private fun getChannelMessages(account: LegacyAccount): NotificationChannel {
         val channelName = resourceProvider.messagesChannelName
         val channelId = getChannelIdFor(account, ChannelType.MESSAGES)
         val importance = NotificationManager.IMPORTANCE_DEFAULT
@@ -134,7 +134,7 @@ class NotificationChannelManager(
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
-    private fun getChannelMiscellaneous(account: Account): NotificationChannel {
+    private fun getChannelMiscellaneous(account: LegacyAccount): NotificationChannel {
         val channelName = resourceProvider.miscellaneousChannelName
         val channelDescription = resourceProvider.miscellaneousChannelDescription
         val channelId = getChannelIdFor(account, ChannelType.MISCELLANEOUS)
@@ -148,7 +148,7 @@ class NotificationChannelManager(
         return miscellaneousChannel
     }
 
-    fun getChannelIdFor(account: Account, channelType: ChannelType): String {
+    fun getChannelIdFor(account: LegacyAccount, channelType: ChannelType): String {
         return if (channelType == ChannelType.MESSAGES) {
             getMessagesChannelId(account, account.messagesNotificationChannelSuffix)
         } else {
@@ -156,12 +156,12 @@ class NotificationChannelManager(
         }
     }
 
-    private fun getMessagesChannelId(account: Account, suffix: String): String {
+    private fun getMessagesChannelId(account: LegacyAccount, suffix: String): String {
         return "messages_channel_${account.uuid}$suffix"
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun getNotificationConfiguration(account: Account): NotificationConfiguration {
+    fun getNotificationConfiguration(account: LegacyAccount): NotificationConfiguration {
         val channelId = getChannelIdFor(account, ChannelType.MESSAGES)
         val notificationChannel = notificationManager.getNotificationChannel(channelId)
 
@@ -174,7 +174,7 @@ class NotificationChannelManager(
         )
     }
 
-    fun recreateMessagesNotificationChannel(account: Account) {
+    fun recreateMessagesNotificationChannel(account: LegacyAccount) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
 
         val oldChannelId = getChannelIdFor(account, ChannelType.MESSAGES)
@@ -210,7 +210,7 @@ class NotificationChannelManager(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun NotificationChannel.matches(account: Account): Boolean {
+    private fun NotificationChannel.matches(account: LegacyAccount): Boolean {
         val systemLight = notificationLightDecoder.decode(
             isBlinkLightsEnabled = shouldShowLights(),
             lightColor = lightColor,
@@ -237,7 +237,7 @@ class NotificationChannelManager(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun NotificationChannel.setPropertiesFrom(account: Account) {
+    private fun NotificationChannel.setPropertiesFrom(account: LegacyAccount) {
         val notificationSettings = account.notificationSettings
 
         if (notificationSettings.isRingEnabled) {
@@ -254,12 +254,12 @@ class NotificationChannelManager(
         enableVibration(notificationSettings.vibration.isEnabled)
     }
 
-    private val Account.notificationChannelGroupId: String
+    private val LegacyAccount.notificationChannelGroupId: String
         get() = uuid
 
     private fun String.toAccountUuid(): String = this
 
-    private val Account.messagesNotificationChannelSuffix: String
+    private val LegacyAccount.messagesNotificationChannelSuffix: String
         get() = messagesNotificationChannelVersion.let { version -> if (version == 0) "" else "_$version" }
 
     private val NotificationSettings.ringtoneUri: Uri?

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationConfigurationConverter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationConfigurationConverter.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.notification.NotificationSettings
 
 /**
@@ -10,7 +10,7 @@ class NotificationConfigurationConverter(
     private val notificationLightDecoder: NotificationLightDecoder,
     private val notificationVibrationDecoder: NotificationVibrationDecoder,
 ) {
-    fun convert(account: Account, notificationConfiguration: NotificationConfiguration): NotificationSettings {
+    fun convert(account: LegacyAccount, notificationConfiguration: NotificationConfiguration): NotificationSettings {
         val light = notificationLightDecoder.decode(
             isBlinkLightsEnabled = notificationConfiguration.isBlinkLightsEnabled,
             lightColor = notificationConfiguration.lightColor,

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationContentCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationContentCreator.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.notification
 
 import android.text.SpannableStringBuilder
 import app.k9mail.core.android.common.contact.ContactRepository
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.extractors.PreviewResult.PreviewType
 import com.fsck.k9.K9
 import com.fsck.k9.helper.MessageHelper
@@ -13,7 +13,7 @@ internal class NotificationContentCreator(
     private val resourceProvider: NotificationResourceProvider,
     private val contactRepository: ContactRepository,
 ) {
-    fun createFromMessage(account: Account, message: LocalMessage): NotificationContent {
+    fun createFromMessage(account: LegacyAccount, message: LocalMessage): NotificationContent {
         val sender = getMessageSender(account, message)
 
         return NotificationContent(
@@ -68,7 +68,8 @@ internal class NotificationContentCreator(
         return subject.ifEmpty { resourceProvider.noSubject() }
     }
 
-    private fun getMessageSender(account: Account, message: Message): String? {
+    @Suppress("ReturnCount")
+    private fun getMessageSender(account: LegacyAccount, message: Message): String? {
         val localContactRepository = if (K9.isShowContactName) contactRepository else null
         var isSelf = false
 

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationController.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.mailstore.LocalMessage
@@ -13,55 +13,55 @@ class NotificationController internal constructor(
     private val sendFailedNotificationController: SendFailedNotificationController,
     private val newMailNotificationController: NewMailNotificationController,
 ) {
-    fun showCertificateErrorNotification(account: Account, incoming: Boolean) {
+    fun showCertificateErrorNotification(account: LegacyAccount, incoming: Boolean) {
         certificateErrorNotificationController.showCertificateErrorNotification(account, incoming)
     }
 
-    fun clearCertificateErrorNotifications(account: Account, incoming: Boolean) {
+    fun clearCertificateErrorNotifications(account: LegacyAccount, incoming: Boolean) {
         certificateErrorNotificationController.clearCertificateErrorNotifications(account, incoming)
     }
 
-    fun showAuthenticationErrorNotification(account: Account, incoming: Boolean) {
+    fun showAuthenticationErrorNotification(account: LegacyAccount, incoming: Boolean) {
         authenticationErrorNotificationController.showAuthenticationErrorNotification(account, incoming)
     }
 
-    fun clearAuthenticationErrorNotification(account: Account, incoming: Boolean) {
+    fun clearAuthenticationErrorNotification(account: LegacyAccount, incoming: Boolean) {
         authenticationErrorNotificationController.clearAuthenticationErrorNotification(account, incoming)
     }
 
-    fun showSendingNotification(account: Account) {
+    fun showSendingNotification(account: LegacyAccount) {
         syncNotificationController.showSendingNotification(account)
     }
 
-    fun clearSendingNotification(account: Account) {
+    fun clearSendingNotification(account: LegacyAccount) {
         syncNotificationController.clearSendingNotification(account)
     }
 
-    fun showSendFailedNotification(account: Account, exception: Exception) {
+    fun showSendFailedNotification(account: LegacyAccount, exception: Exception) {
         sendFailedNotificationController.showSendFailedNotification(account, exception)
     }
 
-    fun clearSendFailedNotification(account: Account) {
+    fun clearSendFailedNotification(account: LegacyAccount) {
         sendFailedNotificationController.clearSendFailedNotification(account)
     }
 
-    fun showFetchingMailNotification(account: Account, folder: LocalFolder) {
+    fun showFetchingMailNotification(account: LegacyAccount, folder: LocalFolder) {
         syncNotificationController.showFetchingMailNotification(account, folder)
     }
 
-    fun showEmptyFetchingMailNotification(account: Account) {
+    fun showEmptyFetchingMailNotification(account: LegacyAccount) {
         syncNotificationController.showEmptyFetchingMailNotification(account)
     }
 
-    fun clearFetchingMailNotification(account: Account) {
+    fun clearFetchingMailNotification(account: LegacyAccount) {
         syncNotificationController.clearFetchingMailNotification(account)
     }
 
-    fun restoreNewMailNotifications(accounts: List<Account>) {
+    fun restoreNewMailNotifications(accounts: List<LegacyAccount>) {
         newMailNotificationController.restoreNewMailNotifications(accounts)
     }
 
-    fun addNewMailNotification(account: Account, message: LocalMessage, silent: Boolean) {
+    fun addNewMailNotification(account: LegacyAccount, message: LocalMessage, silent: Boolean) {
         Timber.v(
             "Creating notification for message %s:%s:%s",
             message.account.uuid,
@@ -72,7 +72,7 @@ class NotificationController internal constructor(
         newMailNotificationController.addNewMailNotification(account, message, silent)
     }
 
-    fun removeNewMailNotification(account: Account, messageReference: MessageReference) {
+    fun removeNewMailNotification(account: LegacyAccount, messageReference: MessageReference) {
         Timber.v("Removing notification for message %s", messageReference)
 
         newMailNotificationController.removeNewMailNotifications(account, clearNewMessageState = true) {
@@ -80,13 +80,16 @@ class NotificationController internal constructor(
         }
     }
 
-    fun clearNewMailNotifications(account: Account, selector: (List<MessageReference>) -> List<MessageReference>) {
+    fun clearNewMailNotifications(
+        account: LegacyAccount,
+        selector: (List<MessageReference>) -> List<MessageReference>,
+    ) {
         Timber.v("Removing some notifications for account %s", account.uuid)
 
         newMailNotificationController.removeNewMailNotifications(account, clearNewMessageState = false, selector)
     }
 
-    fun clearNewMailNotifications(account: Account, clearNewMessageState: Boolean) {
+    fun clearNewMailNotifications(account: LegacyAccount, clearNewMessageState: Boolean) {
         Timber.v("Removing all notifications for account %s", account.uuid)
 
         newMailNotificationController.clearNewMailNotifications(account, clearNewMessageState)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationData.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationData.kt
@@ -1,13 +1,13 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 
 /**
  * Holds information about active and inactive new message notifications of an account.
  */
 internal data class NotificationData(
-    val account: Account,
+    val account: LegacyAccount,
     val activeNotifications: List<NotificationHolder>,
     val inactiveNotifications: List<InactiveNotificationHolder>,
 ) {
@@ -35,7 +35,7 @@ internal data class NotificationData(
     fun isEmpty() = activeNotifications.isEmpty()
 
     companion object {
-        fun create(account: Account): NotificationData {
+        fun create(account: LegacyAccount): NotificationData {
             return NotificationData(account, activeNotifications = emptyList(), inactiveNotifications = emptyList())
         }
     }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationDataStore.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationDataStore.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 
 internal const val MAX_NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS = 9
@@ -16,13 +16,13 @@ internal class NotificationDataStore {
     private val notificationDataMap = mutableMapOf<String, NotificationData>()
 
     @Synchronized
-    fun isAccountInitialized(account: Account): Boolean {
+    fun isAccountInitialized(account: LegacyAccount): Boolean {
         return notificationDataMap[account.uuid] != null
     }
 
     @Synchronized
     fun initializeAccount(
-        account: Account,
+        account: LegacyAccount,
         activeNotifications: List<NotificationHolder>,
         inactiveNotifications: List<InactiveNotificationHolder>,
     ): NotificationData {
@@ -34,7 +34,7 @@ internal class NotificationDataStore {
     }
 
     @Synchronized
-    fun addNotification(account: Account, content: NotificationContent, timestamp: Long): AddNotificationResult? {
+    fun addNotification(account: LegacyAccount, content: NotificationContent, timestamp: Long): AddNotificationResult? {
         val notificationData = getNotificationData(account)
         val messageReference = content.messageReference
 
@@ -108,9 +108,10 @@ internal class NotificationDataStore {
         }
     }
 
+    @Suppress("LongMethod", "ReturnCount")
     @Synchronized
     fun removeNotifications(
-        account: Account,
+        account: LegacyAccount,
         selector: (List<MessageReference>) -> List<MessageReference>,
     ): RemoveNotificationsResult? {
         var notificationData = getNotificationData(account)
@@ -195,11 +196,11 @@ internal class NotificationDataStore {
     }
 
     @Synchronized
-    fun clearNotifications(account: Account) {
+    fun clearNotifications(account: LegacyAccount) {
         notificationDataMap.remove(account.uuid)
     }
 
-    private fun getNotificationData(account: Account): NotificationData {
+    private fun getNotificationData(account: LegacyAccount): NotificationData {
         return notificationDataMap[account.uuid] ?: NotificationData.create(account).also { notificationData ->
             notificationDataMap[account.uuid] = notificationData
         }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationGroupKeys.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationGroupKeys.kt
@@ -1,11 +1,11 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 object NotificationGroupKeys {
     private const val NOTIFICATION_GROUP_KEY_PREFIX = "newMailNotifications-"
 
-    fun getGroupKey(account: Account): String {
+    fun getGroupKey(account: LegacyAccount): String {
         return NOTIFICATION_GROUP_KEY_PREFIX + account.accountNumber
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationHelper.kt
@@ -9,7 +9,7 @@ import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.PendingIntentCompat
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 import com.fsck.k9.notification.NotificationChannelManager.ChannelType
 import timber.log.Timber
@@ -28,12 +28,12 @@ class NotificationHelper(
         return notificationManager
     }
 
-    fun createNotificationBuilder(account: Account, channelType: ChannelType): NotificationCompat.Builder {
+    fun createNotificationBuilder(account: LegacyAccount, channelType: ChannelType): NotificationCompat.Builder {
         val notificationChannel = notificationChannelManager.getChannelIdFor(account, channelType)
         return NotificationCompat.Builder(context, notificationChannel)
     }
 
-    fun notify(account: Account, notificationId: Int, notification: Notification) {
+    fun notify(account: LegacyAccount, notificationId: Int, notification: Notification) {
         try {
             notificationManager.notify(notificationId, notification)
         } catch (e: SecurityException) {
@@ -53,7 +53,7 @@ class NotificationHelper(
         }
     }
 
-    private fun showNotifyErrorNotification(account: Account) {
+    private fun showNotifyErrorNotification(account: LegacyAccount) {
         val title = resourceProvider.notifyErrorTitle()
         val text = resourceProvider.notifyErrorText()
 

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationIds.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationIds.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 internal object NotificationIds {
     const val PUSH_NOTIFICATION_ID = 1
@@ -20,17 +20,17 @@ internal object NotificationIds {
     private const val NUMBER_OF_NOTIFICATIONS_PER_ACCOUNT =
         NUMBER_OF_MISC_ACCOUNT_NOTIFICATIONS + NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS
 
-    fun getNewMailSummaryNotificationId(account: Account): Int {
+    fun getNewMailSummaryNotificationId(account: LegacyAccount): Int {
         return getBaseNotificationId(account) + OFFSET_NEW_MAIL_SUMMARY
     }
 
-    fun getSingleMessageNotificationId(account: Account, index: Int): Int {
+    fun getSingleMessageNotificationId(account: LegacyAccount, index: Int): Int {
         require(index in 0 until NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS) { "Invalid index: $index" }
 
         return getBaseNotificationId(account) + OFFSET_NEW_MAIL_SINGLE + index
     }
 
-    fun getAllMessageNotificationIds(account: Account): List<Int> {
+    fun getAllMessageNotificationIds(account: LegacyAccount): List<Int> {
         val singleMessageNotificationIdRange = (0 until NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS).map { index ->
             getBaseNotificationId(account) + OFFSET_NEW_MAIL_SINGLE + index
         }
@@ -38,27 +38,27 @@ internal object NotificationIds {
         return singleMessageNotificationIdRange.toList() + getNewMailSummaryNotificationId(account)
     }
 
-    fun getFetchingMailNotificationId(account: Account): Int {
+    fun getFetchingMailNotificationId(account: LegacyAccount): Int {
         return getBaseNotificationId(account) + OFFSET_FETCHING_MAIL
     }
 
-    fun getSendFailedNotificationId(account: Account): Int {
+    fun getSendFailedNotificationId(account: LegacyAccount): Int {
         return getBaseNotificationId(account) + OFFSET_SEND_FAILED_NOTIFICATION
     }
 
-    fun getCertificateErrorNotificationId(account: Account, incoming: Boolean): Int {
+    fun getCertificateErrorNotificationId(account: LegacyAccount, incoming: Boolean): Int {
         val offset = if (incoming) OFFSET_CERTIFICATE_ERROR_INCOMING else OFFSET_CERTIFICATE_ERROR_OUTGOING
 
         return getBaseNotificationId(account) + offset
     }
 
-    fun getAuthenticationErrorNotificationId(account: Account, incoming: Boolean): Int {
+    fun getAuthenticationErrorNotificationId(account: LegacyAccount, incoming: Boolean): Int {
         val offset = if (incoming) OFFSET_AUTHENTICATION_ERROR_INCOMING else OFFSET_AUTHENTICATION_ERROR_OUTGOING
 
         return getBaseNotificationId(account) + offset
     }
 
-    private fun getBaseNotificationId(account: Account): Int {
+    private fun getBaseNotificationId(account: LegacyAccount): Int {
         /* skip notification ID 0 */
         return 1 + NUMBER_OF_GENERAL_NOTIFICATIONS +
             account.accountNumber * NUMBER_OF_NOTIFICATIONS_PER_ACCOUNT

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationRepository.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationRepository.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mailstore.LocalStoreProvider
@@ -14,7 +14,7 @@ internal class NotificationRepository(
     private val notificationDataStore = NotificationDataStore()
 
     @Synchronized
-    fun restoreNotifications(account: Account): NotificationData? {
+    fun restoreNotifications(account: LegacyAccount): NotificationData? {
         if (notificationDataStore.isAccountInitialized(account)) return null
 
         val localStore = localStoreProvider.getInstance(account)
@@ -43,7 +43,7 @@ internal class NotificationRepository(
     }
 
     @Synchronized
-    fun addNotification(account: Account, content: NotificationContent, timestamp: Long): AddNotificationResult? {
+    fun addNotification(account: LegacyAccount, content: NotificationContent, timestamp: Long): AddNotificationResult? {
         restoreNotifications(account)
 
         return notificationDataStore.addNotification(account, content, timestamp)?.also { result ->
@@ -57,7 +57,7 @@ internal class NotificationRepository(
 
     @Synchronized
     fun removeNotifications(
-        account: Account,
+        account: LegacyAccount,
         clearNewMessageState: Boolean = true,
         selector: (List<MessageReference>) -> List<MessageReference>,
     ): RemoveNotificationsResult? {
@@ -73,7 +73,7 @@ internal class NotificationRepository(
     }
 
     @Synchronized
-    fun clearNotifications(account: Account, clearNewMessageState: Boolean) {
+    fun clearNotifications(account: LegacyAccount, clearNewMessageState: Boolean) {
         notificationDataStore.clearNotifications(account)
         clearNotificationStore(account)
 
@@ -83,7 +83,7 @@ internal class NotificationRepository(
     }
 
     private fun persistNotificationDataStoreChanges(
-        account: Account,
+        account: LegacyAccount,
         operations: List<NotificationStoreOperation>,
         updateNewMessageState: Boolean,
     ) {
@@ -95,7 +95,7 @@ internal class NotificationRepository(
         }
     }
 
-    private fun setNewMessageState(account: Account, operations: List<NotificationStoreOperation>) {
+    private fun setNewMessageState(account: LegacyAccount, operations: List<NotificationStoreOperation>) {
         val messageStore = messageStoreManager.getMessageStore(account)
 
         for (operation in operations) {
@@ -121,12 +121,12 @@ internal class NotificationRepository(
         }
     }
 
-    private fun clearNewMessageState(account: Account) {
+    private fun clearNewMessageState(account: LegacyAccount) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.clearNewMessageState()
     }
 
-    private fun clearNotificationStore(account: Account) {
+    private fun clearNotificationStore(account: LegacyAccount) {
         val notificationStore = notificationStoreProvider.getNotificationStore(account)
         notificationStore.clearNotifications()
     }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationSettingsUpdater.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationSettingsUpdater.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.notification
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.Preferences
 
 /**
@@ -25,7 +25,7 @@ class NotificationSettingsUpdater(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun updateNotificationSettings(account: Account) {
+    fun updateNotificationSettings(account: LegacyAccount) {
         val notificationConfiguration = notificationChannelManager.getNotificationConfiguration(account)
         val notificationSettings = notificationConfigurationConverter.convert(account, notificationConfiguration)
 

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationStoreProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationStoreProvider.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 interface NotificationStoreProvider {
-    fun getNotificationStore(account: Account): NotificationStore
+    fun getNotificationStore(account: LegacyAccount): NotificationStore
 }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationStrategy.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationStrategy.kt
@@ -1,13 +1,13 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.mailstore.LocalMessage
 
 interface NotificationStrategy {
 
     fun shouldNotifyForMessage(
-        account: Account,
+        account: LegacyAccount,
         localFolder: LocalFolder,
         message: LocalMessage,
         isOldMessage: Boolean,

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import android.app.Notification
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.helper.ExceptionHelper
 
 internal class SendFailedNotificationController(
@@ -11,7 +11,7 @@ internal class SendFailedNotificationController(
     private val actionBuilder: NotificationActionCreator,
     private val resourceProvider: NotificationResourceProvider,
 ) {
-    fun showSendFailedNotification(account: Account, exception: Exception) {
+    fun showSendFailedNotification(account: LegacyAccount, exception: Exception) {
         val title = resourceProvider.sendFailedTitle()
         val text = ExceptionHelper.getRootCauseMessage(exception)
 
@@ -43,12 +43,12 @@ internal class SendFailedNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearSendFailedNotification(account: Account) {
+    fun clearSendFailedNotification(account: LegacyAccount) {
         val notificationId = NotificationIds.getSendFailedNotificationId(account)
         notificationManager.cancel(notificationId)
     }
 
-    private fun createLockScreenNotification(account: Account): Notification {
+    private fun createLockScreenNotification(account: LegacyAccount): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconWarning)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationDataCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationDataCreator.kt
@@ -1,12 +1,12 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 
 internal class SingleMessageNotificationDataCreator {
 
     fun createSingleNotificationData(
-        account: Account,
+        account: LegacyAccount,
         notificationId: Int,
         content: NotificationContent,
         timestamp: Long,
@@ -52,7 +52,7 @@ internal class SingleMessageNotificationDataCreator {
         }
     }
 
-    private fun createSingleNotificationWearActions(account: Account): List<WearNotificationAction> {
+    private fun createSingleNotificationWearActions(account: LegacyAccount): List<WearNotificationAction> {
         return buildList {
             add(WearNotificationAction.Reply)
             add(WearNotificationAction.MarkAsRead)
@@ -81,7 +81,7 @@ internal class SingleMessageNotificationDataCreator {
     }
 
     // We don't support confirming actions on Wear devices. So don't show the action when confirmation is enabled.
-    private fun isSpamActionAvailableForWear(account: Account): Boolean {
+    private fun isSpamActionAvailableForWear(account: LegacyAccount): Boolean {
         return account.hasSpamFolder() && !K9.isConfirmSpam
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.WearableExtender
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.notification.NotificationChannelManager.ChannelType
 import timber.log.Timber
 import androidx.core.app.NotificationCompat.Builder as NotificationBuilder
@@ -23,6 +23,7 @@ internal class SummaryNotificationCreator(
             is SummarySingleNotificationData -> {
                 createSingleMessageNotification(baseNotificationData, summaryNotificationData.singleNotificationData)
             }
+
             is SummaryInboxNotificationData -> {
                 createInboxStyleSummaryNotification(baseNotificationData, summaryNotificationData)
             }
@@ -99,12 +100,15 @@ internal class SummaryNotificationCreator(
         setStyle(style)
     }
 
-    private fun createViewIntent(account: Account, notificationData: SummaryInboxNotificationData): PendingIntent {
+    private fun createViewIntent(
+        account: LegacyAccount,
+        notificationData: SummaryInboxNotificationData,
+    ): PendingIntent {
         return actionCreator.createViewMessagesPendingIntent(account, notificationData.messageReferences)
     }
 
     private fun NotificationBuilder.setDeviceActions(
-        account: Account,
+        account: LegacyAccount,
         notificationData: SummaryInboxNotificationData,
     ) = apply {
         for (action in notificationData.actions) {
@@ -116,7 +120,7 @@ internal class SummaryNotificationCreator(
     }
 
     private fun NotificationBuilder.addMarkAllAsReadAction(
-        account: Account,
+        account: LegacyAccount,
         notificationData: SummaryInboxNotificationData,
     ) {
         val icon = resourceProvider.iconMarkAsRead
@@ -128,7 +132,7 @@ internal class SummaryNotificationCreator(
     }
 
     private fun NotificationBuilder.addDeleteAllAction(
-        account: Account,
+        account: LegacyAccount,
         notificationData: SummaryInboxNotificationData,
     ) {
         val icon = resourceProvider.iconDelete
@@ -139,8 +143,9 @@ internal class SummaryNotificationCreator(
         addAction(icon, title, action)
     }
 
+    @Suppress("NestedBlockDepth")
     private fun NotificationBuilder.setWearActions(
-        account: Account,
+        account: LegacyAccount,
         notificationData: SummaryInboxNotificationData,
     ) = apply {
         val wearableExtender = WearableExtender().apply {
@@ -157,7 +162,7 @@ internal class SummaryNotificationCreator(
     }
 
     private fun WearableExtender.addMarkAllAsReadAction(
-        account: Account,
+        account: LegacyAccount,
         notificationData: SummaryInboxNotificationData,
     ) {
         val icon = resourceProvider.wearIconMarkAsRead
@@ -169,7 +174,10 @@ internal class SummaryNotificationCreator(
         addAction(markAsReadAction)
     }
 
-    private fun WearableExtender.addDeleteAllAction(account: Account, notificationData: SummaryInboxNotificationData) {
+    private fun WearableExtender.addDeleteAllAction(
+        account: LegacyAccount,
+        notificationData: SummaryInboxNotificationData,
+    ) {
         val icon = resourceProvider.wearIconDelete
         val title = resourceProvider.actionDeleteAll()
         val messageReferences = notificationData.messageReferences
@@ -179,7 +187,10 @@ internal class SummaryNotificationCreator(
         addAction(deleteAction)
     }
 
-    private fun WearableExtender.addArchiveAllAction(account: Account, notificationData: SummaryInboxNotificationData) {
+    private fun WearableExtender.addArchiveAllAction(
+        account: LegacyAccount,
+        notificationData: SummaryInboxNotificationData,
+    ) {
         val icon = resourceProvider.wearIconArchive
         val title = resourceProvider.actionArchiveAll()
         val messageReferences = notificationData.messageReferences

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SummaryNotificationDataCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SummaryNotificationDataCreator.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 
 private const val MAX_NUMBER_OF_MESSAGES_FOR_SUMMARY_NOTIFICATION = 5
@@ -53,7 +53,7 @@ internal class SummaryNotificationDataCreator(
         }
     }
 
-    private fun createSummaryWearNotificationActions(account: Account): List<SummaryWearNotificationAction> {
+    private fun createSummaryWearNotificationActions(account: LegacyAccount): List<SummaryWearNotificationAction> {
         return buildList {
             add(SummaryWearNotificationAction.MarkAsRead)
 

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import android.app.Notification
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mailstore.LocalFolder
 
 internal class SyncNotificationController(
@@ -11,7 +11,7 @@ internal class SyncNotificationController(
     private val actionBuilder: NotificationActionCreator,
     private val resourceProvider: NotificationResourceProvider,
 ) {
-    fun showSendingNotification(account: Account) {
+    fun showSendingNotification(account: LegacyAccount) {
         val accountName = account.displayName
         val title = resourceProvider.sendingMailTitle()
         val tickerText = resourceProvider.sendingMailBody(accountName)
@@ -35,12 +35,12 @@ internal class SyncNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearSendingNotification(account: Account) {
+    fun clearSendingNotification(account: LegacyAccount) {
         val notificationId = NotificationIds.getFetchingMailNotificationId(account)
         notificationManager.cancel(notificationId)
     }
 
-    fun showFetchingMailNotification(account: Account, folder: LocalFolder) {
+    fun showFetchingMailNotification(account: LegacyAccount, folder: LocalFolder) {
         val accountName = account.displayName
         val folderId = folder.databaseId
         val folderName = folder.name
@@ -69,7 +69,7 @@ internal class SyncNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun showEmptyFetchingMailNotification(account: Account) {
+    fun showEmptyFetchingMailNotification(account: LegacyAccount) {
         val title = resourceProvider.checkingMailTitle()
         val text = account.displayName
         val notificationId = NotificationIds.getFetchingMailNotificationId(account)
@@ -88,12 +88,12 @@ internal class SyncNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearFetchingMailNotification(account: Account) {
+    fun clearFetchingMailNotification(account: LegacyAccount) {
         val notificationId = NotificationIds.getFetchingMailNotificationId(account)
         notificationManager.cancel(notificationId)
     }
 
-    private fun createSendingLockScreenNotification(account: Account): Notification {
+    private fun createSendingLockScreenNotification(account: LegacyAccount): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconSendingMail)
@@ -103,7 +103,7 @@ internal class SyncNotificationController(
             .build()
     }
 
-    private fun createFetchingMailLockScreenNotification(account: Account): Notification {
+    private fun createFetchingMailLockScreenNotification(account: LegacyAccount): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconCheckingMail)

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -15,7 +15,7 @@ import app.k9mail.legacy.account.Account;
 import app.k9mail.legacy.account.DeletePolicy;
 import app.k9mail.legacy.account.Expunge;
 import app.k9mail.legacy.account.FolderMode;
-import app.k9mail.legacy.account.Account.MessageFormat;
+import app.k9mail.legacy.account.MessageFormat;
 import app.k9mail.legacy.account.Account.QuoteStyle;
 import app.k9mail.legacy.account.ShowPictures;
 import app.k9mail.legacy.account.SortType;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -19,7 +19,7 @@ import app.k9mail.legacy.account.Account.MessageFormat;
 import app.k9mail.legacy.account.Account.QuoteStyle;
 import app.k9mail.legacy.account.Account.ShowPictures;
 import app.k9mail.legacy.account.SortType;
-import app.k9mail.legacy.account.Account.SpecialFolderSelection;
+import app.k9mail.legacy.account.SpecialFolderSelection;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.core.R;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -12,7 +12,7 @@ import android.content.Context;
 import app.k9mail.legacy.account.AccountDefaultsProvider;
 import app.k9mail.legacy.notification.NotificationLight;
 import app.k9mail.legacy.account.Account;
-import app.k9mail.legacy.account.Account.DeletePolicy;
+import app.k9mail.legacy.account.DeletePolicy;
 import app.k9mail.legacy.account.Account.Expunge;
 import app.k9mail.legacy.account.FolderMode;
 import app.k9mail.legacy.account.Account.MessageFormat;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -17,7 +17,7 @@ import app.k9mail.legacy.account.Expunge;
 import app.k9mail.legacy.account.FolderMode;
 import app.k9mail.legacy.account.Account.MessageFormat;
 import app.k9mail.legacy.account.Account.QuoteStyle;
-import app.k9mail.legacy.account.Account.ShowPictures;
+import app.k9mail.legacy.account.ShowPictures;
 import app.k9mail.legacy.account.SortType;
 import app.k9mail.legacy.account.SpecialFolderSelection;
 import app.k9mail.legacy.di.DI;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -11,7 +11,7 @@ import android.content.Context;
 
 import app.k9mail.legacy.account.AccountDefaultsProvider;
 import app.k9mail.legacy.notification.NotificationLight;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.account.DeletePolicy;
 import app.k9mail.legacy.account.Expunge;
 import app.k9mail.legacy.account.FolderMode;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -13,7 +13,7 @@ import app.k9mail.legacy.account.AccountDefaultsProvider;
 import app.k9mail.legacy.notification.NotificationLight;
 import app.k9mail.legacy.account.Account;
 import app.k9mail.legacy.account.DeletePolicy;
-import app.k9mail.legacy.account.Account.Expunge;
+import app.k9mail.legacy.account.Expunge;
 import app.k9mail.legacy.account.FolderMode;
 import app.k9mail.legacy.account.Account.MessageFormat;
 import app.k9mail.legacy.account.Account.QuoteStyle;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -14,7 +14,7 @@ import app.k9mail.legacy.notification.NotificationLight;
 import app.k9mail.legacy.account.Account;
 import app.k9mail.legacy.account.Account.DeletePolicy;
 import app.k9mail.legacy.account.Account.Expunge;
-import app.k9mail.legacy.account.Account.FolderMode;
+import app.k9mail.legacy.account.FolderMode;
 import app.k9mail.legacy.account.Account.MessageFormat;
 import app.k9mail.legacy.account.Account.QuoteStyle;
 import app.k9mail.legacy.account.Account.ShowPictures;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -16,7 +16,7 @@ import app.k9mail.legacy.account.DeletePolicy;
 import app.k9mail.legacy.account.Expunge;
 import app.k9mail.legacy.account.FolderMode;
 import app.k9mail.legacy.account.MessageFormat;
-import app.k9mail.legacy.account.Account.QuoteStyle;
+import app.k9mail.legacy.account.QuoteStyle;
 import app.k9mail.legacy.account.ShowPictures;
 import app.k9mail.legacy.account.SortType;
 import app.k9mail.legacy.account.SpecialFolderSelection;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -18,7 +18,7 @@ import app.k9mail.legacy.account.FolderMode;
 import app.k9mail.legacy.account.Account.MessageFormat;
 import app.k9mail.legacy.account.Account.QuoteStyle;
 import app.k9mail.legacy.account.Account.ShowPictures;
-import app.k9mail.legacy.account.Account.SortType;
+import app.k9mail.legacy.account.SortType;
 import app.k9mail.legacy.account.Account.SpecialFolderSelection;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.K9;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.preferences
 
 import android.content.Context
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.AccountPreferenceSerializer.Companion.ACCOUNT_DESCRIPTION_KEY
 import com.fsck.k9.AccountPreferenceSerializer.Companion.INCOMING_SERVER_SETTINGS_KEY
 import com.fsck.k9.AccountPreferenceSerializer.Companion.OUTGOING_SERVER_SETTINGS_KEY
@@ -140,7 +140,7 @@ internal class AccountSettingsWriter(
         error("Unexpected exit")
     }
 
-    private fun isAccountNameUsed(name: String?, accounts: List<Account>): Boolean {
+    private fun isAccountNameUsed(name: String?, accounts: List<LegacyAccount>): Boolean {
         return accounts.any { it.displayName == name }
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsProvider.kt
@@ -1,11 +1,11 @@
 package com.fsck.k9.preferences
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.mailstore.RemoteFolderDetails
 
 class FolderSettingsProvider(private val folderRepository: FolderRepository) {
-    fun getFolderSettings(account: Account): List<FolderSettings> {
+    fun getFolderSettings(account: LegacyAccount): List<FolderSettings> {
         return folderRepository.getRemoteFolderDetails(account)
             .filterNot { it.containsOnlyDefaultValues() }
             .map { it.toFolderSettings() }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -10,7 +10,7 @@ import java.util.TreeMap;
 import android.content.Context;
 
 import app.k9mail.feature.telemetry.api.TelemetryManager;
-import app.k9mail.legacy.account.Account.SortType;
+import app.k9mail.legacy.account.SortType;
 import app.k9mail.legacy.account.AccountDefaultsProvider;
 import app.k9mail.legacy.di.DI;
 import app.k9mail.legacy.preferences.AppTheme;

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.preferences
 import android.content.ContentResolver
 import android.net.Uri
 import android.util.Xml
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.AccountPreferenceSerializer.Companion.ACCOUNT_DESCRIPTION_KEY
 import com.fsck.k9.AccountPreferenceSerializer.Companion.IDENTITY_DESCRIPTION_KEY
@@ -122,9 +122,10 @@ class SettingsExporter(
         }
     }
 
+    @Suppress("LongMethod", "CyclomaticComplexMethod", "NestedBlockDepth")
     private fun writeAccount(
         serializer: XmlSerializer,
-        account: Account,
+        account: LegacyAccount,
         prefs: Map<String, Any>,
         includePasswords: Boolean,
     ) {
@@ -272,7 +273,7 @@ class SettingsExporter(
         serializer: XmlSerializer,
         keyPart: String,
         valueString: String,
-        account: Account,
+        account: LegacyAccount,
     ) {
         val versionedSetting = AccountSettingsDescriptions.SETTINGS[keyPart]
         if (versionedSetting != null) {
@@ -297,7 +298,7 @@ class SettingsExporter(
     }
 
     private fun writeFolderNameSettings(
-        account: Account,
+        account: LegacyAccount,
         folderRepository: FolderRepository,
         serializer: XmlSerializer,
     ) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo100.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo100.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import com.fsck.k9.preferences.CombinedSettingsUpgrader
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo96.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo96.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import com.fsck.k9.preferences.CombinedSettingsUpgrader
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo98.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo98.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import com.fsck.k9.preferences.CombinedSettingsUpgrader
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo99.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo99.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import com.fsck.k9.preferences.CombinedSettingsUpgrader
 import com.fsck.k9.preferences.InternalSettingsMap
 import com.fsck.k9.preferences.ValidatedSettings

--- a/legacy/core/src/main/java/com/fsck/k9/provider/AttachmentProvider.java
+++ b/legacy/core/src/main/java/com/fsck/k9/provider/AttachmentProvider.java
@@ -19,7 +19,7 @@ import com.fsck.k9.helper.MimeTypeUtil;
 import com.fsck.k9.mailstore.LocalStoreProvider;
 import timber.log.Timber;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalStore;
@@ -96,7 +96,7 @@ public class AttachmentProvider extends ContentProvider {
 
         final AttachmentInfo attachmentInfo;
         try {
-            final Account account = Preferences.getPreferences().getAccount(accountUuid);
+            final LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
             attachmentInfo = DI.get(LocalStoreProvider.class).getInstance(account).getAttachmentInfo(id);
         } catch (MessagingException e) {
             Timber.e(e, "Unable to retrieve attachment info from local store for ID: %s", id);
@@ -143,7 +143,7 @@ public class AttachmentProvider extends ContentProvider {
 
     private String getType(String accountUuid, String id, String mimeType) {
         String type;
-        final Account account = Preferences.getPreferences().getAccount(accountUuid);
+        final LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
 
         try {
             final LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
@@ -182,7 +182,7 @@ public class AttachmentProvider extends ContentProvider {
 
     @Nullable
     private OpenPgpDataSource getAttachmentDataSource(String accountUuid, String attachmentId) throws MessagingException {
-        final Account account = Preferences.getPreferences().getAccount(accountUuid);
+        final LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
         LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
         return localStore.getAttachmentDataSource(attachmentId);
     }

--- a/legacy/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
+++ b/legacy/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
@@ -17,7 +17,7 @@ import android.provider.OpenableColumns;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.Preferences;
 import app.k9mail.legacy.message.controller.MessageReference;
@@ -174,7 +174,7 @@ public class RawMessageProvider extends ContentProvider {
         long folderId = messageReference.getFolderId();
         String uid = messageReference.getUid();
 
-        Account account = Preferences.getPreferences().getAccount(accountUuid);
+        LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
         if (account == null) {
             Timber.w("Account not found: %s", accountUuid);
             return null;

--- a/legacy/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.search
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.search.LocalSearch
 import app.k9mail.legacy.search.api.SearchAttribute
 import app.k9mail.legacy.search.api.SearchCondition
@@ -25,7 +25,7 @@ fun LocalSearch.limitToDisplayableFolders() {
  *
  * The Inbox will always be included even if one of the special folders is configured to point to the Inbox.
  */
-fun LocalSearch.excludeSpecialFolders(account: Account) {
+fun LocalSearch.excludeSpecialFolders(account: LegacyAccount) {
     this.excludeSpecialFolder(account.trashFolderId)
     this.excludeSpecialFolder(account.draftsFolderId)
     this.excludeSpecialFolder(account.spamFolderId)

--- a/legacy/core/src/main/java/com/fsck/k9/search/LocalSearchExtensions.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/search/LocalSearchExtensions.kt
@@ -2,8 +2,8 @@
 
 package com.fsck.k9.search
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.search.LocalSearch
 import app.k9mail.legacy.search.SearchAccount
 
@@ -20,7 +20,7 @@ val LocalSearch.isSingleFolder: Boolean
     get() = isSingleAccount && folderIds.size == 1
 
 @JvmName("getAccountsFromLocalSearch")
-fun LocalSearch.getAccounts(accountManager: AccountManager): List<Account> {
+fun LocalSearch.getAccounts(accountManager: AccountManager): List<LegacyAccount> {
     val accounts = accountManager.getAccounts()
     return if (searchAllAccounts()) {
         accounts

--- a/legacy/core/src/main/java/com/fsck/k9/service/DatabaseUpgradeService.java
+++ b/legacy/core/src/main/java/com/fsck/k9/service/DatabaseUpgradeService.java
@@ -10,7 +10,7 @@ import android.content.Intent;
 import android.os.IBinder;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
@@ -181,11 +181,11 @@ public class DatabaseUpgradeService extends Service {
     private void upgradeDatabases() {
         Preferences preferences = Preferences.getPreferences();
 
-        List<Account> accounts = preferences.getAccounts();
+        List<LegacyAccount> accounts = preferences.getAccounts();
         mProgressEnd = accounts.size();
         mProgress = 0;
 
-        for (Account account : accounts) {
+        for (LegacyAccount account : accounts) {
             mAccountUuid = account.getUuid();
 
             sendProgressBroadcast(mAccountUuid, mProgress, mProgressEnd);

--- a/legacy/core/src/test/java/com/fsck/k9/controller/DefaultMessageCountsProviderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/controller/DefaultMessageCountsProviderTest.kt
@@ -1,8 +1,8 @@
 package com.fsck.k9.controller
 
 import app.cash.turbine.test
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.ListenableMessageStore
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.message.controller.MessageCounts
@@ -26,7 +26,7 @@ private const val STARRED_COUNT = 3
 
 class DefaultMessageCountsProviderTest {
 
-    private val account = Account(ACCOUNT_UUID)
+    private val account = LegacyAccount(ACCOUNT_UUID)
     private val accountManager = mock<AccountManager> {
         on { getAccounts() } doReturn listOf(account)
     }

--- a/legacy/core/src/test/java/com/fsck/k9/controller/LocalDeleteOperationDeciderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/controller/LocalDeleteOperationDeciderTest.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.controller
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
@@ -9,7 +9,7 @@ import kotlin.test.Test
 
 class LocalDeleteOperationDeciderTest {
     private val localDeleteOperationDecider = LocalDeleteOperationDecider()
-    private val account = Account(UUID.randomUUID().toString()).apply {
+    private val account = LegacyAccount(UUID.randomUUID().toString()).apply {
         spamFolderId = SPAM_FOLDER_ID
         trashFolderId = TRASH_FOLDER_ID
     }

--- a/legacy/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/legacy/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import android.content.Context;
 import app.k9mail.core.featureflag.FeatureFlagProvider;
 import app.k9mail.core.featureflag.FeatureFlagResult.Disabled;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.message.controller.SimpleMessagingListener;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9RobolectricTest;
@@ -71,7 +71,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
     private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;
 
     private MessagingController controller;
-    private Account account;
+    private LegacyAccount account;
     @Mock
     private BackendManager backendManager;
     @Mock

--- a/legacy/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
@@ -1,8 +1,8 @@
 package com.fsck.k9.helper
 
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.Address
@@ -115,7 +115,7 @@ class IdentityHelperTest : RobolectricTest() {
         assertThat(identity.email).isEqualTo(DEFAULT_ADDRESS)
     }
 
-    private fun createDummyAccount() = Account(UUID.randomUUID().toString()).apply {
+    private fun createDummyAccount() = LegacyAccount(UUID.randomUUID().toString()).apply {
         replaceIdentities(
             listOf(
                 newIdentity("Default", DEFAULT_ADDRESS),

--- a/legacy/core/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
+++ b/legacy/core/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 import app.k9mail.core.android.testing.RobolectricTest;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.helper.ReplyToParser.ReplyToAddresses;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
@@ -34,13 +34,13 @@ public class ReplyToParserTest extends RobolectricTest {
 
     private ReplyToParser replyToParser;
     private Message message;
-    private Account account;
+    private LegacyAccount account;
 
 
     @Before
     public void setUp() throws Exception {
         message = mock(Message.class);
-        account = mock(Account.class);
+        account = mock(LegacyAccount.class);
 
         replyToParser = new ReplyToParser();
     }

--- a/legacy/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.mailstore
 
 import android.database.sqlite.SQLiteDatabase
 import androidx.core.content.contentValuesOf
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import assertk.assertFailure
 import assertk.assertThat
@@ -34,7 +34,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
     val messageStoreManager: MessageStoreManager by inject()
     val saveMessageDataCreator: SaveMessageDataCreator by inject()
 
-    val account: Account = createAccount()
+    val account: LegacyAccount = createAccount()
     val backendFolder = createBackendFolder()
     val database: LockableDatabase = localStoreProvider.getInstance(account).database
 
@@ -94,7 +94,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
             .hasMessage("Message requires a server ID to be set")
     }
 
-    fun createAccount(): Account {
+    fun createAccount(): LegacyAccount {
         // FIXME: This is a hack to get Preferences into a state where it's safe to call newAccount()
         preferences.clearAccounts()
 

--- a/legacy/core/src/test/java/com/fsck/k9/mailstore/K9BackendStorageTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/mailstore/K9BackendStorageTest.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.mailstore
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderSettings
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import assertk.assertThat
@@ -20,7 +20,7 @@ class K9BackendStorageTest : K9RobolectricTest() {
     val messageStoreManager: MessageStoreManager by inject()
     val saveMessageDataCreator: SaveMessageDataCreator by inject()
 
-    val account: Account = createAccount()
+    val account: LegacyAccount = createAccount()
     val backendStorage = createBackendStorage()
 
     @After
@@ -62,7 +62,7 @@ class K9BackendStorageTest : K9RobolectricTest() {
         assertThat(value).isEqualTo(23L)
     }
 
-    fun createAccount(): Account {
+    fun createAccount(): LegacyAccount {
         // FIXME: This is a hack to get Preferences into a state where it's safe to call newAccount()
         preferences.clearAccounts()
 

--- a/legacy/core/src/test/java/com/fsck/k9/message/IdentityHeaderBuilderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/IdentityHeaderBuilderTest.kt
@@ -2,8 +2,8 @@ package com.fsck.k9.message
 
 import android.net.Uri
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.QuoteStyle
 import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.contains

--- a/legacy/core/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
+++ b/legacy/core/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import app.k9mail.core.android.testing.RobolectricTest;
-import app.k9mail.legacy.account.Account.QuoteStyle;
+import app.k9mail.legacy.account.QuoteStyle;
 import com.fsck.k9.CoreResourceProvider;
 import app.k9mail.legacy.account.Identity;
 import com.fsck.k9.TestCoreResourceProvider;

--- a/legacy/core/src/test/java/com/fsck/k9/message/ReplyActionStrategyTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/ReplyActionStrategyTest.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.message
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
@@ -107,8 +107,8 @@ class ReplyActionStrategyTest {
         assertThat(replyActions.additionalActions).isEmpty()
     }
 
-    private fun createAccount(): Account {
-        return Account("00000000-0000-4000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccount {
+        return LegacyAccount("00000000-0000-4000-0000-000000000000").apply {
             identities += Identity(name = "Myself", email = IDENTITY_EMAIL_ADDRESS)
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/message/quote/TextQuoteCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/quote/TextQuoteCreatorTest.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.message.quote
 
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account.QuoteStyle
+import app.k9mail.legacy.account.QuoteStyle
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.fsck.k9.TestCoreResourceProvider

--- a/legacy/core/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationControllerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationControllerTest.kt
@@ -6,7 +6,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.testing.MockHelper.mockBuilder
 import org.junit.Test
 import org.mockito.Mockito.verify
@@ -104,7 +104,7 @@ class AuthenticationErrorNotificationControllerTest : RobolectricTest() {
         }
     }
 
-    private fun createFakeAccount(): Account {
+    private fun createFakeAccount(): LegacyAccount {
         return mock {
             on { accountNumber } doReturn ACCOUNT_NUMBER
             on { displayName } doReturn ACCOUNT_NAME
@@ -114,7 +114,7 @@ class AuthenticationErrorNotificationControllerTest : RobolectricTest() {
     internal inner class TestAuthenticationErrorNotificationController :
         AuthenticationErrorNotificationController(notificationHelper, mock(), resourceProvider) {
 
-        override fun createContentIntent(account: Account, incoming: Boolean): PendingIntent {
+        override fun createContentIntent(account: LegacyAccount, incoming: Boolean): PendingIntent {
             return contentIntent
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/BaseNotificationDataCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/BaseNotificationDataCreatorTest.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationVibration
 import app.k9mail.legacy.notification.VibratePattern
@@ -202,8 +202,8 @@ class BaseNotificationDataCreatorTest {
         return NotificationData(account, activeNotifications, inactiveNotifications = emptyList())
     }
 
-    private fun createAccount(): Account {
-        return Account("00000000-0000-4000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccount {
+        return LegacyAccount("00000000-0000-4000-0000-000000000000").apply {
             name = "account name"
             replaceIdentities(listOf(Identity()))
         }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationControllerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationControllerTest.kt
@@ -6,7 +6,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.testing.MockHelper.mockBuilder
 import org.junit.Test
 import org.mockito.Mockito.verify
@@ -104,7 +104,7 @@ class CertificateErrorNotificationControllerTest : RobolectricTest() {
         }
     }
 
-    private fun createFakeAccount(): Account {
+    private fun createFakeAccount(): LegacyAccount {
         return mock {
             on { accountNumber } doReturn ACCOUNT_NUMBER
             on { displayName } doReturn ACCOUNT_NAME
@@ -117,7 +117,7 @@ class CertificateErrorNotificationControllerTest : RobolectricTest() {
         mock(),
         resourceProvider,
     ) {
-        override fun createContentIntent(account: Account, incoming: Boolean): PendingIntent {
+        override fun createContentIntent(account: LegacyAccount, incoming: Boolean): PendingIntent {
             return contentIntent
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/LockScreenNotificationCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/LockScreenNotificationCreatorTest.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import androidx.core.app.NotificationCompat
 import androidx.test.core.app.ApplicationProvider
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.testing.MockHelper.mockBuilder
 import org.junit.Test
 import org.mockito.Mockito.verify
@@ -12,7 +12,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 class LockScreenNotificationCreatorTest : RobolectricTest() {
-    private val account = Account("00000000-0000-0000-0000-000000000000")
+    private val account = LegacyAccount("00000000-0000-0000-0000-000000000000")
     private val resourceProvider = TestNotificationResourceProvider()
     private val builder = createFakeNotificationBuilder()
     private val publicBuilder = createFakeNotificationBuilder()

--- a/legacy/core/src/test/java/com/fsck/k9/notification/NewMailNotificationManagerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/NewMailNotificationManagerTest.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
 import app.k9mail.core.testing.TestClock
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.message.controller.MessageReference
 import assertk.assertThat
@@ -360,8 +360,8 @@ class NewMailNotificationManagerTest {
         }
     }
 
-    private fun createAccount(): Account {
-        return Account(ACCOUNT_UUID).apply {
+    private fun createAccount(): LegacyAccount {
+        return LegacyAccount(ACCOUNT_UUID).apply {
             name = ACCOUNT_NAME
             chipColor = ACCOUNT_COLOR
         }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.notification
 
 import app.k9mail.core.android.common.contact.ContactRepository
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.message.extractors.PreviewResult.PreviewType
 import assertk.assertThat
@@ -145,7 +145,7 @@ class NotificationContentCreatorTest : RobolectricTest() {
         )
     }
 
-    private fun createFakeAccount(): Account = mock()
+    private fun createFakeAccount(): LegacyAccount = mock()
 
     private fun createFakeContentRepository(): ContactRepository = mock()
 

--- a/legacy/core/src/test/java/com/fsck/k9/notification/NotificationDataStoreTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/NotificationDataStoreTest.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import assertk.assertThat
 import assertk.assertions.containsExactly
@@ -229,8 +229,8 @@ class NotificationDataStoreTest : RobolectricTest() {
         assertThat(notificationHolder.content).isSameInstanceAs(content)
     }
 
-    private fun createAccount(): Account {
-        return Account("00000000-0000-4000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccount {
+        return LegacyAccount("00000000-0000-4000-0000-000000000000").apply {
             accountNumber = ACCOUNT_NUMBER
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/NotificationIdsTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/NotificationIdsTest.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.containsNoDuplicates
@@ -99,7 +99,7 @@ class NotificationIdsTest {
         return listOf(NotificationIds.PUSH_NOTIFICATION_ID, NotificationIds.BACKGROUND_WORK_NOTIFICATION_ID)
     }
 
-    private fun getAccountNotificationIds(account: Account): List<Int> {
+    private fun getAccountNotificationIds(account: LegacyAccount): List<Int> {
         return listOf(
             NotificationIds.getSendFailedNotificationId(account),
             NotificationIds.getCertificateErrorNotificationId(account, true),
@@ -111,14 +111,14 @@ class NotificationIdsTest {
         ) + getNewMessageNotificationIds(account)
     }
 
-    private fun getNewMessageNotificationIds(account: Account): Array<Int> {
+    private fun getNewMessageNotificationIds(account: LegacyAccount): Array<Int> {
         return (0 until MAX_NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS).map { index ->
             NotificationIds.getSingleMessageNotificationId(account, index)
         }.toTypedArray()
     }
 
-    private fun createAccount(accountNumber: Int): Account {
-        return Account("uuid").apply {
+    private fun createAccount(accountNumber: Int): LegacyAccount {
+        return LegacyAccount("uuid").apply {
             this.accountNumber = accountNumber
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SendFailedNotificationControllerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SendFailedNotificationControllerTest.kt
@@ -6,7 +6,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.testing.MockHelper.mockBuilder
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
@@ -78,7 +78,7 @@ class SendFailedNotificationControllerTest : RobolectricTest() {
         }
     }
 
-    private fun createFakeAccount(): Account {
+    private fun createFakeAccount(): LegacyAccount {
         return mock {
             on { accountNumber } doReturn ACCOUNT_NUMBER
             on { name } doReturn ACCOUNT_NAME

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationDataCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationDataCreatorTest.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import assertk.assertThat
 import assertk.assertions.contains
@@ -257,8 +257,8 @@ class SingleMessageNotificationDataCreatorTest {
         K9.isConfirmSpam = confirm
     }
 
-    private fun createAccount(): Account {
-        return Account("00000000-0000-0000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccount {
+        return LegacyAccount("00000000-0000-0000-0000-000000000000").apply {
             accountNumber = 42
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SummaryNotificationDataCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SummaryNotificationDataCreatorTest.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
 import app.k9mail.core.testing.TestClock
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import assertk.assertThat
 import assertk.assertions.contains
@@ -248,8 +248,8 @@ class SummaryNotificationDataCreatorTest {
         K9.isConfirmDeleteFromNotification = confirm
     }
 
-    private fun createAccount(): Account {
-        return Account("00000000-0000-0000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccount {
+        return LegacyAccount("00000000-0000-0000-0000-000000000000").apply {
             accountNumber = 42
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SyncNotificationControllerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SyncNotificationControllerTest.kt
@@ -6,7 +6,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.notification.NotificationIds.getFetchingMailNotificationId
 import com.fsck.k9.testing.MockHelper.mockBuilder
@@ -128,7 +128,7 @@ class SyncNotificationControllerTest : RobolectricTest() {
         }
     }
 
-    private fun createFakeAccount(): Account {
+    private fun createFakeAccount(): LegacyAccount {
         return mock {
             on { accountNumber } doReturn ACCOUNT_NUMBER
             on { name } doReturn ACCOUNT_NAME

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo100Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo100Test.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.preferences.InternalSettingsMap

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo96Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo96Test.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.preferences.InternalSettingsMap

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo98Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo98Test.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.preferences.InternalSettingsMap

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo99Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/CombinedSettingsUpgraderTo99Test.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.preferences.upgrader
 
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.preferences.InternalSettingsMap

--- a/legacy/core/src/test/java/net/thunderbird/legacy/core/FakeAccountDefaultsProvider.kt
+++ b/legacy/core/src/test/java/net/thunderbird/legacy/core/FakeAccountDefaultsProvider.kt
@@ -1,11 +1,11 @@
 package net.thunderbird.legacy.core
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountDefaultsProvider
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 
 class FakeAccountDefaultsProvider : AccountDefaultsProvider {
-    override fun applyDefaults(account: Account) {
+    override fun applyDefaults(account: LegacyAccount) {
         with(account) {
             // Just ensure a working account object is created
 

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
@@ -2,7 +2,7 @@ package app.k9mail.legacy.mailstore
 
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderDetails
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderTypeMapper.folderTypeOf
 import app.k9mail.legacy.mailstore.RemoteFolderTypeMapper.toFolderType
 import kotlinx.coroutines.CoroutineDispatcher
@@ -22,7 +22,7 @@ class FolderRepository(
     private val messageStoreManager: MessageStoreManager,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
-    fun getFolder(account: Account, folderId: Long): Folder? {
+    fun getFolder(account: LegacyAccount, folderId: Long): Folder? {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolder(folderId) { folder ->
             Folder(
@@ -34,7 +34,7 @@ class FolderRepository(
         }
     }
 
-    fun getFolderDetails(account: Account, folderId: Long): FolderDetails? {
+    fun getFolderDetails(account: LegacyAccount, folderId: Long): FolderDetails? {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolder(folderId) { folder ->
             FolderDetails(
@@ -54,7 +54,7 @@ class FolderRepository(
         }
     }
 
-    fun getRemoteFolders(account: Account): List<RemoteFolder> {
+    fun getRemoteFolders(account: LegacyAccount): List<RemoteFolder> {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolders(excludeLocalOnly = true) { folder ->
             RemoteFolder(
@@ -66,7 +66,7 @@ class FolderRepository(
         }
     }
 
-    fun getRemoteFolderDetails(account: Account): List<RemoteFolderDetails> {
+    fun getRemoteFolderDetails(account: LegacyAccount): List<RemoteFolderDetails> {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolders(excludeLocalOnly = true) { folder ->
             RemoteFolderDetails(
@@ -86,7 +86,7 @@ class FolderRepository(
         }
     }
 
-    fun getPushFoldersFlow(account: Account): Flow<List<RemoteFolder>> {
+    fun getPushFoldersFlow(account: LegacyAccount): Flow<List<RemoteFolder>> {
         val messageStore = messageStoreManager.getMessageStore(account)
         return callbackFlow {
             send(getPushFolders(account))
@@ -104,7 +104,7 @@ class FolderRepository(
             .flowOn(ioDispatcher)
     }
 
-    private fun getPushFolders(account: Account): List<RemoteFolder> {
+    private fun getPushFolders(account: LegacyAccount): List<RemoteFolder> {
         return getRemoteFolderDetails(account)
             .asSequence()
             .filter { folderDetails -> folderDetails.isPushEnabled }
@@ -112,59 +112,59 @@ class FolderRepository(
             .toList()
     }
 
-    fun getFolderServerId(account: Account, folderId: Long): String? {
+    fun getFolderServerId(account: LegacyAccount, folderId: Long): String? {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolder(folderId) { folder ->
             folder.serverId
         }
     }
 
-    fun getFolderId(account: Account, folderServerId: String): Long? {
+    fun getFolderId(account: LegacyAccount, folderServerId: String): Long? {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolderId(folderServerId)
     }
 
-    fun isFolderPresent(account: Account, folderId: Long): Boolean {
+    fun isFolderPresent(account: LegacyAccount, folderId: Long): Boolean {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolder(folderId) { true } ?: false
     }
 
-    fun updateFolderDetails(account: Account, folderDetails: FolderDetails) {
+    fun updateFolderDetails(account: LegacyAccount, folderDetails: FolderDetails) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.updateFolderSettings(folderDetails)
     }
 
-    fun setIncludeInUnifiedInbox(account: Account, folderId: Long, includeInUnifiedInbox: Boolean) {
+    fun setIncludeInUnifiedInbox(account: LegacyAccount, folderId: Long, includeInUnifiedInbox: Boolean) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setIncludeInUnifiedInbox(folderId, includeInUnifiedInbox)
     }
 
-    fun setVisible(account: Account, folderId: Long, visible: Boolean) {
+    fun setVisible(account: LegacyAccount, folderId: Long, visible: Boolean) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setVisible(folderId, visible)
     }
 
-    fun setSyncEnabled(account: Account, folderId: Long, enable: Boolean) {
+    fun setSyncEnabled(account: LegacyAccount, folderId: Long, enable: Boolean) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setSyncEnabled(folderId, enable)
     }
 
-    fun setNotificationsEnabled(account: Account, folderId: Long, enable: Boolean) {
+    fun setNotificationsEnabled(account: LegacyAccount, folderId: Long, enable: Boolean) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setNotificationsEnabled(folderId, enable)
     }
 
-    fun setPushDisabled(account: Account) {
+    fun setPushDisabled(account: LegacyAccount) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setPushDisabled()
     }
 
-    fun hasPushEnabledFolder(account: Account): Boolean {
+    fun hasPushEnabledFolder(account: LegacyAccount): Boolean {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.hasPushEnabledFolder()
     }
 
-    fun hasPushEnabledFolderFlow(account: Account): Flow<Boolean> {
+    fun hasPushEnabledFolderFlow(account: LegacyAccount): Flow<Boolean> {
         val messageStore = messageStoreManager.getMessageStore(account)
         return callbackFlow {
             send(hasPushEnabledFolder(account))

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderTypeMapper.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderTypeMapper.kt
@@ -1,11 +1,11 @@
 package app.k9mail.legacy.mailstore
 
 import app.k9mail.core.mail.folder.api.FolderType
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 object FolderTypeMapper {
 
-    fun folderTypeOf(account: Account, folderId: Long) = when (folderId) {
+    fun folderTypeOf(account: LegacyAccount, folderId: Long) = when (folderId) {
         account.inboxFolderId -> FolderType.INBOX
         account.outboxFolderId -> FolderType.OUTBOX
         account.sentFolderId -> FolderType.SENT

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStoreFactory.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStoreFactory.kt
@@ -1,7 +1,7 @@
 package app.k9mail.legacy.mailstore
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 interface MessageStoreFactory {
-    fun create(account: Account): ListenableMessageStore
+    fun create(account: LegacyAccount): ListenableMessageStore
 }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStoreManager.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStoreManager.kt
@@ -1,7 +1,7 @@
 package app.k9mail.legacy.mailstore
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import java.util.concurrent.ConcurrentHashMap
 
 class MessageStoreManager(
@@ -21,7 +21,7 @@ class MessageStoreManager(
         return getMessageStore(account)
     }
 
-    fun getMessageStore(account: Account): ListenableMessageStore {
+    fun getMessageStore(account: LegacyAccount): ListenableMessageStore {
         return messageStores.getOrPut(account.uuid) { messageStoreFactory.create(account) }
     }
 

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/MessageStoreManagerTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/MessageStoreManagerTest.kt
@@ -1,8 +1,8 @@
 package app.k9mail.legacy.mailstore
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.account.AccountRemovedListener
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.isSameInstanceAs
 import org.junit.Test
@@ -14,7 +14,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class MessageStoreManagerTest {
-    private val account = Account("00000000-0000-4000-0000-000000000000")
+    private val account = LegacyAccount("00000000-0000-4000-0000-000000000000")
     private val messageStore1 = mock<ListenableMessageStore>(name = "messageStore1")
     private val messageStore2 = mock<ListenableMessageStore>(name = "messageStore2")
     private val messageStoreFactory = mock<MessageStoreFactory> {

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessageCountsProvider.kt
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessageCountsProvider.kt
@@ -1,16 +1,16 @@
 package app.k9mail.legacy.message.controller
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.search.LocalSearch
 import app.k9mail.legacy.search.SearchAccount
 import kotlinx.coroutines.flow.Flow
 
 interface MessageCountsProvider {
-    fun getMessageCounts(account: Account): MessageCounts
+    fun getMessageCounts(account: LegacyAccount): MessageCounts
     fun getMessageCounts(searchAccount: SearchAccount): MessageCounts
     fun getMessageCounts(search: LocalSearch): MessageCounts
     fun getMessageCountsFlow(search: LocalSearch): Flow<MessageCounts>
-    fun getUnreadMessageCount(account: Account, folderId: Long): Int
+    fun getUnreadMessageCount(account: LegacyAccount, folderId: Long): Int
 }
 
 data class MessageCounts(val unread: Int, val starred: Int)

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessagingControllerMailChecker.kt
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessagingControllerMailChecker.kt
@@ -1,10 +1,10 @@
 package app.k9mail.legacy.message.controller
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 interface MessagingControllerMailChecker {
     fun checkMail(
-        account: Account?,
+        account: LegacyAccount?,
         ignoreLastCheckedTime: Boolean,
         useManualWakeLock: Boolean,
         notify: Boolean,

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessagingListener.java
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessagingListener.java
@@ -6,35 +6,35 @@ import java.util.List;
 
 import android.content.Context;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Part;
 
 
 public interface MessagingListener {
-    void synchronizeMailboxStarted(Account account, long folderId);
-    void synchronizeMailboxHeadersStarted(Account account, String folderServerId);
-    void synchronizeMailboxHeadersProgress(Account account, String folderServerId, int completed, int total);
-    void synchronizeMailboxHeadersFinished(Account account, String folderServerId, int totalMessagesInMailbox,
+    void synchronizeMailboxStarted(LegacyAccount account, long folderId);
+    void synchronizeMailboxHeadersStarted(LegacyAccount account, String folderServerId);
+    void synchronizeMailboxHeadersProgress(LegacyAccount account, String folderServerId, int completed, int total);
+    void synchronizeMailboxHeadersFinished(LegacyAccount account, String folderServerId, int totalMessagesInMailbox,
             int numNewMessages);
-    void synchronizeMailboxProgress(Account account, long folderId, int completed, int total);
-    void synchronizeMailboxNewMessage(Account account, String folderServerId, Message message);
-    void synchronizeMailboxRemovedMessage(Account account, String folderServerId, String messageServerId);
-    void synchronizeMailboxFinished(Account account, long folderId);
-    void synchronizeMailboxFailed(Account account, long folderId, String message);
+    void synchronizeMailboxProgress(LegacyAccount account, long folderId, int completed, int total);
+    void synchronizeMailboxNewMessage(LegacyAccount account, String folderServerId, Message message);
+    void synchronizeMailboxRemovedMessage(LegacyAccount account, String folderServerId, String messageServerId);
+    void synchronizeMailboxFinished(LegacyAccount account, long folderId);
+    void synchronizeMailboxFailed(LegacyAccount account, long folderId, String message);
 
-    void loadMessageRemoteFinished(Account account, long folderId, String uid);
-    void loadMessageRemoteFailed(Account account, long folderId, String uid, Throwable t);
+    void loadMessageRemoteFinished(LegacyAccount account, long folderId, String uid);
+    void loadMessageRemoteFailed(LegacyAccount account, long folderId, String uid, Throwable t);
 
-    void checkMailStarted(Context context, Account account);
-    void checkMailFinished(Context context, Account account);
+    void checkMailStarted(Context context, LegacyAccount account);
+    void checkMailFinished(Context context, LegacyAccount account);
 
-    void folderStatusChanged(Account account, long folderId);
+    void folderStatusChanged(LegacyAccount account, long folderId);
 
-    void messageUidChanged(Account account, long folderId, String oldUid, String newUid);
+    void messageUidChanged(LegacyAccount account, long folderId, String oldUid, String newUid);
 
-    void loadAttachmentFinished(Account account, Message message, Part part);
-    void loadAttachmentFailed(Account account, Message message, Part part, String reason);
+    void loadAttachmentFinished(LegacyAccount account, Message message, Part part);
+    void loadAttachmentFailed(LegacyAccount account, Message message, Part part, String reason);
 
     void remoteSearchStarted(long folderId);
     void remoteSearchServerQueryComplete(long folderId, int numResults, int maxResults);

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/SimpleMessagingListener.java
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/SimpleMessagingListener.java
@@ -6,79 +6,79 @@ import java.util.List;
 
 import android.content.Context;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Part;
 
 
 public abstract class SimpleMessagingListener implements MessagingListener {
     @Override
-    public void synchronizeMailboxStarted(Account account, long folderId) {
+    public void synchronizeMailboxStarted(LegacyAccount account, long folderId) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersStarted(Account account, String folderServerId) {
+    public void synchronizeMailboxHeadersStarted(LegacyAccount account, String folderServerId) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersProgress(Account account, String folderServerId, int completed, int total) {
+    public void synchronizeMailboxHeadersProgress(LegacyAccount account, String folderServerId, int completed, int total) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersFinished(Account account, String folderServerId, int totalMessagesInMailbox,
+    public void synchronizeMailboxHeadersFinished(LegacyAccount account, String folderServerId, int totalMessagesInMailbox,
             int numNewMessages) {
     }
 
     @Override
-    public void synchronizeMailboxProgress(Account account, long folderId, int completed, int total) {
+    public void synchronizeMailboxProgress(LegacyAccount account, long folderId, int completed, int total) {
     }
 
     @Override
-    public void synchronizeMailboxNewMessage(Account account, String folderServerId, Message message) {
+    public void synchronizeMailboxNewMessage(LegacyAccount account, String folderServerId, Message message) {
     }
 
     @Override
-    public void synchronizeMailboxRemovedMessage(Account account, String folderServerId, String messageServerId) {
+    public void synchronizeMailboxRemovedMessage(LegacyAccount account, String folderServerId, String messageServerId) {
     }
 
     @Override
-    public void synchronizeMailboxFinished(Account account, long folderId) {
+    public void synchronizeMailboxFinished(LegacyAccount account, long folderId) {
     }
 
     @Override
-    public void synchronizeMailboxFailed(Account account, long folderId, String message) {
+    public void synchronizeMailboxFailed(LegacyAccount account, long folderId, String message) {
     }
 
     @Override
-    public void loadMessageRemoteFinished(Account account, long folderId, String uid) {
+    public void loadMessageRemoteFinished(LegacyAccount account, long folderId, String uid) {
     }
 
     @Override
-    public void loadMessageRemoteFailed(Account account, long folderId, String uid, Throwable t) {
+    public void loadMessageRemoteFailed(LegacyAccount account, long folderId, String uid, Throwable t) {
     }
 
     @Override
-    public void checkMailStarted(Context context, Account account) {
+    public void checkMailStarted(Context context, LegacyAccount account) {
     }
 
     @Override
-    public void checkMailFinished(Context context, Account account) {
+    public void checkMailFinished(Context context, LegacyAccount account) {
     }
 
     @Override
-    public void folderStatusChanged(Account account, long folderId) {
+    public void folderStatusChanged(LegacyAccount account, long folderId) {
     }
 
     @Override
-    public void messageUidChanged(Account account, long folderId, String oldUid, String newUid) {
+    public void messageUidChanged(LegacyAccount account, long folderId, String oldUid, String newUid) {
     }
 
     @Override
-    public void loadAttachmentFinished(Account account, Message message, Part part) {
+    public void loadAttachmentFinished(LegacyAccount account, Message message, Part part) {
     }
 
     @Override
-    public void loadAttachmentFailed(Account account, Message message, Part part, String reason) {
+    public void loadAttachmentFailed(LegacyAccount account, Message message, Part part, String reason) {
     }
 
     @Override

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStoreFactory.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStoreFactory.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.storage.messages
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.ListenableMessageStore
 import app.k9mail.legacy.mailstore.MessageStoreFactory
 import com.fsck.k9.mailstore.LocalStoreProvider
@@ -13,7 +13,7 @@ class K9MessageStoreFactory(
     private val storageFilesProviderFactory: StorageFilesProviderFactory,
     private val basicPartInfoExtractor: BasicPartInfoExtractor,
 ) : MessageStoreFactory {
-    override fun create(account: Account): ListenableMessageStore {
+    override fun create(account: LegacyAccount): ListenableMessageStore {
         val localStore = localStoreProvider.getInstance(account)
         val storageFilesProvider = storageFilesProviderFactory.createStorageFilesProvider(account.uuid)
         val messageStore = K9MessageStore(

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo74.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo74.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.storage.migrations
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.DeletePolicy
+import app.k9mail.legacy.account.DeletePolicy
 
 /**
  * Remove all placeholder entries in 'messages' table

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo74.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo74.kt
@@ -2,8 +2,8 @@ package com.fsck.k9.storage.migrations
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.DeletePolicy
+import app.k9mail.legacy.account.LegacyAccount
 
 /**
  * Remove all placeholder entries in 'messages' table
@@ -23,7 +23,7 @@ import app.k9mail.legacy.account.DeletePolicy
  * deleted messages are re-downloaded. And if they are, the next sync after the remote operation has completed will
  * remove them again.
  */
-internal class MigrationTo74(private val db: SQLiteDatabase, private val account: Account) {
+internal class MigrationTo74(private val db: SQLiteDatabase, private val account: LegacyAccount) {
 
     fun removeDeletedMessages() {
         if (account.deletePolicy != DeletePolicy.ON_DELETE) return

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo76.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo76.kt
@@ -4,7 +4,7 @@ import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import app.k9mail.core.android.common.database.map
 import app.k9mail.core.common.mail.Protocols
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mailstore.MigrationsHelper
 import timber.log.Timber
 
@@ -121,7 +121,7 @@ internal class MigrationTo76(private val db: SQLiteDatabase, private val migrati
         db.delete("folders", "id = ?", arrayOf(folderId.toString()))
     }
 
-    private fun Account.isPop3() = incomingServerSettings.type == Protocols.POP3
+    private fun LegacyAccount.isPop3() = incomingServerSettings.type == Protocols.POP3
 
     companion object {
         private const val OUTBOX_FOLDER_TYPE = "outbox"

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo85.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo85.kt
@@ -3,8 +3,8 @@ package com.fsck.k9.storage.migrations
 import android.database.sqlite.SQLiteDatabase
 import android.os.Build
 import androidx.core.content.contentValuesOf
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.FolderMode
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mailstore.MigrationsHelper
 
 internal class MigrationTo85(private val db: SQLiteDatabase, private val migrationsHelper: MigrationsHelper) {
@@ -93,7 +93,7 @@ internal class MigrationTo85(private val db: SQLiteDatabase, private val migrati
         db.update("folders", contentValuesOf("notifications_enabled" to true), whereClause, ignoreFolders)
     }
 
-    private fun getNotificationIgnoredFolders(account: Account): Array<String> {
+    private fun getNotificationIgnoredFolders(account: LegacyAccount): Array<String> {
         val inboxFolderId = account.inboxFolderId
 
         // These special folders were ignored via K9NotificationStrategy unless they were pointing to the inbox.

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo85.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo85.kt
@@ -4,7 +4,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.os.Build
 import androidx.core.content.contentValuesOf
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import com.fsck.k9.mailstore.MigrationsHelper
 
 internal class MigrationTo85(private val db: SQLiteDatabase, private val migrationsHelper: MigrationsHelper) {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo86.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo86.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.storage.migrations
 import android.database.sqlite.SQLiteDatabase
 import android.os.Build
 import androidx.core.content.contentValuesOf
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import com.fsck.k9.mailstore.MigrationsHelper
 
 internal class MigrationTo86(private val db: SQLiteDatabase, private val migrationsHelper: MigrationsHelper) {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo87.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo87.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.storage.migrations
 import android.database.sqlite.SQLiteDatabase
 import android.os.Build
 import androidx.core.content.contentValuesOf
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import com.fsck.k9.mailstore.MigrationsHelper
 
 internal class MigrationTo87(private val db: SQLiteDatabase, private val migrationsHelper: MigrationsHelper) {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo88.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo88.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.storage.migrations
 import android.database.sqlite.SQLiteDatabase
 import android.os.Build
 import androidx.core.content.contentValuesOf
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import com.fsck.k9.mailstore.MigrationsHelper
 
 internal class MigrationTo88(private val db: SQLiteDatabase, private val migrationsHelper: MigrationsHelper) {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/notifications/K9NotificationStoreProvider.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/notifications/K9NotificationStoreProvider.kt
@@ -1,12 +1,12 @@
 package com.fsck.k9.storage.notifications
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mailstore.LocalStoreProvider
 import com.fsck.k9.notification.NotificationStore
 import com.fsck.k9.notification.NotificationStoreProvider
 
 class K9NotificationStoreProvider(private val localStoreProvider: LocalStoreProvider) : NotificationStoreProvider {
-    override fun getNotificationStore(account: Account): NotificationStore {
+    override fun getNotificationStore(account: LegacyAccount): NotificationStore {
         val localStore = localStoreProvider.getInstance(account)
         return K9NotificationStore(lockableDatabase = localStore.database)
     }

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.kt
@@ -3,8 +3,8 @@ package com.fsck.k9.storage
 import android.database.sqlite.SQLiteDatabase
 import androidx.core.content.contentValuesOf
 import app.k9mail.core.android.common.database.map
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.FolderMode
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.Assert
 import assertk.assertFailure
 import assertk.assertThat
@@ -378,7 +378,7 @@ class StoreSchemaDefinitionTest : RobolectricTest() {
     private fun createStoreSchemaDefinition(): StoreSchemaDefinition {
         val account = createAccount()
         val migrationsHelper = object : MigrationsHelper {
-            override fun getAccount(): Account {
+            override fun getAccount(): LegacyAccount {
                 return account
             }
 
@@ -390,8 +390,8 @@ class StoreSchemaDefinitionTest : RobolectricTest() {
         return StoreSchemaDefinition(migrationsHelper)
     }
 
-    private fun createAccount(): Account {
-        return mock<Account> {
+    private fun createAccount(): LegacyAccount {
+        return mock<LegacyAccount> {
             on { legacyInboxFolder } doReturn "Inbox"
             on { importedTrashFolder } doReturn "Trash"
             on { importedDraftsFolder } doReturn "Drafts"

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.kt
@@ -4,7 +4,7 @@ import android.database.sqlite.SQLiteDatabase
 import androidx.core.content.contentValuesOf
 import app.k9mail.core.android.common.database.map
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import assertk.Assert
 import assertk.assertFailure
 import assertk.assertThat

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo85Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo85Test.kt
@@ -2,8 +2,8 @@ package com.fsck.k9.storage.migrations
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.FolderMode
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.mailstore.MigrationsHelper
@@ -186,15 +186,15 @@ class MigrationTo85Test {
         )
     }
 
-    private fun createAccount(): Account {
-        return mock<Account> {
+    private fun createAccount(): LegacyAccount {
+        return mock<LegacyAccount> {
             on { folderNotifyNewMailMode } doAnswer { folderNotifyMode }
         }
     }
 
-    private fun createMigrationsHelper(account: Account): MigrationsHelper {
+    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
         return object : MigrationsHelper {
-            override fun getAccount(): Account {
+            override fun getAccount(): LegacyAccount {
                 return account
             }
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo85Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo85Test.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.storage.migrations
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.mailstore.MigrationsHelper

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo86Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo86Test.kt
@@ -2,8 +2,8 @@ package com.fsck.k9.storage.migrations
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.FolderMode
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.mailstore.MigrationsHelper
@@ -130,15 +130,15 @@ class MigrationTo86Test {
         )
     }
 
-    private fun createAccount(): Account {
-        return mock<Account> {
+    private fun createAccount(): LegacyAccount {
+        return mock<LegacyAccount> {
             on { folderPushMode } doAnswer { folderPushMode }
         }
     }
 
-    private fun createMigrationsHelper(account: Account): MigrationsHelper {
+    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
         return object : MigrationsHelper {
-            override fun getAccount(): Account {
+            override fun getAccount(): LegacyAccount {
                 return account
             }
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo86Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo86Test.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.storage.migrations
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.mailstore.MigrationsHelper

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo87Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo87Test.kt
@@ -2,8 +2,8 @@ package com.fsck.k9.storage.migrations
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.FolderMode
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.mailstore.MigrationsHelper
@@ -130,15 +130,15 @@ class MigrationTo87Test {
         )
     }
 
-    private fun createAccount(): Account {
-        return mock<Account> {
+    private fun createAccount(): LegacyAccount {
+        return mock<LegacyAccount> {
             on { folderSyncMode } doAnswer { folderSyncMode }
         }
     }
 
-    private fun createMigrationsHelper(account: Account): MigrationsHelper {
+    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
         return object : MigrationsHelper {
-            override fun getAccount(): Account {
+            override fun getAccount(): LegacyAccount {
                 return account
             }
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo87Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo87Test.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.storage.migrations
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.mailstore.MigrationsHelper

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo88Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo88Test.kt
@@ -2,8 +2,8 @@ package com.fsck.k9.storage.migrations
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.FolderMode
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.mailstore.MigrationsHelper
@@ -120,15 +120,15 @@ class MigrationTo88Test {
         )
     }
 
-    private fun createAccount(): Account {
-        return mock<Account> {
+    private fun createAccount(): LegacyAccount {
+        return mock<LegacyAccount> {
             on { folderDisplayMode } doAnswer { folderDisplayMode }
         }
     }
 
-    private fun createMigrationsHelper(account: Account): MigrationsHelper {
+    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
         return object : MigrationsHelper {
-            override fun getAccount(): Account {
+            override fun getAccount(): LegacyAccount {
                 return account
             }
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo88Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo88Test.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.storage.migrations
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.FolderMode
+import app.k9mail.legacy.account.FolderMode
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import com.fsck.k9.mailstore.MigrationsHelper

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
@@ -2,8 +2,8 @@ package app.k9mail.legacy.ui.folder
 
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderSettingsChangedListener
 import app.k9mail.legacy.mailstore.FolderTypeMapper
 import app.k9mail.legacy.mailstore.MessageStoreManager
@@ -33,7 +33,7 @@ class DefaultDisplayFolderRepository(
             .thenByDescending { it.isInTopGroup }
             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.folder.name }
 
-    private fun getDisplayFolders(account: Account, includeHiddenFolders: Boolean): List<DisplayFolder> {
+    private fun getDisplayFolders(account: LegacyAccount, includeHiddenFolders: Boolean): List<DisplayFolder> {
         val messageStore = messageStoreManager.getMessageStore(account.uuid)
         return messageStore.getDisplayFolders(
             includeHiddenFolders = includeHiddenFolders,
@@ -53,14 +53,17 @@ class DefaultDisplayFolderRepository(
         }.sortedWith(sortForDisplay)
     }
 
-    override fun getDisplayFoldersFlow(account: Account, includeHiddenFolders: Boolean): Flow<List<DisplayFolder>> {
+    override fun getDisplayFoldersFlow(
+        account: LegacyAccount,
+        includeHiddenFolders: Boolean,
+    ): Flow<List<DisplayFolder>> {
         val messageStore = messageStoreManager.getMessageStore(account.uuid)
 
         return callbackFlow {
             send(getDisplayFolders(account, includeHiddenFolders))
 
             val folderStatusChangedListener = object : SimpleMessagingListener() {
-                override fun folderStatusChanged(statusChangedAccount: Account, folderId: Long) {
+                override fun folderStatusChanged(statusChangedAccount: LegacyAccount, folderId: Long) {
                     if (statusChangedAccount.uuid == account.uuid) {
                         trySendBlocking(getDisplayFolders(account, includeHiddenFolders))
                     }

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
@@ -1,11 +1,11 @@
 package app.k9mail.legacy.ui.folder
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import kotlinx.coroutines.flow.Flow
 
 interface DisplayFolderRepository {
 
-    fun getDisplayFoldersFlow(account: Account, includeHiddenFolders: Boolean): Flow<List<DisplayFolder>>
+    fun getDisplayFoldersFlow(account: LegacyAccount, includeHiddenFolders: Boolean): Flow<List<DisplayFolder>>
 
     fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>>
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/account/AccountRemover.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/account/AccountRemover.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.account
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.Core
 import com.fsck.k9.LocalKeyStoreManager
 import com.fsck.k9.Preferences
@@ -42,7 +42,7 @@ class AccountRemover(
         Timber.v("Finished removing account '%s'.", accountName)
     }
 
-    private fun removeLocalStore(account: Account) {
+    private fun removeLocalStore(account: LegacyAccount) {
         try {
             val localStore = localStoreProvider.getInstance(account)
             localStore.delete()
@@ -55,7 +55,7 @@ class AccountRemover(
         localStoreProvider.removeInstance(account)
     }
 
-    private fun removeBackend(account: Account) {
+    private fun removeBackend(account: LegacyAccount) {
         try {
             backendManager.removeBackend(account)
         } catch (e: Exception) {
@@ -63,7 +63,7 @@ class AccountRemover(
         }
     }
 
-    private fun removeCertificates(account: Account) {
+    private fun removeCertificates(account: LegacyAccount) {
         try {
             localKeyStoreManager.deleteCertificates(account)
         } catch (e: Exception) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.kt
@@ -9,8 +9,8 @@ import android.widget.ArrayAdapter
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.BaseAccount
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.search.SearchAccount.Companion.createUnifiedInboxAccount
 import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.K9.isShowUnifiedInbox
@@ -71,7 +71,7 @@ abstract class AccountList : K9ListActivity(), OnItemClickListener {
      * @param realAccounts
      * An array of accounts to display.
      */
-    private fun populateListView(realAccounts: List<Account>) {
+    private fun populateListView(realAccounts: List<LegacyAccount>) {
         val accounts: MutableList<BaseAccount> = ArrayList()
 
         if (isShowUnifiedInbox) {
@@ -121,7 +121,7 @@ abstract class AccountList : K9ListActivity(), OnItemClickListener {
                 holder.email.visibility = View.GONE
             }
 
-            if (account is Account) {
+            if (account is LegacyAccount) {
                 holder.chip.setBackgroundColor(account.chipColor)
             } else {
                 holder.chip.setBackgroundColor(resources.getColor(R.color.account_list_item_chip_background))

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
@@ -9,7 +9,7 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.di.DI;
 import app.k9mail.legacy.account.Identity;
 import com.fsck.k9.Preferences;
@@ -21,7 +21,7 @@ import java.util.List;
 public class ChooseIdentity extends K9ListActivity {
     private final IdentityFormatter identityFormatter = DI.get(IdentityFormatter.class);
 
-    Account mAccount;
+    LegacyAccount mAccount;
     ArrayAdapter<String> adapter;
 
     public static final String EXTRA_ACCOUNT = "com.fsck.k9.ChooseIdentity_account";

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
@@ -9,8 +9,8 @@ import androidx.core.content.IntentCompat
 import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.EmailAddressValidator
 import com.fsck.k9.Preferences
 import com.fsck.k9.ui.R
@@ -21,7 +21,7 @@ import org.koin.android.ext.android.inject
 class EditIdentity : K9Activity() {
     private val emailAddressValidator: EmailAddressValidator by inject()
 
-    private lateinit var account: Account
+    private lateinit var account: LegacyAccount
     private lateinit var identity: Identity
 
     private lateinit var description: EditText

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/FolderInfoHolder.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/FolderInfoHolder.kt
@@ -2,14 +2,14 @@ package com.fsck.k9.activity
 
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import com.fsck.k9.mailstore.LocalFolder
 
 class FolderInfoHolder(
     private val folderNameFormatter: FolderNameFormatter,
     localFolder: LocalFolder,
-    account: Account,
+    account: LegacyAccount,
 ) {
     @JvmField
     val databaseId = localFolder.databaseId
@@ -23,7 +23,7 @@ class FolderInfoHolder(
     @JvmField
     var moreMessages = localFolder.hasMoreMessages()
 
-    private fun getDisplayName(account: Account, localFolder: LocalFolder): String {
+    private fun getDisplayName(account: LegacyAccount, localFolder: LocalFolder): String {
         val folderId = localFolder.databaseId
         val folder = Folder(
             id = folderId,
@@ -36,7 +36,7 @@ class FolderInfoHolder(
 
     companion object {
         @JvmStatic
-        fun getFolderType(account: Account, folderId: Long): FolderType {
+        fun getFolderType(account: LegacyAccount, folderId: Long): FolderType {
             return when (folderId) {
                 account.inboxFolderId -> FolderType.INBOX
                 account.outboxFolderId -> FolderType.OUTBOX

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -47,7 +47,7 @@ import androidx.core.os.BundleCompat;
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.account.MessageFormat;
 import app.k9mail.legacy.di.DI;
 import app.k9mail.legacy.account.Identity;
@@ -196,7 +196,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     /**
      * The account used for message composition.
      */
-    private Account account;
+    private LegacyAccount account;
     private Identity identity;
     private boolean identityChanged = false;
     private boolean signatureChanged = false;
@@ -801,7 +801,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         super.onActivityResult(requestCode, resultCode, data);
     }
 
-    private void onAccountChosen(Account account, Identity identity) {
+    private void onAccountChosen(LegacyAccount account, Identity identity) {
         if (!this.account.equals(account)) {
             Timber.v("Switching account from %s to %s", this.account, account);
 
@@ -813,7 +813,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             // test whether there is something to save
             if (changesMadeSinceLastSave || (draftMessageId != null)) {
                 final Long previousDraftId = draftMessageId;
-                final Account previousAccount = this.account;
+                final LegacyAccount previousAccount = this.account;
 
                 // make current message appear as new
                 draftMessageId = null;
@@ -1356,7 +1356,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
             if (messageReference != null) {
                 // Check if this is a valid account in our database
-                Account account = preferences.getAccount(messageReference.getAccountUuid());
+                LegacyAccount account = preferences.getAccount(messageReference.getAccountUuid());
                 if (account != null) {
                     relatedMessageReference = messageReference;
                 }
@@ -1375,7 +1375,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     static class SendMessageTask extends AsyncTask<Void, Void, Void> {
         final MessagingController messagingController;
         final Preferences preferences;
-        final Account account;
+        final LegacyAccount account;
         final Contacts contacts;
         final Message message;
         final Long draftId;
@@ -1383,7 +1383,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         final MessageReference messageReference;
         final Flag flag;
 
-        SendMessageTask(MessagingController messagingController, Preferences preferences, Account account,
+        SendMessageTask(MessagingController messagingController, Preferences preferences, LegacyAccount account,
                 Contacts contacts, Message message, Long draftId, String plaintextSubject,
                 MessageReference messageReference, Flag flag) {
             this.messagingController = messagingController;
@@ -1423,7 +1423,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         private void addFlagToReferencedMessage() {
             if (messageReference != null && flag != null) {
                 String accountUuid = messageReference.getAccountUuid();
-                Account account = preferences.getAccount(accountUuid);
+                LegacyAccount account = preferences.getAccount(accountUuid);
                 long folderId = messageReference.getFolderId();
                 String sourceMessageUid = messageReference.getUid();
 
@@ -1667,7 +1667,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     public MessagingListener messagingListener = new SimpleMessagingListener() {
 
         @Override
-        public void messageUidChanged(Account account, long folderId, String oldUid, String newUid) {
+        public void messageUidChanged(LegacyAccount account, long folderId, String oldUid, String newUid) {
             if (relatedMessageReference == null) {
                 return;
             }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -48,7 +48,7 @@ import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import app.k9mail.legacy.account.Account;
-import app.k9mail.legacy.account.Account.MessageFormat;
+import app.k9mail.legacy.account.MessageFormat;
 import app.k9mail.legacy.di.DI;
 import app.k9mail.legacy.account.Identity;
 import com.fsck.k9.K9;

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -36,8 +36,8 @@ import app.k9mail.feature.launcher.FeatureLauncherActivity
 import app.k9mail.feature.launcher.FeatureLauncherTarget
 import app.k9mail.feature.navigation.drawer.FolderDrawer
 import app.k9mail.feature.navigation.drawer.NavigationDrawer
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.preferences.GeneralSettingsManager
 import app.k9mail.legacy.search.LocalSearch
@@ -111,7 +111,7 @@ open class MessageList :
     private var messageViewPlaceHolder: PlaceholderFragment? = null
     private var messageListFragment: MessageListFragment? = null
     private var messageViewContainerFragment: MessageViewContainerFragment? = null
-    private var account: Account? = null
+    private var account: LegacyAccount? = null
     private var search: LocalSearch? = null
     private var singleFolderMode = false
 
@@ -288,7 +288,7 @@ open class MessageList :
         displayViews()
     }
 
-    private fun deleteIncompleteAccounts(accounts: List<Account>) {
+    private fun deleteIncompleteAccounts(accounts: List<LegacyAccount>) {
         accounts.filter { !it.isFinishedSetup }.forEach {
             accountRemover.removeAccountAsync(it.uuid)
         }
@@ -1121,7 +1121,7 @@ open class MessageList :
         MessageActions.actionReply(this, messageReference, true, decryptionResultForReply)
     }
 
-    override fun onCompose(account: Account?) {
+    override fun onCompose(account: LegacyAccount?) {
         MessageActions.actionCompose(this, account)
     }
 
@@ -1170,7 +1170,7 @@ open class MessageList :
         return true
     }
 
-    override fun startSearch(query: String, account: Account?, folderId: Long?): Boolean {
+    override fun startSearch(query: String, account: LegacyAccount?, folderId: Long?): Boolean {
         // If this search was started from a MessageList of a single folder, pass along that folder info
         // so that we can enable remote search.
         val appData = if (account != null && folderId != null) {
@@ -1197,7 +1197,7 @@ open class MessageList :
         return super.startSupportActionMode(callback)
     }
 
-    override fun showThread(account: Account, threadRootId: Long) {
+    override fun showThread(account: LegacyAccount, threadRootId: Long) {
         showMessageViewPlaceHolder()
 
         val tmpSearch = LocalSearch().apply {
@@ -1417,7 +1417,7 @@ open class MessageList :
         configureDrawer()
     }
 
-    private fun LocalSearch.firstAccount(): Account? {
+    private fun LocalSearch.firstAccount(): LegacyAccount? {
         return if (searchAllAccounts()) {
             preferences.defaultAccount
         } else {
@@ -1465,7 +1465,7 @@ open class MessageList :
 
     private class LaunchData(
         val search: LocalSearch,
-        val account: Account? = null,
+        val account: LegacyAccount? = null,
         val messageReference: MessageReference? = null,
         val noThreading: Boolean = false,
         val messageViewOnly: Boolean = false,
@@ -1532,7 +1532,7 @@ open class MessageList :
 
         fun createUnifiedInboxIntent(
             context: Context,
-            account: Account,
+            account: LegacyAccount,
         ): Intent {
             return Intent(context, MessageList::class.java).apply {
                 val search = SearchAccount.createUnifiedInboxAccount(
@@ -1550,7 +1550,7 @@ open class MessageList :
             }
         }
 
-        fun createNewMessagesIntent(context: Context, account: Account): Intent {
+        fun createNewMessagesIntent(context: Context, account: LegacyAccount): Intent {
             val search = LocalSearch().apply {
                 id = SearchAccount.NEW_MESSAGES
                 addAccountUuid(account.uuid)
@@ -1635,7 +1635,7 @@ open class MessageList :
         }
 
         @JvmStatic
-        fun launch(context: Context, account: Account) {
+        fun launch(context: Context, account: LegacyAccount) {
             val folderId = defaultFolderProvider.getDefaultFolder(account)
 
             val search = LocalSearch().apply {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -16,7 +16,7 @@ import androidx.loader.app.LoaderManager;
 import androidx.loader.app.LoaderManager.LoaderCallbacks;
 import androidx.loader.content.Loader;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.autocrypt.AutocryptOperations;
 import app.k9mail.legacy.message.controller.MessageReference;
@@ -90,7 +90,7 @@ public class MessageLoaderHelper {
     // transient state
     private boolean onlyLoadMetadata;
     private MessageReference messageReference;
-    private Account account;
+    private LegacyAccount account;
 
     private LocalMessage localMessage;
     private MessageCryptoAnnotations messageCryptoAnnotations;
@@ -490,7 +490,7 @@ public class MessageLoaderHelper {
 
     MessagingListener downloadMessageListener = new SimpleMessagingListener() {
         @Override
-        public void loadMessageRemoteFinished(final Account account, final long folderId, final String uid) {
+        public void loadMessageRemoteFinished(final LegacyAccount account, final long folderId, final String uid) {
             handler.post(() -> {
                 if (!messageReference.equals(account.getUuid(), folderId, uid)) {
                     return;
@@ -500,7 +500,7 @@ public class MessageLoaderHelper {
         }
 
         @Override
-        public void loadMessageRemoteFailed(Account account, long folderId, String uid, final Throwable t) {
+        public void loadMessageRemoteFailed(LegacyAccount account, long folderId, String uid, final Throwable t) {
             handler.post(new Runnable() {
                 @Override
                 public void run() {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
@@ -11,7 +11,7 @@ import android.os.Bundle;
 
 import androidx.core.content.IntentCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessagingController;
@@ -53,7 +53,7 @@ import com.google.android.material.textview.MaterialTextView;
  * Currently we make no attempts to stop the background code (e.g. {@link MessagingController}) from
  * opening the accounts' databases. If this happens the upgrade is performed in one of the
  * background threads and not by {@link DatabaseUpgradeService}. But this is not a problem. Due to
- * the locking in {@link com.fsck.k9.mailstore.LocalStoreProvider#getInstance(Account)} the upgrade service will block
+ * the locking in {@link com.fsck.k9.mailstore.LocalStoreProvider#getInstance(LegacyAccount)} the upgrade service will block
  * and from the outside (especially for this activity) it will appear as if
  * {@link DatabaseUpgradeService} is performing the upgrade.
  * </p>
@@ -205,7 +205,7 @@ public class UpgradeDatabases extends K9Activity {
                 String accountUuid = intent.getStringExtra(
                         DatabaseUpgradeService.EXTRA_ACCOUNT_UUID);
 
-                Account account = mPreferences.getAccount(accountUuid);
+                LegacyAccount account = mPreferences.getAccount(accountUuid);
 
                 if (account != null) {
                     String upgradeStatus = getString(R.string.upgrade_database_format, account.getDisplayName());

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/IdentityAdapter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/IdentityAdapter.java
@@ -11,7 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.di.DI;
 import app.k9mail.legacy.account.Identity;
 import com.fsck.k9.Preferences;
@@ -38,8 +38,8 @@ public class IdentityAdapter extends BaseAdapter {
 
         List<Object> items = new ArrayList<>();
         Preferences prefs = Preferences.getPreferences();
-        Collection<Account> accounts = prefs.getAccounts();
-        for (Account account : accounts) {
+        Collection<LegacyAccount> accounts = prefs.getAccounts();
+        for (LegacyAccount account : accounts) {
             items.add(account);
             List<Identity> identities = account.getIdentities();
             for (Identity identity : identities) {
@@ -61,7 +61,7 @@ public class IdentityAdapter extends BaseAdapter {
 
     @Override
     public int getItemViewType(int position) {
-        return (mItems.get(position) instanceof Account) ? 0 : 1;
+        return (mItems.get(position) instanceof LegacyAccount) ? 0 : 1;
     }
 
     @Override
@@ -89,7 +89,7 @@ public class IdentityAdapter extends BaseAdapter {
         Object item = mItems.get(position);
 
         View view = null;
-        if (item instanceof Account) {
+        if (item instanceof LegacyAccount) {
             if (convertView != null && convertView.getTag() instanceof AccountHolder) {
                 view = convertView;
             } else {
@@ -100,7 +100,7 @@ public class IdentityAdapter extends BaseAdapter {
                 view.setTag(holder);
             }
 
-            Account account = (Account) item;
+            LegacyAccount account = (LegacyAccount) item;
             AccountHolder holder = (AccountHolder) view.getTag();
             holder.name.setText(account.getDisplayName());
             holder.chip.setBackgroundColor(account.getChipColor());
@@ -126,15 +126,15 @@ public class IdentityAdapter extends BaseAdapter {
     }
 
     /**
-     * Used to store an {@link Identity} instance together with the {@link Account} it belongs to.
+     * Used to store an {@link Identity} instance together with the {@link LegacyAccount} it belongs to.
      *
      * @see IdentityAdapter
      */
     public static class IdentityContainer {
         public final Identity identity;
-        public final Account account;
+        public final LegacyAccount account;
 
-        IdentityContainer(Identity identity, Account account) {
+        IdentityContainer(Identity identity, LegacyAccount account) {
             this.identity = identity;
             this.account = account;
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/MessageActions.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/MessageActions.java
@@ -5,9 +5,8 @@ import android.content.Intent;
 import android.os.Parcelable;
 
 import app.k9mail.feature.launcher.FeatureLauncherActivity;
-import app.k9mail.feature.launcher.FeatureLauncherTarget;
 import app.k9mail.feature.launcher.FeatureLauncherTarget.AccountSetup;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.MessageCompose;
 import app.k9mail.legacy.message.controller.MessageReference;
@@ -18,8 +17,8 @@ public class MessageActions {
      * will be used. If there is no default account set, user will be sent to AccountSetup
      * activity.
      */
-    public static void actionCompose(Context context, Account account) {
-        Account defaultAccount = Preferences.getPreferences().getDefaultAccount();
+    public static void actionCompose(Context context, LegacyAccount account) {
+        LegacyAccount defaultAccount = Preferences.getPreferences().getDefaultAccount();
         if (account == null && defaultAccount == null) {
             FeatureLauncherActivity.launch(context, AccountSetup.INSTANCE);
         } else {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
@@ -11,8 +11,8 @@ import android.os.Bundle
 import android.view.Menu
 import androidx.core.content.ContextCompat
 import androidx.loader.app.LoaderManager
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.AttachErrorState
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.SendErrorState
@@ -53,12 +53,13 @@ private const val REQUEST_CODE_AUTOCRYPT = 5
 
 private const val PGP_DIALOG_DISPLAY_THRESHOLD = 2
 
+@Suppress("LongParameterList")
 class RecipientPresenter(
     private val context: Context,
     loaderManager: LoaderManager,
     private val openPgpApiManager: OpenPgpApiManager,
     private val recipientMvpView: RecipientMvpView,
-    account: Account,
+    account: LegacyAccount,
     private val composePgpInlineDecider: ComposePgpInlineDecider,
     private val composePgpEnableByDefaultDecider: ComposePgpEnableByDefaultDecider,
     private val autocryptStatusInteractor: AutocryptStatusInteractor,
@@ -66,7 +67,7 @@ class RecipientPresenter(
     private val draftStateHeaderParser: AutocryptDraftStateHeaderParser,
 ) {
     private var isToAddressAdded: Boolean = false
-    private lateinit var account: Account
+    private lateinit var account: LegacyAccount
     private var alwaysBccAddresses: Array<Address>? = null
     private var hasContactPicker: Boolean? = null
     private var isReplyToEncryptedMessage = false
@@ -328,7 +329,7 @@ class RecipientPresenter(
         menu.findItem(R.id.add_from_contacts).isVisible = hasContactPermission() && hasContactPicker()
     }
 
-    fun onSwitchAccount(account: Account) {
+    fun onSwitchAccount(account: LegacyAccount) {
         this.account = account
 
         if (account.isAlwaysShowCcBcc) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
@@ -4,20 +4,20 @@ package com.fsck.k9.activity.compose;
 import android.os.AsyncTask;
 import android.os.Handler;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.activity.MessageCompose;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.mail.Message;
 
 public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
     private final MessagingController messagingController;
-    private final Account account;
+    private final LegacyAccount account;
     private final Handler handler;
     private final Message message;
     private final Long existingDraftId;
     private final String plaintextSubject;
 
-    public SaveMessageTask(MessagingController messagingController, Account account, Handler handler, Message message,
+    public SaveMessageTask(MessagingController messagingController, LegacyAccount account, Handler handler, Message message,
             Long existingDraftId, String plaintextSubject) {
         this.messagingController = messagingController;
         this.account = account;

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.kt
@@ -9,7 +9,7 @@ import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.EmailAddressValidator
 import com.fsck.k9.Preferences
 import com.fsck.k9.ui.R
@@ -21,7 +21,7 @@ import org.koin.android.ext.android.inject
 class AccountSetupComposition : K9Activity() {
     private val emailAddressValidator: EmailAddressValidator by inject()
 
-    private lateinit var account: Account
+    private lateinit var account: LegacyAccount
 
     private lateinit var accountSignature: EditText
     private lateinit var accountEmail: EditText

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.widget.SearchView
 import androidx.recyclerview.widget.RecyclerView
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.FolderIconProvider
@@ -35,7 +35,7 @@ class ChooseFolderActivity : K9Activity() {
 
     private lateinit var recyclerView: RecyclerView
     private lateinit var itemAdapter: ItemAdapter<FolderListItem>
-    private lateinit var account: Account
+    private lateinit var account: LegacyAccount
     private lateinit var action: Action
     private var currentFolderId: Long? = null
     private var scrollToFolderId: Long? = null

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,7 +29,7 @@ class ChooseFolderViewModel(
         return foldersFlow.asLiveData()
     }
 
-    fun setDisplayMode(account: Account, showHiddenFolders: Boolean) {
+    fun setDisplayMode(account: LegacyAccount, showHiddenFolders: Boolean) {
         isShowHiddenFolders = showHiddenFolders
         viewModelScope.launch {
             inputFlow.emit(DisplayMode(account, showHiddenFolders))
@@ -37,4 +37,4 @@ class ChooseFolderViewModel(
     }
 }
 
-private data class DisplayMode(val account: Account, val showHiddenFolders: Boolean)
+private data class DisplayMode(val account: LegacyAccount, val showHiddenFolders: Boolean)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import app.k9mail.core.android.common.compat.BundleCompat;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.account.MessageFormat;
 import app.k9mail.legacy.account.QuoteStyle;
 import app.k9mail.legacy.di.DI;
@@ -52,11 +52,11 @@ public class QuotedMessagePresenter {
 
     private SimpleMessageFormat quotedTextFormat;
     private InsertableHtmlContent quotedHtmlContent;
-    private Account account;
+    private LegacyAccount account;
 
 
     public QuotedMessagePresenter(
-            MessageCompose messageCompose, QuotedMessageMvpView quotedMessageMvpView, Account account) {
+            MessageCompose messageCompose, QuotedMessageMvpView quotedMessageMvpView, LegacyAccount account) {
         this.messageCompose = messageCompose;
         this.view = quotedMessageMvpView;
         onSwitchAccount(account);
@@ -67,7 +67,7 @@ public class QuotedMessagePresenter {
         quotedMessageMvpView.setOnClickPresenter(this);
     }
 
-    public void onSwitchAccount(Account account) {
+    public void onSwitchAccount(LegacyAccount account) {
         this.account = account;
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -9,7 +9,7 @@ import androidx.annotation.NonNull;
 import app.k9mail.core.android.common.compat.BundleCompat;
 import app.k9mail.legacy.account.Account;
 import app.k9mail.legacy.account.MessageFormat;
-import app.k9mail.legacy.account.Account.QuoteStyle;
+import app.k9mail.legacy.account.QuoteStyle;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.activity.MessageCompose;
 import com.fsck.k9.activity.MessageCompose.Action;

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -8,7 +8,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import app.k9mail.core.android.common.compat.BundleCompat;
 import app.k9mail.legacy.account.Account;
-import app.k9mail.legacy.account.Account.MessageFormat;
+import app.k9mail.legacy.account.MessageFormat;
 import app.k9mail.legacy.account.Account.QuoteStyle;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.activity.MessageCompose;

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferPresenter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferPresenter.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.ui.endtoend
 
 import android.app.PendingIntent
 import androidx.lifecycle.LifecycleOwner
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
@@ -21,7 +21,7 @@ class AutocryptKeyTransferPresenter internal constructor(
     private val presenterScope: CoroutineScope = MainScope(),
 ) {
 
-    private lateinit var account: Account
+    private lateinit var account: LegacyAccount
     private lateinit var showTransferCodePi: PendingIntent
 
     init {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupMessageLiveEvent.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupMessageLiveEvent.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.ui.endtoend
 import android.app.PendingIntent
 import android.content.Intent
 import androidx.core.content.IntentCompat
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.autocrypt.AutocryptTransferMessageCreator
 import com.fsck.k9.helper.SingleLiveEvent
 import com.fsck.k9.mail.Address
@@ -22,7 +22,7 @@ class AutocryptSetupMessageLiveEvent(
     private val eventScope: CoroutineScope = MainScope(),
 ) : SingleLiveEvent<AutocryptSetupMessage>() {
 
-    fun loadAutocryptSetupMessageAsync(openPgpApi: OpenPgpApi, account: Account) {
+    fun loadAutocryptSetupMessageAsync(openPgpApi: OpenPgpApi, account: LegacyAccount) {
         eventScope.launch {
             val result = withContext(Dispatchers.IO) {
                 loadAutocryptSetupMessage(openPgpApi, account)
@@ -32,7 +32,7 @@ class AutocryptSetupMessageLiveEvent(
         }
     }
 
-    private fun loadAutocryptSetupMessage(openPgpApi: OpenPgpApi, account: Account): AutocryptSetupMessage {
+    private fun loadAutocryptSetupMessage(openPgpApi: OpenPgpApi, account: LegacyAccount): AutocryptSetupMessage {
         val keyIds = longArrayOf(account.openPgpKey)
         val address = Address.parse(account.getIdentity(0).email)[0]
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupTransferLiveEvent.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupTransferLiveEvent.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.ui.endtoend
 
 import android.app.PendingIntent
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.helper.SingleLiveEvent
 import kotlinx.coroutines.CoroutineScope
@@ -16,7 +16,7 @@ class AutocryptSetupTransferLiveEvent(
     private val eventScope: CoroutineScope = MainScope(),
 ) : SingleLiveEvent<AutocryptSetupTransferResult>() {
 
-    fun sendMessageAsync(account: Account, setupMsg: AutocryptSetupMessage) {
+    fun sendMessageAsync(account: LegacyAccount, setupMsg: AutocryptSetupMessage) {
         eventScope.launch {
             val setupMessage = async(Dispatchers.IO) {
                 messagingController.sendMessageBlocking(account, setupMsg.setupMessage)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/helper/DisplayAddressHelper.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/helper/DisplayAddressHelper.kt
@@ -1,9 +1,9 @@
 package com.fsck.k9.ui.helper
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 object DisplayAddressHelper {
-    fun shouldShowRecipients(account: Account, folderId: Long): Boolean {
+    fun shouldShowRecipients(account: LegacyAccount, folderId: Long): Boolean {
         return when (folderId) {
             account.inboxFolderId -> false
             account.archiveFolderId -> false

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsDataStore.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.ui.managefolders
 
 import androidx.preference.PreferenceDataStore
 import app.k9mail.core.mail.folder.api.FolderDetails
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 
 class FolderSettingsDataStore(
     private val folderRepository: FolderRepository,
-    private val account: Account,
+    private val account: LegacyAccount,
     private var folder: FolderDetails,
     private val saveScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) : PreferenceDataStore() {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderDetails
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
@@ -25,7 +25,7 @@ class FolderSettingsViewModel(
     private val actionLiveData = SingleLiveEvent<Action>()
     private var folderSettingsLiveData: LiveData<FolderSettingsResult>? = null
 
-    private lateinit var account: Account
+    private lateinit var account: LegacyAccount
     private var folderId: Long = NO_FOLDER_ID
 
     val showClearFolderInMenu: Boolean
@@ -61,13 +61,13 @@ class FolderSettingsViewModel(
         }
     }
 
-    private suspend fun loadAccount(accountUuid: String): Account {
+    private suspend fun loadAccount(accountUuid: String): LegacyAccount {
         return withContext(Dispatchers.IO) {
             preferences.getAccount(accountUuid) ?: error("Missing account: $accountUuid")
         }
     }
 
-    private suspend fun FolderRepository.loadFolderDetails(account: Account, folderId: Long): FolderDetails? {
+    private suspend fun FolderRepository.loadFolderDetails(account: LegacyAccount, folderId: Long): FolderDetails? {
         return withContext(Dispatchers.IO) {
             getFolderDetails(account, folderId)
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
@@ -7,7 +7,7 @@ import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.K9Activity
 import com.fsck.k9.ui.base.extensions.findNavController
@@ -50,7 +50,7 @@ class ManageFoldersActivity : K9Activity() {
         private const val EXTRA_ACCOUNT = "account"
 
         @JvmStatic
-        fun launch(activity: Activity, account: Account) {
+        fun launch(activity: Activity, account: LegacyAccount) {
             val intent = Intent(activity, ManageFoldersActivity::class.java).apply {
                 putExtra(EXTRA_ACCOUNT, account.uuid)
             }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
@@ -12,7 +12,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.FolderIconProvider
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
@@ -34,7 +34,7 @@ class ManageFoldersFragment : Fragment() {
     private val preferences: Preferences by inject()
     private val folderIconProvider: FolderIconProvider by inject { parametersOf(requireActivity().theme) }
 
-    private lateinit var account: Account
+    private lateinit var account: LegacyAccount
     private lateinit var itemAdapter: ItemAdapter<FolderListItem>
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
@@ -3,14 +3,14 @@ package com.fsck.k9.ui.managefolders
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 
 class ManageFoldersViewModel(
     private val folderRepository: DisplayFolderRepository,
 ) : ViewModel() {
-    fun getFolders(account: Account): LiveData<List<DisplayFolder>> {
+    fun getFolders(account: LegacyAccount): LiveData<List<DisplayFolder>> {
         return folderRepository.getDisplayFoldersFlow(account, includeHiddenFolders = true).asLiveData()
     }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/message/LocalMessageLoader.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/message/LocalMessageLoader.java
@@ -6,7 +6,7 @@ import androidx.loader.content.AsyncTaskLoader;
 
 import timber.log.Timber;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.message.controller.MessageReference;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.mail.MessagingException;
@@ -15,12 +15,12 @@ import com.fsck.k9.mailstore.LocalMessage;
 
 public class LocalMessageLoader extends AsyncTaskLoader<LocalMessage> {
     private final MessagingController controller;
-    private final Account account;
+    private final LegacyAccount account;
     private final MessageReference messageReference;
     private final boolean onlyLoadMetadata;
     private LocalMessage message;
 
-    public LocalMessageLoader(Context context, MessagingController controller, Account account,
+    public LocalMessageLoader(Context context, MessagingController controller, LegacyAccount account,
             MessageReference messageReference, boolean onlyLoadMetaData) {
         super(context);
         this.controller = controller;

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
@@ -4,8 +4,8 @@ import android.content.res.Resources
 import android.text.Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 import com.fsck.k9.helper.ContactNameProvider
 import com.fsck.k9.mail.Address
@@ -15,7 +15,7 @@ import com.fsck.k9.ui.R
  * Get the display name for a participant to be shown in the message details screen.
  */
 internal interface MessageDetailsParticipantFormatter {
-    fun getDisplayName(address: Address, account: Account): CharSequence?
+    fun getDisplayName(address: Address, account: LegacyAccount): CharSequence?
 }
 
 internal class RealMessageDetailsParticipantFormatter(
@@ -24,7 +24,7 @@ internal class RealMessageDetailsParticipantFormatter(
     private val contactNameColor: Int?,
     private val meText: String,
 ) : MessageDetailsParticipantFormatter {
-    override fun getDisplayName(address: Address, account: Account): CharSequence? {
+    override fun getDisplayName(address: Address, account: LegacyAccount): CharSequence? {
         val identity = account.findIdentity(address)
         if (identity != null) {
             return getIdentityName(identity, account)
@@ -37,7 +37,7 @@ internal class RealMessageDetailsParticipantFormatter(
         }
     }
 
-    private fun getIdentityName(identity: Identity, account: Account): String {
+    private fun getIdentityName(identity: Identity, account: LegacyAccount): String {
         return if (account.identities.size == 1) {
             meText
         } else {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsViewModel.kt
@@ -10,8 +10,8 @@ import app.k9mail.core.android.common.contact.ContactPermissionResolver
 import app.k9mail.core.android.common.contact.ContactRepository
 import app.k9mail.core.common.mail.toEmailAddressOrNull
 import app.k9mail.core.mail.folder.api.Folder
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
@@ -124,7 +124,7 @@ internal class MessageDetailsViewModel(
         )
     }
 
-    private fun List<Address>.toParticipants(account: Account): List<Participant> {
+    private fun List<Address>.toParticipants(account: LegacyAccount): List<Participant> {
         return this.map { address ->
             val displayName = participantFormatter.getDisplayName(address, account)
             val emailAddress = address.address

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/DefaultFolderProvider.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/DefaultFolderProvider.kt
@@ -1,12 +1,12 @@
 package com.fsck.k9.ui.messagelist
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 
 /**
  * Decides which folder to display when an account is selected.
  */
 class DefaultFolderProvider {
-    fun getDefaultFolder(account: Account): Long {
+    fun getDefaultFolder(account: LegacyAccount): Long {
         // Until the UI can handle the case where no remote folders have been fetched yet, we fall back to the Outbox
         // which should always exist.
         return account.autoExpandFolderId ?: account.inboxFolderId ?: account.outboxFolderId ?: error("Outbox missing")

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListConfig.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListConfig.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.ui.messagelist
 
-import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.search.LocalSearch
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -28,9 +28,9 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.Expunge
 import app.k9mail.legacy.account.Account.SortType
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.Expunge
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import app.k9mail.legacy.search.LocalSearch

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -28,9 +28,9 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.SortType
 import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.account.Expunge
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import app.k9mail.legacy.search.LocalSearch

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -27,9 +27,9 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
 import app.k9mail.legacy.account.Expunge
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
@@ -118,7 +118,7 @@ class MessageListFragment :
     private lateinit var adapter: MessageListAdapter
 
     private lateinit var accountUuids: Array<String>
-    private var account: Account? = null
+    private var account: LegacyAccount? = null
     private var currentFolder: FolderInfoHolder? = null
     private var remoteSearchFuture: Future<*>? = null
     private var extraSearchResults: List<String>? = null
@@ -627,7 +627,7 @@ class MessageListFragment :
             density = K9.messageListDensity,
         )
 
-    private fun getFolderInfoHolder(folderId: Long, account: Account): FolderInfoHolder {
+    private fun getFolderInfoHolder(folderId: Long, account: LegacyAccount): FolderInfoHolder {
         val localFolder = MlfUtils.getOpenFolder(folderId, account)
         return FolderInfoHolder(folderNameFormatter, localFolder, account)
     }
@@ -1054,9 +1054,9 @@ class MessageListFragment :
     private fun setFlagForSelected(flag: Flag, newState: Boolean) {
         if (adapter.selected.isEmpty()) return
 
-        val messageMap = mutableMapOf<Account, MutableList<Long>>()
-        val threadMap = mutableMapOf<Account, MutableList<Long>>()
-        val accounts = mutableSetOf<Account>()
+        val messageMap = mutableMapOf<LegacyAccount, MutableList<Long>>()
+        val threadMap = mutableMapOf<LegacyAccount, MutableList<Long>>()
+        val accounts = mutableSetOf<LegacyAccount>()
 
         for (messageListItem in adapter.selectedMessages) {
             val account = messageListItem.account
@@ -1183,7 +1183,7 @@ class MessageListFragment :
         }
     }
 
-    private fun groupMessagesByAccount(messages: List<MessageReference>): Map<Account, List<MessageReference>> {
+    private fun groupMessagesByAccount(messages: List<MessageReference>): Map<LegacyAccount, List<MessageReference>> {
         return messages.groupBy { accountManager.getAccount(it.accountUuid)!! }
     }
 
@@ -1824,7 +1824,7 @@ class MessageListFragment :
             handler.refreshTitle()
         }
 
-        override fun synchronizeMailboxStarted(account: Account, folderId: Long) {
+        override fun synchronizeMailboxStarted(account: LegacyAccount, folderId: Long) {
             if (updateForMe(account, folderId)) {
                 handler.progress(true)
                 handler.folderLoading(folderId, true)
@@ -1839,7 +1839,7 @@ class MessageListFragment :
         }
 
         override fun synchronizeMailboxHeadersProgress(
-            account: Account,
+            account: LegacyAccount,
             folderServerId: String,
             completed: Int,
             total: Int,
@@ -1853,7 +1853,7 @@ class MessageListFragment :
         }
 
         override fun synchronizeMailboxHeadersFinished(
-            account: Account,
+            account: LegacyAccount,
             folderServerId: String,
             total: Int,
             completed: Int,
@@ -1866,7 +1866,7 @@ class MessageListFragment :
             informUserOfStatus()
         }
 
-        override fun synchronizeMailboxProgress(account: Account, folderId: Long, completed: Int, total: Int) {
+        override fun synchronizeMailboxProgress(account: LegacyAccount, folderId: Long, completed: Int, total: Int) {
             synchronized(lock) {
                 folderCompleted = completed
                 folderTotal = total
@@ -1875,25 +1875,25 @@ class MessageListFragment :
             informUserOfStatus()
         }
 
-        override fun synchronizeMailboxFinished(account: Account, folderId: Long) {
+        override fun synchronizeMailboxFinished(account: LegacyAccount, folderId: Long) {
             if (updateForMe(account, folderId)) {
                 handler.progress(false)
                 handler.folderLoading(folderId, false)
             }
         }
 
-        override fun synchronizeMailboxFailed(account: Account, folderId: Long, message: String) {
+        override fun synchronizeMailboxFailed(account: LegacyAccount, folderId: Long, message: String) {
             if (updateForMe(account, folderId)) {
                 handler.progress(false)
                 handler.folderLoading(folderId, false)
             }
         }
 
-        override fun checkMailFinished(context: Context?, account: Account?) {
+        override fun checkMailFinished(context: Context?, account: LegacyAccount?) {
             handler.progress(false)
         }
 
-        private fun updateForMe(account: Account?, folderId: Long): Boolean {
+        private fun updateForMe(account: LegacyAccount?, folderId: Long): Boolean {
             if (account == null || account.uuid !in accountUuids) return false
 
             val folderIds = localSearch.folderIds
@@ -1971,7 +1971,7 @@ class MessageListFragment :
             return true
         }
 
-        private fun setContextCapabilities(account: Account?, menu: Menu) {
+        private fun setContextCapabilities(account: LegacyAccount?, menu: Menu) {
             if (!isSingleAccountMode || account == null) {
                 // We don't support cross-account copy/move operations right now
                 menu.findItem(R.id.move).isVisible = false
@@ -2124,11 +2124,11 @@ class MessageListFragment :
     interface MessageListFragmentListener {
         fun setMessageListProgressEnabled(enable: Boolean)
         fun setMessageListProgress(level: Int)
-        fun showThread(account: Account, threadRootId: Long)
+        fun showThread(account: LegacyAccount, threadRootId: Long)
         fun openMessage(messageReference: MessageReference)
         fun setMessageListTitle(title: String, subtitle: String? = null)
-        fun onCompose(account: Account?)
-        fun startSearch(query: String, account: Account?, folderId: Long?): Boolean
+        fun onCompose(account: LegacyAccount?)
+        fun startSearch(query: String, account: LegacyAccount?, folderId: Long?): Boolean
         fun startSupportActionMode(callback: ActionMode.Callback): ActionMode?
         fun goBack()
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -1,11 +1,11 @@
 package com.fsck.k9.ui.messagelist
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mail.Address
 
 data class MessageListItem(
-    val account: Account,
+    val account: LegacyAccount,
     val subject: String?,
     val threadCount: Int,
     val messageDate: Long,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItemMapper.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItemMapper.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.ui.messagelist
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.MessageDetailsAccessor
 import app.k9mail.legacy.mailstore.MessageMapper
 import app.k9mail.legacy.message.extractors.PreviewResult.PreviewType
@@ -9,7 +9,7 @@ import com.fsck.k9.ui.helper.DisplayAddressHelper
 
 class MessageListItemMapper(
     private val messageHelper: MessageHelper,
-    private val account: Account,
+    private val account: LegacyAccount,
 ) : MessageMapper<MessageListItem> {
 
     override fun map(message: MessageDetailsAccessor): MessageListItem {
@@ -50,7 +50,7 @@ class MessageListItemMapper(
         )
     }
 
-    private fun createUniqueId(account: Account, messageId: Long): Long {
+    private fun createUniqueId(account: LegacyAccount, messageId: Long): Long {
         return ((account.accountNumber + 1).toLong() shl 52) + messageId
     }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.ui.messagelist
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.mailstore.MessageListRepository
 import app.k9mail.legacy.search.LocalSearch
@@ -44,7 +44,7 @@ class MessageListLoader(
         return MessageListInfo(messageListItems, hasMoreMessages)
     }
 
-    private fun loadMessageListForAccount(account: Account, config: MessageListConfig): List<MessageListItem> {
+    private fun loadMessageListForAccount(account: LegacyAccount, config: MessageListConfig): List<MessageListItem> {
         val accountUuid = account.uuid
         val threadId = getThreadId(config.search)
         val sortOrder = buildSortOrder(config)
@@ -65,7 +65,7 @@ class MessageListLoader(
         }
     }
 
-    private fun buildSelection(account: Account, config: MessageListConfig): Pair<String, Array<String>> {
+    private fun buildSelection(account: LegacyAccount, config: MessageListConfig): Pair<String, Array<String>> {
         val query = StringBuilder()
         val queryArgs = mutableListOf<String>()
 
@@ -154,7 +154,7 @@ class MessageListLoader(
         return this.sortedWith(comparator)
     }
 
-    private fun loadHasMoreMessages(accounts: List<Account>, folderIds: List<Long>): Boolean {
+    private fun loadHasMoreMessages(accounts: List<LegacyAccount>, folderIds: List<Long>): Boolean {
         return if (accounts.size == 1 && folderIds.size == 1) {
             val account = accounts[0]
             val folderId = folderIds[0]

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.ui.messagelist
 
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.SortType
+import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.mailstore.MessageListRepository
 import app.k9mail.legacy.search.LocalSearch
 import app.k9mail.legacy.search.api.SearchField

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MlfUtils.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MlfUtils.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import android.text.TextUtils;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.di.DI;
 import app.k9mail.legacy.message.controller.MessageReference;
 import com.fsck.k9.helper.Utility;
@@ -18,7 +18,7 @@ import app.k9mail.legacy.account.AccountManager;
 
 public class MlfUtils {
 
-    static LocalFolder getOpenFolder(long folderId, Account account) throws MessagingException {
+    static LocalFolder getOpenFolder(long folderId, LegacyAccount account) throws MessagingException {
         LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);
         localFolder.open();
@@ -27,7 +27,7 @@ public class MlfUtils {
 
     static void setLastSelectedFolder(AccountManager accountManager, List<MessageReference> messages, long folderId) {
         MessageReference firstMsg = messages.get(0);
-        Account account = accountManager.getAccount(firstMsg.getAccountUuid());
+        LegacyAccount account = accountManager.getAccount(firstMsg.getAccountUuid());
         account.setLastSelectedFolderId(folderId);
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SortTypeToastProvider.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/SortTypeToastProvider.kt
@@ -1,13 +1,13 @@
 package com.fsck.k9.ui.messagelist
 
-import app.k9mail.legacy.account.Account.SortType
-import app.k9mail.legacy.account.Account.SortType.SORT_ARRIVAL
-import app.k9mail.legacy.account.Account.SortType.SORT_ATTACHMENT
-import app.k9mail.legacy.account.Account.SortType.SORT_DATE
-import app.k9mail.legacy.account.Account.SortType.SORT_FLAGGED
-import app.k9mail.legacy.account.Account.SortType.SORT_SENDER
-import app.k9mail.legacy.account.Account.SortType.SORT_SUBJECT
-import app.k9mail.legacy.account.Account.SortType.SORT_UNREAD
+import app.k9mail.legacy.account.SortType
+import app.k9mail.legacy.account.SortType.SORT_ARRIVAL
+import app.k9mail.legacy.account.SortType.SORT_ATTACHMENT
+import app.k9mail.legacy.account.SortType.SORT_DATE
+import app.k9mail.legacy.account.SortType.SORT_FLAGGED
+import app.k9mail.legacy.account.SortType.SORT_SENDER
+import app.k9mail.legacy.account.SortType.SORT_SUBJECT
+import app.k9mail.legacy.account.SortType.SORT_UNREAD
 import com.fsck.k9.ui.R
 
 class SortTypeToastProvider {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
@@ -14,7 +14,7 @@ import android.os.AsyncTask;
 import android.widget.Toast;
 
 import androidx.annotation.WorkerThread;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessagingController;
 import app.k9mail.legacy.message.controller.SimpleMessagingListener;
@@ -84,20 +84,20 @@ public class AttachmentController {
 
     private void downloadAttachment(LocalPart localPart, final Runnable attachmentDownloadedCallback) {
         String accountUuid = localPart.getAccountUuid();
-        Account account = Preferences.getPreferences().getAccount(accountUuid);
+        LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
         LocalMessage message = localPart.getMessage();
 
         messageViewFragment.showAttachmentLoadingDialog();
         controller.loadAttachment(account, message, attachment.part, new SimpleMessagingListener() {
             @Override
-            public void loadAttachmentFinished(Account account, Message message, Part part) {
+            public void loadAttachmentFinished(LegacyAccount account, Message message, Part part) {
                 attachment.setContentAvailable();
                 messageViewFragment.hideAttachmentLoadingDialogOnMainThread();
                 messageViewFragment.runOnMainThread(attachmentDownloadedCallback);
             }
 
             @Override
-            public void loadAttachmentFailed(Account account, Message message, Part part, String reason) {
+            public void loadAttachmentFailed(LegacyAccount account, Message message, Part part, String reason) {
                 messageViewFragment.hideAttachmentLoadingDialogOnMainThread();
             }
         });

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractor.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractor.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.ui.messageview
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.mail.Message
 
 /**
@@ -13,7 +13,7 @@ internal class DisplayRecipientsExtractor(
     private val recipientFormatter: MessageViewRecipientFormatter,
     private val maxNumberOfDisplayRecipients: Int,
 ) {
-    fun extractDisplayRecipients(message: Message, account: Account): DisplayRecipients {
+    fun extractDisplayRecipients(message: Message, account: LegacyAccount): DisplayRecipients {
         val toRecipients = message.getRecipients(Message.RecipientType.TO)
         val ccRecipients = message.getRecipients(Message.RecipientType.CC)
         val bccRecipients = message.getRecipients(Message.RecipientType.BCC)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -12,7 +12,7 @@ import android.os.Parcelable;
 import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.mailstore.CryptoResultAnnotation;
 import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.view.MessageCryptoDisplayStatus;
@@ -49,7 +49,7 @@ public class MessageCryptoPresenter {
         }
     }
 
-    public boolean maybeHandleShowMessage(MessageTopView messageView, Account account, MessageViewInfo messageViewInfo) {
+    public boolean maybeHandleShowMessage(MessageTopView messageView, LegacyAccount account, MessageViewInfo messageViewInfo) {
         this.cryptoResultAnnotation = messageViewInfo.cryptoResultAnnotation;
 
         MessageCryptoDisplayStatus displayStatus =

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
@@ -18,7 +18,7 @@ import android.widget.ProgressBar
 import app.k9mail.core.android.common.contact.ContactRepository
 import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.mail.toEmailAddressOrNull
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.ShowPictures
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mailstore.AttachmentViewInfo
@@ -108,7 +108,7 @@ class MessageTopView(
         setShowDownloadButton(messageViewInfo)
     }
 
-    fun showMessage(account: Account, messageViewInfo: MessageViewInfo) {
+    fun showMessage(account: LegacyAccount, messageViewInfo: MessageViewInfo) {
         resetAndPrepareMessageView(messageViewInfo)
 
         val showPicturesSetting = account.showPictures
@@ -196,7 +196,7 @@ class MessageTopView(
         }
     }
 
-    fun setHeaders(message: Message?, account: Account?, showStar: Boolean) {
+    fun setHeaders(message: Message?, account: LegacyAccount?, showStar: Boolean) {
         messageHeaderView.populate(message, account, showStar, showAccountChip)
         messageHeaderView.visibility = VISIBLE
     }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
@@ -19,7 +19,7 @@ import app.k9mail.core.android.common.contact.ContactRepository
 import app.k9mail.core.common.mail.EmailAddress
 import app.k9mail.core.common.mail.toEmailAddressOrNull
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.ShowPictures
+import app.k9mail.legacy.account.ShowPictures
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mailstore.AttachmentViewInfo
 import com.fsck.k9.mailstore.MessageViewInfo

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -29,8 +29,8 @@ import androidx.fragment.app.setFragmentResultListener
 import app.k9mail.core.android.common.activity.CreateDocumentResultContract
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.theme.api.Theme
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import app.k9mail.legacy.preferences.GeneralSettingsManager
 import app.k9mail.legacy.ui.theme.ThemeManager
@@ -105,7 +105,7 @@ class MessageViewFragment :
     private var destinationFolderId: Long? = null
     private lateinit var fragmentListener: MessageViewFragmentListener
 
-    private lateinit var account: Account
+    private lateinit var account: LegacyAccount
     lateinit var messageReference: MessageReference
     private var showAccountChip: Boolean = true
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
@@ -4,8 +4,8 @@ import android.content.res.Resources
 import android.text.Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.K9
 import com.fsck.k9.helper.ContactNameProvider
 import com.fsck.k9.mail.Address
@@ -15,7 +15,7 @@ import com.fsck.k9.ui.R
  * Get the display name for a recipient to be shown in the message view screen.
  */
 internal interface MessageViewRecipientFormatter {
-    fun getDisplayName(address: Address, account: Account): CharSequence
+    fun getDisplayName(address: Address, account: LegacyAccount): CharSequence
 }
 
 internal class RealMessageViewRecipientFormatter(
@@ -25,7 +25,7 @@ internal class RealMessageViewRecipientFormatter(
     private val contactNameColor: Int?,
     private val meText: String,
 ) : MessageViewRecipientFormatter {
-    override fun getDisplayName(address: Address, account: Account): CharSequence {
+    override fun getDisplayName(address: Address, account: LegacyAccount): CharSequence {
         val identity = account.findIdentity(address)
         if (identity != null) {
             return getIdentityName(identity, account)
@@ -40,7 +40,7 @@ internal class RealMessageViewRecipientFormatter(
         }
     }
 
-    private fun getIdentityName(identity: Identity, account: Account): String {
+    private fun getIdentityName(identity: Identity, account: LegacyAccount): String {
         return if (account.identities.size == 1) {
             meText
         } else {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/notification/DeleteConfirmationActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/notification/DeleteConfirmationActivity.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessageReferenceHelper
@@ -21,7 +21,7 @@ class DeleteConfirmationActivity : K9Activity(ThemeType.DIALOG), ConfirmationDia
     private val preferences: Preferences by inject()
     private val messagingController: MessagingController by inject()
 
-    private lateinit var account: Account
+    private lateinit var account: LegacyAccount
     private lateinit var messagesToDelete: List<MessageReference>
 
     public override fun onCreate(savedInstanceState: Bundle?) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/AccountItem.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/AccountItem.kt
@@ -6,7 +6,7 @@ import android.widget.ImageView
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.ui.R
 import com.google.android.material.textview.MaterialTextView
 import com.mikepenz.fastadapter.FastAdapter
@@ -15,7 +15,7 @@ import com.mikepenz.fastadapter.items.AbstractItem
 import com.mikepenz.fastadapter.listeners.TouchEventHook
 
 internal class AccountItem(
-    val account: Account,
+    val account: LegacyAccount,
     override var isDraggable: Boolean,
 ) : AbstractItem<AccountItem.ViewHolder>(), IDraggable {
     override var identifier = 200L + account.accountNumber

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
@@ -21,7 +21,7 @@ import app.k9mail.feature.funding.api.FundingManager
 import app.k9mail.feature.funding.api.FundingType
 import app.k9mail.feature.launcher.FeatureLauncherActivity
 import app.k9mail.feature.launcher.FeatureLauncherTarget
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.livedata.observeNotNull
 import com.fsck.k9.ui.settings.account.AccountSettingsActivity
@@ -90,7 +90,7 @@ class SettingsListFragment : Fragment(), ItemTouchCallback {
         }
     }
 
-    private fun populateSettingsList(accounts: List<Account>) {
+    private fun populateSettingsList(accounts: List<LegacyAccount>) {
         val listItems = buildSettingsList {
             addAction(
                 text = getString(R.string.general_settings_title),
@@ -188,7 +188,7 @@ class SettingsListFragment : Fragment(), ItemTouchCallback {
         }
     }
 
-    private fun launchAccountSettings(account: Account) {
+    private fun launchAccountSettings(account: LegacyAccount) {
         AccountSettingsActivity.start(requireActivity(), account.uuid)
     }
 
@@ -216,7 +216,7 @@ class SettingsListFragment : Fragment(), ItemTouchCallback {
             settingsList.add(UrlActionItem(itemId, text, url, icon))
         }
 
-        fun addAccount(account: Account, isDraggable: Boolean) {
+        fun addAccount(account: LegacyAccount, isDraggable: Boolean) {
             settingsList.add(AccountItem(account, isDraggable))
         }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
@@ -3,8 +3,8 @@ package com.fsck.k9.ui.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -18,7 +18,7 @@ internal class SettingsViewModel(
 ) : ViewModel() {
     val accounts = accountManager.getAccountsFlow().asLiveData()
 
-    fun moveAccount(account: Account, newPosition: Int) {
+    fun moveAccount(account: LegacyAccount, newPosition: Int) {
         viewModelScope.launch(coroutineDispatcher) {
             // Delay saving the account so the animation is not disturbed
             delay(500)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
@@ -9,13 +9,13 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.core.view.isVisible
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.ui.R
 import com.google.android.material.textview.MaterialTextView
 
 class AccountSelectionSpinner : AppCompatSpinner {
-    var selection: Account
-        get() = selectedItem as Account
+    var selection: LegacyAccount
+        get() = selectedItem as LegacyAccount
         set(account) {
             selectedAccount = account
             val adapter = adapter as AccountsAdapter
@@ -24,7 +24,7 @@ class AccountSelectionSpinner : AppCompatSpinner {
         }
 
     private val cachedBackground: Drawable
-    private var selectedAccount: Account? = null
+    private var selectedAccount: LegacyAccount? = null
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
@@ -40,7 +40,7 @@ class AccountSelectionSpinner : AppCompatSpinner {
         adapter.notifyDataSetChanged()
     }
 
-    fun setAccounts(accounts: List<Account>) {
+    fun setAccounts(accounts: List<LegacyAccount>) {
         val adapter = adapter as AccountsAdapter
         adapter.clear()
         adapter.addAll(accounts)
@@ -52,7 +52,7 @@ class AccountSelectionSpinner : AppCompatSpinner {
         background = if (showAccountSwitcher) cachedBackground else null
     }
 
-    internal class AccountsAdapter(context: Context) : ArrayAdapter<Account>(context, 0) {
+    internal class AccountsAdapter(context: Context) : ArrayAdapter<LegacyAccount>(context, 0) {
         var title: CharSequence = ""
 
         override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -3,6 +3,7 @@ package com.fsck.k9.ui.settings.account
 import androidx.preference.PreferenceDataStore
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.SpecialFolderSelection
+import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationVibration
 import com.fsck.k9.Preferences
@@ -152,7 +153,7 @@ class AccountSettingsDataStore(
                     reschedulePoll()
                 }
             }
-            "delete_policy" -> account.deletePolicy = Account.DeletePolicy.valueOf(value)
+            "delete_policy" -> account.deletePolicy = DeletePolicy.valueOf(value)
             "expunge_policy" -> account.expungePolicy = Account.Expunge.valueOf(value)
             "max_push_folders" -> account.maxPushFolders = value.toInt()
             "idle_refresh_period" -> account.idleRefreshMinutes = value.toInt()

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -1,10 +1,8 @@
 package com.fsck.k9.ui.settings.account
 
 import androidx.preference.PreferenceDataStore
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.Expunge
-import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.MessageFormat
 import app.k9mail.legacy.account.QuoteStyle
 import app.k9mail.legacy.account.ShowPictures
@@ -163,7 +161,7 @@ class AccountSettingsDataStore(
             "max_push_folders" -> account.maxPushFolders = value.toInt()
             "idle_refresh_period" -> account.idleRefreshMinutes = value.toInt()
             "message_format" -> account.messageFormat = MessageFormat.valueOf(value)
-            "quote_style" -> account.quoteStyle = Account.QuoteStyle.valueOf(value)
+            "quote_style" -> account.quoteStyle = QuoteStyle.valueOf(value)
             "account_quote_prefix" -> account.quotePrefix = value
             "account_setup_auto_expand_folder" -> account.autoExpandFolderId = extractFolderId(value)
             "archive_folder" -> saveSpecialFolderSelection(value, account::setArchiveFolderId)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -4,6 +4,7 @@ import androidx.preference.PreferenceDataStore
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.Expunge
+import app.k9mail.legacy.account.ShowPictures
 import app.k9mail.legacy.account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationVibration
@@ -145,7 +146,7 @@ class AccountSettingsDataStore(
 
         when (key) {
             "account_description" -> account.name = value
-            "show_pictures_enum" -> account.showPictures = Account.ShowPictures.valueOf(value)
+            "show_pictures_enum" -> account.showPictures = ShowPictures.valueOf(value)
             "account_display_count" -> account.displayCount = value.toInt()
             "account_message_age" -> account.maximumPolledMessageAge = value.toInt()
             "account_autodownload_size" -> account.maximumAutoDownloadMessageSize = value.toInt()

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -4,6 +4,7 @@ import androidx.preference.PreferenceDataStore
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import app.k9mail.legacy.account.DeletePolicy
+import app.k9mail.legacy.account.Expunge
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationVibration
 import com.fsck.k9.Preferences
@@ -154,7 +155,7 @@ class AccountSettingsDataStore(
                 }
             }
             "delete_policy" -> account.deletePolicy = DeletePolicy.valueOf(value)
-            "expunge_policy" -> account.expungePolicy = Account.Expunge.valueOf(value)
+            "expunge_policy" -> account.expungePolicy = Expunge.valueOf(value)
             "max_push_folders" -> account.maxPushFolders = value.toInt()
             "idle_refresh_period" -> account.idleRefreshMinutes = value.toInt()
             "message_format" -> account.messageFormat = Account.MessageFormat.valueOf(value)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -2,9 +2,9 @@ package com.fsck.k9.ui.settings.account
 
 import androidx.preference.PreferenceDataStore
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.account.Account.SpecialFolderSelection
 import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.Expunge
+import app.k9mail.legacy.account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationLight
 import app.k9mail.legacy.notification.NotificationVibration
 import com.fsck.k9.Preferences

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -4,6 +4,9 @@ import androidx.preference.PreferenceDataStore
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.Expunge
+import app.k9mail.legacy.account.LegacyAccount
+import app.k9mail.legacy.account.MessageFormat
+import app.k9mail.legacy.account.QuoteStyle
 import app.k9mail.legacy.account.ShowPictures
 import app.k9mail.legacy.account.SpecialFolderSelection
 import app.k9mail.legacy.notification.NotificationLight
@@ -159,7 +162,7 @@ class AccountSettingsDataStore(
             "expunge_policy" -> account.expungePolicy = Expunge.valueOf(value)
             "max_push_folders" -> account.maxPushFolders = value.toInt()
             "idle_refresh_period" -> account.idleRefreshMinutes = value.toInt()
-            "message_format" -> account.messageFormat = Account.MessageFormat.valueOf(value)
+            "message_format" -> account.messageFormat = MessageFormat.valueOf(value)
             "quote_style" -> account.quoteStyle = Account.QuoteStyle.valueOf(value)
             "account_quote_prefix" -> account.quotePrefix = value
             "account_setup_auto_expand_folder" -> account.autoExpandFolderId = extractFolderId(value)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -3,6 +3,7 @@ package com.fsck.k9.ui.settings.account
 import androidx.preference.PreferenceDataStore
 import app.k9mail.legacy.account.DeletePolicy
 import app.k9mail.legacy.account.Expunge
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.MessageFormat
 import app.k9mail.legacy.account.QuoteStyle
 import app.k9mail.legacy.account.ShowPictures
@@ -19,7 +20,7 @@ import java.util.concurrent.ExecutorService
 class AccountSettingsDataStore(
     private val preferences: Preferences,
     private val executorService: ExecutorService,
-    private val account: Account,
+    private val account: LegacyAccount,
     private val jobManager: K9JobManager,
     private val notificationChannelManager: NotificationChannelManager,
     private val notificationController: NotificationController,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreFactory.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreFactory.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.ui.settings.account
 
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.job.K9JobManager
@@ -16,7 +16,7 @@ class AccountSettingsDataStoreFactory(
     private val notificationController: NotificationController,
     private val messagingController: MessagingController,
 ) {
-    fun create(account: Account): AccountSettingsDataStore {
+    fun create(account: LegacyAccount): AccountSettingsDataStore {
         return AccountSettingsDataStore(
             preferences,
             executorService,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -21,6 +21,7 @@ import app.k9mail.feature.launcher.FeatureLauncherActivity
 import app.k9mail.feature.launcher.FeatureLauncherTarget
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
+import app.k9mail.legacy.account.QuoteStyle
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.activity.ManageIdentities
 import com.fsck.k9.activity.setup.AccountSetupComposition
@@ -196,8 +197,8 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     private fun initializeQuoteStyle() {
         findPreference<Preference>(PREFERENCE_QUOTE_STYLE)?.apply {
             setOnPreferenceChangeListener { _, newValue ->
-                val quoteStyle = Account.QuoteStyle.valueOf(newValue.toString())
-                notifyDependencyChange(quoteStyle == Account.QuoteStyle.HEADER)
+                val quoteStyle = QuoteStyle.valueOf(newValue.toString())
+                notifyDependencyChange(quoteStyle == QuoteStyle.HEADER)
                 true
             }
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -19,8 +19,8 @@ import app.k9mail.core.featureflag.FeatureFlagProvider
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.feature.launcher.FeatureLauncherActivity
 import app.k9mail.feature.launcher.FeatureLauncherTarget
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.account.QuoteStyle
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.activity.ManageIdentities
@@ -177,7 +177,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeUploadSentMessages(account: Account) {
+    private fun initializeUploadSentMessages(account: LegacyAccount) {
         findPreference<Preference>(PREFERENCE_UPLOAD_SENT_MESSAGES)?.apply {
             if (!messagingController.supportsUpload(account)) {
                 remove()
@@ -204,7 +204,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeDeletePolicy(account: Account) {
+    private fun initializeDeletePolicy(account: LegacyAccount) {
         (findPreference(PREFERENCE_DELETE_POLICY) as? ListPreference)?.apply {
             if (!messagingController.supportsFlags(account)) {
                 removeEntry(DELETE_POLICY_MARK_AS_READ)
@@ -212,7 +212,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeExpungePolicy(account: Account) {
+    private fun initializeExpungePolicy(account: LegacyAccount) {
         findPreference<Preference>(PREFERENCE_EXPUNGE_POLICY)?.apply {
             if (!messagingController.supportsExpunge(account)) {
                 remove()
@@ -220,7 +220,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeMessageAge(account: Account) {
+    private fun initializeMessageAge(account: LegacyAccount) {
         findPreference<Preference>(PREFERENCE_MESSAGE_AGE)?.apply {
             if (!messagingController.supportsSearchByDate(account)) {
                 remove()
@@ -228,13 +228,13 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeAdvancedPushSettings(account: Account) {
+    private fun initializeAdvancedPushSettings(account: LegacyAccount) {
         if (!messagingController.isPushCapable(account)) {
             findPreference<Preference>(PREFERENCE_ADVANCED_PUSH_SETTINGS)?.remove()
         }
     }
 
-    private fun initializeNotifications(account: Account) {
+    private fun initializeNotifications(account: LegacyAccount) {
         if (!vibrator.hasVibrator) {
             findPreference<Preference>(PREFERENCE_NOTIFICATION_VIBRATION)?.remove()
         }
@@ -270,7 +270,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun maybeUpdateNotificationPreferences(account: Account) {
+    private fun maybeUpdateNotificationPreferences(account: LegacyAccount) {
         if (notificationSoundPreference != null ||
             notificationLightPreference != null ||
             notificationVibrationPreference != null
@@ -280,7 +280,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     @SuppressLint("NewApi")
-    private fun updateNotificationPreferences(account: Account) {
+    private fun updateNotificationPreferences(account: LegacyAccount) {
         notificationSettingsUpdater.updateNotificationSettings(account)
         val notificationSettings = account.notificationSettings
 
@@ -298,13 +298,13 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeCryptoSettings(account: Account) {
+    private fun initializeCryptoSettings(account: LegacyAccount) {
         findPreference<Preference>(PREFERENCE_OPENPGP)?.let {
             configureCryptoPreferences(account)
         }
     }
 
-    private fun configureCryptoPreferences(account: Account) {
+    private fun configureCryptoPreferences(account: LegacyAccount) {
         var pgpProviderName: String? = null
         var pgpProvider = account.openPgpProvider
         val isPgpConfigured = pgpProvider != null
@@ -329,7 +329,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         return OpenPgpProviderUtil.getOpenPgpProviderName(packageManager, pgpProvider)
     }
 
-    private fun configureEnablePgpSupport(account: Account, isPgpConfigured: Boolean, pgpProviderName: String?) {
+    private fun configureEnablePgpSupport(account: LegacyAccount, isPgpConfigured: Boolean, pgpProviderName: String?) {
         (findPreference<Preference>(PREFERENCE_OPENPGP_ENABLE) as SwitchPreference).apply {
             if (!isPgpConfigured) {
                 isChecked = false
@@ -356,7 +356,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun configurePgpKey(account: Account, pgpProvider: String?) {
+    private fun configurePgpKey(account: LegacyAccount, pgpProvider: String?) {
         (findPreference<Preference>(PREFERENCE_OPENPGP_KEY) as OpenPgpKeyPreference).apply {
             value = account.openPgpKey
             setOpenPgpProvider(openPgpApiManager, pgpProvider)
@@ -366,14 +366,14 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun configureAutocryptTransfer(account: Account) {
+    private fun configureAutocryptTransfer(account: LegacyAccount) {
         findPreference<Preference>(PREFERENCE_AUTOCRYPT_TRANSFER)!!.onClick {
             val intent = AutocryptKeyTransferActivity.createIntent(requireContext(), account.uuid)
             startActivity(intent)
         }
     }
 
-    private fun initializeFolderSettings(account: Account) {
+    private fun initializeFolderSettings(account: LegacyAccount) {
         findPreference<Preference>(PREFERENCE_FOLDERS)?.let {
             if (!messagingController.supportsFolderSubscriptions(account)) {
                 findPreference<Preference>(PREFERENCE_SUBSCRIBED_FOLDERS_ONLY).remove()
@@ -391,7 +391,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun loadFolders(account: Account) {
+    private fun loadFolders(account: LegacyAccount) {
         viewModel.getFolders(account).observe(this@AccountSettingsFragment) { remoteFolderInfo ->
             if (remoteFolderInfo != null) {
                 setFolders(PREFERENCE_AUTO_EXPAND_FOLDER, remoteFolderInfo.folders)
@@ -424,7 +424,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         super.onActivityResult(requestCode, resultCode, data)
     }
 
-    private fun getAccount(): Account {
+    private fun getAccount(): LegacyAccount {
         return viewModel.getAccountBlocking(accountUuid)
     }
 
@@ -453,12 +453,12 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         requireActivity().finish()
     }
 
-    private fun setOpenPgpProvider(account: Account, openPgpProviderPackage: String) {
+    private fun setOpenPgpProvider(account: LegacyAccount, openPgpProviderPackage: String) {
         account.openPgpProvider = openPgpProviderPackage
         dataStore.saveSettingsInBackground()
     }
 
-    private fun removeOpenPgpProvider(account: Account) {
+    private fun removeOpenPgpProvider(account: LegacyAccount) {
         account.openPgpProvider = null
         account.openPgpKey = NO_OPENPGP_KEY
         dataStore.saveSettingsInBackground()

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -6,8 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import app.k9mail.core.mail.folder.api.FolderType
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
+import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.mailstore.SpecialFolderSelectionStrategy
 import kotlinx.coroutines.CoroutineDispatcher
@@ -24,10 +24,10 @@ class AccountSettingsViewModel(
 ) : ViewModel() {
     val accounts = accountManager.getAccountsFlow().asLiveData()
     private var accountUuid: String? = null
-    private val accountLiveData = MutableLiveData<Account?>()
+    private val accountLiveData = MutableLiveData<LegacyAccount?>()
     private val foldersLiveData = MutableLiveData<RemoteFolderInfo>()
 
-    fun getAccount(accountUuid: String): LiveData<Account?> {
+    fun getAccount(accountUuid: String): LiveData<LegacyAccount?> {
         if (this.accountUuid != accountUuid) {
             this.accountUuid = accountUuid
             viewModelScope.launch {
@@ -42,10 +42,10 @@ class AccountSettingsViewModel(
     }
 
     /**
-     * Returns the cached [Account] if possible. Otherwise does a blocking load because `PreferenceFragmentCompat`
+     * Returns the cached [LegacyAccount] if possible. Otherwise does a blocking load because `PreferenceFragmentCompat`
      * doesn't support asynchronous preference loading.
      */
-    fun getAccountBlocking(accountUuid: String): Account {
+    fun getAccountBlocking(accountUuid: String): LegacyAccount {
         return accountLiveData.value
             ?: loadAccount(accountUuid).also { account ->
                 this.accountUuid = accountUuid
@@ -54,11 +54,11 @@ class AccountSettingsViewModel(
             ?: error("Account $accountUuid not found")
     }
 
-    private fun loadAccount(accountUuid: String): Account? {
+    private fun loadAccount(accountUuid: String): LegacyAccount? {
         return accountManager.getAccount(accountUuid)
     }
 
-    fun getFolders(account: Account): LiveData<RemoteFolderInfo> {
+    fun getFolders(account: LegacyAccount): LiveData<RemoteFolderInfo> {
         if (foldersLiveData.value == null) {
             loadFolders(account)
         }
@@ -66,7 +66,7 @@ class AccountSettingsViewModel(
         return foldersLiveData
     }
 
-    private fun loadFolders(account: Account) {
+    private fun loadFolders(account: LegacyAccount) {
         viewModelScope.launch {
             val remoteFolderInfo = withContext(backgroundDispatcher) {
                 val folders = folderRepository.getRemoteFolders(account)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
@@ -23,7 +23,7 @@ import android.widget.ListAdapter;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.ui.base.K9Activity;
@@ -48,9 +48,9 @@ public class OpenPgpAppSelectDialog extends K9Activity {
             String.format("https://play.google.com/store/apps/details?id=%s", OPENKEYCHAIN_PACKAGE)));
 
 
-    private Account account;
+    private LegacyAccount account;
 
-    public static void startOpenPgpChooserActivity(Context context, Account account) {
+    public static void startOpenPgpChooserActivity(Context context, LegacyAccount account) {
         Intent i = new Intent(context, OpenPgpAppSelectDialog.class);
         i.putExtra(EXTRA_ACCOUNT, account.getUuid());
         context.startActivity(i);

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -18,7 +18,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.appcompat.widget.TooltipCompat;
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons;
-import app.k9mail.legacy.account.Account;
+import app.k9mail.legacy.account.LegacyAccount;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.FontSizes;
 import com.fsck.k9.K9;
@@ -194,7 +194,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         starView.setOnClickListener(listener);
     }
 
-    public void populate(final Message message, final Account account, boolean showStar, boolean showAccountChip) {
+    public void populate(final Message message, final LegacyAccount account, boolean showStar, boolean showAccountChip) {
         if (showAccountChip) {
             accountNameView.setVisibility(View.VISIBLE);
             accountNameView.setText(account.getDisplayName());
@@ -244,7 +244,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         setVisibility(View.VISIBLE);
     }
 
-    private void setRecipientNames(Message message, Account account) {
+    private void setRecipientNames(Message message, LegacyAccount account) {
         DisplayRecipientsExtractor displayRecipientsExtractor = new DisplayRecipientsExtractor(recipientFormatter,
                 recipientNamesView.getMaxNumberOfRecipientNames());
 
@@ -254,7 +254,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
                 displayRecipients.getNumberOfRecipients());
     }
 
-    private void setReplyActions(Message message, Account account) {
+    private void setReplyActions(Message message, LegacyAccount account) {
         ReplyActions replyActions = replyActionStrategy.getReplyActions(account, message);
         this.replyActions = replyActions;
 

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.activity.compose
 
 import androidx.test.core.app.ApplicationProvider
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
@@ -56,7 +56,7 @@ class RecipientPresenterTest : K9RobolectricTest() {
         }
     }
     private val recipientMvpView = mock<RecipientMvpView>()
-    private val account = mock<Account>()
+    private val account = mock<LegacyAccount>()
     private val composePgpInlineDecider = mock<ComposePgpInlineDecider>()
     private val composePgpEnableByDefaultDecider = mock<ComposePgpEnableByDefaultDecider>()
     private val autocryptStatusInteractor = mock<AutocryptStatusInteractor>()

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.kt
@@ -4,8 +4,8 @@ import android.app.Activity
 import android.app.PendingIntent
 import android.content.Intent
 import android.os.Parcelable
-import app.k9mail.legacy.account.Account.QuoteStyle
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.QuoteStyle
 import assertk.Assert
 import assertk.all
 import assertk.assertThat

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatterTest.kt
@@ -5,8 +5,8 @@ import android.text.Spannable
 import android.text.style.ForegroundColorSpan
 import androidx.core.text.getSpans
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
@@ -32,7 +32,7 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
         }
     }
 
-    private val account = Account("uuid").apply {
+    private val account = LegacyAccount("uuid").apply {
         identities += Identity(name = IDENTITY_NAME, email = IDENTITY_ADDRESS)
     }
 
@@ -47,7 +47,7 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity address with multiple identities`() {
-        val account = Account("uuid").apply {
+        val account = LegacyAccount("uuid").apply {
             identities += Identity(name = IDENTITY_NAME, email = IDENTITY_ADDRESS)
             identities += Identity(name = "Another identity", email = "irrelevant@domain.example")
         }
@@ -59,7 +59,7 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity without a display name`() {
-        val account = Account("uuid").apply {
+        val account = LegacyAccount("uuid").apply {
             identities += Identity(name = null, email = IDENTITY_ADDRESS)
         }
 
@@ -70,7 +70,7 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity and address without a display name`() {
-        val account = Account("uuid").apply {
+        val account = LegacyAccount("uuid").apply {
             identities += Identity(name = null, email = IDENTITY_ADDRESS)
             identities += Identity(name = "Another identity", email = "irrelevant@domain.example")
         }

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
@@ -12,7 +12,7 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import app.k9mail.core.android.testing.RobolectricTest
 import app.k9mail.core.testing.TestClock
-import app.k9mail.legacy.account.Account
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -425,7 +425,7 @@ class MessageListAdapterTest : RobolectricTest() {
     }
 
     fun createMessageListItem(
-        account: Account = Account(SOME_ACCOUNT_UUID),
+        account: LegacyAccount = LegacyAccount(SOME_ACCOUNT_UUID),
         subject: String? = "irrelevant",
         threadCount: Int = 0,
         messageDate: Long = 0L,

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.ui.messageview
 
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.Address
@@ -11,14 +11,14 @@ import org.junit.Test
 private const val IDENTITY_ADDRESS = "me@domain.example"
 
 class DisplayRecipientsExtractorTest {
-    private val account = Account("uuid").apply {
+    private val account = LegacyAccount("uuid").apply {
         identities += Identity(
             email = IDENTITY_ADDRESS,
         )
     }
 
     private val recipientFormatter = object : MessageViewRecipientFormatter {
-        override fun getDisplayName(address: Address, account: Account): CharSequence {
+        override fun getDisplayName(address: Address, account: LegacyAccount): CharSequence {
             return if (account.isAnIdentity(address)) {
                 "me"
             } else {
@@ -172,7 +172,7 @@ class DisplayRecipientsExtractorTest {
         }
         var numberOfTimesCalled = 0
         val recipientFormatter = object : MessageViewRecipientFormatter {
-            override fun getDisplayName(address: Address, account: Account): CharSequence {
+            override fun getDisplayName(address: Address, account: LegacyAccount): CharSequence {
                 numberOfTimesCalled++
                 return address.address
             }

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatterTest.kt
@@ -5,8 +5,8 @@ import android.text.Spannable
 import android.text.style.ForegroundColorSpan
 import androidx.core.text.getSpans
 import app.k9mail.core.android.testing.RobolectricTest
-import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Identity
+import app.k9mail.legacy.account.LegacyAccount
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
@@ -29,7 +29,7 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
         }
     }
 
-    private val account = Account("uuid").apply {
+    private val account = LegacyAccount("uuid").apply {
         identities += Identity(email = IDENTITY_ADDRESS)
     }
 
@@ -44,7 +44,7 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
 
     @Test
     fun `multiple identities`() {
-        val account = Account("uuid").apply {
+        val account = LegacyAccount("uuid").apply {
             identities += Identity(description = "My identity", email = IDENTITY_ADDRESS)
             identities += Identity(email = "another.one@domain.example")
         }
@@ -57,7 +57,7 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity without a description`() {
-        val account = Account("uuid").apply {
+        val account = LegacyAccount("uuid").apply {
             identities += Identity(name = "My name", email = IDENTITY_ADDRESS)
             identities += Identity(email = "another.one@domain.example")
         }
@@ -70,7 +70,7 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity without a description and name`() {
-        val account = Account("uuid").apply {
+        val account = LegacyAccount("uuid").apply {
             identities += Identity(email = IDENTITY_ADDRESS)
             identities += Identity(email = "another.one@domain.example")
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -72,6 +72,7 @@ include(
 )
 
 include(
+    ":feature:account:api",
     ":feature:account:avatar",
     ":feature:account:common",
     ":feature:account:edit",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -74,6 +74,7 @@ include(
 include(
     ":feature:account:api",
     ":feature:account:avatar",
+    ":feature:account:core",
     ":feature:account:common",
     ":feature:account:edit",
     ":feature:account:oauth",


### PR DESCRIPTION
This introduces a unidirectional flow around the mutable `Account` object, now referred to as `LegacyAccount`. The `LegacyAccountWrapper`, an immutable representation of `LegacyAccount`, facilitates its use within a unidirectional data flow and ensures proper state management and change notification.

The `LegacyAccountWrapperManager` controls this process by enabling subscriptions to changes on top of the existing `AccountManager`.

Subclasses of `LegacyAccount` have been relocated to separate classes, making it easier to dissect this large class in the future and reducing their dependency on the `LegacyAccount` class.

A new `:feature:account:api` module has been added to introduce a new definition for `Account` and `AccountId`, designed for future extension and eventual replacement of the existing `LegacyAccount`. The `AccountProfile` includes attributes necessary for representing an account, such as `name` and `color` definitions. This is supported by a repository and data source that handle retrieval and updates to the `AccountProfile`.

Resolves [#8925](https://github.com/thunderbird/thunderbird-android/issues/8925).