### PR TITLE
Change CI Gradle config to 4 workers and 10GB of memory

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.daemon=false
 org.gradle.parallel=true
-org.gradle.workers.max=2
+org.gradle.workers.max=4
+org.gradle.jvmargs=-Xmx10g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError
 
 kotlin.incremental=false
 kotlin.compiler.execution.strategy=in-process


### PR DESCRIPTION
Testing with 4 workers and 10GB memory.

See: [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)


This seems to be the best option to speed up builds. The macOS 15 runner is not as quick as expected: #9119

Resolves #9125