### PR TITLE
Fixes Outlook outgoing server autoconfig failure

### DIFF
--- a/app-k9mail/src/debug/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
@@ -64,6 +64,8 @@ class K9OAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e647013a-ada4-4114-b419-e43d250f99c5",
             scopes = listOf(
+                "openid",
+                "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",
                 "https://outlook.office.com/SMTP.Send",
                 "offline_access",

--- a/app-k9mail/src/release/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
+++ b/app-k9mail/src/release/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
@@ -64,6 +64,8 @@ class K9OAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e647013a-ada4-4114-b419-e43d250f99c5",
             scopes = listOf(
+                "openid",
+                "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",
                 "https://outlook.office.com/SMTP.Send",
                 "offline_access",

--- a/app-thunderbird/src/beta/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/beta/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -65,6 +65,8 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e6f8716e-299d-4ed9-bbf3-453f192f44e5",
             scopes = listOf(
+                "openid",
+                "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",
                 "https://outlook.office.com/SMTP.Send",
                 "offline_access",

--- a/app-thunderbird/src/daily/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/daily/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -64,6 +64,8 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e6f8716e-299d-4ed9-bbf3-453f192f44e5",
             scopes = listOf(
+                "openid",
+                "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",
                 "https://outlook.office.com/SMTP.Send",
                 "offline_access",

--- a/app-thunderbird/src/debug/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/debug/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -64,6 +64,8 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e6f8716e-299d-4ed9-bbf3-453f192f44e5",
             scopes = listOf(
+                "openid",
+                "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",
                 "https://outlook.office.com/SMTP.Send",
                 "offline_access",

--- a/app-thunderbird/src/release/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/release/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -64,6 +64,8 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e6f8716e-299d-4ed9-bbf3-453f192f44e5",
             scopes = listOf(
+                "openid",
+                "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",
                 "https://outlook.office.com/SMTP.Send",
                 "offline_access",

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/AccountEditModuleKtTest.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/AccountEditModuleKtTest.kt
@@ -52,6 +52,7 @@ class AccountEditModuleKtTest : KoinTest {
         single<OAuth2TokenProviderFactory> {
             OAuth2TokenProviderFactory { _ ->
                 object : OAuth2TokenProvider {
+                    override val primaryEmail: String? get() = TODO()
                     override fun getToken(timeoutMillis: Long) = TODO()
                     override fun invalidateToken() = TODO()
                 }

--- a/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ServerValidationModuleKtTest.kt
+++ b/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ServerValidationModuleKtTest.kt
@@ -49,6 +49,7 @@ class ServerValidationModuleKtTest : KoinTest {
         single<OAuth2TokenProviderFactory> {
             OAuth2TokenProviderFactory { _ ->
                 object : OAuth2TokenProvider {
+                    override val primaryEmail: String? get() = TODO()
                     override fun getToken(timeoutMillis: Long) = TODO()
                     override fun invalidateToken() = TODO()
                 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
@@ -67,6 +67,7 @@ class AccountSetupModuleKtTest : KoinTest {
         single<OAuth2TokenProviderFactory> {
             OAuth2TokenProviderFactory { _ ->
                 object : OAuth2TokenProvider {
+                    override val primaryEmail: String? get() = TODO()
                     override fun getToken(timeoutMillis: Long) = TODO()
                     override fun invalidateToken() = TODO()
                 }

--- a/legacy/common/src/main/java/com/fsck/k9/backends/RealOAuth2TokenProvider.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/RealOAuth2TokenProvider.kt
@@ -17,19 +17,25 @@ import timber.log.Timber
 class RealOAuth2TokenProvider(
     context: Context,
     private val authStateStorage: AuthStateStorage,
-
 ) : OAuth2TokenProvider {
     private val authService = AuthorizationService(context)
     private var requestFreshToken = false
+    private val authState
+        get() = authStateStorage.getAuthorizationState()
+            ?.let { AuthState.jsonDeserialize(it) }
+            ?: throw AuthenticationFailedException("Login required")
+
+    override val primaryEmail: String?
+        get() = authState.parsedIdToken
+            ?.additionalClaims
+            ?.get("email")
+            ?.toString()
 
     @Suppress("TooGenericExceptionCaught")
     override fun getToken(timeoutMillis: Long): String {
         val latch = CountDownLatch(1)
         var token: String? = null
         var exception: AuthorizationException? = null
-
-        val authState = authStateStorage.getAuthorizationState()?.let { AuthState.jsonDeserialize(it) }
-            ?: throw AuthenticationFailedException("Login required")
 
         if (requestFreshToken) {
             authState.needsTokenRefresh = true

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2TokenProvider.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2TokenProvider.kt
@@ -1,20 +1,20 @@
-package com.fsck.k9.mail.oauth;
+package com.fsck.k9.mail.oauth
 
+import com.fsck.k9.mail.AuthenticationFailedException
 
-import com.fsck.k9.mail.AuthenticationFailedException;
-
-
-public interface OAuth2TokenProvider {
-    /**
-     * A default timeout value to use when fetching tokens.
-     */
-    int OAUTH2_TIMEOUT = 30000;
-
+interface OAuth2TokenProvider {
+    companion object {
+        /**
+         * A default timeout value to use when fetching tokens.
+         */
+        const val OAUTH2_TIMEOUT: Int = 30000
+    }
 
     /**
      * Fetch a token. No guarantees are provided for validity.
      */
-    String getToken(long timeoutMillis) throws AuthenticationFailedException;
+    @Throws(AuthenticationFailedException::class)
+    fun getToken(timeoutMillis: Long): String
 
     /**
      * Invalidate the token for this username.
@@ -25,5 +25,5 @@ public interface OAuth2TokenProvider {
      * <p>
      * Invalidating a token and then failure with a new token should be treated as a permanent failure.
      */
-    void invalidateToken();
+    fun invalidateToken()
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2TokenProvider.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2TokenProvider.kt
@@ -7,8 +7,21 @@ interface OAuth2TokenProvider {
         /**
          * A default timeout value to use when fetching tokens.
          */
-        const val OAUTH2_TIMEOUT: Int = 30000
+        const val OAUTH2_TIMEOUT = 30000L
     }
+
+    /**
+     * Fetch the primary email found in the id_token additional claims,
+     * if it is available.
+     *
+     * > Some providers, like Microsoft, require this as they need the primary account email to be the username,
+     * not the email the user entered
+     *
+     * @return the primary email present in the id_token, otherwise null.
+     */
+    val primaryEmail: String?
+        @Throws(AuthenticationFailedException::class)
+        get
 
     /**
      * Fetch a token. No guarantees are provided for validity.
@@ -19,10 +32,9 @@ interface OAuth2TokenProvider {
     /**
      * Invalidate the token for this username.
      *
-     * <p>
      * Note that the token should always be invalidated on credential failure. However invalidating a token every
      * single time is not recommended.
-     * <p>
+     *
      * Invalidating a token and then failure with a new token should be treated as a permanent failure.
      */
     fun invalidateToken()

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
@@ -385,7 +385,7 @@ internal class RealImapConnection(
         val oauthTokenProvider = checkNotNull(oauthTokenProvider)
         val responseParser = checkNotNull(responseParser)
 
-        val token = oauthTokenProvider.getToken(OAuth2TokenProvider.OAUTH2_TIMEOUT.toLong())
+        val token = oauthTokenProvider.getToken(OAuth2TokenProvider.OAUTH2_TIMEOUT)
 
         val authString = method.buildInitialClientResponse(settings.username, token)
         val tag = sendSaslIrCommand(method.command, authString, true)

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapServerSettingsValidatorTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapServerSettingsValidatorTest.kt
@@ -351,7 +351,7 @@ class ImapServerSettingsValidatorTest {
     }
 }
 
-class FakeOAuth2TokenProvider : OAuth2TokenProvider {
+class FakeOAuth2TokenProvider(override val primaryEmail: String? = null) : OAuth2TokenProvider {
     override fun getToken(timeoutMillis: Long): String {
         return AUTHORIZATION_TOKEN
     }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
@@ -1233,7 +1233,7 @@ class RealImapConnectionTest {
     }
 }
 
-class TestTokenProvider : OAuth2TokenProvider {
+class TestTokenProvider(override val primaryEmail: String? = null) : OAuth2TokenProvider {
     private var invalidationCount = 0
 
     override fun getToken(timeoutMillis: Long): String {


### PR DESCRIPTION
Fixes: #8024 

The issue mainly occurred when the primary email associated with an account did not match the username used for authenticating to the Outlook SMTP. To resolve this problem, we are now retrieving the primary email included in the OAuth2 tokens to ensure proper authentication with the outgoing server.

Changeset:
- Migrate `OAuth2TokenProvider` to Kotlin
- When available, use the primary email; otherwise, use the given username for authenticating in outgoing servers.