### PR TITLE
Refactor: move RemoteFolder to feature:folder:api-module

### DIFF
--- a/feature/folder/api/build.gradle.kts
+++ b/feature/folder/api/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id(ThunderbirdPlugins.Library.jvm)
+    alias(libs.plugins.android.lint)
+}
+
+dependencies {
+    implementation(projects.core.mail.folder.api)
+}

--- a/feature/folder/api/src/main/kotlin/net/thunderbird/feature/folder/api/RemoteFolder.kt
+++ b/feature/folder/api/src/main/kotlin/net/thunderbird/feature/folder/api/RemoteFolder.kt
@@ -1,4 +1,4 @@
-package app.k9mail.legacy.folder
+package net.thunderbird.feature.folder.api
 
 import app.k9mail.core.mail.folder.api.FolderType
 

--- a/legacy/core/build.gradle.kts
+++ b/legacy/core/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(projects.core.android.common)
     api(projects.core.android.network)
     api(projects.core.mail.folder.api)
+    api(projects.feature.folder.api)
 
     api(projects.legacy.account)
     api(projects.legacy.di)

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderSelectionStrategy.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderSelectionStrategy.kt
@@ -1,13 +1,16 @@
 package com.fsck.k9.mailstore
 
 import app.k9mail.core.mail.folder.api.FolderType
-import app.k9mail.legacy.folder.RemoteFolder
+import net.thunderbird.feature.folder.api.RemoteFolder
 
 /**
  * Implements the automatic special folder selection strategy.
  */
 class SpecialFolderSelectionStrategy {
-    fun selectSpecialFolder(folders: List<RemoteFolder>, type: FolderType): RemoteFolder? {
+    fun selectSpecialFolder(
+        folders: List<RemoteFolder>,
+        type: FolderType,
+    ): RemoteFolder? {
         return folders.firstOrNull { folder -> folder.type == type }
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
@@ -4,9 +4,9 @@ import app.k9mail.core.common.mail.Protocols
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.Account.SpecialFolderSelection
-import app.k9mail.legacy.folder.RemoteFolder
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.Preferences
+import net.thunderbird.feature.folder.api.RemoteFolder
 
 /**
  * Updates special folders in [Account] if they are marked as [SpecialFolderSelection.AUTOMATIC] or if they are marked

--- a/legacy/mailstore/build.gradle.kts
+++ b/legacy/mailstore/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
 
     implementation(projects.mail.common)
     implementation(projects.core.mail.folder.api)
+    implementation(projects.feature.folder.api)
 }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
@@ -3,7 +3,6 @@ package app.k9mail.legacy.mailstore
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderDetails
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.RemoteFolder
 import app.k9mail.legacy.mailstore.FolderTypeMapper.folderTypeOf
 import app.k9mail.legacy.mailstore.RemoteFolderTypeMapper.toFolderType
 import kotlinx.coroutines.CoroutineDispatcher
@@ -16,6 +15,7 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
+import net.thunderbird.feature.folder.api.RemoteFolder
 
 @Suppress("TooManyFunctions")
 class FolderRepository(

--- a/legacy/ui/folder/build.gradle.kts
+++ b/legacy/ui/folder/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(projects.legacy.mailstore)
     implementation(projects.legacy.message)
     implementation(projects.legacy.search)
+    implementation(projects.feature.folder.api)
 
     implementation(libs.androidx.lifecycle.livedata.ktx)
 }

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/FolderNameFormatter.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/FolderNameFormatter.kt
@@ -3,7 +3,7 @@ package app.k9mail.legacy.ui.folder
 import android.content.res.Resources
 import app.k9mail.core.mail.folder.api.Folder
 import app.k9mail.core.mail.folder.api.FolderType
-import app.k9mail.legacy.folder.RemoteFolder
+import net.thunderbird.feature.folder.api.RemoteFolder
 
 class FolderNameFormatter(private val resources: Resources) {
     fun displayName(folder: Folder): String {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -20,7 +20,6 @@ import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.feature.launcher.FeatureLauncherActivity
 import app.k9mail.feature.launcher.FeatureLauncherTarget
 import app.k9mail.legacy.account.Account
-import app.k9mail.legacy.folder.RemoteFolder
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.activity.ManageIdentities
 import com.fsck.k9.activity.setup.AccountSetupComposition
@@ -39,6 +38,7 @@ import com.fsck.k9.ui.settings.oneTimeClickListener
 import com.fsck.k9.ui.settings.remove
 import com.fsck.k9.ui.settings.removeEntry
 import com.takisoft.preferencex.PreferenceFragmentCompat
+import net.thunderbird.feature.folder.api.RemoteFolder
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import org.koin.core.parameter.parametersOf

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -8,13 +8,13 @@ import androidx.lifecycle.viewModelScope
 import app.k9mail.core.mail.folder.api.FolderType
 import app.k9mail.legacy.account.Account
 import app.k9mail.legacy.account.AccountManager
-import app.k9mail.legacy.folder.RemoteFolder
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.mailstore.SpecialFolderSelectionStrategy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import net.thunderbird.feature.folder.api.RemoteFolder
 
 class AccountSettingsViewModel(
     private val accountManager: AccountManager,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/FolderListPreference.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/FolderListPreference.kt
@@ -8,9 +8,9 @@ import android.text.style.StyleSpan
 import android.util.AttributeSet
 import androidx.core.content.res.TypedArrayUtils
 import androidx.preference.ListPreference
-import app.k9mail.legacy.folder.RemoteFolder
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import com.fsck.k9.ui.R
+import net.thunderbird.feature.folder.api.RemoteFolder
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.parameter.parametersOf

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -118,6 +118,7 @@ include(
 
 include(
     ":feature:funding:api",
+    ":feature:folder:api",
     ":feature:funding:googleplay",
     ":feature:funding:link",
     ":feature:funding:noop",


### PR DESCRIPTION
This is part of legacy module refactor endeavor.
- Moves `app.k9mail.legacy.folder.RemoteFolder` into new module `feature:folder:api`