### PR TITLE
Add Mail sync debug logging

### DIFF
--- a/core/android/logging/src/main/kotlin/net/thunderbird/core/android/logging/KoinModule.kt
+++ b/core/android/logging/src/main/kotlin/net/thunderbird/core/android/logging/KoinModule.kt
@@ -4,5 +4,11 @@ import org.koin.dsl.module
 
 val loggingModule = module {
     factory<ProcessExecutor> { RealProcessExecutor() }
-    factory<LogFileWriter> { LogcatLogFileWriter(contentResolver = get(), processExecutor = get()) }
+    factory<LogFileWriter> {
+        MultiLogFileWriter(
+            contentResolver = get(),
+            processExecutor = get(),
+            context = get(),
+        )
+    }
 }

--- a/core/android/logging/src/main/kotlin/net/thunderbird/core/android/logging/LogFileWriter.kt
+++ b/core/android/logging/src/main/kotlin/net/thunderbird/core/android/logging/LogFileWriter.kt
@@ -1,7 +1,9 @@
 package net.thunderbird.core.android.logging
 
 import android.content.ContentResolver
+import android.content.Context
 import android.net.Uri
+import android.provider.OpenableColumns
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -12,26 +14,43 @@ interface LogFileWriter {
     suspend fun writeLogTo(contentUri: Uri)
 }
 
