### PR TITLE
fix(avatar): add missing storage migration to prepopulate the avatar monogram

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     implementation(projects.core.featureflag)
     implementation(projects.core.ui.legacy.theme2.common)
 
+    implementation(projects.feature.account.avatar.api)
+    implementation(projects.feature.account.avatar.impl)
     implementation(projects.feature.account.setup)
     implementation(projects.feature.mail.account.api)
     implementation(projects.feature.migration.provider)

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
@@ -24,9 +24,13 @@ import kotlinx.coroutines.withContext
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.common.mail.Protocols
 import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.feature.account.avatar.AvatarMonogramCreator
+import net.thunderbird.feature.account.storage.profile.AvatarDto
+import net.thunderbird.feature.account.storage.profile.AvatarTypeDto
 import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection
 
 // TODO Move to feature/account/setup
+@Suppress("LongParameterList")
 internal class AccountCreator(
     private val accountColorPicker: AccountColorPicker,
     private val localFoldersCreator: SpecialLocalFoldersCreator,
@@ -34,8 +38,9 @@ internal class AccountCreator(
     private val context: Context,
     private val messagingController: MessagingController,
     private val deletePolicyProvider: DeletePolicyProvider,
-    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val avatarMonogramCreator: AvatarMonogramCreator,
     private val unifiedInboxConfigurator: UnifiedInboxConfigurator,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AccountSetupExternalContract.AccountCreator {
 
     @Suppress("TooGenericExceptionCaught")
@@ -53,6 +58,13 @@ internal class AccountCreator(
         val newAccount = preferences.newAccount(account.uuid)
 
         newAccount.email = account.emailAddress
+
+        newAccount.avatar = AvatarDto(
+            avatarType = AvatarTypeDto.MONOGRAM,
+            avatarMonogram = avatarMonogramCreator.create(account.options.accountName, account.emailAddress),
+            avatarImageUri = null,
+            avatarIconName = null,
+        )
 
         newAccount.setIncomingServerSettings(account.incomingServerSettings)
         newAccount.outgoingServerSettings = account.outgoingServerSettings

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AppCommonAccountModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AppCommonAccountModule.kt
@@ -5,6 +5,8 @@ import net.thunderbird.app.common.account.data.DefaultAccountProfileLocalDataSou
 import net.thunderbird.app.common.account.data.DefaultLegacyAccountWrapperManager
 import net.thunderbird.core.android.account.AccountDefaultsProvider
 import net.thunderbird.core.android.account.LegacyAccountWrapperManager
+import net.thunderbird.feature.account.avatar.AvatarMonogramCreator
+import net.thunderbird.feature.account.avatar.DefaultAvatarMonogramCreator
 import net.thunderbird.feature.account.core.AccountCoreExternalContract.AccountProfileLocalDataSource
 import net.thunderbird.feature.account.core.featureAccountCoreModule
 import net.thunderbird.feature.account.storage.legacy.featureAccountStorageLegacyModule
@@ -45,6 +47,10 @@ internal val appCommonAccountModule = module {
         )
     }
 
+    factory<AvatarMonogramCreator> {
+        DefaultAvatarMonogramCreator()
+    }
+
     factory<AccountSetupExternalContract.AccountCreator> {
         AccountCreator(
             accountColorPicker = get(),
@@ -53,6 +59,7 @@ internal val appCommonAccountModule = module {
             context = androidApplication(),
             deletePolicyProvider = get(),
             messagingController = get(),
+            avatarMonogramCreator = get(),
             unifiedInboxConfigurator = get(),
         )
     }

--- a/feature/account/avatar/api/build.gradle.kts
+++ b/feature/account/avatar/api/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id(ThunderbirdPlugins.Library.kmp)
+}
+
+android {
+    namespace = "net.thunderbird.feature.account.avatar"
+}

--- a/feature/account/avatar/api/src/commonMain/kotlin/net/thunderbird/feature/account/avatar/AvatarMonogramCreator.kt
+++ b/feature/account/avatar/api/src/commonMain/kotlin/net/thunderbird/feature/account/avatar/AvatarMonogramCreator.kt
@@ -1,0 +1,18 @@
+package net.thunderbird.feature.account.avatar
+
+/**
+ * Interface for creating a monogram based on a name or email address.
+ *
+ * This interface is used to generate a monogram, which is typically the initials of a person's name,
+ * or a representation based on an email address. Implementations should handle null or empty inputs gracefully.
+ */
+fun interface AvatarMonogramCreator {
+    /**
+     * Creates a monogram for the given name or email.
+     *
+     * @param name The name to generate a monogram for.
+     * @param email The email address to generate a monogram for.
+     * @return A string representing the monogram, or an empty string if the name or email is null or empty.
+     */
+    fun create(name: String?, email: String?): String
+}

--- a/feature/account/avatar/impl/build.gradle.kts
+++ b/feature/account/avatar/impl/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    namespace = "app.k9mail.feature.account.avatar"
+    namespace = "net.thunderbird.feature.account.avatar.impl"
     resourcePrefix = "account_avatar_"
 }
 

--- a/feature/account/avatar/impl/build.gradle.kts
+++ b/feature/account/avatar/impl/build.gradle.kts
@@ -11,5 +11,7 @@ dependencies {
     implementation(projects.core.ui.compose.designsystem)
     implementation(projects.core.common)
 
+    implementation(projects.feature.account.avatar.api)
+
     testImplementation(projects.core.ui.compose.testing)
 }

--- a/feature/account/avatar/impl/src/debug/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlinedPreview.kt
+++ b/feature/account/avatar/impl/src/debug/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlinedPreview.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.account.avatar.ui
+package net.thunderbird.feature.account.avatar.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -7,24 +7,23 @@ import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
 
 @Composable
 @Preview(showBackground = true)
-internal fun AvatarPreview() {
+internal fun AvatarOutlinedPreview() {
     PreviewWithThemes {
-        Avatar(
+        AvatarOutlined(
             color = Color(0xFFe57373),
             name = "example",
-            selected = false,
         )
     }
 }
 
 @Composable
 @Preview(showBackground = true)
-internal fun AvatarSelectedPreview() {
+internal fun AvatarOutlinedLargePreview() {
     PreviewWithThemes {
-        Avatar(
+        AvatarOutlined(
             color = Color(0xFFe57373),
             name = "example",
-            selected = true,
+            size = AvatarSize.LARGE,
         )
     }
 }

--- a/feature/account/avatar/impl/src/debug/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarPreview.kt
+++ b/feature/account/avatar/impl/src/debug/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarPreview.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.account.avatar.ui
+package net.thunderbird.feature.account.avatar.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -7,23 +7,24 @@ import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
 
 @Composable
 @Preview(showBackground = true)
-internal fun AvatarOutlinedPreview() {
+internal fun AvatarPreview() {
     PreviewWithThemes {
-        AvatarOutlined(
+        Avatar(
             color = Color(0xFFe57373),
             name = "example",
+            selected = false,
         )
     }
 }
 
 @Composable
 @Preview(showBackground = true)
-internal fun AvatarOutlinedLargePreview() {
+internal fun AvatarSelectedPreview() {
     PreviewWithThemes {
-        AvatarOutlined(
+        Avatar(
             color = Color(0xFFe57373),
             name = "example",
-            size = AvatarSize.LARGE,
+            selected = true,
         )
     }
 }

--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/DefaultAvatarMonogramCreator.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/DefaultAvatarMonogramCreator.kt
@@ -1,0 +1,27 @@
+package net.thunderbird.feature.account.avatar
+
+/**
+ * Creates a monogram based on a name or email address.
+ *
+ * This implementation generates a monogram by taking the first two characters of the name or email,
+ * removing spaces, and converting them to uppercase.
+ */
+class DefaultAvatarMonogramCreator : AvatarMonogramCreator {
+    override fun create(name: String?, email: String?): String {
+        return if (name != null && name.isNotEmpty()) {
+            composeAvatarMonogram(name)
+        } else if (email != null && email.isNotEmpty()) {
+            composeAvatarMonogram(email)
+        } else {
+            AVATAR_MONOGRAM_DEFAULT
+        }
+    }
+
+    private fun composeAvatarMonogram(name: String): String {
+        return name.replace(" ", "").take(2).uppercase()
+    }
+
+    private companion object {
+        private const val AVATAR_MONOGRAM_DEFAULT = "XX"
+    }
+}

--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/Avatar.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/Avatar.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.account.avatar.ui
+package net.thunderbird.feature.account.avatar.ui
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.border

--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlined.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlined.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.account.avatar.ui
+package net.thunderbird.feature.account.avatar.ui
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable

--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarSize.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarSize.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.account.avatar.ui
+package net.thunderbird.feature.account.avatar.ui
 
 enum class AvatarSize {
     MEDIUM,

--- a/feature/account/avatar/impl/src/test/kotlin/net/thunderbird/feature/account/avatar/DefaultAvatarMonogramCreatorTest.kt
+++ b/feature/account/avatar/impl/src/test/kotlin/net/thunderbird/feature/account/avatar/DefaultAvatarMonogramCreatorTest.kt
@@ -1,0 +1,41 @@
+package net.thunderbird.feature.account.avatar
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class DefaultAvatarMonogramCreatorTest {
+
+    private val testSubject = DefaultAvatarMonogramCreator()
+
+    @Test
+    fun `create returns correct monogram for name`() {
+        val name = "John Doe"
+        val expectedMonogram = "JO"
+
+        val result = testSubject.create(name, null)
+
+        assertThat(result).isEqualTo(expectedMonogram)
+    }
+
+    @Test
+    fun `create returns correct monogram for email`() {
+        val email = "test@example.com"
+        val expectedMonogram = "TE"
+
+        val result = testSubject.create(null, email)
+
+        assertThat(result).isEqualTo(expectedMonogram)
+    }
+
+    @Test
+    fun `create returns default monogram for null or empty inputs`() {
+        val expectedMonogram = "XX"
+
+        val resultWithNulls = testSubject.create(null, null)
+        assertThat(resultWithNulls).isEqualTo(expectedMonogram)
+
+        val resultWithEmptyStrings = testSubject.create("", "")
+        assertThat(resultWithEmptyStrings).isEqualTo(expectedMonogram)
+    }
+}

--- a/feature/account/settings/impl/build.gradle.kts
+++ b/feature/account/settings/impl/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 dependencies {
     api(projects.feature.account.settings.api)
     implementation(projects.feature.account.core)
-    implementation(projects.feature.account.avatar)
+    implementation(projects.feature.account.avatar.impl)
 
     implementation(projects.core.outcome)
 

--- a/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/ui/general/components/GeneralSettingsProfileView.kt
+++ b/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/ui/general/components/GeneralSettingsProfileView.kt
@@ -16,8 +16,8 @@ import app.k9mail.core.ui.compose.designsystem.atom.card.CardElevated
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextHeadlineSmall
 import app.k9mail.core.ui.compose.theme2.MainTheme
-import app.k9mail.feature.account.avatar.ui.AvatarOutlined
-import app.k9mail.feature.account.avatar.ui.AvatarSize
+import net.thunderbird.feature.account.avatar.ui.AvatarOutlined
+import net.thunderbird.feature.account.avatar.ui.AvatarSize
 
 @Composable
 internal fun GeneralSettingsProfileView(

--- a/feature/navigation/drawer/dropdown/build.gradle.kts
+++ b/feature/navigation/drawer/dropdown/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation(projects.core.ui.theme.api)
     implementation(projects.core.ui.compose.designsystem)
 
-    implementation(projects.feature.account.avatar)
+    implementation(projects.feature.account.avatar.impl)
     implementation(projects.feature.mail.account.api)
     implementation(projects.feature.mail.folder.api)
 

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
@@ -12,7 +12,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextLabelSmall
 import app.k9mail.core.ui.compose.theme2.ColorRoles
 import app.k9mail.core.ui.compose.theme2.toColorRoles
-import app.k9mail.feature.account.avatar.ui.Avatar
+import net.thunderbird.feature.account.avatar.ui.Avatar
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.labelForCount
 

--- a/feature/navigation/drawer/siderail/build.gradle.kts
+++ b/feature/navigation/drawer/siderail/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation(projects.core.ui.theme.api)
     implementation(projects.core.ui.compose.designsystem)
 
-    implementation(projects.feature.account.avatar)
+    implementation(projects.feature.account.avatar.impl)
     implementation(projects.feature.mail.account.api)
     implementation(projects.feature.mail.folder.api)
 

--- a/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/AccountAvatar.kt
@@ -12,7 +12,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextLabelSmall
 import app.k9mail.core.ui.compose.theme2.ColorRoles
 import app.k9mail.core.ui.compose.theme2.toColorRoles
-import app.k9mail.feature.account.avatar.ui.Avatar
+import net.thunderbird.feature.account.avatar.ui.Avatar
 import net.thunderbird.feature.navigation.drawer.siderail.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.siderail.ui.common.labelForCount
 

--- a/legacy/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/legacy/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -23,7 +23,7 @@ import net.thunderbird.core.preference.storage.StoragePersister;
 import net.thunderbird.core.preference.storage.StorageUpdater;
 
 public class K9StoragePersister implements StoragePersister {
-    private static final int DB_VERSION = 26;
+    private static final int DB_VERSION = 27;
     private static final String DB_NAME = "preferences_storage";
 
     private final Context context;

--- a/legacy/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo27.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo27.kt
@@ -1,0 +1,84 @@
+package com.fsck.k9.preferences.migration
+
+import android.database.sqlite.SQLiteDatabase
+import net.thunderbird.feature.account.storage.profile.AvatarTypeDto
+
+/**
+ * Migration to add avatar monograms for accounts that have the MONOGRAM avatar type
+ * and do not have an existing avatar monogram.
+ */
+class StorageMigrationTo27(
+    private val db: SQLiteDatabase,
+    private val migrationsHelper: StorageMigrationHelper,
+) {
+    fun addAvatarMonogram() {
+        val accountUuidsValue = migrationsHelper.readValue(db, "accountUuids")
+        if (accountUuidsValue.isNullOrEmpty()) {
+            return
+        }
+
+        val accountUuids = accountUuidsValue.split(",")
+        for (accountUuid in accountUuids) {
+            addAvatarMonogramToAccount(accountUuid)
+        }
+    }
+
+    private fun addAvatarMonogramToAccount(accountUuid: String) {
+        val avatarType = readAvatarType(accountUuid)
+        val avatarMonogram = readAvatarMonogram(accountUuid)
+
+        if (avatarType == AvatarTypeDto.MONOGRAM.name && avatarMonogram.isEmpty()) {
+            val monogram = generateAvatarMonogram(accountUuid)
+            insertAvatarMonogram(accountUuid, monogram)
+        }
+    }
+
+    private fun generateAvatarMonogram(accountUuid: String): String {
+        val name = readName(accountUuid)
+        val email = readEmail(accountUuid)
+        return getAvatarMonogram(name, email)
+    }
+
+    private fun getAvatarMonogram(name: String?, email: String?): String {
+        return if (name != null && name.isNotEmpty()) {
+            composeAvatarMonogram(name)
+        } else if (email != null && email.isNotEmpty()) {
+            composeAvatarMonogram(email)
+        } else {
+            AVATAR_MONOGRAM_DEFAULT
+        }
+    }
+
+    private fun composeAvatarMonogram(name: String): String {
+        return name.replace(" ", "").take(2).uppercase()
+    }
+
+    private fun readAvatarType(accountUuid: String): String {
+        return migrationsHelper.readValue(db, "$accountUuid.$AVATAR_TYPE_KEY") ?: ""
+    }
+
+    private fun readAvatarMonogram(accountUuid: String): String {
+        return migrationsHelper.readValue(db, "$accountUuid.$AVATAR_MONOGRAM_KEY") ?: ""
+    }
+
+    private fun readName(accountUuid: String): String {
+        return migrationsHelper.readValue(db, "$accountUuid.$NAME_KEY") ?: ""
+    }
+
+    private fun readEmail(accountUuid: String): String {
+        return migrationsHelper.readValue(db, "$accountUuid.$EMAIL_KEY") ?: ""
+    }
+
+    private fun insertAvatarMonogram(accountUuid: String, monogram: String) {
+        migrationsHelper.insertValue(db, "$accountUuid.$AVATAR_MONOGRAM_KEY", monogram)
+    }
+
+    private companion object {
+        const val NAME_KEY = "name.0"
+        const val EMAIL_KEY = "email.0"
+        const val AVATAR_TYPE_KEY = "avatarType"
+        const val AVATAR_MONOGRAM_KEY = "avatarMonogram"
+
+        private const val AVATAR_MONOGRAM_DEFAULT = "XX"
+    }
+}

--- a/legacy/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
@@ -33,5 +33,6 @@ internal object StorageMigrations {
         if (oldVersion < 24) StorageMigrationTo24(db, migrationsHelper).removeLegacyAuthenticationModes()
         if (oldVersion < 25) StorageMigrationTo25(db, migrationsHelper).convertToAuthTypeNone()
         if (oldVersion < 26) StorageMigrationTo26(db, migrationsHelper).fixIdentities()
+        if (oldVersion < 27) StorageMigrationTo27(db, migrationsHelper).addAvatarMonogram()
     }
 }

--- a/legacy/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo27Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo27Test.kt
@@ -1,0 +1,109 @@
+package com.fsck.k9.preferences.migration
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.key
+import com.fsck.k9.preferences.createPreferencesDatabase
+import java.util.UUID
+import kotlin.test.Test
+import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.feature.account.storage.profile.AvatarTypeDto
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StorageMigrationTo27Test {
+    private val database = createPreferencesDatabase()
+    private val migrationHelper = DefaultStorageMigrationHelper()
+    private val migration = StorageMigrationTo27(database, migrationHelper)
+
+    @Before
+    fun setUp() {
+        Log.logger = TestLogger()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `avatar monogram should be added for accounts with MONOGRAM avatar type and no monogram, name and email`() {
+        val accountUuid = createAccount(
+            "avatarType" to AvatarTypeDto.MONOGRAM.name,
+            "avatarMonogram" to null,
+            "name.0" to null,
+            "email.0" to null,
+        )
+        writeAccountUuids(accountUuid)
+
+        migration.addAvatarMonogram()
+
+        assertThat(migrationHelper.readAllValues(database))
+            .key("$accountUuid.avatarMonogram").isEqualTo("XX")
+    }
+
+    @Test
+    fun `avatar monogram should not be added for accounts with MONOGRAM avatar type and existing monogram`() {
+        val accountUuid = createAccount(
+            "avatarType" to AvatarTypeDto.MONOGRAM.name,
+            "avatarMonogram" to "AB",
+        )
+        writeAccountUuids(accountUuid)
+
+        migration.addAvatarMonogram()
+
+        assertThat(migrationHelper.readAllValues(database))
+            .key("$accountUuid.avatarMonogram").isEqualTo("AB")
+    }
+
+    @Test
+    fun `avatar monogram should be added for accounts with name and no monogram`() {
+        val accountUuid = createAccount(
+            "avatarType" to AvatarTypeDto.MONOGRAM.name,
+            "avatarMonogram" to null,
+            "name.0" to "John Doe",
+            "email.0" to "test@example.com",
+        )
+        writeAccountUuids(accountUuid)
+
+        migration.addAvatarMonogram()
+
+        assertThat(migrationHelper.readAllValues(database))
+            .key("$accountUuid.avatarMonogram").isEqualTo("JO")
+    }
+
+    @Test
+    fun `avatar monogram should be added for accounts with no name and monogram but email`() {
+        val accountUuid = createAccount(
+            "avatarType" to AvatarTypeDto.MONOGRAM.name,
+            "avatarMonogram" to null,
+            "name.0" to null,
+            "email.0" to "test@example.com",
+        )
+        writeAccountUuids(accountUuid)
+
+        migration.addAvatarMonogram()
+
+        assertThat(migrationHelper.readAllValues(database))
+            .key("$accountUuid.avatarMonogram").isEqualTo("TE")
+    }
+
+    private fun writeAccountUuids(vararg accounts: String) {
+        val accountUuids = accounts.joinToString(separator = ",")
+        migrationHelper.insertValue(database, "accountUuids", accountUuids)
+    }
+
+    private fun createAccount(vararg pairs: Pair<String, String?>): String {
+        val accountUuid = UUID.randomUUID().toString()
+
+        for ((key, value) in pairs) {
+            migrationHelper.insertValue(database, "$accountUuid.$key", value)
+        }
+
+        return accountUuid
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -63,7 +63,8 @@ include(
 
 include(
     ":feature:account:api",
-    ":feature:account:avatar",
+    ":feature:account:avatar:api",
+    ":feature:account:avatar:impl",
     ":feature:account:core",
     ":feature:account:common",
     ":feature:account:edit",


### PR DESCRIPTION
Fixes #9330

The storage migration was missing, so the new fields couldn't be prepopulated as expected.