### PR TITLE
Remove un-used com.fsck.k9.glide.K9AppGlideModule

### DIFF
--- a/legacy/common/src/main/java/com/fsck/k9/glide/K9AppGlideModule.java
+++ b/legacy/common/src/main/java/com/fsck/k9/glide/K9AppGlideModule.java
@@ -1,8 +1,0 @@
-package com.fsck.k9.glide;
-
-import com.bumptech.glide.annotation.GlideModule;
-import com.bumptech.glide.module.AppGlideModule;
-
-@GlideModule
-public class K9AppGlideModule extends AppGlideModule {
-}


### PR DESCRIPTION
- `com.fsck.k9.glide.K9AppGlideModule` is no longer being used. So, this PR removes it.
