### PR TITLE
Fix: Crashes upon navigating to account specific general settings

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/Preferences.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/Preferences.kt
@@ -29,6 +29,7 @@ import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.core.preference.storage.StorageEditor
 import net.thunderbird.core.preference.storage.StoragePersister
 import net.thunderbird.feature.account.storage.legacy.AccountDtoStorageHandler
+import net.thunderbird.feature.account.storage.profile.AvatarTypeDto
 
 @Suppress("MaxLineLength")
 class Preferences internal constructor(
@@ -131,7 +132,16 @@ class Preferences internal constructor(
                 loadAccounts()
             }
 
-            return accountsMap!![accountUuid]
+            val account = accountsMap!![accountUuid]
+            account?.avatar = if (
+                account!!.avatar.avatarType == AvatarTypeDto.MONOGRAM &&
+                account.avatar.avatarMonogram.isNullOrBlank()
+            ) {
+                account.avatar.copy(avatarMonogram = account.displayName.take(2).uppercase())
+            } else {
+                account.avatar
+            }
+            return account
         }
     }
 

--- a/legacy/core/src/test/java/com/fsck/k9/PreferencesTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/PreferencesTest.kt
@@ -9,6 +9,7 @@ import com.fsck.k9.mail.ServerSettings
 import kotlin.test.Test
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_OTHER_RAW
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
+import net.thunderbird.core.android.account.Identity
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.preferences.TestStoragePersister
 import net.thunderbird.core.logging.Logger
@@ -91,6 +92,12 @@ class PreferencesTest {
             // To be able to persist `Account` we need to set server settings
             incomingServerSettings = SERVER_SETTINGS
             outgoingServerSettings = SERVER_SETTINGS
+            identities = mutableListOf(
+                Identity(
+                    name = "Test User",
+                    email = "test_email@gmail.com",
+                ),
+            )
         }
 
         preferences.saveAccount(account)


### PR DESCRIPTION
 - Fixes #9330 
###  Reason:
 - We're getting an IllegalArgumentException in the account-specific general settings screen because AccountAvatar defaults to Monogram, but LegacyAccount is currently instantiated without any AccountAvatar implementation, causing a crash at [this line](https://github.com/thunderbird/thunderbird-android/blob/dc3d2703a05a5c94fa792398731b236580d6bd35/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultAccountAvatarDataMapper.kt#L13).
 
 ### Proposed Solution:
 - If a LegacyAccount has no avatar and the type is Monogram, create a Monogram avatar and assign it to the account.
 
#### **Note:**
 - The `createAndSaveAccount(accountUuid: String)` function in `PreferencesTest `was updated to add an Identity to the account to avoid `NullPointerException` from a missing email in tests.
 