### PR TITLE
Revert "Fixes Navigation Drawer Email Folder Click Bug"

### DIFF
--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -24,7 +23,6 @@ import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayT
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
 
-@Suppress("LongMethod")
 @Composable
 internal fun FolderListItem(
     displayFolder: DisplayFolder,
@@ -52,17 +50,10 @@ internal fun FolderListItem(
             .fillMaxWidth()
             .animateContentSize(),
     ) {
-        val hasExpandableItems = remember { treeFolder !== null && treeFolder.children.isNotEmpty() }
         NavigationDrawerItem(
             label = mapFolderName(displayFolder, folderNameFormatter, parentPrefix),
             selected = selected,
-            onClick = {
-                if (hasExpandableItems) {
-                    isExpanded.value = !isExpanded.value
-                } else {
-                    onClick(displayFolder)
-                }
-            },
+            onClick = { onClick(displayFolder) },
             modifier = Modifier.fillMaxWidth(),
             icon = {
                 Icon(
@@ -74,7 +65,7 @@ internal fun FolderListItem(
                     unreadCount = unreadCount,
                     starredCount = starredCount,
                     showStarredCount = showStarredCount,
-                    expandableState = if (hasExpandableItems) isExpanded else null,
+                    expandableState = if (treeFolder !== null && treeFolder.children.isNotEmpty()) isExpanded else null,
                 )
             },
         )


### PR DESCRIPTION
Reverts thunderbird/thunderbird-android#9082

While this fixes the issue, it prevents nested folders from being clickable. We need to handle Gmail differently when generating the virtual folders instead.