### PR TITLE
Add remote folder creator api

### DIFF
--- a/backend/api/build.gradle.kts
+++ b/backend/api/build.gradle.kts
@@ -4,5 +4,7 @@ plugins {
 }
 
 dependencies {
+    implementation(projects.core.account)
+    implementation(projects.core.outcome)
     api(projects.mail.common)
 }

--- a/backend/api/src/main/kotlin/net/thunderbird/backend/api/BackendFactory.kt
+++ b/backend/api/src/main/kotlin/net/thunderbird/backend/api/BackendFactory.kt
@@ -1,0 +1,8 @@
+package net.thunderbird.backend.api
+
+import com.fsck.k9.backend.api.Backend
+import net.thunderbird.core.account.BaseAccount
+
+interface BackendFactory<TAccount : BaseAccount> {
+    fun createBackend(account: TAccount): Backend
+}

--- a/backend/api/src/main/kotlin/net/thunderbird/backend/api/BackendStorageFactory.kt
+++ b/backend/api/src/main/kotlin/net/thunderbird/backend/api/BackendStorageFactory.kt
@@ -1,0 +1,8 @@
+package net.thunderbird.backend.api
+
+import com.fsck.k9.backend.api.BackendStorage
+import net.thunderbird.core.account.BaseAccount
+
+interface BackendStorageFactory<in TAccount : BaseAccount> {
+    fun createBackendStorage(account: TAccount): BackendStorage
+}

--- a/backend/api/src/main/kotlin/net/thunderbird/backend/api/folder/RemoteFolderCreator.kt
+++ b/backend/api/src/main/kotlin/net/thunderbird/backend/api/folder/RemoteFolderCreator.kt
@@ -1,0 +1,65 @@
+package net.thunderbird.backend.api.folder
+
+import com.fsck.k9.mail.folders.FolderServerId
+import net.thunderbird.core.account.BaseAccount
+import net.thunderbird.core.outcome.Outcome
+
+interface RemoteFolderCreator {
+    /**
+     * Creates a folder on the remote server. If the folder already exists and [mustCreate] is `false`,
+     * the operation will succeed returning [RemoteFolderCreationOutcome.Success.AlreadyExists].
+     *
+     * @param folderServerId The folder server ID.
+     * @param mustCreate If `true`, the folder must be created returning
+     * [RemoteFolderCreationOutcome.Error.FailedToCreateRemoteFolder]. If `false`, the folder will be created
+     * only if it doesn't exist.
+     * @return The result of the operation.
+     * @see RemoteFolderCreationOutcome.Success
+     * @see RemoteFolderCreationOutcome.Error
+     */
+    suspend fun create(
+        folderServerId: FolderServerId,
+        mustCreate: Boolean,
+    ): Outcome<RemoteFolderCreationOutcome.Success, RemoteFolderCreationOutcome.Error>
+
+    interface Factory {
+        fun create(account: BaseAccount): RemoteFolderCreator
+    }
+}
+
+sealed interface RemoteFolderCreationOutcome {
+    sealed interface Success : RemoteFolderCreationOutcome {
+        /**
+         * Used to flag that the folder was created successfully.
+         */
+        data object Created : Success
+
+        /**
+         * Used to flag that the folder creation was skipped because the folder already exists and
+         * the creation is NOT mandatory.
+         */
+        data object AlreadyExists : Success
+    }
+
+    sealed interface Error : RemoteFolderCreationOutcome {
+        /**
+         * Used to flag that the folder creation has failed because the folder already exists and
+         * the creation is mandatory.
+         */
+        data object AlreadyExists : Error
+
+        /**
+         * Used to flag that the folder creation failed on the remote server.
+         * @param reason The reason why the folder creation failed.
+         */
+        data class FailedToCreateRemoteFolder(
+            val reason: String,
+        ) : Error
+
+        /**
+         * Used to flag that the Create Folder operation is not supported by the server.
+         * E.g. POP3 servers don't support creating archive folders.
+         */
+        data object NotSupportedOperation : Error
+    }
+}

