### PR TITLE
fix(drawer): openFolder must be called with accountId and folderId

### DIFF
--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/DropDownDrawer.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/DropDownDrawer.kt
@@ -24,7 +24,7 @@ internal data class FolderDrawerState(
 class DropDownDrawer(
     override val parent: AppCompatActivity,
     private val openAccount: (accountId: String) -> Unit,
-    private val openFolder: (folderId: Long) -> Unit,
+    private val openFolder: (accountId: String, folderId: Long) -> Unit,
     private val openUnifiedFolder: () -> Unit,
     private val openManageFolders: () -> Unit,
     private val openSettings: () -> Unit,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
@@ -49,7 +49,7 @@ internal interface DrawerContract {
 
     sealed interface Effect {
         data class OpenAccount(val accountId: String) : Effect
-        data class OpenFolder(val folderId: Long) : Effect
+        data class OpenFolder(val accountId: String, val folderId: Long) : Effect
         data object OpenUnifiedFolder : Effect
         data object OpenManageFolders : Effect
         data object OpenSettings : Effect

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerView.kt
@@ -14,7 +14,7 @@ import org.koin.androidx.compose.koinViewModel
 internal fun DrawerView(
     drawerState: FolderDrawerState,
     openAccount: (accountId: String) -> Unit,
-    openFolder: (folderId: Long) -> Unit,
+    openFolder: (accountId: String, folderId: Long) -> Unit,
     openUnifiedFolder: () -> Unit,
     openManageFolders: () -> Unit,
     openSettings: () -> Unit,
@@ -24,7 +24,10 @@ internal fun DrawerView(
     val (state, dispatch) = viewModel.observe { effect ->
         when (effect) {
             is Effect.OpenAccount -> openAccount(effect.accountId)
-            is Effect.OpenFolder -> openFolder(effect.folderId)
+            is Effect.OpenFolder -> openFolder(
+                effect.accountId,
+                effect.folderId,
+            )
             Effect.OpenUnifiedFolder -> openUnifiedFolder()
             is Effect.OpenManageFolders -> openManageFolders()
             is Effect.OpenSettings -> openSettings()

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
@@ -173,7 +173,12 @@ internal class DrawerViewModel(
 
     private fun openFolder(folder: DisplayFolder) {
         if (folder is DisplayAccountFolder) {
-            emitEffect(Effect.OpenFolder(folder.folder.id))
+            emitEffect(
+                Effect.OpenFolder(
+                    accountId = folder.accountId,
+                    folderId = folder.folder.id,
+                ),
+            )
         } else if (folder is DisplayUnifiedFolder) {
             emitEffect(Effect.OpenUnifiedFolder)
         }

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewKtTest.kt
@@ -29,7 +29,7 @@ internal class DrawerViewKtTest : ComposeTest() {
             DrawerView(
                 drawerState = FolderDrawerState(),
                 openAccount = { counter.openAccountCount++ },
-                openFolder = { counter.openFolderCount++ },
+                openFolder = { _, _ -> counter.openFolderCount++ },
                 openUnifiedFolder = { counter.openUnifiedFolderCount++ },
                 openManageFolders = { counter.openManageFoldersCount++ },
                 openSettings = { counter.openSettingsCount++ },
@@ -46,7 +46,12 @@ internal class DrawerViewKtTest : ComposeTest() {
         assertThat(counter).isEqualTo(verifyCounter)
 
         verifyCounter.openFolderCount++
-        viewModel.effect(Effect.OpenFolder(1))
+        viewModel.effect(
+            Effect.OpenFolder(
+                accountId = "accountId",
+                folderId = 1,
+            ),
+        )
 
         verifyCounter.openUnifiedFolderCount++
         viewModel.effect(Effect.OpenUnifiedFolder)
@@ -74,7 +79,7 @@ internal class DrawerViewKtTest : ComposeTest() {
             DrawerView(
                 drawerState = state.value,
                 openAccount = { },
-                openFolder = { },
+                openFolder = { _, _ -> },
                 openUnifiedFolder = { },
                 openManageFolders = { },
                 openSettings = { },
@@ -111,7 +116,7 @@ internal class DrawerViewKtTest : ComposeTest() {
             DrawerView(
                 drawerState = FolderDrawerState(),
                 openAccount = {},
-                openFolder = {},
+                openFolder = { _, _ -> },
                 openUnifiedFolder = {},
                 openManageFolders = {},
                 openSettings = {},

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
@@ -328,7 +328,12 @@ internal class DrawerViewModelTest {
         val displayFolders = displayFoldersMap[displayAccounts[0].id] ?: emptyList()
         testSubject.event(Event.OnFolderClick(displayFolders[1]))
 
-        assertThat(turbines.awaitEffectItem()).isEqualTo(Effect.OpenFolder(displayFolders[1].folder.id))
+        assertThat(turbines.awaitEffectItem()).isEqualTo(
+            Effect.OpenFolder(
+                accountId = displayFolders[1].accountId,
+                folderId = displayFolders[1].folder.id,
+            ),
+        )
 
         turbines.assertThatAndEffectTurbineConsumed {
             isEqualTo(Effect.CloseDrawer)

--- a/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/SideRailDrawer.kt
+++ b/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/SideRailDrawer.kt
@@ -24,7 +24,7 @@ internal data class FolderDrawerState(
 class SideRailDrawer(
     override val parent: AppCompatActivity,
     private val openAccount: (accountId: String) -> Unit,
-    private val openFolder: (folderId: Long) -> Unit,
+    private val openFolder: (accountId: String, folderId: Long) -> Unit,
     private val openUnifiedFolder: () -> Unit,
     private val openManageFolders: () -> Unit,
     private val openSettings: () -> Unit,

--- a/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerContract.kt
@@ -41,7 +41,7 @@ internal interface DrawerContract {
 
     sealed interface Effect {
         data class OpenAccount(val accountId: String) : Effect
-        data class OpenFolder(val folderId: Long) : Effect
+        data class OpenFolder(val accountId: String, val folderId: Long) : Effect
         data object OpenUnifiedFolder : Effect
         data object OpenManageFolders : Effect
         data object OpenSettings : Effect

--- a/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerView.kt
+++ b/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerView.kt
@@ -11,7 +11,7 @@ import org.koin.androidx.compose.koinViewModel
 internal fun DrawerView(
     drawerState: FolderDrawerState,
     openAccount: (accountId: String) -> Unit,
-    openFolder: (folderId: Long) -> Unit,
+    openFolder: (accountId: String, folderId: Long) -> Unit,
     openUnifiedFolder: () -> Unit,
     openManageFolders: () -> Unit,
     openSettings: () -> Unit,
@@ -21,7 +21,11 @@ internal fun DrawerView(
     val (state, dispatch) = viewModel.observe { effect ->
         when (effect) {
             is DrawerContract.Effect.OpenAccount -> openAccount(effect.accountId)
-            is DrawerContract.Effect.OpenFolder -> openFolder(effect.folderId)
+            is DrawerContract.Effect.OpenFolder -> openFolder(
+                effect.accountId,
+                effect.folderId,
+            )
+
             DrawerContract.Effect.OpenUnifiedFolder -> openUnifiedFolder()
             is DrawerContract.Effect.OpenManageFolders -> openManageFolders()
             is DrawerContract.Effect.OpenSettings -> openSettings()

--- a/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerViewModel.kt
@@ -116,6 +116,7 @@ internal class DrawerViewModel(
                     state.value.config.copy(showAccountSelector = state.value.config.showAccountSelector.not()),
                 ).launchIn(viewModelScope)
             }
+
             DrawerContract.Event.OnManageFoldersClick -> emitEffect(DrawerContract.Effect.OpenManageFolders)
             DrawerContract.Event.OnSettingsClick -> emitEffect(DrawerContract.Effect.OpenSettings)
             DrawerContract.Event.OnSyncAccount -> onSyncAccount()
@@ -158,7 +159,12 @@ internal class DrawerViewModel(
 
     private fun openFolder(folder: DisplayFolder) {
         if (folder is DisplayAccountFolder) {
-            emitEffect(DrawerContract.Effect.OpenFolder(folder.folder.id))
+            emitEffect(
+                DrawerContract.Effect.OpenFolder(
+                    accountId = folder.accountId,
+                    folderId = folder.folder.id,
+                ),
+            )
         } else if (folder is DisplayUnifiedFolder) {
             emitEffect(DrawerContract.Effect.OpenUnifiedFolder)
         }

--- a/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerViewKtTest.kt
@@ -29,7 +29,7 @@ internal class DrawerViewKtTest : ComposeTest() {
             DrawerView(
                 drawerState = FolderDrawerState(),
                 openAccount = { counter.openAccountCount++ },
-                openFolder = { counter.openFolderCount++ },
+                openFolder = { _, _ -> counter.openFolderCount++ },
                 openUnifiedFolder = { counter.openUnifiedFolderCount++ },
                 openManageFolders = { counter.openManageFoldersCount++ },
                 openSettings = { counter.openSettingsCount++ },
@@ -46,7 +46,12 @@ internal class DrawerViewKtTest : ComposeTest() {
         assertThat(counter).isEqualTo(verifyCounter)
 
         verifyCounter.openFolderCount++
-        viewModel.effect(Effect.OpenFolder(1))
+        viewModel.effect(
+            Effect.OpenFolder(
+                accountId = "accountId",
+                folderId = 1,
+            ),
+        )
 
         verifyCounter.openUnifiedFolderCount++
         viewModel.effect(Effect.OpenUnifiedFolder)
@@ -74,7 +79,7 @@ internal class DrawerViewKtTest : ComposeTest() {
             DrawerView(
                 drawerState = state.value,
                 openAccount = { },
-                openFolder = { },
+                openFolder = { _, _ -> },
                 openUnifiedFolder = { },
                 openManageFolders = { },
                 openSettings = { },
@@ -111,7 +116,7 @@ internal class DrawerViewKtTest : ComposeTest() {
             DrawerView(
                 drawerState = FolderDrawerState(),
                 openAccount = {},
-                openFolder = {},
+                openFolder = { _, _ -> },
                 openUnifiedFolder = {},
                 openManageFolders = {},
                 openSettings = {},

--- a/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/DrawerViewModelTest.kt
@@ -326,7 +326,12 @@ internal class DrawerViewModelTest {
         val displayFolders = displayFoldersMap[displayAccounts[0].id] ?: emptyList()
         testSubject.event(Event.OnFolderClick(displayFolders[1]))
 
-        assertThat(turbines.awaitEffectItem()).isEqualTo(Effect.OpenFolder(displayFolders[1].folder.id))
+        assertThat(turbines.awaitEffectItem()).isEqualTo(
+            Effect.OpenFolder(
+                accountId = displayFolders[1].accountId,
+                folderId = displayFolders[1].folder.id,
+            ),
+        )
 
         turbines.assertThatAndEffectTurbineConsumed {
             isEqualTo(Effect.CloseDrawer)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -652,7 +652,7 @@ open class MessageList :
                 navigationDrawer = DropDownDrawer(
                     parent = this,
                     openAccount = { accountId -> openRealAccount(accountId) },
-                    openFolder = { folderId -> openFolder(folderId) },
+                    openFolder = { accountId, folderId -> openFolder(accountId, folderId) },
                     openUnifiedFolder = { openUnifiedInbox() },
                     openManageFolders = { launchManageFoldersScreen() },
                     openSettings = { SettingsActivity.launch(this) },
@@ -663,7 +663,7 @@ open class MessageList :
                 navigationDrawer = SideRailDrawer(
                     parent = this,
                     openAccount = { accountId -> openRealAccount(accountId) },
-                    openFolder = { folderId -> openFolder(folderId) },
+                    openFolder = { accountId, folderId -> openFolder(accountId, folderId) },
                     openUnifiedFolder = { openUnifiedInbox() },
                     openManageFolders = { launchManageFoldersScreen() },
                     openSettings = { SettingsActivity.launch(this) },
@@ -692,21 +692,21 @@ open class MessageList :
         }
     }
 
-    private fun openFolder(folderId: Long) {
+    private fun openFolder(accountId: String, folderId: Long) {
         if (displayMode == DisplayMode.SPLIT_VIEW) {
             removeMessageViewContainerFragment()
             showMessageViewPlaceHolder()
         }
 
         val search = LocalSearch()
-        search.addAccountUuid(account!!.uuid)
+        search.addAccountUuid(accountId)
         search.addAllowedFolder(folderId)
 
         performSearch(search)
     }
 
     private fun openFolderImmediately(folderId: Long) {
-        openFolder(folderId)
+        openFolder(account!!.uuid, folderId)
         commitOpenFolderTransaction()
     }
 


### PR DESCRIPTION
The MessageList maintains it's own state, but in case an account is deleted it still references the deleted account and when trying to open a folder without accountId, it will use the old account that doesn't exist anymore.