### PR TITLE
PR merged workflow improvements

### DIFF
--- a/.github/workflows/pulls-merged.yml
+++ b/.github/workflows/pulls-merged.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   pull-request-merged:
+    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     environment: botmobile
     steps:
@@ -41,10 +42,10 @@ jobs:
 
       - name: Thank you
         if: |
-          github.event.pull_request.merged == true &&
           github.event.pull_request.author_association != 'OWNER' &&
           github.event.pull_request.author_association != 'MEMBER' &&
-          github.event.pull_request.author_association != 'COLLABORATOR'
+          github.event.pull_request.author_association != 'COLLABORATOR' &&
+          github.event.pull_request.author_association != 'CONTRIBUTOR'
         env:
           PR_NUMBER: ${{  github.event.pull_request.number  }}
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}


### PR DESCRIPTION
* Only set milestone if PR is merged, otherwise we set milestone on closed PRs.
* Don't repeat thank you message for people who have already contributed.


For the second point, we could potentially flip it around and just show the message if they have the FIRST_TIMER or FIRST_TIME_CONTRIBUTOR associations. 