-class LogcatLogFileWriter(
+class MultiLogFileWriter(
     private val contentResolver: ContentResolver,
     private val processExecutor: ProcessExecutor,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val context: Context?,
 ) : LogFileWriter {
     override suspend fun writeLogTo(contentUri: Uri) {
         return withContext(coroutineDispatcher) {
             writeLogBlocking(contentUri)
         }
     }
-
     private fun writeLogBlocking(contentUri: Uri) {
-        Timber.v("Writing logcat output to content URI: %s", contentUri)
-
+        Timber.v("Writing output to content URI: %s", contentUri)
+        var uriString = ""
+        contentResolver.query(contentUri, null, null, null, null)?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            cursor.moveToFirst()
+            uriString = cursor.getString(nameIndex)
+        }
         val outputStream = contentResolver.openOutputStream(contentUri, "wt")
             ?: error("Error opening contentUri for writing")
-
-        outputStream.use {
-            processExecutor.exec("logcat -d").use { inputStream ->
-                IOUtils.copy(inputStream, outputStream)
+        if (uriString.contains("thunderbird-sync-logs")) {
+            outputStream.use {
+                try {
+                    context?.openFileInput("thunderbird-sync-logs.txt").use { inputStream ->
+                        IOUtils.copy(inputStream, outputStream)
+                    }
+                } catch (e: Exception) {
+                    println(e)
+                }
+            }
+            context?.openFileOutput("thunderbird-sync-logs.txt", Context.MODE_PRIVATE)?.bufferedWriter()?.write("")
+        } else {
+            outputStream.use {
+                processExecutor.exec("logcat -d").use { inputStream ->
+                    IOUtils.copy(inputStream, outputStream)
+                }
             }
         }
     }

--- a/core/android/logging/src/test/kotlin/net/thunderbird/core/android/logging/LogcatLogFileWriterTest.kt
+++ b/core/android/logging/src/test/kotlin/net/thunderbird/core/android/logging/LogcatLogFileWriterTest.kt
@@ -23,10 +23,11 @@ class LogcatLogFileWriterTest {
     @Test
     fun `write log to contentUri`() = runBlocking {
         val logData = "a".repeat(10_000)
-        val logFileWriter = LogcatLogFileWriter(
+        val logFileWriter = MultiLogFileWriter(
             contentResolver = createContentResolver(),
             processExecutor = createProcessExecutor(logData),
             coroutineDispatcher = Dispatchers.Unconfined,
+            context = null,
         )
 
         logFileWriter.writeLogTo(contentUri)
@@ -36,10 +37,11 @@ class LogcatLogFileWriterTest {
 
     @Test(expected = FileNotFoundException::class)
     fun `contentResolver throws`() = runBlocking {
-        val logFileWriter = LogcatLogFileWriter(
+        val logFileWriter = MultiLogFileWriter(
             contentResolver = createThrowingContentResolver(FileNotFoundException()),
             processExecutor = createProcessExecutor("irrelevant"),
             coroutineDispatcher = Dispatchers.Unconfined,
+            context = null,
         )
 
         logFileWriter.writeLogTo(contentUri)
@@ -47,10 +49,11 @@ class LogcatLogFileWriterTest {
 
     @Test(expected = IOException::class)
     fun `processExecutor throws`() = runBlocking {
-        val logFileWriter = LogcatLogFileWriter(
+        val logFileWriter = MultiLogFileWriter(
             contentResolver = createContentResolver(),
             processExecutor = ThrowingProcessExecutor(IOException()),
             coroutineDispatcher = Dispatchers.Unconfined,
+            context = null,
         )
 
         logFileWriter.writeLogTo(contentUri)

--- a/legacy/core/src/main/java/com/fsck/k9/FileLoggerTree.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/FileLoggerTree.kt
@@ -1,0 +1,65 @@
+package com.fsck.k9
+
+import android.content.Context
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class FileLoggerTree(private val context: Context) : Timber.Tree() {
+    private val coroutineContext: CoroutineContext = Dispatchers.IO
+    private val coroutineScope = CoroutineScope(coroutineContext + SupervisorJob())
+
+    private val writeFile = AtomicReference<File>()
+    private val accumulatedLogs = ConcurrentHashMap<String, String>()
+
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        if (message.contains("sync")) {
+            try {
+                accumulatedLogs[convertLongToTime(System.currentTimeMillis())] = "priority = $priority, $message"
+                createLogFile()
+            } catch (e: Exception) {
+                Timber.e(" Error while logging into file: $e")
+            }
+        }
+    }
+
+    private fun createLogFile() =
+        coroutineScope.launch {
+            writeFile.lazySet(
+                context.createFile(fileName = "$DEFAULT_SYNC_FILENAME.txt"),
+            )
+            writeToLogFile()
+        }
+
+    private suspend fun writeToLogFile() {
+        val result = runCatching {
+            writeFile.get().bufferedWriter().use { it.write(accumulatedLogs.toString()) }
+        }
+        if (result.isFailure) {
+            result.exceptionOrNull()?.printStackTrace()
+        }
+    }
+
+    private fun convertLongToTime(long: Long): String {
+        val date = Date(long)
+        val format = SimpleDateFormat(ANDROID_LOG_TIME_FORMAT, Locale.US)
+        return format.format(date)
+    }
+    companion object {
+        private const val ANDROID_LOG_TIME_FORMAT = "MM-dd-yy kk:mm:ss.SSS"
+        const val DEFAULT_SYNC_FILENAME = "thunderbird-sync-logs"
+    }
+
+    private fun Context.createFile(fileName: String): File {
+        return File(filesDir, fileName)
+    }
+}

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -124,6 +124,13 @@ object K9 : KoinComponent {
         }
 
     @JvmStatic
+    var isSyncLoggingEnabled: Boolean = false
+        set(debug) {
+            field = debug
+            updateSyncLogging()
+        }
+
+    @JvmStatic
     var isSensitiveDebugLoggingEnabled: Boolean = false
 
     @JvmStatic
@@ -286,6 +293,8 @@ object K9 : KoinComponent {
     var fundingReminderShownTimestamp: Long = 0
     var fundingActivityCounterInMillis: Long = 0
 
+    private var savedContext: Context? = null
+
     val isQuietTime: Boolean
         get() {
             if (!isQuietTimeEnabled) {
@@ -323,6 +332,7 @@ object K9 : KoinComponent {
         com.fsck.k9.logging.Timber.logger = TimberLogger()
 
         checkCachedDatabaseVersion(context)
+        savedContext = context
 
         loadPrefs(generalSettingsManager.storage)
     }
@@ -331,6 +341,7 @@ object K9 : KoinComponent {
     @Suppress("LongMethod")
     fun loadPrefs(storage: Storage) {
         isDebugLoggingEnabled = storage.getBoolean("enableDebugLogging", DEVELOPER_MODE)
+        isSyncLoggingEnabled = storage.getBoolean("enableSyncDebugLogging", false)
         isSensitiveDebugLoggingEnabled = storage.getBoolean("enableSensitiveLogging", false)
         isShowAnimations = storage.getBoolean("animations", true)
         isUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false)
@@ -422,6 +433,7 @@ object K9 : KoinComponent {
     @Suppress("LongMethod")
     internal fun save(editor: StorageEditor) {
         editor.putBoolean("enableDebugLogging", isDebugLoggingEnabled)
+        editor.putBoolean("enableSyncDebugLogging", isSyncLoggingEnabled)
         editor.putBoolean("enableSensitiveLogging", isSensitiveDebugLoggingEnabled)
         editor.putEnum("backgroundOperations", backgroundOps)
         editor.putBoolean("animations", isShowAnimations)
@@ -498,6 +510,15 @@ object K9 : KoinComponent {
         Timber.uprootAll()
         if (isDebugLoggingEnabled) {
             Timber.plant(DebugTree())
+        }
+    }
+
+    private fun updateSyncLogging() {
+        if (savedContext != null && Timber.forest().contains(FileLoggerTree(savedContext!!))) {
+            savedContext?.let { Timber.uproot(FileLoggerTree(it)) }
+        }
+        if (isSyncLoggingEnabled) {
+            savedContext?.let { Timber.plant(FileLoggerTree(it)) }
         }
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -84,6 +84,9 @@ class GeneralSettingsDescriptions {
         s.put("enableDebugLogging", Settings.versions(
                 new V(1, new BooleanSetting(false))
         ));
+        s.put("enableSyncDebugLogging", Settings.versions(
+            new V(1, new BooleanSetting(false))
+        ));
         s.put("enableSensitiveLogging", Settings.versions(
                 new V(1, new BooleanSetting(false))
         ));

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -45,6 +45,7 @@ class GeneralSettingsDataStore(
             "privacy_hide_useragent" -> K9.isHideUserAgent
             "privacy_hide_timezone" -> K9.isHideTimeZone
             "debug_logging" -> K9.isDebugLoggingEnabled
+            "sync_debug_logging" -> K9.isSyncLoggingEnabled
             "sensitive_logging" -> K9.isSensitiveDebugLoggingEnabled
             "volume_navigation" -> K9.isUseVolumeKeysForNavigation
             "enable_telemetry" -> K9.isTelemetryEnabled
@@ -75,6 +76,7 @@ class GeneralSettingsDataStore(
             "privacy_hide_useragent" -> K9.isHideUserAgent = value
             "privacy_hide_timezone" -> K9.isHideTimeZone = value
             "debug_logging" -> K9.isDebugLoggingEnabled = value
+            "sync_debug_logging" -> K9.isSyncLoggingEnabled = value
             "sensitive_logging" -> K9.isSensitiveDebugLoggingEnabled = value
             "volume_navigation" -> K9.isUseVolumeKeysForNavigation = value
             "enable_telemetry" -> setTelemetryEnabled(value)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts.CreateDocument
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
@@ -11,12 +12,16 @@ import androidx.preference.PreferenceScreen
 import app.k9mail.core.featureflag.FeatureFlagProvider
 import app.k9mail.core.featureflag.toFeatureFlagKey
 import app.k9mail.feature.telemetry.api.TelemetryManager
+import com.fsck.k9.FileLoggerTree
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.extensions.withArguments
 import com.fsck.k9.ui.observe
 import com.fsck.k9.ui.settings.remove
 import com.google.android.material.snackbar.Snackbar
 import com.takisoft.preferencex.PreferenceFragmentCompat
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -41,7 +46,20 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
         this.rootKey = rootKey
         setHasOptionsMenu(true)
         setPreferencesFromResource(R.xml.general_settings, rootKey)
-
+        val listener = Preference.OnPreferenceChangeListener { _, newValue ->
+            if (!(newValue as Boolean)) {
+                val now = Calendar.getInstance()
+                val uriString = String.format(
+                    Locale.US,
+                    "%s_%s.txt",
+                    FileLoggerTree.DEFAULT_SYNC_FILENAME,
+                    SimpleDateFormat("yyyy-MM-dd", Locale.US).format(now.time)
+                )
+                exportLogsResultContract.launch(uriString)
+            }
+            true
+        }
+        findPreference<Preference>("sync_debug_logging")?.onPreferenceChangeListener = listener
         featureFlagProvider.provide("disable_font_size_config".toFeatureFlagKey())
             .onEnabled {
                 val parentPreference = findPreference<PreferenceCategory>("global_preferences")
@@ -64,8 +82,8 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
         dismissSnackbar()
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         activity?.title = preferenceScreen.title
     }
 
@@ -81,6 +99,16 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.exportLogs) {
             exportLogsResultContract.launch(GeneralSettingsViewModel.DEFAULT_FILENAME)
+            return true
+        } else if (item.itemId == R.id.exportSyncLogs) {
+            val now = Calendar.getInstance()
+            val uriString = String.format(
+                Locale.US,
+                "%s_%s.txt",
+                FileLoggerTree.DEFAULT_SYNC_FILENAME,
+                SimpleDateFormat("yyyy-MM-dd", Locale.US).format(now.time)
+            )
+            exportLogsResultContract.launch(uriString)
             return true
         }
 

--- a/legacy/ui/legacy/src/main/res/menu/debug_settings_option.xml
+++ b/legacy/ui/legacy/src/main/res/menu/debug_settings_option.xml
@@ -10,4 +10,10 @@
         app:showAsAction="never"
         />
 
+    <item
+        android:id="@+id/exportSyncLogs"
+        android:title="@string/debug_sync_export_logs_title"
+        app:showAsAction="never"
+        />
+
 </menu>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -165,10 +165,14 @@
 
     <string name="version">Version</string>
     <string name="debug_enable_debug_logging_title">Enable debug logging</string>
+    <string name="debug_enable_sync_debug_logging_title">Enable sync debug logging</string>
     <string name="debug_enable_debug_logging_summary">Log extra diagnostic information</string>
+    <string name="debug_enable_sync_debug_logging_summary">Log sync diagnostic information for 24 hours</string>
+
     <string name="debug_enable_sensitive_logging_title">Log sensitive information</string>
     <string name="debug_enable_sensitive_logging_summary">May show passwords in logs.</string>
     <string name="debug_export_logs_title">Export logs</string>
+    <string name="debug_sync_export_logs_title">Export Sync logs</string>
     <string name="debug_export_logs_success">Export successful. Logs might contain sensitive information. Be careful who you send them to.</string>
     <string name="debug_export_logs_failure">Export failed.</string>
 

--- a/legacy/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/general_settings.xml
@@ -542,6 +542,11 @@
             android:summary="@string/debug_enable_debug_logging_summary"
             android:title="@string/debug_enable_debug_logging_title"
             />
+        <CheckBoxPreference
+            android:key="sync_debug_logging"
+            android:summary="@string/debug_enable_sync_debug_logging_summary"
+            android:title="@string/debug_enable_sync_debug_logging_title"
+            />
 
         <CheckBoxPreference
             android:key="sensitive_logging"


### PR DESCRIPTION
First pass at adding Mail sync debugging for #8836 
Logs to a file any debug messaging related to mail syncing and exports to a file when logging ends or file is exported manually.

TODO to consider feature complete:
- The uncaught exception handler in case of crash
- Original request includes a 24 hour limit on logging. The current sync logs are very minimal and so I don't think this will be an issue right off the bat. I want to follow up with that work but didn't have the time. My intention is to use a workmanager, either one of the current ones or a new one, to schedule the end of the logging, but am open to other ideas