### PR TITLE
Replace XML Based LinearProgressIndicator with Jetpack Compose equivalent in Messagelist screen

### DIFF
--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/LinearProgressIndicatorPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/atom/LinearProgressIndicatorPreview.kt
@@ -1,0 +1,17 @@
+package app.k9mail.core.ui.compose.designsystem.atom
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
+
+@Preview
+@Preview(showBackground = true)
+@Composable
+private fun LinearProgressIndicatorPreview() {
+    PreviewWithThemes {
+        LinearProgressIndicator(
+            progress = 10000,
+            visible = true,
+        )
+    }
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/LinearProgressIndicator.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/LinearProgressIndicator.kt
@@ -1,0 +1,28 @@
+package app.k9mail.core.ui.compose.designsystem.atom
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import androidx.compose.material3.LinearProgressIndicator as Material3LinearProgressIndicator
+
+@Composable
+fun LinearProgressIndicator(
+    progress: Int,
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (visible) {
+        Material3LinearProgressIndicator(
+            progress = { progress.toFloat() / 10000.0f },
+            modifier = modifier
+                .fillMaxWidth()
+                .height(8.dp)
+                .offset(y = ((-6).dp))
+                .zIndex(1f),
+        )
+    }
+}

--- a/legacy/ui/legacy/build.gradle.kts
+++ b/legacy/ui/legacy/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(projects.mail.common)
     implementation(projects.uiUtils.toolbarBottomSheet)
     implementation(projects.core.android.contact)
+    implementation(projects.core.ui.compose.designsystem)
 
     implementation(projects.core.featureflag)
     implementation(projects.core.ui.theme.api)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.k9mail.legacy.message.controller.MessageReference
 import java.util.LinkedList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import net.thunderbird.core.logging.Logger
 
 class MessageListViewModel(
@@ -14,11 +16,17 @@ class MessageListViewModel(
 ) : ViewModel() {
     private var currentMessageListLiveData: MessageListLiveData? = null
     private val messageListLiveData = MediatorLiveData<MessageListInfo>()
+    private val _widowProgress: MutableStateFlow<Int> = MutableStateFlow(0)
 
+    val widowProgress: StateFlow<Int> = _widowProgress
     val messageSortOverrides = LinkedList<Pair<MessageReference, MessageSortOverride>>()
 
     fun getMessageListLiveData(): LiveData<MessageListInfo> {
         return messageListLiveData
+    }
+
+    fun updateWindowProgress(progress: Int) {
+        _widowProgress.value = progress
     }
 
     fun loadMessageList(config: MessageListConfig, forceUpdate: Boolean = false) {

--- a/legacy/ui/legacy/src/main/res/layout/message_list.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list.xml
@@ -23,7 +23,7 @@
             android:layout_alignParentTop="true"
             />
 
-        <ProgressBar
+        <androidx.compose.ui.platform.ComposeView
             android:id="@+id/message_list_progress"
             style="?android:attr/progressBarStyleHorizontal"
             android:layout_width="match_parent"
@@ -31,8 +31,7 @@
             android:layout_below="@id/toolbar"
             android:layout_marginTop="-6dp"
             android:elevation="8dp"
-            android:max="10000"
-            android:visibility="invisible"
+            android:visibility="visible"
             />
 
         <com.fsck.k9.view.ViewSwitcher

--- a/legacy/ui/legacy/src/main/res/layout/split_message_list.xml
+++ b/legacy/ui/legacy/src/main/res/layout/split_message_list.xml
@@ -23,7 +23,7 @@
             android:layout_alignParentTop="true"
             />
 
-        <ProgressBar
+        <androidx.compose.ui.platform.ComposeView
             android:id="@+id/message_list_progress"
             style="?android:attr/progressBarStyleHorizontal"
             android:layout_width="match_parent"
@@ -31,8 +31,7 @@
             android:layout_below="@id/toolbar"
             android:layout_marginTop="-6dp"
             android:elevation="8dp"
-            android:max="10000"
-            android:visibility="invisible"
+            android:visibility="visible"
             />
 
         <LinearLayout


### PR DESCRIPTION
 - Fixes #9302 
###   Implementation Details:
 - Added `LinearProgressIndicator` `Composable `to the design system.
 - Replaced the XML-based `LinearProgressIndicator `in `MessageList `with the new composable version, ensuring identical functionality and behavior.