### PR TITLE
Refactor: Empty Module Cleanup

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -164,7 +164,6 @@ include(
     ":legacy:di",
     ":legacy:mailstore",
     ":legacy:message",
-    ":legacy:preferences",
     ":legacy:search",
     ":legacy:storage",
     ":legacy:testing",


### PR DESCRIPTION
- Removed` :legacy:preferences` reference from` settings.gradle` as it has become empty due to recent refactoring and no longer needed.