### PR TITLE
Fix known keyboard navigation bugs

### DIFF
--- a/legacy/ui/legacy/src/main/res/layout/message_compose_recipients.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_compose_recipients.xml
@@ -252,6 +252,7 @@
             android:background="@android:color/transparent"
             android:paddingTop="10dp"
             android:paddingBottom="10dp"
+            android:focusable="true"
             android:dropDownWidth="wrap_content"
             style="@style/RecipientEditText"
             />

--- a/legacy/ui/legacy/src/main/res/layout/message_list_fragment.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list_fragment.xml
@@ -8,6 +8,17 @@
     android:layout_height="match_parent"
     tools:context=".messagelist.MessageListFragment"
     >
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/floating_action_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/floatingActionButtonMargin"
+        android:contentDescription="@string/compose_action"
+        app:layout_behavior="com.fsck.k9.ui.fab.HideFabOnScrollBehavior"
+        app:srcCompat="@drawable/ic_edit"
+        android:focusable="true"
+        />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swiperefresh"
@@ -29,15 +40,6 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/floating_action_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/floatingActionButtonMargin"
-        android:contentDescription="@string/compose_action"
-        app:layout_behavior="com.fsck.k9.ui.fab.HideFabOnScrollBehavior"
-        app:srcCompat="@drawable/ic_edit"
-        />
+
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Explicitly adding the `focusable` field to the RecipientSelectView allows it to be navigated through via arrow keys. 
Explicitly adding the `focusable` field to the Floating Action Button for Compose adds it to the tab navigation. Moving it to the first child of the parent Layout Coordinator allows for it to be focused before the messages in the list while retaining its position. I will say the focus on the compose button is very faint and hard to see. It may be worth investigating during a future refactor
Using Ctrl-Tab shifts tab focus to the top navigation bar and its assorted buttons.

Fixes #8230, #5852 
Edit: Removed `#8321` from fixes list as it appears to work locally but did not work on some Samsung devices, which I don't have access to for testing
