### PR TITLE
Select correct child folder in account drawer

### DIFF
--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
@@ -90,7 +90,7 @@ internal fun FolderListItem(
                 displayFolder = displayChild,
                 selected = false,
                 showStarredCount = showStarredCount,
-                onClick = { onClick(displayChild) },
+                onClick = onClick,
                 folderNameFormatter = folderNameFormatter,
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
Fixes #9078 

It looks to me like the wrong `displayFolder` is passed on. If I take the folder from the click handler directly it seems to work for me. I'd appreciate if someone could pick this up and write a test for it. It is only visible on folders a few levels down, for me the structure was

Archives -> 2008 -> 2008-11

Clicking on the 2008 folder loaded the 2008 folder. Clicking on the 2008-11 folder also loaded the 2008 folder. With this patch it selects the right folder.