### PR TITLE
Fixes transparent navigation bar when 3 buttons system navigation

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.SystemClock
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem
@@ -17,8 +18,11 @@ import androidx.appcompat.view.ActionMode
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.insets.GradientProtection
+import androidx.core.view.insets.ProtectionLayout
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
@@ -273,7 +277,23 @@ class MessageListFragment :
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return if (error == null) {
-            inflater.inflate(R.layout.message_list_fragment, container, false)
+            inflater.inflate(R.layout.message_list_fragment, container, false).also { view ->
+                val typedValued = TypedValue()
+                requireContext().theme.resolveAttribute(
+                    com.google.android.material.R.attr.colorSurface,
+                    typedValued,
+                    true,
+                )
+                view.findViewById<ProtectionLayout>(R.id.protection_layout)
+                    .setProtections(
+                        listOf(
+                            GradientProtection(
+                                WindowInsetsCompat.Side.BOTTOM,
+                                typedValued.data,
+                            ),
+                        ),
+                    )
+            }
         } else {
             inflater.inflate(R.layout.message_list_error, container, false)
         }

--- a/legacy/ui/legacy/src/main/res/layout/message_list_fragment.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list_fragment.xml
@@ -26,17 +26,24 @@
         android:layout_height="match_parent"
         >
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/message_list"
+        <androidx.core.view.insets.ProtectionLayout
+            android:id="@+id/protection_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:fadingEdge="none"
-            android:paddingBottom="@dimen/floatingActionButtonSpacing"
-            android:scrollbarStyle="outsideOverlay"
-            android:scrollbars="vertical"
-            tools:listitem="@layout/message_list_item"
-            />
+            >
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/message_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:fadingEdge="none"
+                android:paddingBottom="@dimen/floatingActionButtonSpacing"
+                android:scrollbarStyle="outsideOverlay"
+                android:scrollbars="vertical"
+                tools:listitem="@layout/message_list_item"
+                />
+        </androidx.core.view.insets.ProtectionLayout>
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 


### PR DESCRIPTION
Resolves #9136.

Introduces a protection layer to the `MessageListFragment`'s `RecyclerView`, preventing the system navigation bar from blending within the messages.

| Light mode | Dark mode |
| -- | -- |
| Android 9 - Samsung S8 | |
| ![image](https://github.com/user-attachments/assets/c1693dcb-5ab4-4c87-ad88-e05f975feb40) | ![image](https://github.com/user-attachments/assets/88015c2c-8821-42b4-94fc-56b05fc99d33) |
| Android 9 - Moto G6 | |
| ![image](https://github.com/user-attachments/assets/29944d41-4157-4ffe-a801-7bee665b594c) | ![image](https://github.com/user-attachments/assets/a6c0048e-37d4-4a4c-8fc4-c68f16c8b2be) |
| Android 13 - Moto edge 20 Pro - Gesture Navigation | |
| ![Screenshot 2025-05-12 at 10 02 40 AM](https://github.com/user-attachments/assets/8b110244-bc7d-47d4-839e-0f28a75cbdb7) | ![Screenshot 2025-05-12 at 10 03 03 AM](https://github.com/user-attachments/assets/11e9ba87-9f58-4d20-aef8-8d0825b115ec) |
| Android 13 - Moto edge 20 Pro - 3 buttons Navigation | |
| ![Screenshot 2025-05-12 at 10 03 22 AM](https://github.com/user-attachments/assets/b5c4fda5-6d4a-485c-a045-edf8044b5791) | ![Screenshot 2025-05-12 at 10 03 35 AM](https://github.com/user-attachments/assets/687f08dd-bf4f-4257-844a-72e655d54215) |
