### PR TITLE
Move Outcome to `:core:outcome` module

### DIFF
--- a/core/outcome/build.gradle.kts
+++ b/core/outcome/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id(ThunderbirdPlugins.Library.jvm)
+    alias(libs.plugins.android.lint)
+}

--- a/core/outcome/src/main/kotlin/net/thunderbird/core/outcome/Outcome.kt
+++ b/core/outcome/src/main/kotlin/net/thunderbird/core/outcome/Outcome.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.funding.googleplay.domain
+package net.thunderbird.core.outcome
 
 sealed interface Outcome<out SUCCESS, out FAILURE> {
     data class Success<out SUCCESS>(val data: SUCCESS) : Outcome<SUCCESS, Nothing>

--- a/feature/funding/googleplay/build.gradle.kts
+++ b/feature/funding/googleplay/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api(projects.feature.funding.api)
 
     implementation(projects.core.common)
+    implementation(projects.core.outcome)
     implementation(projects.core.ui.compose.designsystem)
 
     implementation(libs.android.billing)

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/DataContract.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/DataContract.kt
@@ -2,7 +2,6 @@ package app.k9mail.feature.funding.googleplay.data
 
 import android.app.Activity
 import app.k9mail.feature.funding.googleplay.domain.DomainContract.BillingError
-import app.k9mail.feature.funding.googleplay.domain.Outcome
 import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
 import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
 import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
@@ -10,6 +9,7 @@ import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesUpdatedListener
 import kotlinx.coroutines.flow.StateFlow
+import net.thunderbird.core.outcome.Outcome
 import com.android.billingclient.api.BillingClient as GoogleBillingClient
 import com.android.billingclient.api.BillingResult as GoogleBillingResult
 

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/GoogleBillingClient.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/GoogleBillingClient.kt
@@ -5,12 +5,9 @@ import app.k9mail.core.common.cache.Cache
 import app.k9mail.feature.funding.googleplay.data.DataContract.Remote
 import app.k9mail.feature.funding.googleplay.data.remote.startConnection
 import app.k9mail.feature.funding.googleplay.domain.DomainContract.BillingError
-import app.k9mail.feature.funding.googleplay.domain.Outcome
 import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
 import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
 import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
-import app.k9mail.feature.funding.googleplay.domain.handleAsync
-import app.k9mail.feature.funding.googleplay.domain.mapFailure
 import com.android.billingclient.api.BillingClient.ProductType
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingFlowParams.ProductDetailsParams
@@ -33,6 +30,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.outcome.handleAsync
+import net.thunderbird.core.outcome.mapFailure
 import timber.log.Timber
 
 @Suppress("TooManyFunctions")

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/mapper/BillingResultMapper.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/data/mapper/BillingResultMapper.kt
@@ -2,9 +2,9 @@ package app.k9mail.feature.funding.googleplay.data.mapper
 
 import app.k9mail.feature.funding.googleplay.data.DataContract.Mapper
 import app.k9mail.feature.funding.googleplay.domain.DomainContract.BillingError
-import app.k9mail.feature.funding.googleplay.domain.Outcome
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
+import net.thunderbird.core.outcome.Outcome
 
 class BillingResultMapper : Mapper.BillingResult {
 

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/BillingManager.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/BillingManager.kt
@@ -7,6 +7,9 @@ import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
 import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
 import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
 import kotlinx.coroutines.flow.StateFlow
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.outcome.flatMapSuccess
+import net.thunderbird.core.outcome.mapSuccess
 
 internal class BillingManager(
     private val billingClient: DataContract.BillingClient,

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/DomainContract.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/DomainContract.kt
@@ -7,6 +7,7 @@ import app.k9mail.feature.funding.googleplay.domain.entity.OneTimeContribution
 import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.StateFlow
+import net.thunderbird.core.outcome.Outcome
 
 interface DomainContract {
 

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/usecase/GetAvailableContributions.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/domain/usecase/GetAvailableContributions.kt
@@ -3,8 +3,8 @@ package app.k9mail.feature.funding.googleplay.domain.usecase
 import app.k9mail.feature.funding.googleplay.domain.DomainContract.BillingError
 import app.k9mail.feature.funding.googleplay.domain.DomainContract.BillingManager
 import app.k9mail.feature.funding.googleplay.domain.DomainContract.UseCase
-import app.k9mail.feature.funding.googleplay.domain.Outcome
 import app.k9mail.feature.funding.googleplay.domain.entity.AvailableContributions
+import net.thunderbird.core.outcome.Outcome
 
 class GetAvailableContributions(
     private val billingManager: BillingManager,

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModel.kt
@@ -7,13 +7,13 @@ import app.k9mail.feature.funding.googleplay.domain.DomainContract.UseCase
 import app.k9mail.feature.funding.googleplay.domain.entity.AvailableContributions
 import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
 import app.k9mail.feature.funding.googleplay.domain.entity.RecurringContribution
-import app.k9mail.feature.funding.googleplay.domain.handle
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.Effect
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.Event
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.State
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.ViewModel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
+import net.thunderbird.core.outcome.handle
 
 @Suppress("TooManyFunctions")
 internal class ContributionViewModel(

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/data/mapper/BillingResultMapperTest.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/data/mapper/BillingResultMapperTest.kt
@@ -1,7 +1,6 @@
 package app.k9mail.feature.funding.googleplay.data.mapper
 
 import app.k9mail.feature.funding.googleplay.domain.DomainContract.BillingError
-import app.k9mail.feature.funding.googleplay.domain.Outcome
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -12,6 +11,7 @@ import com.android.billingclient.api.BillingResult
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.outcome.Outcome
 
 class BillingResultMapperTest {
 

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModelTest.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionViewModelTest.kt
@@ -5,7 +5,6 @@ import app.k9mail.core.ui.compose.testing.mvi.MviContext
 import app.k9mail.core.ui.compose.testing.mvi.MviTurbines
 import app.k9mail.core.ui.compose.testing.mvi.runMviTest
 import app.k9mail.core.ui.compose.testing.mvi.turbinesWithInitialStateCheck
-import app.k9mail.feature.funding.googleplay.domain.Outcome
 import app.k9mail.feature.funding.googleplay.domain.entity.AvailableContributions
 import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
 import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContract.ContributionListState
@@ -15,6 +14,7 @@ import app.k9mail.feature.funding.googleplay.ui.contribution.ContributionContrac
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
+import net.thunderbird.core.outcome.Outcome
 import org.junit.Rule
 
 class ContributionViewModelTest {

--- a/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/FakeBillingManager.kt
+++ b/feature/funding/googleplay/src/test/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/FakeBillingManager.kt
@@ -3,10 +3,10 @@ package app.k9mail.feature.funding.googleplay.ui.contribution
 import android.app.Activity
 import app.k9mail.feature.funding.googleplay.domain.DomainContract
 import app.k9mail.feature.funding.googleplay.domain.DomainContract.BillingError
-import app.k9mail.feature.funding.googleplay.domain.Outcome
 import app.k9mail.feature.funding.googleplay.domain.entity.Contribution
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import net.thunderbird.core.outcome.Outcome
 
 class FakeBillingManager : DomainContract.BillingManager {
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -126,6 +126,7 @@ include(
 include(
     ":core:common",
     ":core:featureflags",
+    ":core:outcome",
     ":core:testing",
     ":core:android:common",
     ":core:android:network",


### PR DESCRIPTION
The `Outcome` result pattern is handy for other use cases and this lifts it to the `:core:outcome` module.
