### PR TITLE
Add blank issue type and use consistent casing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Let us know about crashes or existing functionality not working like it should.
+description: Let us know about crashes or existing functionality not working like it should
 labels: [ "type: bug", "unconfirmed" ]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Feature Request
+  - name: Feature request
     url: https://connect.mozilla.org/t5/ideas/idb-p/ideas/label-name/thunderbird%20android
-    about: Submit your ideas to improve Thunderbird for Android.
-  - name: Mozilla Support Forum (SUMO)
+    about: Submit your ideas to improve Thunderbird for Android
+  - name: Mozilla support forum (SUMO)
     url: https://support.mozilla.org/products/thunderbird-android
-    about: Most issues are not bugs. Ask the community for help.
+    about: Many issues are not bugs, ask the community for help

--- a/.github/ISSUE_TEMPLATE/maintainer.md
+++ b/.github/ISSUE_TEMPLATE/maintainer.md
@@ -1,0 +1,8 @@
+---
+name: Maintainer issue
+about: Please use one of the other issue templates instead
+title: ''
+labels: []
+assignees: []
+---
+


### PR DESCRIPTION
Unfortunately there is no way to enable blank issues just for maintainers. It is cumbersome to do it with one of the hacks that still works after github restricted changing the URL. Here is an attempt to allow us to create targeted issues while encouraging others to use the existing templates.

If it doesn't work out we can also add some automation to auto-close issues that don't use a template for people who are not maintainers.

I've also made the sentences consistent with GitHub's auto-generated ones, the security report one does not have a period at the end, and sentence case for the headlines.