### PR TITLE
chore(ci): Fix render notes to escape entities

### DIFF
--- a/scripts/ci/render-notes.py
+++ b/scripts/ci/render-notes.py
@@ -101,6 +101,7 @@ def render_notes(
             "template": "changelog_master.xml",
             "outfile": f"./app-{application}/src/{build_type}/res/raw/changelog_master.xml",
             "render_data": render_data["releases"][version],
+            "autoescape": True,
         },
         "changelog": {
             "template": "changelog.txt",
@@ -112,6 +113,7 @@ def render_notes(
             "template": "changelog_long.txt",
             "outfile": longform_file,
             "render_data": render_data["releases"][version],
+            "autoescape": True,
         },
     }
 
@@ -120,7 +122,7 @@ def render_notes(
     for render_file in render_files:
         with open(os.path.join(template_base, render_files[render_file]["template"]), "r") as file:
             template = file.read()
-        template = Template(template)
+        template = Template(template, autoescape=render_files[render_file].get("autoescape", False))
         rendered = template.render(render_files[render_file]["render_data"])
         if render_file == "changelog_master":
             if print_only:


### PR DESCRIPTION
Fixes #9122 for the next releases

We should also go back and fix the changelog on the `release` and `beta` branch