### PR TITLE
Refactor core logging

### DIFF
--- a/app-common/src/main/kotlin/net/thunderbird/app/common/core/AppCommonCoreModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/core/AppCommonCoreModule.kt
@@ -22,7 +22,7 @@ val appCommonCoreModule: Module = module {
         )
     }
 
-    single<LogSink> {
+    single<CompositeLogSink> {
         CompositeLogSink(
             level = get(),
             sinks = get(),
@@ -31,7 +31,7 @@ val appCommonCoreModule: Module = module {
 
     single<Logger> {
         DefaultLogger(
-            sink = get(),
+            sink = get<CompositeLogSink>(),
         )
     }
 }

--- a/core/logging/impl-composite/src/commonMain/kotlin/net/thunderbird/core/logging/composite/CompositeLogSink.kt
+++ b/core/logging/impl-composite/src/commonMain/kotlin/net/thunderbird/core/logging/composite/CompositeLogSink.kt
@@ -1,39 +1,36 @@
 package net.thunderbird.core.logging.composite
 
-import net.thunderbird.core.logging.LogEvent
 import net.thunderbird.core.logging.LogLevel
 import net.thunderbird.core.logging.LogSink
 
 /**
  * A [LogSink] that aggregates multiple [LogSink] and forwards log events to them.
  *
- * This [LogSink] is useful when you want to log messages to multiple destinations
+ * This [CompositeLogSink] is useful when you want to log messages to multiple destinations
  * (e.g., console, file, etc.) without having to manage each [LogSink] individually.
  *
  * It checks the log level of each event against its own level and forwards the event
  * to all managed sinks that can handle the event's level.
  *
  * @param level The minimum log level this sink will process. Log events with a lower priority will be ignored.
- * @param manager The [LogSinkManager] that manages the collection of sinks.
- * @param sinks Initial list of [LogSink] to be managed by this composite sink.
+ * @param manager The [CompositeLogSinkManager] that manages the collection of sinks.
  */
-class CompositeLogSink(
-    override val level: LogLevel,
-    private val manager: LogSinkManager = DefaultLogSinkManager(),
+interface CompositeLogSink : LogSink {
+    val manager: CompositeLogSinkManager
+}
+
+/**
+ * Creates a [CompositeLogSink] with the specified log level and manager.
+ *
+ * @param level The minimum [LogLevel] for messages to be logged.
+ * @param manager The [CompositeLogSinkManager] that manages the collection of sinks.
+ * @param sinks A list of [LogSink] instances to be managed by this composite sink.
+ * @return A new instance of [CompositeLogSink].
+ */
+fun CompositeLogSink(
+    level: LogLevel,
+    manager: CompositeLogSinkManager = DefaultLogSinkManager(),
     sinks: List<LogSink> = emptyList(),
-) : LogSink {
-
-    init {
-        manager.addAll(sinks)
-    }
-
-    override fun log(event: LogEvent) {
-        if (canLog(event.level)) {
-            manager.getAll().forEach { sink ->
-                if (sink.canLog(event.level)) {
-                    sink.log(event)
-                }
-            }
-        }
-    }
+): CompositeLogSink {
+    return DefaultCompositeLogSink(level, manager, sinks)
 }

--- a/core/logging/impl-composite/src/commonMain/kotlin/net/thunderbird/core/logging/composite/CompositeLogSinkManager.kt
+++ b/core/logging/impl-composite/src/commonMain/kotlin/net/thunderbird/core/logging/composite/CompositeLogSinkManager.kt
@@ -3,9 +3,9 @@ package net.thunderbird.core.logging.composite
 import net.thunderbird.core.logging.LogSink
 
 /**
- * LogSinkManager is responsible for managing a collection of [LogSink] instances.
+ * CompositeLogSinkManager is responsible for managing a collection of [LogSink] instances.
  */
-interface LogSinkManager {
+interface CompositeLogSinkManager {
 
     /**
      * Retrieves all [LogSink] instances managed by this manager.

--- a/core/logging/impl-composite/src/commonMain/kotlin/net/thunderbird/core/logging/composite/DefaultCompositeLogSink.kt
+++ b/core/logging/impl-composite/src/commonMain/kotlin/net/thunderbird/core/logging/composite/DefaultCompositeLogSink.kt
@@ -1,0 +1,26 @@
+package net.thunderbird.core.logging.composite
+
+import net.thunderbird.core.logging.LogEvent
+import net.thunderbird.core.logging.LogLevel
+import net.thunderbird.core.logging.LogSink
+
+internal class DefaultCompositeLogSink(
+    override val level: LogLevel,
+    override val manager: CompositeLogSinkManager = DefaultLogSinkManager(),
+    sinks: List<LogSink> = emptyList(),
+) : CompositeLogSink {
+
+    init {
+        manager.addAll(sinks)
+    }
+
+    override fun log(event: LogEvent) {
+        if (canLog(event.level)) {
+            manager.getAll().forEach { sink ->
+                if (sink.canLog(event.level)) {
+                    sink.log(event)
+                }
+            }
+        }
+    }
+}

--- a/core/logging/impl-composite/src/commonMain/kotlin/net/thunderbird/core/logging/composite/DefaultLogSinkManager.kt
+++ b/core/logging/impl-composite/src/commonMain/kotlin/net/thunderbird/core/logging/composite/DefaultLogSinkManager.kt
@@ -3,9 +3,9 @@ package net.thunderbird.core.logging.composite
 import net.thunderbird.core.logging.LogSink
 
 /**
- * Default implementation of [LogSinkManager] that manages a collection of [LogSink] instances.
+ * Default implementation of [CompositeLogSinkManager] that manages a collection of [LogSink] instances.
  */
-class DefaultLogSinkManager : LogSinkManager {
+internal class DefaultLogSinkManager : CompositeLogSinkManager {
     private val sinks: MutableList<LogSink> = mutableListOf()
 
     override fun getAll(): List<LogSink> {

--- a/core/logging/impl-composite/src/commonTest/kotlin/net/thunderbird/core/logging/composite/DefaultCompositeLogSinkTest.kt
+++ b/core/logging/impl-composite/src/commonTest/kotlin/net/thunderbird/core/logging/composite/DefaultCompositeLogSinkTest.kt
@@ -8,17 +8,17 @@ import net.thunderbird.core.logging.LogEvent
 import net.thunderbird.core.logging.LogLevel
 import org.junit.Test
 
-class CompositeLogSinkTest {
+class DefaultCompositeLogSinkTest {
 
     @Test
     fun `init should set initial sinks`() {
         // Arrange
         val sink1 = FakeLogSink(LogLevel.INFO)
         val sink2 = FakeLogSink(LogLevel.INFO)
-        val sinkManager = FakeLogSinkManager()
+        val sinkManager = FakeCompositeLogSinkManager()
 
         // Act
-        CompositeLogSink(
+        DefaultCompositeLogSink(
             level = LogLevel.INFO,
             manager = sinkManager,
             sinks = listOf(sink1, sink2),
@@ -35,9 +35,9 @@ class CompositeLogSinkTest {
         // Arrange
         val sink1 = FakeLogSink(LogLevel.INFO)
         val sink2 = FakeLogSink(LogLevel.INFO)
-        val sinkManager = FakeLogSinkManager(mutableListOf(sink1, sink2))
+        val sinkManager = FakeCompositeLogSinkManager(mutableListOf(sink1, sink2))
 
-        val testSubject = CompositeLogSink(
+        val testSubject = DefaultCompositeLogSink(
             level = LogLevel.INFO,
             manager = sinkManager,
         )
@@ -57,9 +57,9 @@ class CompositeLogSinkTest {
         // Arrange
         val sink1 = FakeLogSink(LogLevel.INFO)
         val sink2 = FakeLogSink(LogLevel.INFO)
-        val sinkManager = FakeLogSinkManager(mutableListOf(sink1, sink2))
+        val sinkManager = FakeCompositeLogSinkManager(mutableListOf(sink1, sink2))
 
-        val testSubject = CompositeLogSink(
+        val testSubject = DefaultCompositeLogSink(
             level = LogLevel.WARN,
             manager = sinkManager,
         )
@@ -77,9 +77,9 @@ class CompositeLogSinkTest {
         // Arrange
         val sink1 = FakeLogSink(LogLevel.WARN)
         val sink2 = FakeLogSink(LogLevel.INFO)
-        val sinkManager = FakeLogSinkManager(mutableListOf(sink1, sink2))
+        val sinkManager = FakeCompositeLogSinkManager(mutableListOf(sink1, sink2))
 
-        val testSubject = CompositeLogSink(
+        val testSubject = DefaultCompositeLogSink(
             level = LogLevel.INFO,
             manager = sinkManager,
         )
@@ -93,7 +93,7 @@ class CompositeLogSinkTest {
         assertThat(sink2.events[0]).isEqualTo(LOG_EVENT)
     }
 
-    private companion object {
+    private companion object Companion {
         const val TIMESTAMP = 0L
 
         val LOG_EVENT = LogEvent(

--- a/core/logging/impl-composite/src/commonTest/kotlin/net/thunderbird/core/logging/composite/FakeCompositeLogSinkManager.kt
+++ b/core/logging/impl-composite/src/commonTest/kotlin/net/thunderbird/core/logging/composite/FakeCompositeLogSinkManager.kt
@@ -2,9 +2,9 @@ package net.thunderbird.core.logging.composite
 
 import net.thunderbird.core.logging.LogSink
 
-class FakeLogSinkManager(
+class FakeCompositeLogSinkManager(
     val sinks: MutableList<LogSink> = mutableListOf(),
-) : LogSinkManager {
+) : CompositeLogSinkManager {
 
     override fun getAll(): List<LogSink> = sinks
 

--- a/core/logging/impl-console/src/androidMain/kotlin/net/thunderbird/core/logging/console/ConsoleLogSink.android.kt
+++ b/core/logging/impl-console/src/androidMain/kotlin/net/thunderbird/core/logging/console/ConsoleLogSink.android.kt
@@ -2,12 +2,13 @@ package net.thunderbird.core.logging.console
 
 import net.thunderbird.core.logging.LogEvent
 import net.thunderbird.core.logging.LogLevel
-import net.thunderbird.core.logging.LogSink
 import timber.log.Timber
 
-internal class AndroidConsoleLogSink(
+actual fun ConsoleLogSink(level: LogLevel): ConsoleLogSink = AndroidConsoleLogSink(level)
+
+private class AndroidConsoleLogSink(
     override val level: LogLevel,
-) : LogSink {
+) : ConsoleLogSink {
 
     override fun log(event: LogEvent) {
         val timber = event.tag?.let { Timber.tag(it) } ?: Timber

--- a/core/logging/impl-console/src/androidMain/kotlin/net/thunderbird/core/logging/console/PlatformLogSink.android.kt
+++ b/core/logging/impl-console/src/androidMain/kotlin/net/thunderbird/core/logging/console/PlatformLogSink.android.kt
@@ -1,8 +1,0 @@
-package net.thunderbird.core.logging.console
-
-import net.thunderbird.core.logging.LogLevel
-import net.thunderbird.core.logging.LogSink
-
-internal actual fun platformLogSink(level: LogLevel): LogSink {
-    return AndroidConsoleLogSink(level)
-}

--- a/core/logging/impl-console/src/androidUnitTest/kotlin/net/thunderbird/core/logging/console/ConsoleLogSinkTest.android.kt
+++ b/core/logging/impl-console/src/androidUnitTest/kotlin/net/thunderbird/core/logging/console/ConsoleLogSinkTest.android.kt
@@ -9,12 +9,12 @@ import net.thunderbird.core.logging.LogEvent
 import net.thunderbird.core.logging.LogLevel
 import timber.log.Timber
 
-class AndroidConsoleLogSinkTest {
+class ConsoleLogSinkTest {
 
     @Test
     fun shouldHaveCorrectLogLevel() {
         // Arrange
-        val testSubject = AndroidConsoleLogSink(LogLevel.INFO)
+        val testSubject = ConsoleLogSink(LogLevel.INFO)
 
         // Act & Assert
         assertThat(testSubject.level).isEqualTo(LogLevel.INFO)
@@ -61,7 +61,7 @@ class AndroidConsoleLogSinkTest {
             timestamp = 0L,
         )
 
-        val testSubject = AndroidConsoleLogSink(LogLevel.VERBOSE)
+        val testSubject = ConsoleLogSink(LogLevel.VERBOSE)
 
         // Act
         testSubject.log(eventVerbose)

--- a/core/logging/impl-console/src/commonMain/kotlin/net/thunderbird/core/logging/console/ConsoleLogSink.kt
+++ b/core/logging/impl-console/src/commonMain/kotlin/net/thunderbird/core/logging/console/ConsoleLogSink.kt
@@ -1,6 +1,5 @@
 package net.thunderbird.core.logging.console
 
-import net.thunderbird.core.logging.LogEvent
 import net.thunderbird.core.logging.LogLevel
 import net.thunderbird.core.logging.LogSink
 
@@ -11,12 +10,14 @@ import net.thunderbird.core.logging.LogSink
  *
  * @param level The minimum [LogLevel] for messages to be logged.
  */
-class ConsoleLogSink(
-    override val level: LogLevel,
-) : LogSink {
-    private val platformSink = platformLogSink(level)
+interface ConsoleLogSink : LogSink
 
-    override fun log(event: LogEvent) {
-        platformSink.log(event)
-    }
-}
+/**
+ * Creates a [ConsoleLogSink] with the specified log level.
+ *
+ * @param level The minimum [LogLevel] for messages to be logged.
+ * @return A new instance of [ConsoleLogSink].
+ */
+expect fun ConsoleLogSink(
+    level: LogLevel = LogLevel.INFO,
+): ConsoleLogSink

--- a/core/logging/impl-console/src/commonMain/kotlin/net/thunderbird/core/logging/console/PlatformLogSink.kt
+++ b/core/logging/impl-console/src/commonMain/kotlin/net/thunderbird/core/logging/console/PlatformLogSink.kt
@@ -1,6 +1,0 @@
-package net.thunderbird.core.logging.console
-
-import net.thunderbird.core.logging.LogLevel
-import net.thunderbird.core.logging.LogSink
-
-internal expect fun platformLogSink(level: LogLevel): LogSink

--- a/core/logging/impl-console/src/jvmMain/kotlin/net/thunderbird/core/logging/console/ConsoleLogSink.jvm.kt
+++ b/core/logging/impl-console/src/jvmMain/kotlin/net/thunderbird/core/logging/console/ConsoleLogSink.jvm.kt
@@ -2,11 +2,12 @@ package net.thunderbird.core.logging.console
 
 import net.thunderbird.core.logging.LogEvent
 import net.thunderbird.core.logging.LogLevel
-import net.thunderbird.core.logging.LogSink
 
-internal class JvmConsoleLogSink(
+actual fun ConsoleLogSink(level: LogLevel): ConsoleLogSink = JvmConsoleLogSink(level)
+
+private class JvmConsoleLogSink(
     override val level: LogLevel,
-) : LogSink {
+) : ConsoleLogSink {
 
     override fun log(event: LogEvent) {
         println("[$level] ${composeMessage(event)}")

--- a/core/logging/impl-console/src/jvmMain/kotlin/net/thunderbird/core/logging/console/PlatformLogSink.jvm.kt
+++ b/core/logging/impl-console/src/jvmMain/kotlin/net/thunderbird/core/logging/console/PlatformLogSink.jvm.kt
@@ -1,8 +1,0 @@
-package net.thunderbird.core.logging.console
-
-import net.thunderbird.core.logging.LogLevel
-import net.thunderbird.core.logging.LogSink
-
-internal actual fun platformLogSink(level: LogLevel): LogSink {
-    return JvmConsoleLogSink(level)
-}

--- a/core/logging/impl-console/src/jvmTest/kotlin/net/thunderbird/core/logging/console/ConsoleLogSinkTest.jvm.kt
+++ b/core/logging/impl-console/src/jvmTest/kotlin/net/thunderbird/core/logging/console/ConsoleLogSinkTest.jvm.kt
@@ -7,12 +7,12 @@ import kotlin.test.assertEquals
 import net.thunderbird.core.logging.LogEvent
 import net.thunderbird.core.logging.LogLevel
 
-class JvmConsoleLogSinkTest {
+class ConsoleLogSinkTest {
 
     @Test
     fun shouldHaveCorrectLogLevel() {
         // Arrange
-        val testSubject = JvmConsoleLogSink(LogLevel.INFO)
+        val testSubject = ConsoleLogSink(LogLevel.INFO)
 
         // Act & Assert
         assertEquals(LogLevel.INFO, testSubject.level)
@@ -34,7 +34,7 @@ class JvmConsoleLogSinkTest {
                 timestamp = 0L,
             )
 
-            val testSubject = JvmConsoleLogSink(LogLevel.VERBOSE)
+            val testSubject = ConsoleLogSink(LogLevel.VERBOSE)
 
             // Act
             testSubject.log(eventInfo)

--- a/quality/konsist/src/test/kotlin/net/thunderbird/quality/ValidateLogger.kt
+++ b/quality/konsist/src/test/kotlin/net/thunderbird/quality/ValidateLogger.kt
@@ -16,7 +16,7 @@ class ValidateLogger {
     @Test
     fun `no class should use Android util logging`() {
         projectScope.files
-            .filterNot { it.hasNameMatching("AndroidConsoleLogSinkTest".toRegex()) }
+            .filterNot { it.hasNameMatching("ConsoleLogSinkTest.android".toRegex()) }
             .assertFalse(
                 additionalMessage = "No class should use android.util.Log import, use net.thunderbird.core.logging.Logger instead."
             ) {
@@ -27,7 +27,7 @@ class ValidateLogger {
     @Test
     fun `no class should use Timber logging`() {
         projectScope.files
-            .filterNot { it.hasNameMatching("AndroidConsoleLogSink|AndroidConsoleLogSinkTest".toRegex()) }
+            .filterNot { it.hasNameMatching("ConsoleLogSink.android|ConsoleLogSinkTest.android".toRegex()) }
             .filterNot {
                 // Exclude legacy code that still uses Timber
                 it.hasNameMatching("LogFileWriter|FileLoggerTree|K9".toRegex())


### PR DESCRIPTION
While talking about the project Rafael suggested an improvement to the logger and as we where already half through the implementation, this is the finished version. I think with the added interfaces it's more clear which logger is used and the exposed composite manager allows adding loggers at runtime or removing them. For example a user enables extended debug logging.