--- a/backend/imap/build.gradle.kts
+++ b/backend/imap/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 
 dependencies {
     api(projects.backend.api)
+    api(projects.core.outcome)
+    api(projects.core.account)
     api(projects.mail.protocols.imap)
     api(projects.mail.protocols.smtp)
 

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.kt
@@ -18,7 +18,7 @@ import com.fsck.k9.mail.transport.smtp.SmtpTransport
 class ImapBackend(
     private val accountName: String,
     backendStorage: BackendStorage,
-    private val imapStore: ImapStore,
+    internal val imapStore: ImapStore,
     private val powerManager: PowerManager,
     private val idleRefreshManager: IdleRefreshManager,
     private val pushConfigProvider: ImapPushConfigProvider,

--- a/backend/imap/src/main/kotlin/net/thunderbird/backend/imap/ImapRemoteFolderCreator.kt
+++ b/backend/imap/src/main/kotlin/net/thunderbird/backend/imap/ImapRemoteFolderCreator.kt
@@ -1,0 +1,71 @@
+package net.thunderbird.backend.imap
+
+import com.fsck.k9.backend.imap.ImapBackend
+import com.fsck.k9.logging.Logger
+import com.fsck.k9.mail.MessagingException
+import com.fsck.k9.mail.folders.FolderServerId
+import com.fsck.k9.mail.store.imap.ImapStore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.thunderbird.backend.api.BackendFactory
+import net.thunderbird.backend.api.folder.RemoteFolderCreationOutcome
+import net.thunderbird.backend.api.folder.RemoteFolderCreator
+import net.thunderbird.core.account.BaseAccount
+import net.thunderbird.core.outcome.Outcome
+
+class ImapRemoteFolderCreator(
+    private val logger: Logger,
+    private val imapStore: ImapStore,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : RemoteFolderCreator {
+    override suspend fun create(
+        folderServerId: FolderServerId,
+        mustCreate: Boolean,
+    ): Outcome<RemoteFolderCreationOutcome.Success, RemoteFolderCreationOutcome.Error> = withContext(ioDispatcher) {
+        val remoteFolder = imapStore.getFolder(name = folderServerId.serverId)
+        val outcome = try {
+            val folderExists = remoteFolder.exists()
+            when {
+                folderExists && mustCreate -> Outcome.failure(
+                    RemoteFolderCreationOutcome.Error.AlreadyExists,
+                )
+
+                folderExists -> Outcome.success(RemoteFolderCreationOutcome.Success.AlreadyExists)
+
+                !folderExists && remoteFolder.create() -> Outcome.success(RemoteFolderCreationOutcome.Success.Created)
+
+                else -> Outcome.failure(
+                    RemoteFolderCreationOutcome.Error.FailedToCreateRemoteFolder(
+                        reason = "Failed to create folder on remote server.",
+                    ),
+                )
+            }
+        } catch (e: MessagingException) {
+            logger.e(e, "Unhandled exception while trying to create remote folder '${folderServerId.serverId}'.")
+            Outcome.failure(
+                RemoteFolderCreationOutcome.Error.FailedToCreateRemoteFolder(
+                    reason = e.message ?: "Unhandled exception. Please check the logs.",
+                ),
+            )
+        } finally {
+            remoteFolder.close()
+        }
+
+        outcome
+    }
+}
+
+class ImapRemoteFolderCreatorFactory(
+    private val logger: Logger,
+    private val backendFactory: BackendFactory<BaseAccount>,
+) : RemoteFolderCreator.Factory {
+    override fun create(account: BaseAccount): RemoteFolderCreator {
+        val backend = backendFactory.createBackend(account) as ImapBackend
+        return ImapRemoteFolderCreator(
+            logger = logger,
+            imapStore = backend.imapStore,
+            ioDispatcher = Dispatchers.IO,
+        )
+    }
+}

--- a/backend/imap/src/test/java/com/fsck/k9/backend/imap/TestImapFolder.kt
+++ b/backend/imap/src/test/java/com/fsck/k9/backend/imap/TestImapFolder.kt
@@ -187,4 +187,8 @@ open class TestImapFolder(override val serverId: String) : ImapFolder {
     override fun expungeUids(uids: List<String>) {
         throw UnsupportedOperationException("not implemented")
     }
+
+    override fun create(): Boolean {
+        throw UnsupportedOperationException("not implemented")
+    }
 }

--- a/backend/imap/src/test/kotlin/net/thunderbird/backend/imap/ImapRemoteFolderCreatorTest.kt
+++ b/backend/imap/src/test/kotlin/net/thunderbird/backend/imap/ImapRemoteFolderCreatorTest.kt
@@ -1,0 +1,137 @@
+package net.thunderbird.backend.imap
+
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import com.fsck.k9.backend.imap.TestImapFolder
+import com.fsck.k9.logging.NoOpLogger
+import com.fsck.k9.mail.folders.FolderServerId
+import com.fsck.k9.mail.store.imap.FolderListItem
+import com.fsck.k9.mail.store.imap.ImapFolder
+import com.fsck.k9.mail.store.imap.ImapStore
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.backend.api.folder.RemoteFolderCreationOutcome
+import net.thunderbird.backend.api.folder.RemoteFolderCreationOutcome.Error.FailedToCreateRemoteFolder
+import net.thunderbird.core.outcome.Outcome
+import org.junit.Test
+
+class ImapRemoteFolderCreatorTest {
+    private val logger = NoOpLogger()
+
+    @Test
+    fun `when mustCreate true and folder exists, should return Error AlreadyExists`() = runTest {
+        // Arrange
+        val folderServerId = FolderServerId("New Folder")
+        val fakeFolder = object : TestImapFolder(folderServerId.serverId) {
+            override fun exists(): Boolean = true
+        }
+        val imapStore = FakeImapStore(fakeFolder)
+        val sut = ImapRemoteFolderCreator(logger, imapStore)
+
+        // Act
+        val outcome = sut.create(folderServerId, mustCreate = true)
+
+        // Assert
+        assertAll {
+            assertThat(outcome.isFailure).isTrue()
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Failure<RemoteFolderCreationOutcome.Error>>()
+                .prop("error") { it.error }
+                .isEqualTo(RemoteFolderCreationOutcome.Error.AlreadyExists)
+        }
+    }
+
+    @Test
+    fun `when mustCreate false and folder exists, should return AlreadyExists`() = runTest {
+        // Arrange
+        val folderServerId = FolderServerId("New Folder")
+        val fakeFolder = object : TestImapFolder(folderServerId.serverId) {
+            override fun exists(): Boolean = true
+        }
+        val imapStore = FakeImapStore(fakeFolder)
+        val sut = ImapRemoteFolderCreator(logger, imapStore)
+
+        // Act
+        val outcome = sut.create(folderServerId, mustCreate = false)
+
+        // Assert
+        assertAll {
+            assertThat(outcome.isSuccess).isTrue()
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Success<RemoteFolderCreationOutcome.Success>>()
+                .prop("data") { it.data }
+                .isEqualTo(RemoteFolderCreationOutcome.Success.AlreadyExists)
+        }
+    }
+
+    @Test
+    fun `when folder does not exist and creation succeeds, should return Created`() = runTest {
+        // Arrange
+        val folderServerId = FolderServerId("New Folder")
+        val fakeFolder = object : TestImapFolder(folderServerId.serverId) {
+            override fun exists(): Boolean = false
+            override fun create(): Boolean = true
+        }
+        val imapStore = FakeImapStore(fakeFolder)
+        val sut = ImapRemoteFolderCreator(logger, imapStore)
+
+        // Act
+        val outcome = sut.create(folderServerId, mustCreate = true)
+
+        // Assert
+        assertAll {
+            assertThat(outcome.isSuccess).isTrue()
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Success<RemoteFolderCreationOutcome.Success>>()
+                .prop("data") { it.data }
+                .isEqualTo(RemoteFolderCreationOutcome.Success.Created)
+        }
+    }
+
+    @Test
+    fun `when folder does not exist and creation fails, should return FailedToCreateRemoteFolder`() = runTest {
+        // Arrange
+        val folderServerId = FolderServerId("New Folder")
+        val fakeFolder = object : TestImapFolder(folderServerId.serverId) {
+            override fun exists(): Boolean = false
+            override fun create(): Boolean = false
+        }
+        val imapStore = FakeImapStore(fakeFolder)
+        val sut = ImapRemoteFolderCreator(logger, imapStore)
+
+        // Act
+        val outcome = sut.create(folderServerId, mustCreate = true)
+
+        // Assert
+        assertAll {
+            assertThat(outcome.isFailure).isTrue()
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Failure<FailedToCreateRemoteFolder>>()
+                .prop("error") { it.error }
+                .isInstanceOf<FailedToCreateRemoteFolder>()
+                .prop(FailedToCreateRemoteFolder::reason)
+                .isEqualTo("Failed to create folder on remote server.")
+        }
+    }
+}
+
+private class FakeImapStore(
+    private val folder: TestImapFolder,
+) : ImapStore {
+    override fun checkSettings() {
+        throw NotImplementedError("checkSettings not implemented")
+    }
+
+    override fun getFolder(name: String): ImapFolder = folder
+
+    override fun getFolders(): List<FolderListItem> {
+        throw NotImplementedError("getFolders not implemented")
+    }
+
+    override fun closeAllConnections() {
+        throw NotImplementedError("closeAllConnections not implemented")
+    }
+}

--- a/legacy/common/src/main/java/com/fsck/k9/backends/KoinModule.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/KoinModule.kt
@@ -1,17 +1,20 @@
 package com.fsck.k9.backends
 
-import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.backend.imap.BackendIdleRefreshManager
 import com.fsck.k9.backend.imap.SystemAlarmManager
 import com.fsck.k9.mail.oauth.OAuth2TokenProviderFactory
 import com.fsck.k9.mail.store.imap.IdleRefreshManager
+import net.thunderbird.backend.api.BackendFactory
+import net.thunderbird.backend.api.folder.RemoteFolderCreator
+import net.thunderbird.backend.imap.ImapRemoteFolderCreatorFactory
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import com.fsck.k9.backend.BackendFactory as LegacyBackendFactory
 
 val backendsModule = module {
     single {
-        val developmentBackends = get<Map<String, BackendFactory>>(named("developmentBackends"))
+        val developmentBackends = get<Map<String, LegacyBackendFactory>>(named("developmentBackends"))
         BackendManager(
             mapOf(
                 "imap" to get<ImapBackendFactory>(),
@@ -31,6 +34,18 @@ val backendsModule = module {
             clientInfoAppVersion = get(named("ClientInfoAppVersion")),
         )
     }
+
+    single<BackendFactory<*>>(named("imap")) {
+        get<ImapBackendFactory>()
+    }
+
+    single<RemoteFolderCreator.Factory>(named("imap")) {
+        ImapRemoteFolderCreatorFactory(
+            logger = get(),
+            backendFactory = get(named("imap")),
+        )
+    }
+
     single<SystemAlarmManager> { AndroidAlarmManager(context = get(), alarmManager = get()) }
     single<IdleRefreshManager> { BackendIdleRefreshManager(alarmManager = get()) }
     single { Pop3BackendFactory(get(), get()) }

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -9,6 +9,7 @@ import app.k9mail.legacy.account.AccountDefaultsProvider
 import app.k9mail.legacy.account.SortType
 import app.k9mail.legacy.di.DI
 import com.fsck.k9.core.BuildConfig
+import com.fsck.k9.logging.Logger
 import com.fsck.k9.mail.K9MailLib
 import com.fsck.k9.mailstore.LocalStore
 import com.fsck.k9.preferences.RealGeneralSettingsManager
@@ -25,6 +26,7 @@ object K9 : KoinComponent {
     private val generalSettingsManager: RealGeneralSettingsManager by inject()
     private val telemetryManager: TelemetryManager by inject()
     private val featureFlagProvider: FeatureFlagProvider by inject()
+    private val logger: Logger by inject()
 
     /**
      * If this is `true`, various development settings will be enabled.
@@ -320,7 +322,7 @@ object K9 : KoinComponent {
                 override fun debugSensitive(): Boolean = isSensitiveDebugLoggingEnabled
             },
         )
-        com.fsck.k9.logging.Timber.logger = TimberLogger()
+        com.fsck.k9.logging.Timber.logger = logger
 
         checkCachedDatabaseVersion(context)
 

--- a/legacy/core/src/main/java/com/fsck/k9/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/KoinModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import app.k9mail.core.android.common.coreCommonAndroidModule
 import com.fsck.k9.helper.Contacts
 import com.fsck.k9.helper.DefaultTrustedSocketFactory
+import com.fsck.k9.logging.Logger
 import com.fsck.k9.mail.ssl.LocalKeyStore
 import com.fsck.k9.mail.ssl.TrustManagerFactory
 import com.fsck.k9.mail.ssl.TrustedSocketFactory
@@ -14,6 +15,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val mainModule = module {
+    single<Logger> { TimberLogger() }
     includes(coreCommonAndroidModule)
     single<CoroutineScope>(named("AppCoroutineScope")) { GlobalScope }
     single {

--- a/legacy/core/src/main/java/com/fsck/k9/backend/BackendFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/backend/BackendFactory.kt
@@ -2,7 +2,16 @@ package com.fsck.k9.backend
 
 import app.k9mail.legacy.account.LegacyAccount
 import com.fsck.k9.backend.api.Backend
+import net.thunderbird.backend.api.BackendFactory
 
-interface BackendFactory {
-    fun createBackend(account: LegacyAccount): Backend
+@Deprecated(
+    message = "Use net.thunderbird.backend.api.BackendFactory<TAccount : BaseAccount> instead",
+    replaceWith = ReplaceWith(
+        expression = "BackendFactory<LegacyAccount>",
+        "net.thunderbird.backend.api.BackendFactory",
+        "app.k9mail.legacy.account.LegacyAccount",
+    ),
+)
+interface BackendFactory : BackendFactory<LegacyAccount> {
+    override fun createBackend(account: LegacyAccount): Backend
 }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
@@ -4,6 +4,7 @@ import app.k9mail.legacy.account.LegacyAccount
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import com.fsck.k9.Preferences
+import net.thunderbird.backend.api.BackendStorageFactory
 
 class K9BackendStorageFactory(
     private val preferences: Preferences,
@@ -11,8 +12,8 @@ class K9BackendStorageFactory(
     private val messageStoreManager: MessageStoreManager,
     private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
     private val saveMessageDataCreator: SaveMessageDataCreator,
-) {
-    fun createBackendStorage(account: LegacyAccount): K9BackendStorage {
+) : BackendStorageFactory<LegacyAccount> {
+    override fun createBackendStorage(account: LegacyAccount): K9BackendStorage {
         val messageStore = messageStoreManager.getMessageStore(account)
         val folderSettingsProvider = FolderSettingsProvider(preferences, account)
         val specialFolderUpdater = SpecialFolderUpdater(

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -6,6 +6,7 @@ import app.k9mail.legacy.mailstore.MessageStoreManager
 import com.fsck.k9.message.extractors.AttachmentCounter
 import com.fsck.k9.message.extractors.MessageFulltextCreator
 import com.fsck.k9.message.extractors.MessagePreviewCreator
+import net.thunderbird.backend.api.BackendStorageFactory
 import org.koin.dsl.module
 
 val mailStoreModule = module {
@@ -25,6 +26,9 @@ val mailStoreModule = module {
             specialFolderSelectionStrategy = get(),
             saveMessageDataCreator = get(),
         )
+    }
+    single<BackendStorageFactory<*>> {
+        get<K9BackendStorageFactory>()
     }
     factory { SpecialLocalFoldersCreator(preferences = get(), localStoreProvider = get()) }
     single { MessageStoreManager(accountManager = get(), messageStoreFactory = get()) }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
@@ -92,6 +92,14 @@ interface ImapFolder {
 
     @Throws(MessagingException::class)
     fun expungeUids(uids: List<String>)
+
+    /**
+     * Creates this folder on the IMAP server.
+     *
+     * @throws MessagingException when fails to create folder on IMAP server.
+     */
+    @Throws(MessagingException::class)
+    fun create(): Boolean
 }
 
 interface FetchListener {

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
@@ -248,7 +248,13 @@ class RealImapFolderTest {
 
     @Test
     fun create_withoutNegativeImapResponse_shouldReturnTrue() {
-        val imapFolder = createFolder("Folder")
+        val folderName = "Folder"
+        val imapFolder = createFolder(folderName)
+
+        val createResponses = listOf(
+            createImapResponse("* OK - CREATE completed"),
+        )
+        whenever(imapConnection.executeSimpleCommand("CREATE \"$folderName\"")).thenReturn(createResponses)
 
         val success = imapFolder.create()
 

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapFolder.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapFolder.kt
@@ -128,6 +128,10 @@ internal open class TestImapFolder(
         throw UnsupportedOperationException("not implemented")
     }
 
+    override fun create(): Boolean {
+        throw UnsupportedOperationException("not implemented")
+    }
+
     fun throwOnOpen(block: () -> Nothing) {
         openAction = block
     }


### PR DESCRIPTION
This PR is part of the fix for #7062. Merging this PR won't fix the issue yet.

- Add `Logger` interface to Koin's dependency graph
- Add `RemoteFolderCreator`, enabling folder creation on the remote server.
- Create `BackendFactory`, `BackendStorageFactory`, avoiding the use of legacy dependency
