### PR TITLE
Replace Direct Calls to K9.isMessageListSenderAboveSubject with PreferenceDataStore integration

### DIFF
--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/GeneralSettings.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/GeneralSettings.kt
@@ -23,6 +23,7 @@ data class GeneralSettings(
     val isShowAnimations: Boolean,
     val isShowCorrespondentNames: Boolean,
     val shouldShowSetupArchiveFolderDialog: Boolean,
+    val isMessageListSenderAboveSubject: Boolean,
 )
 
 enum class BackgroundSync {

--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/GeneralSettingsManager.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/GeneralSettingsManager.kt
@@ -22,4 +22,5 @@ interface GeneralSettingsManager {
     fun setIsShowAnimations(isShowAnimations: Boolean)
     fun setIsShowCorrespondentNames(isShowCorrespondentNames: Boolean)
     fun setSetupArchiveShouldNotShowAgain(shouldShowSetupArchiveFolderDialog: Boolean)
+    fun setIsMessageListSenderAboveSubject(isMessageListSenderAboveSubject: Boolean)
 }

--- a/feature/mail/message/list/src/test/kotlin/net/thunderbird/feature/mail/message/list/domain/usecase/BuildSwipeActionsTest.kt
+++ b/feature/mail/message/list/src/test/kotlin/net/thunderbird/feature/mail/message/list/domain/usecase/BuildSwipeActionsTest.kt
@@ -390,6 +390,8 @@ private class FakeGeneralSettingsManager(
     override fun setSetupArchiveShouldNotShowAgain(shouldShowSetupArchiveFolderDialog: Boolean) {
         generalSettings.update { it.copy(shouldShowSetupArchiveFolderDialog = shouldShowSetupArchiveFolderDialog) }
     }
+
+    override fun setIsMessageListSenderAboveSubject(isMessageListSenderAboveSubject: Boolean) = error("not implemented")
 }
 
 private class FakeStorage(

--- a/feature/mail/message/list/src/test/kotlin/net/thunderbird/feature/mail/message/list/domain/usecase/BuildSwipeActionsTest.kt
+++ b/feature/mail/message/list/src/test/kotlin/net/thunderbird/feature/mail/message/list/domain/usecase/BuildSwipeActionsTest.kt
@@ -40,6 +40,7 @@ class BuildSwipeActionsTest {
             isShowAnimations = false,
             isShowCorrespondentNames = false,
             shouldShowSetupArchiveFolderDialog = false,
+            isMessageListSenderAboveSubject = false,
         )
 
     @Test

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
@@ -12,6 +12,7 @@ import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.K9
 import com.fsck.k9.activity.MessageList
 import net.thunderbird.core.android.account.SortType
+import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.feature.search.LocalSearch
 import net.thunderbird.feature.search.SearchAccount
 import org.koin.core.component.KoinComponent
@@ -21,6 +22,7 @@ import org.koin.core.component.inject
 internal class MessageListRemoteViewFactory(private val context: Context) : RemoteViewsFactory, KoinComponent {
     private val messageListLoader: MessageListLoader by inject()
     private val coreResourceProvider: CoreResourceProvider by inject()
+    private val generalSettingsManager: GeneralSettingsManager by inject()
 
     private lateinit var unifiedInboxSearch: LocalSearch
 
@@ -35,7 +37,7 @@ internal class MessageListRemoteViewFactory(private val context: Context) : Remo
             unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
         ).relatedSearch
 
-        senderAboveSubject = K9.isMessageListSenderAboveSubject
+        senderAboveSubject = generalSettingsManager.getSettings().isMessageListSenderAboveSubject
         readTextColor = ContextCompat.getColor(context, R.color.message_list_widget_text_read)
         unreadTextColor = ContextCompat.getColor(context, R.color.message_list_widget_text_unread)
     }

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -181,9 +181,6 @@ object K9 : KoinComponent {
     var messageListPreviewLines = 2
 
     @JvmStatic
-    var isMessageListSenderAboveSubject = false
-
-    @JvmStatic
     var isShowContactName = false
 
     @JvmStatic
@@ -334,7 +331,6 @@ object K9 : KoinComponent {
         isSensitiveDebugLoggingEnabled = storage.getBoolean("enableSensitiveLogging", false)
         isUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false)
         isShowAccountSelector = storage.getBoolean("showAccountSelector", true)
-        isMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false)
         messageListPreviewLines = storage.getInt("messageListPreviewLines", 2)
 
         isAutoFitWidth = storage.getBoolean("autofitWidth", true)
@@ -434,7 +430,6 @@ object K9 : KoinComponent {
         editor.putString("quietTimeEnds", quietTimeEnds)
 
         editor.putEnum("messageListDensity", messageListDensity)
-        editor.putBoolean("messageListSenderAboveSubject", isMessageListSenderAboveSubject)
         editor.putBoolean("showAccountSelector", isShowAccountSelector)
         editor.putInt("messageListPreviewLines", messageListPreviewLines)
         editor.putBoolean("showContactName", isShowContactName)

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/RealGeneralSettingsManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/RealGeneralSettingsManager.kt
@@ -163,6 +163,10 @@ internal class RealGeneralSettingsManager(
         getSettings().copy(shouldShowSetupArchiveFolderDialog = shouldShowSetupArchiveFolderDialog).persist()
     }
 
+    override fun setIsMessageListSenderAboveSubject(isMessageListSenderAboveSubject: Boolean) {
+        getSettings().copy(isMessageListSenderAboveSubject = isMessageListSenderAboveSubject).persist()
+    }
+
     private fun writeSettings(editor: StorageEditor, settings: GeneralSettings) {
         editor.putBoolean("showRecentChanges", settings.showRecentChanges)
         editor.putEnum("theme", settings.appTheme)
@@ -175,6 +179,7 @@ internal class RealGeneralSettingsManager(
         editor.putBoolean("animations", settings.isShowAnimations)
         editor.putBoolean("showCorrespondentNames", settings.isShowCorrespondentNames)
         editor.putBoolean(KEY_SHOULD_SHOW_SETUP_ARCHIVE_FOLDER_DIALOG, settings.shouldShowSetupArchiveFolderDialog)
+        editor.putBoolean("messageListSenderAboveSubject", settings.isMessageListSenderAboveSubject)
     }
 
     private fun loadGeneralSettings(): GeneralSettings {
@@ -202,6 +207,7 @@ internal class RealGeneralSettingsManager(
                 key = KEY_SHOULD_SHOW_SETUP_ARCHIVE_FOLDER_DIALOG,
                 defValue = true,
             ),
+            isMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false),
         )
 
         updateSettingsFlow(settings)

--- a/legacy/core/src/test/java/com/fsck/k9/helper/MessageHelperTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/helper/MessageHelperTest.kt
@@ -50,6 +50,7 @@ class MessageHelperTest : RobolectricTest() {
                 isShowMessageListStars = false,
                 isShowAnimations = false,
                 shouldShowSetupArchiveFolderDialog = false,
+                isMessageListSenderAboveSubject = false,
             ),
         )
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.kt
@@ -160,6 +160,7 @@ class NotificationContentCreatorTest : RobolectricTest() {
                     isShowMessageListStars = false,
                     isShowAnimations = false,
                     shouldShowSetupArchiveFolderDialog = false,
+                    isMessageListSenderAboveSubject = false,
                 )
             },
         )

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityConfig.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityConfig.kt
@@ -48,7 +48,7 @@ data class MessageListActivityConfig(
                 isShowUnifiedInbox = generalSettingsManager.getSettings().isShowUnifiedInbox,
                 isShowMessageListStars = generalSettingsManager.getSettings().isShowMessageListStars,
                 isShowCorrespondentNames = generalSettingsManager.getSettings().isShowCorrespondentNames,
-                isMessageListSenderAboveSubject = K9.isMessageListSenderAboveSubject,
+                isMessageListSenderAboveSubject = generalSettingsManager.getSettings().isMessageListSenderAboveSubject,
                 isShowContactName = K9.isShowContactName,
                 isChangeContactNameColor = K9.isChangeContactNameColor,
                 isShowContactPicture = K9.isShowContactPicture,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -682,7 +682,7 @@ class MessageListFragment :
             fontSizes = K9.fontSizes,
             previewLines = K9.messageListPreviewLines,
             stars = !isOutbox && generalSettingsManager.getSettings().isShowMessageListStars,
-            senderAboveSubject = K9.isMessageListSenderAboveSubject,
+            senderAboveSubject = generalSettingsManager.getSettings().isMessageListSenderAboveSubject,
             showContactPicture = K9.isShowContactPicture,
             showingThreadedList = showingThreadedList,
             backGroundAsReadIndicator = K9.isUseBackgroundAsUnreadIndicator,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -30,7 +30,7 @@ class GeneralSettingsDataStore(
             "show_starred_count" -> generalSettingsManager.getSettings().isShowStarredCount
             "messagelist_stars" -> generalSettingsManager.getSettings().isShowMessageListStars
             "messagelist_show_correspondent_names" -> generalSettingsManager.getSettings().isShowCorrespondentNames
-            "messagelist_sender_above_subject" -> K9.isMessageListSenderAboveSubject
+            "messagelist_sender_above_subject" -> generalSettingsManager.getSettings().isMessageListSenderAboveSubject
             "messagelist_show_contact_name" -> K9.isShowContactName
             "messagelist_change_contact_name_color" -> K9.isChangeContactNameColor
             "messagelist_show_contact_picture" -> K9.isShowContactPicture
@@ -61,7 +61,9 @@ class GeneralSettingsDataStore(
             "show_starred_count" -> setIsShowStarredCount(isShowStarredCount = value)
             "messagelist_stars" -> setIsShowMessageListStars(isShowMessageListStars = value)
             "messagelist_show_correspondent_names" -> setIsShowCorrespondentNames(isShowCorrespondentNames = value)
-            "messagelist_sender_above_subject" -> K9.isMessageListSenderAboveSubject = value
+            "messagelist_sender_above_subject" -> setIsMessageListSenderAboveSubject(
+                isMessageListSenderAboveSubject = value,
+            )
             "messagelist_show_contact_name" -> K9.isShowContactName = value
             "messagelist_change_contact_name_color" -> K9.isChangeContactNameColor = value
             "messagelist_show_contact_picture" -> K9.isShowContactPicture = value
@@ -285,6 +287,11 @@ class GeneralSettingsDataStore(
     private fun setIsShowCorrespondentNames(isShowCorrespondentNames: Boolean) {
         skipSaveSettings = true
         generalSettingsManager.setIsShowCorrespondentNames(isShowCorrespondentNames)
+    }
+
+    private fun setIsMessageListSenderAboveSubject(isMessageListSenderAboveSubject: Boolean) {
+        skipSaveSettings = true
+        generalSettingsManager.setIsMessageListSenderAboveSubject(isMessageListSenderAboveSubject)
     }
 
     private fun appThemeToString(theme: AppTheme) = when (theme) {


### PR DESCRIPTION
- Fixes #9321 

Thunderbird Android currently uses K9.isMessageListSenderAboveSubject directly in the codebase to determine whether the sender name (instead of the sender email) should appear above the subject in the message list. This approach bypasses the modern preference management system.

This Pull requests aims to refactor all direct usages of `K9.isMessageListSenderAboveSubject` to retrieve the preference via `GeneralSettingsDataStore` ( an implementation of `PreferenceDataStore`).