### PR TITLE
Bring back GH actions read permission to fix daily builds workflow

### DIFF
--- a/.github/workflows/daily_builds.yml
+++ b/.github/workflows/daily_builds.yml
@@ -15,3 +15,4 @@ jobs:
     secrets: inherit
     permissions:
       id-token: write # For GCS publishing (ftp.mo)
+      contents: read


### PR DESCRIPTION
Looks like daily builds have been broken for about 2 weeks since botmobile landed. I believe this will fix it.