### PR TITLE
Change runner to macos-15 (arm64)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     timeout-minutes: 90
 
     steps:


### PR DESCRIPTION
This is a trial of using the macos-15 GitHub runner instead of ubuntu. It should run quicker and enable Kotlin Multiplatform in the future.

See: [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
