### PR TITLE
feat(drawer): change drawer layout to dropdown ui

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Inbox
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Report
 import androidx.compose.material.icons.outlined.Security
@@ -61,6 +62,9 @@ object Icons {
 
         val ArrowBack: ImageVector
             get() = MaterialIcons.AutoMirrored.Outlined.ArrowBack
+
+        val KeyboardArrowDown: ImageVector
+            get() = MaterialIcons.Outlined.KeyboardArrowDown
 
         val Check: ImageVector
             get() = MaterialIcons.Outlined.Check

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.filled.Outbox
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.AllInbox
 import androidx.compose.material.icons.outlined.Archive
 import androidx.compose.material.icons.outlined.Check
@@ -54,6 +55,9 @@ object Icons {
     object Outlined {
         val AccountCircle: ImageVector
             get() = MaterialIcons.Outlined.AccountCircle
+
+        val Add: ImageVector
+            get() = MaterialIcons.Outlined.Add
 
         val AllInbox: ImageVector
             get() = MaterialIcons.Outlined.AllInbox

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/icon/Icons.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Inbox
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Report
 import androidx.compose.material.icons.outlined.Security
@@ -65,6 +66,9 @@ object Icons {
 
         val KeyboardArrowDown: ImageVector
             get() = MaterialIcons.Outlined.KeyboardArrowDown
+
+        val KeyboardArrowUp: ImageVector
+            get() = MaterialIcons.Outlined.KeyboardArrowUp
 
         val Check: ImageVector
             get() = MaterialIcons.Outlined.Check

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerItem.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerItem.kt
@@ -9,6 +9,16 @@ import androidx.compose.ui.text.style.TextOverflow
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextLabelLarge
 import androidx.compose.material3.NavigationDrawerItem as Material3NavigationDrawerItem
 
+/**
+ * A navigation drawer item that can be used in a navigation drawer.
+ *
+ * @param label The content of the label to be displayed in the item as a String.
+ * @param selected Whether this item is selected.
+ * @param onClick The callback to be invoked when this item is clicked.
+ * @param modifier The [Modifier] to be applied to this item.
+ * @param icon An optional composable that represents an icon for this item.
+ * @param badge An optional composable that represents a badge for this item.
+ */
 @Composable
 fun NavigationDrawerItem(
     label: String,
@@ -36,6 +46,16 @@ fun NavigationDrawerItem(
     )
 }
 
+/**
+ * A navigation drawer item that can be used in a navigation drawer.
+ *
+ * @param label The content of the label to be displayed in the item as AnnotatedString.
+ * @param selected Whether this item is selected.
+ * @param onClick The callback to be invoked when this item is clicked.
+ * @param modifier The [Modifier] to be applied to this item.
+ * @param icon An optional composable that represents an icon for this item.
+ * @param badge An optional composable that represents a badge for this item.
+ */
 @Composable
 fun NavigationDrawerItem(
     label: AnnotatedString,
@@ -53,6 +73,37 @@ fun NavigationDrawerItem(
                 maxLines = 2,
             )
         },
+        selected = selected,
+        onClick = onClick,
+        modifier = Modifier
+            .padding(NavigationDrawerItemDefaults.ItemPadding)
+            .then(modifier),
+        icon = icon,
+        badge = badge,
+    )
+}
+
+/**
+ * A navigation drawer item that can be used in a navigation drawer.
+ *
+ * @param label The content of the label to be displayed in the item.
+ * @param selected Whether this item is selected.
+ * @param onClick The callback to be invoked when this item is clicked.
+ * @param modifier The [Modifier] to be applied to this item.
+ * @param icon An optional composable that represents an icon for this item.
+ * @param badge An optional composable that represents a badge for this item.
+ */
+@Composable
+fun NavigationDrawerItem(
+    label: @Composable () -> Unit,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)? = null,
+    badge: (@Composable () -> Unit)? = null,
+) {
+    Material3NavigationDrawerItem(
+        label = label,
         selected = selected,
         onClick = onClick,
         modifier = Modifier

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerItem.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerItem.kt
@@ -28,7 +28,7 @@ fun NavigationDrawerItem(
     icon: (@Composable () -> Unit)? = null,
     badge: (@Composable () -> Unit)? = null,
 ) {
-    Material3NavigationDrawerItem(
+    NavigationDrawerItem(
         label = {
             TextLabelLarge(
                 text = label,
@@ -38,9 +38,7 @@ fun NavigationDrawerItem(
         },
         selected = selected,
         onClick = onClick,
-        modifier = Modifier
-            .padding(NavigationDrawerItemDefaults.ItemPadding)
-            .then(modifier),
+        modifier = modifier,
         icon = icon,
         badge = badge,
     )
@@ -65,7 +63,7 @@ fun NavigationDrawerItem(
     icon: (@Composable () -> Unit)? = null,
     badge: (@Composable () -> Unit)? = null,
 ) {
-    Material3NavigationDrawerItem(
+    NavigationDrawerItem(
         label = {
             TextLabelLarge(
                 text = label,
@@ -75,9 +73,7 @@ fun NavigationDrawerItem(
         },
         selected = selected,
         onClick = onClick,
-        modifier = Modifier
-            .padding(NavigationDrawerItemDefaults.ItemPadding)
-            .then(modifier),
+        modifier = modifier,
         icon = icon,
         badge = badge,
     )

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerItemBadge.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/drawer/NavigationDrawerItemBadge.kt
@@ -28,15 +28,15 @@ fun NavigationDrawerItemBadge(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        TextLabelLarge(
+            text = label,
+        )
         if (imageVector != null) {
             Icon(
                 imageVector = imageVector,
                 modifier = Modifier.size(MainTheme.sizes.iconSmall)
-                    .padding(end = MainTheme.spacings.quarter),
+                    .padding(start = MainTheme.spacings.quarter),
             )
         }
-        TextLabelLarge(
-            text = label,
-        )
     }
 }

--- a/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/SelectThemeColorScheme.kt
+++ b/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/SelectThemeColorScheme.kt
@@ -1,12 +1,12 @@
 package app.k9mail.core.ui.compose.theme2
 
-import android.annotation.SuppressLint
 import android.content.Context
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.material.color.MaterialColors
@@ -115,6 +115,23 @@ private fun ColorScheme.toDynamicThemeColorScheme(
     )
 }
 
+/**
+ * The color roles of a theme accent color. They are used to define the main accent color and its complementary colors
+ * in a Material Design theme.
+ *
+ * These roles are used to create a harmonious color scheme that works well together.
+ *
+ * The roles are:
+ * - `accent`: The main accent color.
+ * - `onAccent`: The color used for text and icons on top of the accent color.
+ * - `accentContainer`: A container color that complements the accent color.
+ * - `onAccentContainer`: The color used for text and icons on top of the accent container color.
+ *
+ * @param accent The main accent color.
+ * @param onAccent The color used for text and icons on top of the accent color.
+ * @param accentContainer A container color that complements the accent color.
+ * @param onAccentContainer The color used for text and icons on top of the accent container color.
+ */
 data class ColorRoles(
     val accent: Color,
     val onAccent: Color,
@@ -122,8 +139,24 @@ data class ColorRoles(
     val onAccentContainer: Color,
 )
 
+/**
+ * Returns a harmonized color that is derived from the given color and the target color.
+ *
+ * This function uses Material Colors to harmonize the two colors.
+ *
+ * @param target The target color to harmonize with.
+ * @return A new color that is harmonized with the target color.
+ */
 fun Color.toHarmonizedColor(target: Color) = Color(MaterialColors.harmonize(toArgb(), target.toArgb()))
 
+/**
+ * Returns a [ColorRoles] object that contains the accent colors derived from the given color.
+ *
+ * This function uses Material Colors to retrieve the accent colors based on the provided color.
+ *
+ * @param context The context to use for retrieving the color roles.
+ * @return A [ColorRoles] object containing the accent colors.
+ */
 fun Color.toColorRoles(context: Context): ColorRoles {
     val colorRoles = MaterialColors.getColorRoles(context, this.toArgb())
     return ColorRoles(
@@ -134,8 +167,16 @@ fun Color.toColorRoles(context: Context): ColorRoles {
     )
 }
 
-@SuppressLint("RestrictedApi")
-fun Color.toSurfaceContainer(context: Context): Color {
-    val surfaceContainer = MaterialColors.getSurfaceContainerFromSeed(context, this.toArgb())
-    return Color(surfaceContainer)
+/**
+ * Returns a surface container color that is a composite of the given color and the theme surface container color.
+ *
+ * The alpha value is applied to the given color before compositing.
+ *
+ * @param alpha The alpha value to apply to the color.
+ * @return A new color that is a composite of the given color and the theme surface container color.
+ */
+@Composable
+fun Color.toSurfaceContainer(alpha: Float): Color {
+    val color = copy(alpha = alpha)
+    return color.compositeOver(MainTheme.colors.surfaceContainer)
 }

--- a/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/SelectThemeColorScheme.kt
+++ b/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/SelectThemeColorScheme.kt
@@ -1,5 +1,6 @@
 package app.k9mail.core.ui.compose.theme2
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -131,4 +132,10 @@ fun Color.toColorRoles(context: Context): ColorRoles {
         accentContainer = Color(colorRoles.accentContainer),
         onAccentContainer = Color(colorRoles.onAccentContainer),
     )
+}
+
+@SuppressLint("RestrictedApi")
+fun Color.toSurfaceContainer(context: Context): Color {
+    val surfaceContainer = MaterialColors.getSurfaceContainerFromSeed(context, this.toArgb())
+    return Color(surfaceContainer)
 }

--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlined.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlined.kt
@@ -18,9 +18,8 @@ import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
-import app.k9mail.core.ui.compose.theme2.ColorRoles
 import app.k9mail.core.ui.compose.theme2.MainTheme
-import app.k9mail.core.ui.compose.theme2.toColorRoles
+import app.k9mail.core.ui.compose.theme2.toSurfaceContainer
 
 @Composable
 fun AvatarOutlined(
@@ -31,17 +30,18 @@ fun AvatarOutlined(
     onClick: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
-    val colorRoles = color.toColorRoles(context)
+    val avatarColor = calculateAvatarColor(color)
+    val containerColor = avatarColor.toSurfaceContainer(context)
 
     AvatarLayout(
-        color = color,
-        colorRoles = colorRoles,
+        color = containerColor,
+        borderColor = avatarColor,
         onClick = onClick,
         modifier = modifier.size(getAvatarSize(size)),
     ) {
         AvatarPlaceholder(
+            color = avatarColor,
             displayName = name,
-            color = color,
             size = size,
         )
         // TODO: Add image loading
@@ -51,19 +51,19 @@ fun AvatarOutlined(
 @Composable
 private fun AvatarLayout(
     color: Color,
-    colorRoles: ColorRoles,
+    borderColor: Color,
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
     content: @Composable BoxScope.() -> Unit,
 ) {
     Surface(
-        color = colorRoles.accentContainer,
+        color = color,
         modifier = modifier
             .clip(CircleShape)
             .border(
                 width = 2.dp,
                 shape = CircleShape,
-                color = color,
+                color = borderColor,
             )
             .clickable(
                 enabled = onClick != null,

--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlined.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlined.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -20,7 +19,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.core.ui.compose.theme2.toSurfaceContainer
 
-private const val AVATAR_ALPHA = 0.12f
+private const val AVATAR_ALPHA = 0.2f
 
 @Composable
 fun AvatarOutlined(
@@ -58,8 +57,8 @@ private fun AvatarLayout(
 ) {
     Surface(
         color = color,
+        shape = CircleShape,
         modifier = modifier
-            .clip(CircleShape)
             .border(
                 width = 2.dp,
                 shape = CircleShape,

--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlined.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarOutlined.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
@@ -20,6 +19,8 @@ import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.core.ui.compose.theme2.toSurfaceContainer
+
+private const val AVATAR_ALPHA = 0.12f
 
 @Composable
 fun AvatarOutlined(
@@ -29,9 +30,8 @@ fun AvatarOutlined(
     size: AvatarSize = AvatarSize.MEDIUM,
     onClick: (() -> Unit)? = null,
 ) {
-    val context = LocalContext.current
     val avatarColor = calculateAvatarColor(color)
-    val containerColor = avatarColor.toSurfaceContainer(context)
+    val containerColor = avatarColor.toSurfaceContainer(alpha = AVATAR_ALPHA)
 
     AvatarLayout(
         color = containerColor,

--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/CalculateAvatarColor.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/CalculateAvatarColor.kt
@@ -1,0 +1,15 @@
+package net.thunderbird.feature.account.avatar.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import app.k9mail.core.ui.compose.theme2.toHarmonizedColor
+
+@Composable
+internal fun calculateAvatarColor(accountColor: Color): Color {
+    return if (accountColor == Color.Unspecified) {
+        MainTheme.colors.tertiary
+    } else {
+        accountColor.toHarmonizedColor(MainTheme.colors.surface)
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContentPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContentPreview.kt
@@ -10,8 +10,8 @@ import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import kotlinx.collections.immutable.persistentListOf
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawerExternalContract.DrawerConfig
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_FOLDER
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.MAIL_DISPLAY_ACCOUNT
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.UNIFIED_FOLDER
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.createAccountList
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.createDisplayFolderList
@@ -37,8 +37,8 @@ internal fun DrawerContentWithAccountPreview() {
     PreviewWithTheme {
         DrawerContent(
             state = DrawerContract.State(
-                accounts = persistentListOf(DISPLAY_ACCOUNT),
-                selectedAccountId = DISPLAY_ACCOUNT.id,
+                accounts = persistentListOf(MAIL_DISPLAY_ACCOUNT),
+                selectedAccountId = MAIL_DISPLAY_ACCOUNT.id,
                 folders = persistentListOf(),
             ),
             onEvent = {},
@@ -53,7 +53,7 @@ internal fun DrawerContentWithFoldersPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(
-                    DISPLAY_ACCOUNT,
+                    MAIL_DISPLAY_ACCOUNT,
                 ),
                 selectedAccountId = null,
                 folders = persistentListOf(
@@ -73,9 +73,9 @@ internal fun DrawerContentWithSelectedFolderPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(
-                    DISPLAY_ACCOUNT,
+                    MAIL_DISPLAY_ACCOUNT,
                 ),
-                selectedAccountId = DISPLAY_ACCOUNT.id,
+                selectedAccountId = MAIL_DISPLAY_ACCOUNT.id,
                 folders = persistentListOf(
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,
@@ -94,9 +94,9 @@ internal fun DrawerContentWithSelectedUnifiedFolderPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(
-                    DISPLAY_ACCOUNT,
+                    MAIL_DISPLAY_ACCOUNT,
                 ),
-                selectedAccountId = DISPLAY_ACCOUNT.id,
+                selectedAccountId = MAIL_DISPLAY_ACCOUNT.id,
                 folders = persistentListOf(
                     UNIFIED_FOLDER,
                     DISPLAY_FOLDER,
@@ -117,9 +117,9 @@ internal fun DrawerContentSingleAccountPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(
-                    DISPLAY_ACCOUNT,
+                    MAIL_DISPLAY_ACCOUNT,
                 ),
-                selectedAccountId = DISPLAY_ACCOUNT.id,
+                selectedAccountId = MAIL_DISPLAY_ACCOUNT.id,
                 folders = displayFolders,
                 selectedFolderId = displayFolders[0].id,
                 config = DrawerConfig(
@@ -142,9 +142,9 @@ internal fun DrawerContentSingleAccountWithAccountSelectionPreview() {
         DrawerContent(
             state = DrawerContract.State(
                 accounts = persistentListOf(
-                    DISPLAY_ACCOUNT,
+                    MAIL_DISPLAY_ACCOUNT,
                 ),
-                selectedAccountId = DISPLAY_ACCOUNT.id,
+                selectedAccountId = MAIL_DISPLAY_ACCOUNT.id,
                 folders = displayFolders,
                 selectedFolderId = displayFolders[0].id,
                 config = DrawerConfig(

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/FakeData.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/FakeData.kt
@@ -14,12 +14,11 @@ import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayF
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 
 internal object FakeData {
-
-    const val UNIFIED_ACCOUNT_ID = "unified_account"
 
     const val DISPLAY_NAME = "Account Name"
     const val EMAIL_ADDRESS = "test@example.com"

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/FakeData.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/FakeData.kt
@@ -10,14 +10,16 @@ import net.thunderbird.core.android.account.Identity
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderType
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccountFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 
 internal object FakeData {
+
+    const val UNIFIED_ACCOUNT_ID = "unified_account"
 
     const val DISPLAY_NAME = "Account Name"
     const val EMAIL_ADDRESS = "test@example.com"
@@ -38,7 +40,12 @@ internal object FakeData {
         email = EMAIL_ADDRESS
     }
 
-    val DISPLAY_ACCOUNT = DisplayAccount(
+    val UNIFIED_DISPLAY_ACCOUNT = UnifiedDisplayAccount(
+        unreadMessageCount = 224,
+        starredMessageCount = 42,
+    )
+
+    val MAIL_DISPLAY_ACCOUNT = MailDisplayAccount(
         id = ACCOUNT_ID_RAW,
         name = DISPLAY_NAME,
         email = EMAIL_ADDRESS,
@@ -54,7 +61,7 @@ internal object FakeData {
         isLocalOnly = false,
     )
 
-    val DISPLAY_FOLDER = DisplayAccountFolder(
+    val DISPLAY_FOLDER = MailDisplayFolder(
         accountId = ACCOUNT_ID_RAW,
         folder = FOLDER,
         isInTopGroup = false,
@@ -86,9 +93,9 @@ internal object FakeData {
         children = persistentListOf(),
     )
 
-    val UNIFIED_FOLDER = DisplayUnifiedFolder(
+    val UNIFIED_FOLDER = UnifiedDisplayFolder(
         id = "unified_inbox",
-        unifiedType = DisplayUnifiedFolderType.INBOX,
+        unifiedType = UnifiedDisplayFolderType.INBOX,
         unreadMessageCount = 123,
         starredMessageCount = 567,
     )
@@ -140,9 +147,9 @@ internal object FakeData {
         ),
     )
 
-    fun createAccountList(): PersistentList<DisplayAccount> {
+    fun createAccountList(): PersistentList<MailDisplayAccount> {
         return persistentListOf(
-            DisplayAccount(
+            MailDisplayAccount(
                 id = "account1",
                 name = "job@example.com",
                 email = "job@example.com",
@@ -150,7 +157,7 @@ internal object FakeData {
                 unreadMessageCount = 2,
                 starredMessageCount = 0,
             ),
-            DisplayAccount(
+            MailDisplayAccount(
                 id = "account2",
                 name = "Jodie Doe",
                 email = "jodie@example.com",
@@ -158,7 +165,7 @@ internal object FakeData {
                 unreadMessageCount = 12,
                 starredMessageCount = 0,
             ),
-            DisplayAccount(
+            MailDisplayAccount(
                 id = "account3",
                 name = "John Doe",
                 email = "john@example.com",

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatarPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatarPreview.kt
@@ -3,14 +3,14 @@ package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.MAIL_DISPLAY_ACCOUNT
 
 @Composable
 @Preview(showBackground = true)
 internal fun AccountAvatarPreview() {
     PreviewWithThemes {
         AccountAvatar(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = {},
             selected = false,
         )
@@ -22,7 +22,7 @@ internal fun AccountAvatarPreview() {
 internal fun AccountAvatarWithUnreadCountPreview() {
     PreviewWithThemes {
         AccountAvatar(
-            account = DISPLAY_ACCOUNT.copy(
+            account = MAIL_DISPLAY_ACCOUNT.copy(
                 unreadMessageCount = 12,
             ),
             onClick = {},
@@ -36,7 +36,7 @@ internal fun AccountAvatarWithUnreadCountPreview() {
 internal fun AccountAvatarWithUnreadCountMaxedPreview() {
     PreviewWithThemes {
         AccountAvatar(
-            account = DISPLAY_ACCOUNT.copy(
+            account = MAIL_DISPLAY_ACCOUNT.copy(
                 unreadMessageCount = 100,
             ),
             onClick = {},
@@ -50,7 +50,7 @@ internal fun AccountAvatarWithUnreadCountMaxedPreview() {
 internal fun AccountAvatarSelectedPreview() {
     PreviewWithThemes {
         AccountAvatar(
-            account = DISPLAY_ACCOUNT.copy(
+            account = MAIL_DISPLAY_ACCOUNT.copy(
                 color = 0xFFFF0000.toInt(),
             ),
             onClick = {},

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItemBadgePreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItemBadgePreview.kt
@@ -1,0 +1,53 @@
+package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
+
+@Composable
+@Preview(showBackground = true)
+internal fun AccountListItemBadgePreview() {
+    PreviewWithThemes {
+        AccountListItemBadge(
+            unreadCount = 5,
+            starredCount = 3,
+            showStarredCount = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun AccountListItemBadgeWithMaxUnreadPreview() {
+    PreviewWithThemes {
+        AccountListItemBadge(
+            unreadCount = 999,
+            starredCount = 0,
+            showStarredCount = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun AccountListItemBadgeWithStarsPreview() {
+    PreviewWithThemes {
+        AccountListItemBadge(
+            unreadCount = 5,
+            starredCount = 3,
+            showStarredCount = true,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun AccountListItemBadgeWithStarsAndMaxCountPreview() {
+    PreviewWithThemes {
+        AccountListItemBadge(
+            unreadCount = 5,
+            starredCount = 999,
+            showStarredCount = true,
+        )
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItemPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItemPreview.kt
@@ -3,14 +3,14 @@ package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.MAIL_DISPLAY_ACCOUNT
 
 @Composable
 @Preview(showBackground = true)
 internal fun AccountListItemPreview() {
     PreviewWithThemes {
         AccountListItem(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = { },
             selected = false,
             showStarredCount = false,
@@ -23,7 +23,7 @@ internal fun AccountListItemPreview() {
 internal fun AccountListItemSelectedPreview() {
     PreviewWithThemes {
         AccountListItem(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = { },
             selected = true,
             showStarredCount = false,

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListPreview.kt
@@ -16,7 +16,7 @@ internal fun AccountListPreview() {
             ),
             selectedAccount = null,
             onAccountClick = { },
-            onSyncAllAccountsClick = { },
+            showStarredCount = false,
         )
     }
 }
@@ -31,7 +31,7 @@ internal fun AccountListWithSelectedPreview() {
             ),
             selectedAccount = DISPLAY_ACCOUNT,
             onAccountClick = { },
-            onSyncAllAccountsClick = { },
+            showStarredCount = false,
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListPreview.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import kotlinx.collections.immutable.persistentListOf
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.MAIL_DISPLAY_ACCOUNT
 
 @Composable
 @Preview(showBackground = true)
@@ -12,7 +12,7 @@ internal fun AccountListPreview() {
     PreviewWithTheme {
         AccountList(
             accounts = persistentListOf(
-                DISPLAY_ACCOUNT,
+                MAIL_DISPLAY_ACCOUNT,
             ),
             selectedAccount = null,
             onAccountClick = { },
@@ -27,9 +27,9 @@ internal fun AccountListWithSelectedPreview() {
     PreviewWithTheme {
         AccountList(
             accounts = persistentListOf(
-                DISPLAY_ACCOUNT,
+                MAIL_DISPLAY_ACCOUNT,
             ),
-            selectedAccount = DISPLAY_ACCOUNT,
+            selectedAccount = MAIL_DISPLAY_ACCOUNT,
             onAccountClick = { },
             showStarredCount = false,
         )

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountViewPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountViewPreview.kt
@@ -3,16 +3,16 @@ package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.MAIL_DISPLAY_ACCOUNT
 
 @Composable
 @Preview(showBackground = true)
 internal fun AccountViewPreview() {
     PreviewWithThemes {
         AccountView(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = {},
-            showAccount = true,
+            showAccountSelection = true,
         )
     }
 }
@@ -22,9 +22,9 @@ internal fun AccountViewPreview() {
 internal fun AccountViewWithoutAccountPreview() {
     PreviewWithThemes {
         AccountView(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = {},
-            showAccount = false,
+            showAccountSelection = false,
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountViewPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountViewPreview.kt
@@ -12,43 +12,19 @@ internal fun AccountViewPreview() {
         AccountView(
             account = DISPLAY_ACCOUNT,
             onClick = {},
-            showAvatar = false,
+            showAccount = true,
         )
     }
 }
 
 @Composable
 @Preview(showBackground = true)
-internal fun AccountViewWithColorPreview() {
+internal fun AccountViewWithoutAccountPreview() {
     PreviewWithThemes {
         AccountView(
             account = DISPLAY_ACCOUNT,
             onClick = {},
-            showAvatar = false,
-        )
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-internal fun AccountViewWithLongDisplayName() {
-    PreviewWithThemes {
-        AccountView(
-            account = DISPLAY_ACCOUNT,
-            onClick = {},
-            showAvatar = false,
-        )
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-internal fun AccountViewWithLongEmailPreview() {
-    PreviewWithThemes {
-        AccountView(
-            account = DISPLAY_ACCOUNT,
-            onClick = {},
-            showAvatar = false,
+            showAccount = false,
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItemBadgePreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItemBadgePreview.kt
@@ -1,8 +1,6 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.folder
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
 
@@ -98,19 +96,6 @@ internal fun FolderListItemBadgeWith1000CountsPreview() {
             unreadCount = 1000,
             starredCount = 1000,
             showStarredCount = true,
-        )
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-internal fun FolderListItemBadgeWithExpandableStatePreview() {
-    PreviewWithThemes {
-        FolderListItemBadge(
-            unreadCount = 1000,
-            starredCount = 1000,
-            showStarredCount = true,
-            expandableState = remember { mutableStateOf(false) },
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItemPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItemPreview.kt
@@ -16,7 +16,7 @@ internal fun FolderListItemPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = DISPLAY_FOLDER,
-            selected = false,
+            selectedFolderId = "unknown",
             showStarredCount = false,
             onClick = {},
             folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
@@ -30,7 +30,7 @@ internal fun FolderListItemSelectedPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = DISPLAY_FOLDER,
-            selected = true,
+            selectedFolderId = DISPLAY_FOLDER.id,
             showStarredCount = false,
             onClick = {},
             folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
@@ -44,7 +44,7 @@ internal fun FolderListItemWithStarredPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = DISPLAY_FOLDER,
-            selected = false,
+            selectedFolderId = "unknown",
             showStarredCount = true,
             onClick = {},
             folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
@@ -58,7 +58,7 @@ internal fun FolderListItemWithStarredSelectedPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = DISPLAY_FOLDER,
-            selected = true,
+            selectedFolderId = DISPLAY_FOLDER.id,
             showStarredCount = true,
             onClick = {},
             folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
@@ -76,7 +76,7 @@ internal fun FolderListItemWithInboxFolderPreview() {
                     type = FolderType.INBOX,
                 ),
             ),
-            selected = false,
+            selectedFolderId = "unknown",
             showStarredCount = true,
             onClick = {},
             folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
@@ -90,7 +90,7 @@ internal fun FolderListItemWithUnifiedFolderPreview() {
     PreviewWithThemes {
         FolderListItem(
             displayFolder = UNIFIED_FOLDER,
-            selected = false,
+            selectedFolderId = "unknown",
             showStarredCount = false,
             onClick = {},
             folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
@@ -105,7 +105,7 @@ internal fun FolderListItemWithUnifiedFolderSelectedPreview() {
         FolderListItem(
             displayFolder = UNIFIED_FOLDER,
             treeFolder = DISPLAY_TREE_FOLDER_WITH_UNIFIED_FOLDER,
-            selected = false,
+            selectedFolderId = UNIFIED_FOLDER.id,
             showStarredCount = false,
             onClick = {},
             folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItemPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItemPreview.kt
@@ -112,3 +112,18 @@ internal fun FolderListItemWithUnifiedFolderSelectedPreview() {
         )
     }
 }
+
+@Composable
+@Preview(showBackground = true)
+internal fun FolderListItemStarredCountPreview() {
+    PreviewWithThemes {
+        FolderListItem(
+            displayFolder = UNIFIED_FOLDER,
+            treeFolder = DISPLAY_TREE_FOLDER_WITH_UNIFIED_FOLDER,
+            selectedFolderId = null,
+            showStarredCount = true,
+            onClick = {},
+            folderNameFormatter = FolderNameFormatter(LocalContext.current.resources),
+        )
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListItemPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListItemPreview.kt
@@ -12,7 +12,7 @@ internal fun SettingListItemPreview() {
         SettingListItem(
             label = "Settings",
             onClick = {},
-            imageVector = Icons.Outlined.Settings,
+            icon = Icons.Outlined.Settings,
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListPreview.kt
@@ -11,6 +11,19 @@ internal fun SettingListPreview() {
         FolderSettingList(
             onManageFoldersClick = {},
             onSettingsClick = {},
+            isUnifiedAccount = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SettingListWithUnifiedAccountPreview() {
+    PreviewWithTheme {
+        FolderSettingList(
+            onManageFoldersClick = {},
+            onSettingsClick = {},
+            isUnifiedAccount = true,
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListPreview.kt
@@ -8,7 +8,7 @@ import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 @Preview(showBackground = true)
 internal fun SettingListPreview() {
     PreviewWithTheme {
-        SettingList(
+        FolderSettingList(
             onManageFoldersClick = {},
             onSettingsClick = {},
         )

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListPreview.kt
@@ -9,21 +9,8 @@ import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 internal fun SettingListPreview() {
     PreviewWithTheme {
         SettingList(
-            onAccountSelectorClick = {},
             onManageFoldersClick = {},
-            showAccountSelector = false,
-        )
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-internal fun SettingListShowAccountSelectorPreview() {
-    PreviewWithTheme {
-        SettingList(
-            onAccountSelectorClick = {},
-            onManageFoldersClick = {},
-            showAccountSelector = true,
+            onSettingsClick = {},
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicatorPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicatorPreview.kt
@@ -1,4 +1,4 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
+package net.thunderbird.feature.navigation.drawer.siderail.ui.account
 
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
@@ -11,9 +11,9 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 
 @Composable
 @Preview(showBackground = true)
-internal fun AccountIndicatorPreview() {
+internal fun SideRailAccountIndicatorPreview() {
     PreviewWithThemes {
-        AccountIndicator(
+        SideRailAccountIndicator(
             accountColor = 0,
             modifier = Modifier.height(MainTheme.spacings.double),
         )
@@ -22,9 +22,9 @@ internal fun AccountIndicatorPreview() {
 
 @Composable
 @Preview(showBackground = true)
-internal fun AccountIndicatorPreviewWithYellowAccountColor() {
+internal fun SideRailAccountIndicatorPreviewWithYellowAccountColor() {
     PreviewWithThemes {
-        AccountIndicator(
+        SideRailAccountIndicator(
             accountColor = Color.Yellow.toArgb(),
             modifier = Modifier.height(MainTheme.spacings.double),
         )
@@ -33,9 +33,9 @@ internal fun AccountIndicatorPreviewWithYellowAccountColor() {
 
 @Composable
 @Preview(showBackground = true)
-internal fun AccountIndicatorPreviewWithGrayAccountColor() {
+internal fun SideRailAccountIndicatorPreviewWithGrayAccountColor() {
     PreviewWithThemes {
-        AccountIndicator(
+        SideRailAccountIndicator(
             accountColor = Color.Gray.toArgb(),
             modifier = Modifier.height(MainTheme.spacings.double),
         )

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicatorPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicatorPreview.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
 import app.k9mail.core.ui.compose.theme2.MainTheme
@@ -14,7 +13,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 internal fun SideRailAccountIndicatorPreview() {
     PreviewWithThemes {
         SideRailAccountIndicator(
-            accountColor = 0,
+            accountColor = Color.Unspecified,
             modifier = Modifier.height(MainTheme.spacings.double),
         )
     }
@@ -25,7 +24,7 @@ internal fun SideRailAccountIndicatorPreview() {
 internal fun SideRailAccountIndicatorPreviewWithYellowAccountColor() {
     PreviewWithThemes {
         SideRailAccountIndicator(
-            accountColor = Color.Yellow.toArgb(),
+            accountColor = Color.Yellow,
             modifier = Modifier.height(MainTheme.spacings.double),
         )
     }
@@ -36,7 +35,7 @@ internal fun SideRailAccountIndicatorPreviewWithYellowAccountColor() {
 internal fun SideRailAccountIndicatorPreviewWithGrayAccountColor() {
     PreviewWithThemes {
         SideRailAccountIndicator(
-            accountColor = Color.Gray.toArgb(),
+            accountColor = Color.Gray,
             modifier = Modifier.height(MainTheme.spacings.double),
         )
     }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItemPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItemPreview.kt
@@ -3,14 +3,14 @@ package net.thunderbird.feature.navigation.drawer.siderail.ui.account
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.MAIL_DISPLAY_ACCOUNT
 
 @Composable
 @Preview(showBackground = true)
 internal fun SideRailAccountListItemPreview() {
     PreviewWithThemes {
         SideRailAccountListItem(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = { },
             selected = false,
         )
@@ -22,7 +22,7 @@ internal fun SideRailAccountListItemPreview() {
 internal fun SideRailAccountListItemSelectedPreview() {
     PreviewWithThemes {
         SideRailAccountListItem(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = { },
             selected = true,
         )

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItemPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItemPreview.kt
@@ -1,4 +1,4 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
+package net.thunderbird.feature.navigation.drawer.siderail.ui.account
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
@@ -7,26 +7,24 @@ import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_AC
 
 @Composable
 @Preview(showBackground = true)
-internal fun AccountListItemPreview() {
+internal fun SideRailAccountListItemPreview() {
     PreviewWithThemes {
-        AccountListItem(
+        SideRailAccountListItem(
             account = DISPLAY_ACCOUNT,
             onClick = { },
             selected = false,
-            showStarredCount = false,
         )
     }
 }
 
 @Composable
 @Preview(showBackground = true)
-internal fun AccountListItemSelectedPreview() {
+internal fun SideRailAccountListItemSelectedPreview() {
     PreviewWithThemes {
-        AccountListItem(
+        SideRailAccountListItem(
             account = DISPLAY_ACCOUNT,
             onClick = { },
             selected = true,
-            showStarredCount = false,
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListPreview.kt
@@ -1,4 +1,4 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
+package net.thunderbird.feature.navigation.drawer.siderail.ui.account
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
@@ -8,14 +8,15 @@ import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_AC
 
 @Composable
 @Preview(showBackground = true)
-internal fun AccountListPreview() {
+internal fun SideRailAccountListPreview() {
     PreviewWithTheme {
-        AccountList(
+        SideRailAccountList(
             accounts = persistentListOf(
                 DISPLAY_ACCOUNT,
             ),
             selectedAccount = null,
             onAccountClick = { },
+            onSettingsClick = { },
             onSyncAllAccountsClick = { },
         )
     }
@@ -23,14 +24,15 @@ internal fun AccountListPreview() {
 
 @Composable
 @Preview(showBackground = true)
-internal fun AccountListWithSelectedPreview() {
+internal fun SideRailAccountListWithSelectedPreview() {
     PreviewWithTheme {
-        AccountList(
+        SideRailAccountList(
             accounts = persistentListOf(
                 DISPLAY_ACCOUNT,
             ),
             selectedAccount = DISPLAY_ACCOUNT,
             onAccountClick = { },
+            onSettingsClick = { },
             onSyncAllAccountsClick = { },
         )
     }

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListPreview.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
 import kotlinx.collections.immutable.persistentListOf
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.MAIL_DISPLAY_ACCOUNT
 
 @Composable
 @Preview(showBackground = true)
@@ -12,7 +12,7 @@ internal fun SideRailAccountListPreview() {
     PreviewWithTheme {
         SideRailAccountList(
             accounts = persistentListOf(
-                DISPLAY_ACCOUNT,
+                MAIL_DISPLAY_ACCOUNT,
             ),
             selectedAccount = null,
             onAccountClick = { },
@@ -28,9 +28,9 @@ internal fun SideRailAccountListWithSelectedPreview() {
     PreviewWithTheme {
         SideRailAccountList(
             accounts = persistentListOf(
-                DISPLAY_ACCOUNT,
+                MAIL_DISPLAY_ACCOUNT,
             ),
-            selectedAccount = DISPLAY_ACCOUNT,
+            selectedAccount = MAIL_DISPLAY_ACCOUNT,
             onAccountClick = { },
             onSettingsClick = { },
             onSyncAllAccountsClick = { },

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountViewPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountViewPreview.kt
@@ -3,14 +3,14 @@ package net.thunderbird.feature.navigation.drawer.siderail.ui.account
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.MAIL_DISPLAY_ACCOUNT
 
 @Composable
 @Preview(showBackground = true)
 internal fun SideRailAccountViewPreview() {
     PreviewWithThemes {
         SideRailAccountView(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = {},
             showAvatar = false,
         )
@@ -22,7 +22,7 @@ internal fun SideRailAccountViewPreview() {
 internal fun SideRailAccountViewWithColorPreview() {
     PreviewWithThemes {
         SideRailAccountView(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = {},
             showAvatar = false,
         )
@@ -34,7 +34,7 @@ internal fun SideRailAccountViewWithColorPreview() {
 internal fun SideRailAccountViewWithLongDisplayName() {
     PreviewWithThemes {
         SideRailAccountView(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = {},
             showAvatar = false,
         )
@@ -46,7 +46,7 @@ internal fun SideRailAccountViewWithLongDisplayName() {
 internal fun SideRailAccountViewWithLongEmailPreview() {
     PreviewWithThemes {
         SideRailAccountView(
-            account = DISPLAY_ACCOUNT,
+            account = MAIL_DISPLAY_ACCOUNT,
             onClick = {},
             showAvatar = false,
         )

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountViewPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountViewPreview.kt
@@ -1,0 +1,54 @@
+package net.thunderbird.feature.navigation.drawer.siderail.ui.account
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
+
+@Composable
+@Preview(showBackground = true)
+internal fun SideRailAccountViewPreview() {
+    PreviewWithThemes {
+        SideRailAccountView(
+            account = DISPLAY_ACCOUNT,
+            onClick = {},
+            showAvatar = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SideRailAccountViewWithColorPreview() {
+    PreviewWithThemes {
+        SideRailAccountView(
+            account = DISPLAY_ACCOUNT,
+            onClick = {},
+            showAvatar = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SideRailAccountViewWithLongDisplayName() {
+    PreviewWithThemes {
+        SideRailAccountView(
+            account = DISPLAY_ACCOUNT,
+            onClick = {},
+            showAvatar = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SideRailAccountViewWithLongEmailPreview() {
+    PreviewWithThemes {
+        SideRailAccountView(
+            account = DISPLAY_ACCOUNT,
+            onClick = {},
+            showAvatar = false,
+        )
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingItemPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingItemPreview.kt
@@ -1,4 +1,4 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui.setting
+package net.thunderbird.feature.navigation.drawer.siderail.ui.setting
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
@@ -7,9 +7,9 @@ import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 
 @Composable
 @Preview(showBackground = true)
-internal fun SettingItemPreview() {
+internal fun SideRailSettingItemPreview() {
     PreviewWithThemes {
-        SettingItem(
+        SideRailSettingItem(
             icon = Icons.Outlined.Settings,
             label = "Setting",
             onClick = {},

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingListPreview.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingListPreview.kt
@@ -1,0 +1,29 @@
+package net.thunderbird.feature.navigation.drawer.siderail.ui.setting
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
+
+@Composable
+@Preview(showBackground = true)
+internal fun SideRailSettingListPreview() {
+    PreviewWithTheme {
+        SideRailSettingList(
+            onAccountSelectorClick = {},
+            onManageFoldersClick = {},
+            showAccountSelector = false,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SideRailSettingListShowAccountSelectorPreview() {
+    PreviewWithTheme {
+        SideRailSettingList(
+            onAccountSelectorClick = {},
+            onManageFoldersClick = {},
+            showAccountSelector = true,
+        )
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/DropDownDrawer.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/DropDownDrawer.kt
@@ -11,6 +11,7 @@ import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.ui.theme.api.FeatureThemeProvider
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawer
 import net.thunderbird.feature.navigation.drawer.api.R
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.createMailDisplayAccountFolderId
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerView
@@ -82,6 +83,7 @@ class DropDownDrawer(
     override fun selectUnifiedInbox() {
         drawerState.update {
             it.copy(
+                selectedAccountUuid = UnifiedDisplayAccount.UNIFIED_ACCOUNT_ID,
                 selectedFolderId = UnifiedDisplayFolderType.INBOX.id,
             )
         }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/DropDownDrawer.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/DropDownDrawer.kt
@@ -23,6 +23,7 @@ internal data class FolderDrawerState(
     val selectedFolderId: String? = null,
 )
 
+@Suppress("LongParameterList")
 class DropDownDrawer(
     override val parent: AppCompatActivity,
     private val openAccount: (accountId: String) -> Unit,
@@ -30,6 +31,7 @@ class DropDownDrawer(
     private val openUnifiedFolder: () -> Unit,
     private val openManageFolders: () -> Unit,
     private val openSettings: () -> Unit,
+    private val openAddAccount: () -> Unit,
     createDrawerListener: () -> DrawerLayout.DrawerListener,
 ) : NavigationDrawer, KoinComponent {
 
@@ -55,6 +57,7 @@ class DropDownDrawer(
                     openUnifiedFolder = openUnifiedFolder,
                     openManageFolders = openManageFolders,
                     openSettings = openSettings,
+                    openAddAccount = openAddAccount,
                     featureFlagProvider = featureFlagProvider,
                     closeDrawer = { close() },
                 )

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/DropDownDrawer.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/DropDownDrawer.kt
@@ -11,8 +11,8 @@ import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.ui.theme.api.FeatureThemeProvider
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawer
 import net.thunderbird.feature.navigation.drawer.api.R
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.createDisplayAccountFolderId
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.createMailDisplayAccountFolderId
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerView
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -74,7 +74,7 @@ class DropDownDrawer(
         drawerState.update {
             it.copy(
                 selectedAccountUuid = accountUuid,
-                selectedFolderId = createDisplayAccountFolderId(accountUuid, folderId),
+                selectedFolderId = createMailDisplayAccountFolderId(accountUuid, folderId),
             )
         }
     }
@@ -82,7 +82,7 @@ class DropDownDrawer(
     override fun selectUnifiedInbox() {
         drawerState.update {
             it.copy(
-                selectedFolderId = DisplayUnifiedFolderType.INBOX.id,
+                selectedFolderId = UnifiedDisplayFolderType.INBOX.id,
             )
         }
     }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/UnifiedFolderRepository.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/UnifiedFolderRepository.kt
@@ -14,7 +14,7 @@ internal class UnifiedFolderRepository(
     private val messageCountsProvider: MessageCountsProvider,
 ) : DomainContract.UnifiedFolderRepository {
 
-    override fun getDisplayUnifiedFolderFlow(unifiedFolderType: UnifiedDisplayFolderType): Flow<UnifiedDisplayFolder> {
+    override fun getUnifiedDisplayFolderFlow(unifiedFolderType: UnifiedDisplayFolderType): Flow<UnifiedDisplayFolder> {
         return messageCountsProvider.getMessageCountsFlow(createUnifiedFolderSearch(unifiedFolderType)).map {
             UnifiedDisplayFolder(
                 id = UNIFIED_INBOX_ID,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/UnifiedFolderRepository.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/UnifiedFolderRepository.kt
@@ -4,8 +4,8 @@ import app.k9mail.legacy.message.controller.MessageCountsProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 import net.thunderbird.feature.search.LocalMessageSearch
 import net.thunderbird.feature.search.api.MessageSearchField
 import net.thunderbird.feature.search.api.SearchAttribute
@@ -14,20 +14,20 @@ internal class UnifiedFolderRepository(
     private val messageCountsProvider: MessageCountsProvider,
 ) : DomainContract.UnifiedFolderRepository {
 
-    override fun getDisplayUnifiedFolderFlow(unifiedFolderType: DisplayUnifiedFolderType): Flow<DisplayUnifiedFolder> {
+    override fun getDisplayUnifiedFolderFlow(unifiedFolderType: UnifiedDisplayFolderType): Flow<UnifiedDisplayFolder> {
         return messageCountsProvider.getMessageCountsFlow(createUnifiedFolderSearch(unifiedFolderType)).map {
-            DisplayUnifiedFolder(
+            UnifiedDisplayFolder(
                 id = UNIFIED_INBOX_ID,
-                unifiedType = DisplayUnifiedFolderType.INBOX,
+                unifiedType = UnifiedDisplayFolderType.INBOX,
                 unreadMessageCount = it.unread,
                 starredMessageCount = it.starred,
             )
         }
     }
 
-    private fun createUnifiedFolderSearch(unifiedFolderType: DisplayUnifiedFolderType): LocalMessageSearch {
+    private fun createUnifiedFolderSearch(unifiedFolderType: UnifiedDisplayFolderType): LocalMessageSearch {
         return when (unifiedFolderType) {
-            DisplayUnifiedFolderType.INBOX -> return createUnifiedInboxSearch()
+            UnifiedDisplayFolderType.INBOX -> return createUnifiedInboxSearch()
         }
     }
 

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/DomainContract.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/DomainContract.kt
@@ -2,11 +2,11 @@ package net.thunderbird.feature.navigation.drawer.dropdown.domain
 
 import kotlinx.coroutines.flow.Flow
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawerExternalContract.DrawerConfig
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 
 internal interface DomainContract {
 
@@ -20,7 +20,7 @@ internal interface DomainContract {
         }
 
         fun interface GetDisplayAccounts {
-            operator fun invoke(): Flow<List<DisplayAccount>>
+            operator fun invoke(): Flow<List<MailDisplayAccount>>
         }
 
         fun interface GetDisplayFoldersForAccount {
@@ -47,6 +47,6 @@ internal interface DomainContract {
     }
 
     interface UnifiedFolderRepository {
-        fun getDisplayUnifiedFolderFlow(unifiedFolderType: DisplayUnifiedFolderType): Flow<DisplayUnifiedFolder>
+        fun getDisplayUnifiedFolderFlow(unifiedFolderType: UnifiedDisplayFolderType): Flow<UnifiedDisplayFolder>
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/DomainContract.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/DomainContract.kt
@@ -2,9 +2,9 @@ package net.thunderbird.feature.navigation.drawer.dropdown.domain
 
 import kotlinx.coroutines.flow.Flow
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawerExternalContract.DrawerConfig
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 
@@ -20,11 +20,11 @@ internal interface DomainContract {
         }
 
         fun interface GetDisplayAccounts {
-            operator fun invoke(): Flow<List<MailDisplayAccount>>
+            operator fun invoke(showUnifiedAccount: Boolean): Flow<List<DisplayAccount>>
         }
 
         fun interface GetDisplayFoldersForAccount {
-            operator fun invoke(accountId: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>>
+            operator fun invoke(accountId: String): Flow<List<DisplayFolder>>
         }
 
         fun interface GetDisplayTreeFolder {
@@ -47,6 +47,6 @@ internal interface DomainContract {
     }
 
     interface UnifiedFolderRepository {
-        fun getDisplayUnifiedFolderFlow(unifiedFolderType: UnifiedDisplayFolderType): Flow<UnifiedDisplayFolder>
+        fun getUnifiedDisplayFolderFlow(unifiedFolderType: UnifiedDisplayFolderType): Flow<UnifiedDisplayFolder>
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/DisplayAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/DisplayAccount.kt
@@ -1,6 +1,6 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.domain.entity
 
-interface DisplayAccount {
+sealed interface DisplayAccount {
     val id: String
     val unreadMessageCount: Int
     val starredMessageCount: Int

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/DisplayAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/DisplayAccount.kt
@@ -1,10 +1,7 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.domain.entity
 
-internal data class DisplayAccount(
-    val id: String,
-    val name: String,
-    val email: String,
-    val color: Int,
-    val unreadMessageCount: Int,
-    val starredMessageCount: Int,
-)
+interface DisplayAccount {
+    val id: String
+    val unreadMessageCount: Int
+    val starredMessageCount: Int
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/MailDisplayAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/MailDisplayAccount.kt
@@ -1,0 +1,10 @@
+package net.thunderbird.feature.navigation.drawer.dropdown.domain.entity
+
+internal data class MailDisplayAccount(
+    override val id: String,
+    val name: String,
+    val email: String,
+    val color: Int,
+    override val unreadMessageCount: Int,
+    override val starredMessageCount: Int,
+) : DisplayAccount

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/MailDisplayFolder.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/MailDisplayFolder.kt
@@ -2,16 +2,16 @@ package net.thunderbird.feature.navigation.drawer.dropdown.domain.entity
 
 import net.thunderbird.feature.mail.folder.api.Folder
 
-internal data class DisplayAccountFolder(
+internal data class MailDisplayFolder(
     val accountId: String,
     val folder: Folder,
     val isInTopGroup: Boolean,
     override val unreadMessageCount: Int,
     override val starredMessageCount: Int,
 ) : DisplayFolder {
-    override val id: String = createDisplayAccountFolderId(accountId, folder.id)
+    override val id: String = createMailDisplayAccountFolderId(accountId, folder.id)
 }
 
-fun createDisplayAccountFolderId(accountId: String, folderId: Long): String {
+fun createMailDisplayAccountFolderId(accountId: String, folderId: Long): String {
     return "${accountId}_$folderId"
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayAccount.kt
@@ -1,7 +1,12 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.domain.entity
 
 internal data class UnifiedDisplayAccount(
-    override val id: String,
     override val unreadMessageCount: Int,
     override val starredMessageCount: Int,
-) : DisplayAccount
+) : DisplayAccount {
+    override val id: String = UNIFIED_ACCOUNT_ID
+
+    companion object {
+        const val UNIFIED_ACCOUNT_ID = "unified_account"
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayAccount.kt
@@ -1,8 +1,7 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.domain.entity
 
-internal data class DisplayUnifiedFolder(
+internal data class UnifiedDisplayAccount(
     override val id: String,
-    val unifiedType: DisplayUnifiedFolderType,
     override val unreadMessageCount: Int,
     override val starredMessageCount: Int,
-) : DisplayFolder
+) : DisplayAccount

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayAccount.kt
@@ -1,6 +1,6 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.domain.entity
 
-internal data class UnifiedDisplayAccount(
+data class UnifiedDisplayAccount(
     override val unreadMessageCount: Int,
     override val starredMessageCount: Int,
 ) : DisplayAccount {

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayFolder.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayFolder.kt
@@ -1,0 +1,8 @@
+package net.thunderbird.feature.navigation.drawer.dropdown.domain.entity
+
+internal data class UnifiedDisplayFolder(
+    override val id: String,
+    val unifiedType: UnifiedDisplayFolderType,
+    override val unreadMessageCount: Int,
+    override val starredMessageCount: Int,
+) : DisplayFolder

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayFolderType.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/UnifiedDisplayFolderType.kt
@@ -5,7 +5,7 @@ package net.thunderbird.feature.navigation.drawer.dropdown.domain.entity
  *
  * The id is unique for each unified folder type.
  */
-internal enum class DisplayUnifiedFolderType(
+internal enum class UnifiedDisplayFolderType(
     val id: String,
 ) {
     INBOX("unified_inbox"),

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayAccounts.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayAccounts.kt
@@ -17,7 +17,9 @@ import kotlinx.coroutines.launch
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UseCase
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayAccount
 
 internal class GetDisplayAccounts(
     private val accountManager: AccountManager,
@@ -27,7 +29,7 @@ internal class GetDisplayAccounts(
 ) : UseCase.GetDisplayAccounts {
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun invoke(): Flow<List<MailDisplayAccount>> {
+    override fun invoke(showUnifiedAccount: Boolean): Flow<List<DisplayAccount>> {
         return accountManager.getAccountsFlow()
             .flatMapLatest { accounts ->
                 val messageCountsFlows: List<Flow<MessageCounts>> = accounts.map { account ->
@@ -35,7 +37,7 @@ internal class GetDisplayAccounts(
                 }
 
                 combine(messageCountsFlows) { messageCountsList ->
-                    messageCountsList.mapIndexed { index, messageCounts ->
+                    val displayAccounts = messageCountsList.mapIndexed { index, messageCounts ->
                         MailDisplayAccount(
                             id = accounts[index].uuid,
                             name = accounts[index].displayName,
@@ -45,8 +47,23 @@ internal class GetDisplayAccounts(
                             starredMessageCount = messageCounts.starred,
                         )
                     }
+
+                    if (showUnifiedAccount) {
+                        withUnifiedAccount(displayAccounts)
+                    } else {
+                        displayAccounts
+                    }
                 }
             }
+    }
+
+    private fun withUnifiedAccount(accounts: List<DisplayAccount>): List<DisplayAccount> {
+        val unified = UnifiedDisplayAccount(
+            unreadMessageCount = accounts.sumOf { it.unreadMessageCount },
+            starredMessageCount = accounts.sumOf { it.starredMessageCount },
+        )
+
+        return listOf(unified) + accounts
     }
 
     private fun getMessageCountsFlow(account: LegacyAccount): Flow<MessageCounts> {

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayAccounts.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayAccounts.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UseCase
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 
 internal class GetDisplayAccounts(
     private val accountManager: AccountManager,
@@ -27,7 +27,7 @@ internal class GetDisplayAccounts(
 ) : UseCase.GetDisplayAccounts {
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun invoke(): Flow<List<DisplayAccount>> {
+    override fun invoke(): Flow<List<MailDisplayAccount>> {
         return accountManager.getAccountsFlow()
             .flatMapLatest { accounts ->
                 val messageCountsFlows: List<Flow<MessageCounts>> = accounts.map { account ->
@@ -36,7 +36,7 @@ internal class GetDisplayAccounts(
 
                 combine(messageCountsFlows) { messageCountsList ->
                     messageCountsList.mapIndexed { index, messageCounts ->
-                        DisplayAccount(
+                        MailDisplayAccount(
                             id = accounts[index].uuid,
                             name = accounts[index].displayName,
                             email = accounts[index].email,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayFoldersForAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayFoldersForAccount.kt
@@ -2,23 +2,26 @@ package net.thunderbird.feature.navigation.drawer.dropdown.domain.usecase
 
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UnifiedFolderRepository
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UseCase
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 
 internal class GetDisplayFoldersForAccount(
     private val displayFolderRepository: DisplayFolderRepository,
     private val unifiedFolderRepository: UnifiedFolderRepository,
 ) : UseCase.GetDisplayFoldersForAccount {
-    override fun invoke(accountId: String, includeUnifiedFolders: Boolean): Flow<List<DisplayFolder>> {
-        val accountFoldersFlow: Flow<List<DisplayFolder>> =
-            displayFolderRepository.getDisplayFoldersFlow(accountId).map { displayFolders ->
+    override fun invoke(accountId: String): Flow<List<DisplayFolder>> {
+        if (accountId == UnifiedDisplayAccount.UNIFIED_ACCOUNT_ID) {
+            return unifiedFolderRepository.getUnifiedDisplayFolderFlow(UnifiedDisplayFolderType.INBOX)
+                .map { displayUnifiedFolder ->
+                    listOf(displayUnifiedFolder)
+                }
+        } else {
+            return displayFolderRepository.getDisplayFoldersFlow(accountId).map { displayFolders ->
                 displayFolders.map { displayFolder ->
                     MailDisplayFolder(
                         accountId = accountId,
@@ -29,21 +32,6 @@ internal class GetDisplayFoldersForAccount(
                     )
                 }
             }
-
-        val unifiedFoldersFlow: Flow<List<DisplayFolder>> = if (includeUnifiedFolders) {
-            unifiedFolderRepository.getDisplayUnifiedFolderFlow(UnifiedDisplayFolderType.INBOX)
-                .map { displayUnifiedFolder ->
-                    listOf(displayUnifiedFolder)
-                }
-        } else {
-            flowOf(emptyList<UnifiedDisplayFolder>())
-        }
-
-        return combine(
-            accountFoldersFlow,
-            unifiedFoldersFlow,
-        ) { accountFolders, unifiedFolders ->
-            unifiedFolders + accountFolders
         }
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayFoldersForAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayFoldersForAccount.kt
@@ -7,10 +7,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UnifiedFolderRepository
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UseCase
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccountFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 
 internal class GetDisplayFoldersForAccount(
     private val displayFolderRepository: DisplayFolderRepository,
@@ -20,7 +20,7 @@ internal class GetDisplayFoldersForAccount(
         val accountFoldersFlow: Flow<List<DisplayFolder>> =
             displayFolderRepository.getDisplayFoldersFlow(accountId).map { displayFolders ->
                 displayFolders.map { displayFolder ->
-                    DisplayAccountFolder(
+                    MailDisplayFolder(
                         accountId = accountId,
                         folder = displayFolder.folder,
                         isInTopGroup = displayFolder.isInTopGroup,
@@ -31,12 +31,12 @@ internal class GetDisplayFoldersForAccount(
             }
 
         val unifiedFoldersFlow: Flow<List<DisplayFolder>> = if (includeUnifiedFolders) {
-            unifiedFolderRepository.getDisplayUnifiedFolderFlow(DisplayUnifiedFolderType.INBOX)
+            unifiedFolderRepository.getDisplayUnifiedFolderFlow(UnifiedDisplayFolderType.INBOX)
                 .map { displayUnifiedFolder ->
                     listOf(displayUnifiedFolder)
                 }
         } else {
-            flowOf(emptyList<DisplayUnifiedFolder>())
+            flowOf(emptyList<UnifiedDisplayFolder>())
         }
 
         return combine(

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayTreeFolder.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayTreeFolder.kt
@@ -5,16 +5,16 @@ import kotlinx.collections.immutable.toImmutableList
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UseCase
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccountFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
 
 internal class GetDisplayTreeFolder : UseCase.GetDisplayTreeFolder {
     private var placeholderCounter = 0L
 
     override fun invoke(folders: List<DisplayFolder>, maxDepth: Int): DisplayTreeFolder {
-        val unifiedFolderTreeList = folders.filterIsInstance<DisplayUnifiedFolder>().map {
+        val unifiedFolderTreeList = folders.filterIsInstance<UnifiedDisplayFolder>().map {
             DisplayTreeFolder(
                 displayFolder = it,
                 displayName = it.unifiedType.id,
@@ -24,7 +24,7 @@ internal class GetDisplayTreeFolder : UseCase.GetDisplayTreeFolder {
             )
         }
 
-        val accountFolders = folders.filterIsInstance<DisplayAccountFolder>().map {
+        val accountFolders = folders.filterIsInstance<MailDisplayFolder>().map {
             val path = flattenPath(it.folder.name, maxDepth)
             println("Flattened path for ${it.folder.name} → $path")
             path to it
@@ -51,7 +51,7 @@ internal class GetDisplayTreeFolder : UseCase.GetDisplayTreeFolder {
     }
 
     private fun buildAccountFolderTree(
-        paths: List<Pair<List<String>, DisplayAccountFolder>>,
+        paths: List<Pair<List<String>, MailDisplayFolder>>,
         parentPath: String = "",
     ): List<DisplayTreeFolder> {
         return paths.groupBy { it.first.getOrNull(0) ?: "(Unnamed)" }
@@ -87,9 +87,9 @@ internal class GetDisplayTreeFolder : UseCase.GetDisplayTreeFolder {
             }
     }
 
-    private fun createPlaceholderFolder(name: String): DisplayAccountFolder {
+    private fun createPlaceholderFolder(name: String): MailDisplayFolder {
         placeholderCounter += 1
-        return DisplayAccountFolder(
+        return MailDisplayFolder(
             accountId = "placeholder",
             folder = Folder(
                 id = placeholderCounter,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
@@ -58,7 +58,6 @@ internal fun DrawerContent(
                         selectedAccount = selectedAccount,
                         onAccountClick = { onEvent(Event.OnAccountClick(it)) },
                         onSyncAllAccountsClick = { onEvent(Event.OnSyncAllAccounts) },
-                        onSettingsClick = { onEvent(Event.OnSettingsClick) },
                     )
                 }
                 Column(
@@ -77,9 +76,8 @@ internal fun DrawerContent(
                     )
                     DividerHorizontal()
                     SettingList(
-                        onAccountSelectorClick = { onEvent(Event.OnAccountSelectorClick) },
                         onManageFoldersClick = { onEvent(Event.OnManageFoldersClick) },
-                        showAccountSelector = state.config.showAccountSelector,
+                        onSettingsClick = { onEvent(Event.OnSettingsClick) },
                     )
                 }
             }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Event
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.State
@@ -37,14 +38,15 @@ internal fun DrawerContent(
             .width(DRAWER_WIDTH + additionalWidth)
             .fillMaxHeight()
             .testTagAsResourceId("DrawerContent"),
+        color = MainTheme.colors.surfaceContainerLow,
     ) {
         val selectedAccount = state.accounts.firstOrNull { it.id == state.selectedAccountId }
         Column {
             selectedAccount?.let {
                 AccountView(
                     account = selectedAccount,
-                    onClick = { onEvent(Event.OnAccountViewClick(selectedAccount)) },
-                    showAvatar = state.config.showAccountSelector,
+                    onClick = { onEvent(Event.OnAccountSelectorClick) },
+                    showAccount = state.config.showAccountSelector,
                 )
 
                 DividerHorizontal()

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
@@ -18,7 +18,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Event
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.State
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountList
@@ -58,13 +58,13 @@ internal fun DrawerContent(
                 AccountView(
                     account = selectedAccount,
                     onClick = { onEvent(Event.OnAccountSelectorClick) },
-                    showAccount = state.config.showAccountSelector.not(),
+                    showAccountSelection = state.showAccountSelection,
                 )
 
                 DividerHorizontal()
             }
             AnimatedContent(
-                targetState = state.config.showAccountSelector,
+                targetState = state.showAccountSelection,
                 label = "AccountSelectorVisibility",
                 transitionSpec = {
                     if (targetState) {
@@ -95,7 +95,7 @@ internal fun DrawerContent(
 private fun AccountContent(
     state: State,
     onEvent: (Event) -> Unit,
-    selectedAccount: MailDisplayAccount?,
+    selectedAccount: DisplayAccount?,
 ) {
     Surface(
         color = MainTheme.colors.surfaceContainerLow,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
@@ -19,6 +19,8 @@ import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Event
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.State
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountList
@@ -131,7 +133,7 @@ private fun FolderContent(
         ) {
             FolderList(
                 rootFolder = state.rootFolder,
-                selectedFolder = state.folders.firstOrNull { it.id == state.selectedFolderId },
+                selectedFolder = state.selectedFolder,
                 onFolderClick = { folder ->
                     onEvent(Event.OnFolderClick(folder))
                 },
@@ -146,3 +148,4 @@ private fun FolderContent(
         }
     }
 }
+

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Event
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.State
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountList
@@ -123,6 +125,10 @@ private fun FolderContent(
     state: State,
     onEvent: (Event) -> Unit,
 ) {
+    val isUnifiedAccount = remember(state.selectedAccountId) {
+        state.accounts.any { it.id == state.selectedAccountId && it is UnifiedDisplayAccount }
+    }
+
     Surface(
         color = MainTheme.colors.surfaceContainerLow,
     ) {
@@ -142,6 +148,7 @@ private fun FolderContent(
             FolderSettingList(
                 onManageFoldersClick = { onEvent(Event.OnManageFoldersClick) },
                 onSettingsClick = { onEvent(Event.OnSettingsClick) },
+                isUnifiedAccount = isUnifiedAccount,
             )
         }
     }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
@@ -18,9 +18,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Event
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.State
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountList
@@ -97,7 +95,7 @@ internal fun DrawerContent(
 private fun AccountContent(
     state: State,
     onEvent: (Event) -> Unit,
-    selectedAccount: DisplayAccount?,
+    selectedAccount: MailDisplayAccount?,
 ) {
     Surface(
         color = MainTheme.colors.surfaceContainerLow,
@@ -148,4 +146,3 @@ private fun FolderContent(
         }
     }
 }
-

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContent.kt
@@ -114,6 +114,7 @@ private fun AccountContent(
             )
             DividerHorizontal()
             AccountSettingList(
+                onAddAccountClick = { onEvent(Event.OnAddAccountClick) },
                 onSyncAllAccountsClick = { onEvent(Event.OnSyncAllAccounts) },
             )
         }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
@@ -5,9 +5,9 @@ import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawerExternalContract.DrawerConfig
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 
 internal interface DrawerContract {
 
@@ -20,7 +20,7 @@ internal interface DrawerContract {
             showStarredCount = false,
             showAccountSelector = true,
         ),
-        val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
+        val accounts: ImmutableList<MailDisplayAccount> = persistentListOf(),
         val selectedAccountId: String? = null,
         val rootFolder: DisplayTreeFolder = DisplayTreeFolder(
             displayFolder = null,
@@ -38,8 +38,8 @@ internal interface DrawerContract {
     sealed interface Event {
         data class SelectAccount(val accountId: String?) : Event
         data class SelectFolder(val folderId: String?) : Event
-        data class OnAccountClick(val account: DisplayAccount) : Event
-        data class OnAccountViewClick(val account: DisplayAccount) : Event
+        data class OnAccountClick(val account: MailDisplayAccount) : Event
+        data class OnAccountViewClick(val account: MailDisplayAccount) : Event
         data class OnFolderClick(val folder: DisplayFolder) : Event
         data object OnAccountSelectorClick : Event
         data object OnManageFoldersClick : Event

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
@@ -47,6 +47,7 @@ internal interface DrawerContract {
         data object OnSettingsClick : Event
         data object OnSyncAccount : Event
         data object OnSyncAllAccounts : Event
+        data object OnAddAccountClick : Event
     }
 
     sealed interface Effect {
@@ -55,6 +56,7 @@ internal interface DrawerContract {
         data object OpenUnifiedFolder : Effect
         data object OpenManageFolders : Effect
         data object OpenSettings : Effect
+        data object OpenAddAccount : Effect
         data object CloseDrawer : Effect
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
@@ -5,9 +5,9 @@ import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawerExternalContract.DrawerConfig
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 
 internal interface DrawerContract {
 
@@ -20,7 +20,7 @@ internal interface DrawerContract {
             showStarredCount = false,
             showAccountSelector = true,
         ),
-        val accounts: ImmutableList<MailDisplayAccount> = persistentListOf(),
+        val accounts: ImmutableList<DisplayAccount> = persistentListOf(),
         val selectedAccountId: String? = null,
         val rootFolder: DisplayTreeFolder = DisplayTreeFolder(
             displayFolder = null,
@@ -32,14 +32,15 @@ internal interface DrawerContract {
         val folders: ImmutableList<DisplayFolder> = persistentListOf(),
         val selectedFolderId: String? = null,
         val selectedFolder: DisplayFolder? = null,
+        val showAccountSelection: Boolean = false,
         val isLoading: Boolean = false,
     )
 
     sealed interface Event {
         data class SelectAccount(val accountId: String?) : Event
         data class SelectFolder(val folderId: String?) : Event
-        data class OnAccountClick(val account: MailDisplayAccount) : Event
-        data class OnAccountViewClick(val account: MailDisplayAccount) : Event
+        data class OnAccountClick(val account: DisplayAccount) : Event
+        data class OnAccountViewClick(val account: DisplayAccount) : Event
         data class OnFolderClick(val folder: DisplayFolder) : Event
         data object OnAccountSelectorClick : Event
         data object OnManageFoldersClick : Event

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerContract.kt
@@ -31,6 +31,7 @@ internal interface DrawerContract {
         ),
         val folders: ImmutableList<DisplayFolder> = persistentListOf(),
         val selectedFolderId: String? = null,
+        val selectedFolder: DisplayFolder? = null,
         val isLoading: Boolean = false,
     )
 

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerView.kt
@@ -12,6 +12,7 @@ import net.thunderbird.feature.navigation.drawer.dropdown.FolderDrawerState
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Effect
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Event
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.ViewModel
+import net.thunderbird.feature.navigation.drawer.siderail.ui.SideRailDrawerContent
 import org.koin.androidx.compose.koinViewModel
 
 @Suppress("LongParameterList")

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerView.kt
@@ -24,6 +24,7 @@ internal fun DrawerView(
     openUnifiedFolder: () -> Unit,
     openManageFolders: () -> Unit,
     openSettings: () -> Unit,
+    openAddAccount: () -> Unit,
     closeDrawer: () -> Unit,
     featureFlagProvider: FeatureFlagProvider,
     viewModel: ViewModel = koinViewModel<DrawerViewModel>(),
@@ -39,6 +40,7 @@ internal fun DrawerView(
             Effect.OpenUnifiedFolder -> openUnifiedFolder()
             is Effect.OpenManageFolders -> openManageFolders()
             is Effect.OpenSettings -> openSettings()
+            Effect.OpenAddAccount -> openAddAccount()
             Effect.CloseDrawer -> closeDrawer()
         }
     }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
@@ -184,17 +184,19 @@ internal class DrawerViewModel(
     }
 
     private fun selectAccount(accountId: String?) {
-        viewModelScope.launch {
-            updateState {
-                it.copy(
-                    selectedAccountId = accountId,
-                )
-            }
-            delay(ACCOUNT_CLOSE_DELAY)
-            updateState {
-                it.copy(
-                    showAccountSelection = false,
-                )
+        if (accountId != state.value.selectedAccountId) {
+            viewModelScope.launch {
+                updateState {
+                    it.copy(
+                        selectedAccountId = accountId,
+                    )
+                }
+                delay(ACCOUNT_CLOSE_DELAY)
+                updateState {
+                    it.copy(
+                        showAccountSelection = false,
+                    )
+                }
             }
         }
     }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
@@ -180,6 +180,7 @@ internal class DrawerViewModel(
             Event.OnSettingsClick -> emitEffect(Effect.OpenSettings)
             Event.OnSyncAccount -> onSyncAccount()
             Event.OnSyncAllAccounts -> onSyncAllAccounts()
+            Event.OnAddAccountClick -> emitEffect(Effect.OpenAddAccount)
         }
     }
 

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextLabelSmall
 import app.k9mail.core.ui.compose.theme2.ColorRoles
-import app.k9mail.core.ui.compose.theme2.toColorRoles
 import net.thunderbird.feature.account.avatar.ui.Avatar
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountColor
@@ -25,11 +24,10 @@ internal fun AccountAvatar(
     modifier: Modifier = Modifier,
     onClick: ((DisplayAccount) -> Unit)? = null,
 ) {
-    val context = LocalContext.current
     val name = getDisplayAccountName(account)
     val color = getDisplayAccountColor(account)
-    val accountColor = calculateAccountColor(color)
-    val accountColorRoles = accountColor.toColorRoles(context)
+    val accountColor = rememberCalculatedAccountColor(color)
+    val accountColorRoles = rememberCalculatedAccountColorRoles(accountColor)
 
     Box(
         modifier = modifier,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
@@ -29,7 +28,7 @@ internal fun AccountAvatar(
     val context = LocalContext.current
     val name = getDisplayAccountName(account)
     val color = getDisplayAccountColor(account)
-    val accountColor = calculateAccountColor(color.toArgb())
+    val accountColor = calculateAccountColor(color)
     val accountColorRoles = accountColor.toColorRoles(context)
 
     Box(

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
@@ -13,18 +14,22 @@ import app.k9mail.core.ui.compose.designsystem.atom.text.TextLabelSmall
 import app.k9mail.core.ui.compose.theme2.ColorRoles
 import app.k9mail.core.ui.compose.theme2.toColorRoles
 import net.thunderbird.feature.account.avatar.ui.Avatar
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountColor
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountName
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.labelForCount
 
 @Composable
 internal fun AccountAvatar(
-    account: MailDisplayAccount,
+    account: DisplayAccount,
     selected: Boolean,
     modifier: Modifier = Modifier,
-    onClick: ((MailDisplayAccount) -> Unit)? = null,
+    onClick: ((DisplayAccount) -> Unit)? = null,
 ) {
     val context = LocalContext.current
-    val accountColor = calculateAccountColor(account.color)
+    val name = getDisplayAccountName(account)
+    val color = getDisplayAccountColor(account)
+    val accountColor = calculateAccountColor(color.toArgb())
     val accountColorRoles = accountColor.toColorRoles(context)
 
     Box(
@@ -33,7 +38,7 @@ internal fun AccountAvatar(
     ) {
         Avatar(
             color = accountColor,
-            name = account.name,
+            name = name,
             onClick = onClick?.let { { onClick(account) } },
             selected = selected,
         )

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountAvatar.kt
@@ -13,15 +13,15 @@ import app.k9mail.core.ui.compose.designsystem.atom.text.TextLabelSmall
 import app.k9mail.core.ui.compose.theme2.ColorRoles
 import app.k9mail.core.ui.compose.theme2.toColorRoles
 import net.thunderbird.feature.account.avatar.ui.Avatar
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.labelForCount
 
 @Composable
 internal fun AccountAvatar(
-    account: DisplayAccount,
+    account: MailDisplayAccount,
     selected: Boolean,
     modifier: Modifier = Modifier,
-    onClick: ((DisplayAccount) -> Unit)? = null,
+    onClick: ((MailDisplayAccount) -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val accountColor = calculateAccountColor(account.color)

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountList.kt
@@ -1,71 +1,42 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.designsystem.atom.Surface
-import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import kotlinx.collections.immutable.ImmutableList
-import net.thunderbird.feature.navigation.drawer.dropdown.R
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.setting.SettingItem
 
 @Composable
 internal fun AccountList(
     accounts: ImmutableList<DisplayAccount>,
     selectedAccount: DisplayAccount?,
     onAccountClick: (DisplayAccount) -> Unit,
-    onSyncAllAccountsClick: () -> Unit,
+    showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
-        modifier = modifier,
-        color = MainTheme.colors.surfaceContainer,
-    ) {
-        val horizontalInsetPadding = getDisplayCutOutHorizontalInsetPadding()
+    val listState = rememberLazyListState()
 
-        Column(
-            modifier = Modifier
-                .fillMaxHeight()
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .windowInsetsPadding(horizontalInsetPadding)
-                .width(MainTheme.sizes.large),
-        ) {
-            LazyColumn(
-                modifier = Modifier.weight(1f),
-                contentPadding = PaddingValues(vertical = MainTheme.spacings.default),
-            ) {
-                items(
-                    items = accounts,
-                    key = { account -> account.id },
-                ) { account ->
-                    AccountListItem(
-                        account = account,
-                        onClick = { onAccountClick(account) },
-                        selected = selectedAccount == account,
-                    )
-                }
-            }
-            Column(
-                modifier = Modifier.padding(vertical = MainTheme.spacings.oneHalf),
-            ) {
-                SettingItem(
-                    icon = Icons.Outlined.Sync,
-                    label = stringResource(id = R.string.navigation_drawer_dropdown_action_sync_all_accounts),
-                    onClick = onSyncAllAccountsClick,
-                )
-            }
+    LazyColumn(
+        state = listState,
+        modifier = modifier
+            .fillMaxWidth(),
+        contentPadding = PaddingValues(vertical = MainTheme.spacings.default),
+    ) {
+        items(
+            items = accounts,
+            key = { account -> account.id },
+        ) { account ->
+            AccountListItem(
+                account = account,
+                onClick = { onAccountClick(account) },
+                selected = selectedAccount == account,
+                showStarredCount = showStarredCount,
+            )
         }
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountList.kt
@@ -9,13 +9,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import kotlinx.collections.immutable.ImmutableList
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 
 @Composable
 internal fun AccountList(
-    accounts: ImmutableList<MailDisplayAccount>,
-    selectedAccount: MailDisplayAccount?,
-    onAccountClick: (MailDisplayAccount) -> Unit,
+    accounts: ImmutableList<DisplayAccount>,
+    selectedAccount: DisplayAccount?,
+    onAccountClick: (DisplayAccount) -> Unit,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountList.kt
@@ -9,13 +9,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import kotlinx.collections.immutable.ImmutableList
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 
 @Composable
 internal fun AccountList(
-    accounts: ImmutableList<DisplayAccount>,
-    selectedAccount: DisplayAccount?,
-    onAccountClick: (DisplayAccount) -> Unit,
+    accounts: ImmutableList<MailDisplayAccount>,
+    selectedAccount: MailDisplayAccount?,
+    onAccountClick: (MailDisplayAccount) -> Unit,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItem.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -17,16 +16,22 @@ import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerI
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.account.avatar.ui.AvatarOutlined
 import net.thunderbird.feature.account.avatar.ui.AvatarSize
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountColor
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountName
 
 @Composable
 internal fun AccountListItem(
-    account: MailDisplayAccount,
-    onClick: (MailDisplayAccount) -> Unit,
+    account: DisplayAccount,
+    onClick: (DisplayAccount) -> Unit,
     selected: Boolean,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val color = getDisplayAccountColor(account)
+    val name = getDisplayAccountName(account)
+
     NavigationDrawerItem(
         label = { AccountLabel(account = account) },
         selected = selected,
@@ -35,8 +40,8 @@ internal fun AccountListItem(
             .height(MainTheme.sizes.large),
         icon = {
             AvatarOutlined(
-                color = Color(account.color),
-                name = account.name,
+                color = color,
+                name = name,
                 size = AvatarSize.MEDIUM,
             )
         },
@@ -52,9 +57,11 @@ internal fun AccountListItem(
 
 @Composable
 private fun AccountLabel(
-    account: MailDisplayAccount,
+    account: DisplayAccount,
     modifier: Modifier = Modifier,
 ) {
+    val name = getDisplayAccountName(account)
+
     Column(
         verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
         modifier = modifier.fillMaxWidth(),
@@ -66,7 +73,7 @@ private fun AccountLabel(
                 }
             },
         )
-        if (account.name != account.email) {
+        if (account is MailDisplayAccount && account.name != account.email) {
             TextBodyMedium(
                 text = account.email,
             )

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItem.kt
@@ -17,12 +17,12 @@ import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerI
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.account.avatar.ui.AvatarOutlined
 import net.thunderbird.feature.account.avatar.ui.AvatarSize
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 
 @Composable
 internal fun AccountListItem(
-    account: DisplayAccount,
-    onClick: (DisplayAccount) -> Unit,
+    account: MailDisplayAccount,
+    onClick: (MailDisplayAccount) -> Unit,
     selected: Boolean,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
@@ -52,7 +52,7 @@ internal fun AccountListItem(
 
 @Composable
 private fun AccountLabel(
-    account: DisplayAccount,
+    account: MailDisplayAccount,
     modifier: Modifier = Modifier,
 ) {
     Column(

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItem.kt
@@ -1,12 +1,22 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItem
 import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.account.avatar.ui.AvatarOutlined
+import net.thunderbird.feature.account.avatar.ui.AvatarSize
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 
 @Composable
@@ -14,17 +24,52 @@ internal fun AccountListItem(
     account: DisplayAccount,
     onClick: (DisplayAccount) -> Unit,
     selected: Boolean,
+    showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        modifier = modifier.width(MainTheme.sizes.large)
-            .padding(vertical = MainTheme.spacings.half),
-        contentAlignment = Alignment.Center,
+    NavigationDrawerItem(
+        label = { AccountLabel(account = account) },
+        selected = selected,
+        onClick = { onClick(account) },
+        modifier = modifier.fillMaxWidth()
+            .height(MainTheme.sizes.large),
+        icon = {
+            AvatarOutlined(
+                color = Color(account.color),
+                name = account.name,
+                size = AvatarSize.MEDIUM,
+            )
+        },
+        badge = {
+            AccountListItemBadge(
+                unreadCount = account.unreadMessageCount,
+                starredCount = account.starredMessageCount,
+                showStarredCount = showStarredCount,
+            )
+        },
+    )
+}
+
+@Composable
+private fun AccountLabel(
+    account: DisplayAccount,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+        modifier = modifier.fillMaxWidth(),
     ) {
-        AccountAvatar(
-            account = account,
-            onClick = onClick,
-            selected = selected,
+        TextBodyLarge(
+            text = buildAnnotatedString {
+                withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                    append(name)
+                }
+            },
         )
+        if (account.name != account.email) {
+            TextBodyMedium(
+                text = account.email,
+            )
+        }
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItemBadge.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItemBadge.kt
@@ -1,6 +1,6 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
@@ -34,9 +34,9 @@ private fun AccountCountAndStarredBadge(
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Row(
+    Column(
         modifier = modifier,
-        verticalAlignment = Alignment.Companion.CenterVertically,
+        horizontalAlignment = Alignment.End,
     ) {
         val resources = LocalContext.current.resources
 

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItemBadge.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItemBadge.kt
@@ -1,55 +1,42 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui.folder
+package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
-import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItemBadge
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.labelForCount
 
 @Composable
-internal fun FolderListItemBadge(
+internal fun AccountListItemBadge(
     unreadCount: Int,
     starredCount: Int,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
-    expandableState: MutableState<Boolean>? = null,
 ) {
-    FolderCountAndStarredBadge(
+    AccountCountAndStarredBadge(
         unreadCount = unreadCount,
         starredCount = starredCount,
         showStarredCount = showStarredCount,
-        onClick = { expandableState?.value = !expandableState.value },
-        isExpanded = expandableState?.value,
         modifier = modifier,
     )
 }
 
 @Composable
-private fun FolderCountAndStarredBadge(
+private fun AccountCountAndStarredBadge(
     unreadCount: Int,
     starredCount: Int,
     showStarredCount: Boolean,
-    onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    isExpanded: Boolean? = null,
 ) {
     Row(
         modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = Alignment.Companion.CenterVertically,
     ) {
         val resources = LocalContext.current.resources
 
@@ -64,7 +51,7 @@ private fun FolderCountAndStarredBadge(
         }
 
         if (showStarredCount && starredCount > 0) {
-            Spacer(modifier = Modifier.width(MainTheme.spacings.half))
+            Spacer(modifier = Modifier.Companion.width(MainTheme.spacings.half))
             NavigationDrawerItemBadge(
                 label = labelForCount(
                     count = starredCount,
@@ -72,21 +59,6 @@ private fun FolderCountAndStarredBadge(
                 ),
                 imageVector = Icons.Filled.Star,
             )
-        }
-
-        if (isExpanded != null) {
-            Box(
-                modifier = Modifier
-                    .size(MainTheme.sizes.iconAvatar)
-                    .padding(start = MainTheme.spacings.quarter)
-                    .clip(CircleShape)
-                    .clickable(onClick = onClick),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = if (isExpanded) Icons.Outlined.KeyboardArrowUp else Icons.Outlined.KeyboardArrowDown,
-                )
-            }
         }
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -36,37 +35,40 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.account.avatar.ui.AvatarOutlined
 import net.thunderbird.feature.account.avatar.ui.AvatarSize
 import net.thunderbird.feature.navigation.drawer.dropdown.R
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountColor
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountName
 
 @Composable
 internal fun AccountView(
-    account: MailDisplayAccount,
+    account: DisplayAccount,
     onClick: () -> Unit,
-    showAccount: Boolean,
+    showAccountSelection: Boolean,
     modifier: Modifier = Modifier,
 ) {
     AccountLayout(
         onClick = onClick,
         modifier = modifier,
     ) {
-        if (showAccount) {
+        if (showAccountSelection) {
+            AccountSelectionView()
+        } else {
             AccountSelectedView(
                 account = account,
             )
-        } else {
-            AccountSelectionView()
         }
 
         AnimatedSelectionIcon(
-            showAccount,
+            showAccountSelection,
         )
     }
 }
 
 @Composable
-private fun AnimatedSelectionIcon(showAccount: Boolean) {
+private fun AnimatedSelectionIcon(showAccountSelection: Boolean) {
     val rotationAngle by animateFloatAsState(
-        targetValue = if (showAccount) 0f else 180f,
+        targetValue = if (showAccountSelection) 180f else 0f,
         label = "rotationAngle",
     )
 
@@ -82,11 +84,14 @@ private fun AnimatedSelectionIcon(showAccount: Boolean) {
 
 @Composable
 private fun RowScope.AccountSelectedView(
-    account: MailDisplayAccount,
+    account: DisplayAccount,
 ) {
+    val color = getDisplayAccountColor(account)
+    val name = getDisplayAccountName(account)
+
     AvatarOutlined(
-        color = Color(account.color),
-        name = account.name,
+        color = color,
+        name = name,
         size = AvatarSize.MEDIUM,
     )
     Column(
@@ -98,11 +103,11 @@ private fun RowScope.AccountSelectedView(
         TextBodyLarge(
             text = buildAnnotatedString {
                 withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                    append(account.name)
+                    append(name)
                 }
             },
         )
-        if (account.name != account.email) {
+        if (account is MailDisplayAccount && account.name != account.email) {
             TextBodyMedium(
                 text = account.email,
             )

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
@@ -1,102 +1,156 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.LayoutDirection
-import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.account.avatar.ui.AvatarOutlined
+import net.thunderbird.feature.account.avatar.ui.AvatarSize
+import net.thunderbird.feature.navigation.drawer.dropdown.R
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 
-@Suppress("LongMethod")
 @Composable
 internal fun AccountView(
     account: DisplayAccount,
     onClick: () -> Unit,
-    showAvatar: Boolean,
+    showAccount: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth()
-            .height(intrinsicSize = IntrinsicSize.Max),
-        verticalAlignment = Alignment.CenterVertically,
+    AccountLayout(
+        onClick = onClick,
+        modifier = modifier,
     ) {
-        AnimatedVisibility(visible = showAvatar) {
-            Surface(
-                color = MainTheme.colors.surfaceContainer,
-                modifier = Modifier.fillMaxHeight(),
-            ) {
-                val horizontalInsetPadding = getDisplayCutOutHorizontalInsetPadding()
-
-                Box(
-                    modifier = Modifier
-                        .windowInsetsPadding(horizontalInsetPadding)
-                        .width(MainTheme.sizes.large),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    AccountAvatar(
-                        account = account,
-                        onClick = null,
-                        selected = false,
-                    )
-                }
-            }
-        }
-        Row(
-            modifier = modifier
-                .clickable(onClick = onClick)
-                .height(intrinsicSize = IntrinsicSize.Max)
-                .fillMaxWidth()
-                .defaultMinSize(minHeight = MainTheme.sizes.large)
-                .padding(
-                    top = MainTheme.spacings.double,
-                    start = MainTheme.spacings.double,
-                    end = MainTheme.spacings.triple,
-                    bottom = MainTheme.spacings.double,
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            AccountIndicator(
-                accountColor = account.color,
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .padding(end = MainTheme.spacings.oneHalf),
+        if (showAccount) {
+            AccountSelectedView(
+                account = account,
             )
-            Column(
-                verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
-            ) {
-                TextBodyLarge(
-                    text = account.name,
-                    color = MainTheme.colors.onSurface,
-                )
-                if (account.name != account.email) {
-                    TextBodyMedium(
-                        text = account.email,
-                        color = MainTheme.colors.onSurfaceVariant,
-                    )
+        } else {
+            AccountSelectionView()
+        }
+
+        AnimatedSelectionIcon(
+            showAccount,
+        )
+    }
+}
+
+@Composable
+private fun AnimatedSelectionIcon(showAccount: Boolean) {
+    val rotationAngle by animateFloatAsState(
+        targetValue = if (showAccount) 0f else 180f,
+        label = "rotationAngle",
+    )
+
+    Icon(
+        imageVector = Icons.Outlined.KeyboardArrowDown,
+        contentDescription = null,
+        tint = MainTheme.colors.onSurfaceVariant,
+        modifier = Modifier
+            .padding(end = MainTheme.spacings.double)
+            .rotate(rotationAngle),
+    )
+}
+
+@Composable
+private fun RowScope.AccountSelectedView(
+    account: DisplayAccount,
+) {
+    AvatarOutlined(
+        color = Color(account.color),
+        name = account.name,
+        size = AvatarSize.MEDIUM,
+    )
+    Column(
+        verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+        modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f),
+    ) {
+        TextBodyLarge(
+            text = buildAnnotatedString {
+                withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                    append(account.name)
                 }
+            },
+        )
+        if (account.name != account.email) {
+            TextBodyMedium(
+                text = account.email,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RowScope.AccountSelectionView() {
+    TextBodyLarge(
+        text = buildAnnotatedString {
+            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                append(stringResource(R.string.navigation_drawer_dropdown_avount_view_selection_title))
             }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f),
+    )
+}
+
+@Composable
+private fun AccountLayout(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val horizontalInsetPadding = getDisplayCutOutHorizontalInsetPadding()
+
+    Box(
+        modifier = modifier
+            .windowInsetsPadding(horizontalInsetPadding)
+            .clickable(onClick = onClick)
+            .padding(
+                top = MainTheme.spacings.default,
+                start = MainTheme.spacings.triple,
+                end = MainTheme.spacings.double,
+                bottom = MainTheme.spacings.default,
+            ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(MainTheme.sizes.large),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.double),
+        ) {
+            content()
         }
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
@@ -36,11 +36,11 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.account.avatar.ui.AvatarOutlined
 import net.thunderbird.feature.account.avatar.ui.AvatarSize
 import net.thunderbird.feature.navigation.drawer.dropdown.R
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 
 @Composable
 internal fun AccountView(
-    account: DisplayAccount,
+    account: MailDisplayAccount,
     onClick: () -> Unit,
     showAccount: Boolean,
     modifier: Modifier = Modifier,
@@ -82,7 +82,7 @@ private fun AnimatedSelectionIcon(showAccount: Boolean) {
 
 @Composable
 private fun RowScope.AccountSelectedView(
-    account: DisplayAccount,
+    account: MailDisplayAccount,
 ) {
     AvatarOutlined(
         color = Color(account.color),

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
@@ -1,6 +1,5 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -16,10 +15,8 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -27,8 +24,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.LayoutDirection
-import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
-import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.theme2.MainTheme
@@ -37,6 +32,7 @@ import net.thunderbird.feature.account.avatar.ui.AvatarSize
 import net.thunderbird.feature.navigation.drawer.dropdown.R
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.AnimatedExpandIcon
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountColor
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountName
 
@@ -59,27 +55,12 @@ internal fun AccountView(
             )
         }
 
-        AnimatedSelectionIcon(
-            showAccountSelection,
+        AnimatedExpandIcon(
+            isExpanded = showAccountSelection,
+            modifier = Modifier.padding(end = MainTheme.spacings.double),
+            tint = MainTheme.colors.onSurfaceVariant,
         )
     }
-}
-
-@Composable
-private fun AnimatedSelectionIcon(showAccountSelection: Boolean) {
-    val rotationAngle by animateFloatAsState(
-        targetValue = if (showAccountSelection) 180f else 0f,
-        label = "rotationAngle",
-    )
-
-    Icon(
-        imageVector = Icons.Outlined.KeyboardArrowDown,
-        contentDescription = null,
-        tint = MainTheme.colors.onSurfaceVariant,
-        modifier = Modifier
-            .padding(end = MainTheme.spacings.double)
-            .rotate(rotationAngle),
-    )
 }
 
 @Composable

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/CalculateAccountColor.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/CalculateAccountColor.kt
@@ -6,10 +6,10 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.core.ui.compose.theme2.toHarmonizedColor
 
 @Composable
-internal fun calculateAccountColor(accountColor: Int): Color {
-    return if (accountColor == 0) {
+internal fun calculateAccountColor(accountColor: Color): Color {
+    return if (accountColor == Color.Unspecified) {
         MainTheme.colors.primary
     } else {
-        Color(accountColor).toHarmonizedColor(MainTheme.colors.surface)
+        accountColor.toHarmonizedColor(MainTheme.colors.surface)
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/CalculateAccountColor.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/CalculateAccountColor.kt
@@ -1,15 +1,31 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.core.ui.compose.theme2.toHarmonizedColor
 
+/**
+ * Calculates the account color based on the provided account color and surface color.
+ *
+ * If the account color is unspecified, it returns the fallback color.
+ * Otherwise, it harmonizes the account color with the surface color.
+ *
+ * @param accountColor The color of the account.
+ * @param fallbackColor The fallback color to use if the account color is unspecified.
+ */
 @Composable
-internal fun calculateAccountColor(accountColor: Color): Color {
-    return if (accountColor == Color.Unspecified) {
-        MainTheme.colors.primary
-    } else {
-        accountColor.toHarmonizedColor(MainTheme.colors.surface)
+internal fun rememberCalculatedAccountColor(
+    accountColor: Color,
+    fallbackColor: Color = MainTheme.colors.primary,
+): Color {
+    val surfaceColor = MainTheme.colors.surface
+    return remember(accountColor, surfaceColor, fallbackColor) {
+        if (accountColor == Color.Unspecified) {
+            fallbackColor
+        } else {
+            accountColor.toHarmonizedColor(surfaceColor)
+        }
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/CalculateAccountColorRoles.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/CalculateAccountColorRoles.kt
@@ -1,0 +1,27 @@
+package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import app.k9mail.core.ui.compose.theme2.ColorRoles
+import app.k9mail.core.ui.compose.theme2.toColorRoles
+
+/**
+ * Calculates the color roles for the given account color.
+ *
+ * This function is used to derive the color roles for an account based on its color and
+ * use remember to avoid unnecessary recomputations.
+ *
+ * @param accountColor The color of the account.
+ */
+@Composable
+internal fun rememberCalculatedAccountColorRoles(
+    accountColor: Color,
+): ColorRoles {
+    val context = LocalContext.current
+
+    return remember(accountColor) {
+        accountColor.toColorRoles(context)
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/common/AnimatedExpandIcon.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/common/AnimatedExpandIcon.kt
@@ -1,0 +1,30 @@
+package net.thunderbird.feature.navigation.drawer.dropdown.ui.common
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+
+@Composable
+internal fun AnimatedExpandIcon(
+    isExpanded: Boolean,
+    modifier: Modifier = Modifier,
+    tint: Color? = null,
+) {
+    val rotationAngle by animateFloatAsState(
+        targetValue = if (isExpanded) 180f else 0f,
+        label = "rotationAngle",
+    )
+
+    Icon(
+        imageVector = Icons.Outlined.KeyboardArrowDown,
+        contentDescription = null,
+        tint = tint,
+        modifier = modifier
+            .rotate(rotationAngle),
+    )
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/common/DisplayAccountUtils.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/common/DisplayAccountUtils.kt
@@ -1,0 +1,38 @@
+package net.thunderbird.feature.navigation.drawer.dropdown.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.navigation.drawer.dropdown.R
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayAccount
+
+@Composable
+internal fun getDisplayAccountColor(account: DisplayAccount): Color {
+    return when (account) {
+        is UnifiedDisplayAccount -> {
+            MainTheme.colors.onSurfaceVariant
+        }
+        is MailDisplayAccount -> {
+            Color(account.color)
+        }
+
+        else -> throw IllegalArgumentException("Unknown account type: ${account::class.java.simpleName}")
+    }
+}
+
+@Composable
+internal fun getDisplayAccountName(account: DisplayAccount): String {
+    return when (account) {
+        is UnifiedDisplayAccount -> {
+            stringResource(R.string.navigation_drawer_dropdown_unified_account_title)
+        }
+        is MailDisplayAccount -> {
+            account.name
+        }
+
+        else -> throw IllegalArgumentException("Unknown account type: ${account::class.java.simpleName}")
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderList.kt
@@ -41,7 +41,6 @@ internal fun FolderList(
                     "Null DisplayFolder for folder ${folder.displayName}"
                 },
                 treeFolder = folder,
-                selected = currentDisplayFolder == selectedFolder,
                 showStarredCount = showStarredCount,
                 onClick = onFolderClick,
                 folderNameFormatter = folderNameFormatter,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderList.kt
@@ -31,8 +31,7 @@ internal fun FolderList(
 
     LazyColumn(
         state = listState,
-        modifier = modifier
-            .fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         contentPadding = PaddingValues(vertical = MainTheme.spacings.default),
     ) {
         items(

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderList.kt
@@ -15,7 +15,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
 
 @Composable
 internal fun FolderList(
@@ -50,7 +50,7 @@ internal fun FolderList(
                 folderNameFormatter = folderNameFormatter,
                 selectedFolderId = selectedFolder?.id,
             )
-            if (currentDisplayFolder is DisplayUnifiedFolder) {
+            if (currentDisplayFolder is UnifiedDisplayFolder) {
                 DividerHorizontal(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderList.kt
@@ -2,7 +2,6 @@ package net.thunderbird.feature.navigation.drawer.dropdown.ui.folder
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -10,12 +9,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
 
 @Composable
 internal fun FolderList(
@@ -50,16 +47,6 @@ internal fun FolderList(
                 folderNameFormatter = folderNameFormatter,
                 selectedFolderId = selectedFolder?.id,
             )
-            if (currentDisplayFolder is UnifiedDisplayFolder) {
-                DividerHorizontal(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(
-                            vertical = MainTheme.spacings.default,
-                            horizontal = MainTheme.spacings.triple,
-                        ),
-                )
-            }
         }
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
@@ -26,14 +26,13 @@ import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedD
 @Composable
 internal fun FolderListItem(
     displayFolder: DisplayFolder,
-    selected: Boolean,
     onClick: (DisplayFolder) -> Unit,
     showStarredCount: Boolean,
     folderNameFormatter: FolderNameFormatter,
+    selectedFolderId: String?,
     modifier: Modifier = Modifier,
     treeFolder: DisplayTreeFolder? = null,
     parentPrefix: String? = "",
-    selectedFolderId: String? = null,
     indentationLevel: Int = 1,
 ) {
     val isExpanded = rememberSaveable { mutableStateOf(false) }
@@ -53,7 +52,7 @@ internal fun FolderListItem(
     ) {
         NavigationDrawerItem(
             label = mapFolderName(displayFolder, folderNameFormatter, parentPrefix),
-            selected = selected,
+            selected = selectedFolderId == displayFolder.id,
             onClick = { onClick(displayFolder) },
             modifier = Modifier.fillMaxWidth(),
             icon = {
@@ -80,7 +79,7 @@ internal fun FolderListItem(
             if (displayChild === null) continue
             FolderListItem(
                 displayFolder = displayChild,
-                selected = selectedFolderId?.let { displayChild.id == selectedFolderId } == true,
+                selectedFolderId = selectedFolderId,
                 showStarredCount = showStarredCount,
                 onClick = onClick,
                 folderNameFormatter = folderNameFormatter,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
@@ -17,11 +17,11 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.navigation.drawer.dropdown.R
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccountFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 
 @Composable
 internal fun FolderListItem(
@@ -88,7 +88,7 @@ internal fun FolderListItem(
                     .fillMaxWidth()
                     .padding(start = MainTheme.spacings.double * indentationLevel),
                 treeFolder = child,
-                parentPrefix = if (displayParent is DisplayAccountFolder) displayParent.folder.name else null,
+                parentPrefix = if (displayParent is MailDisplayFolder) displayParent.folder.name else null,
                 indentationLevel = indentationLevel + 1,
             )
         }
@@ -102,28 +102,28 @@ private fun mapFolderName(
     parentPrefix: String? = "",
 ): String {
     return when (displayFolder) {
-        is DisplayAccountFolder -> folderNameFormatter.displayName(displayFolder.folder).removePrefix("$parentPrefix/")
-        is DisplayUnifiedFolder -> mapUnifiedFolderName(displayFolder)
+        is MailDisplayFolder -> folderNameFormatter.displayName(displayFolder.folder).removePrefix("$parentPrefix/")
+        is UnifiedDisplayFolder -> mapUnifiedFolderName(displayFolder)
         else -> throw IllegalArgumentException("Unknown display folder: $displayFolder")
     }
 }
 
 @Composable
-private fun mapUnifiedFolderName(folder: DisplayUnifiedFolder): String {
+private fun mapUnifiedFolderName(folder: UnifiedDisplayFolder): String {
     return when (folder.unifiedType) {
-        DisplayUnifiedFolderType.INBOX -> stringResource(R.string.navigation_drawer_dropdown_unified_inbox_title)
+        UnifiedDisplayFolderType.INBOX -> stringResource(R.string.navigation_drawer_dropdown_unified_inbox_title)
     }
 }
 
 private fun mapFolderIcon(folder: DisplayFolder): ImageVector {
     return when (folder) {
-        is DisplayAccountFolder -> mapDisplayAccountFolderIcon(folder)
-        is DisplayUnifiedFolder -> mapDisplayUnifiedFolderIcon(folder)
+        is MailDisplayFolder -> mapDisplayAccountFolderIcon(folder)
+        is UnifiedDisplayFolder -> mapDisplayUnifiedFolderIcon(folder)
         else -> throw IllegalArgumentException("Unknown display folder type: $folder")
     }
 }
 
-private fun mapDisplayAccountFolderIcon(folder: DisplayAccountFolder): ImageVector {
+private fun mapDisplayAccountFolderIcon(folder: MailDisplayFolder): ImageVector {
     return when (folder.folder.type) {
         FolderType.INBOX -> Icons.Outlined.Inbox
         FolderType.OUTBOX -> Icons.Outlined.Outbox
@@ -136,8 +136,8 @@ private fun mapDisplayAccountFolderIcon(folder: DisplayAccountFolder): ImageVect
     }
 }
 
-private fun mapDisplayUnifiedFolderIcon(folder: DisplayUnifiedFolder): ImageVector {
+private fun mapDisplayUnifiedFolderIcon(folder: UnifiedDisplayFolder): ImageVector {
     when (folder.unifiedType) {
-        DisplayUnifiedFolderType.INBOX -> return Icons.Outlined.AllInbox
+        UnifiedDisplayFolderType.INBOX -> return Icons.Outlined.AllInbox
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItem.kt
@@ -36,7 +36,7 @@ internal fun FolderListItem(
     selectedFolderId: String? = null,
     indentationLevel: Int = 1,
 ) {
-    var isExpanded = rememberSaveable { mutableStateOf(false) }
+    val isExpanded = rememberSaveable { mutableStateOf(false) }
 
     var unreadCount = displayFolder.unreadMessageCount
     var starredCount = displayFolder.starredMessageCount

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItemBadge.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/folder/FolderListItemBadge.kt
@@ -1,20 +1,12 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.folder
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
-import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerItemBadge
 import app.k9mail.core.ui.compose.theme2.MainTheme
@@ -26,14 +18,11 @@ internal fun FolderListItemBadge(
     starredCount: Int,
     showStarredCount: Boolean,
     modifier: Modifier = Modifier,
-    expandableState: MutableState<Boolean>? = null,
 ) {
     FolderCountAndStarredBadge(
         unreadCount = unreadCount,
         starredCount = starredCount,
         showStarredCount = showStarredCount,
-        onClick = { expandableState?.value = !expandableState.value },
-        isExpanded = expandableState?.value,
         modifier = modifier,
     )
 }
@@ -43,13 +32,11 @@ private fun FolderCountAndStarredBadge(
     unreadCount: Int,
     starredCount: Int,
     showStarredCount: Boolean,
-    onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    isExpanded: Boolean? = null,
 ) {
-    Row(
+    Column(
         modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically,
+        horizontalAlignment = Alignment.End,
     ) {
         val resources = LocalContext.current.resources
 
@@ -72,21 +59,6 @@ private fun FolderCountAndStarredBadge(
                 ),
                 imageVector = Icons.Filled.Star,
             )
-        }
-
-        if (isExpanded != null) {
-            Box(
-                modifier = Modifier
-                    .size(MainTheme.sizes.iconAvatar)
-                    .padding(start = MainTheme.spacings.quarter)
-                    .clip(CircleShape)
-                    .clickable(onClick = onClick),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = if (isExpanded) Icons.Outlined.KeyboardArrowUp else Icons.Outlined.KeyboardArrowDown,
-                )
-            }
         }
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/AccountSettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/AccountSettingList.kt
@@ -1,6 +1,5 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.setting
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -12,6 +11,7 @@ import net.thunderbird.feature.navigation.drawer.dropdown.R
 
 @Composable
 internal fun AccountSettingList(
+    onAddAccountClick: () -> Unit,
     onSyncAllAccountsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -25,6 +25,13 @@ internal fun AccountSettingList(
                 label = stringResource(id = R.string.navigation_drawer_dropdown_action_sync_all_accounts),
                 onClick = onSyncAllAccountsClick,
                 icon = Icons.Outlined.Sync,
+            )
+        }
+        item {
+            SettingListItem(
+                label = stringResource(id = R.string.navigation_drawer_dropdown_action_add_account),
+                onClick = onAddAccountClick,
+                icon = Icons.Outlined.Add,
             )
         }
     }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/AccountSettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/AccountSettingList.kt
@@ -1,0 +1,29 @@
+package net.thunderbird.feature.navigation.drawer.dropdown.ui.setting
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.navigation.drawer.dropdown.R
+
+@Composable
+internal fun AccountSettingList(
+    onSyncAllAccountsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(vertical = MainTheme.spacings.default)
+            .fillMaxWidth(),
+    ) {
+        SettingListItem(
+            label = stringResource(id = R.string.navigation_drawer_dropdown_action_sync_all_accounts),
+            onClick = onSyncAllAccountsClick,
+            icon = Icons.Outlined.Sync,
+        )
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/AccountSettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/AccountSettingList.kt
@@ -15,15 +15,17 @@ internal fun AccountSettingList(
     onSyncAllAccountsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    SettingList(
         modifier = modifier
             .padding(vertical = MainTheme.spacings.default)
             .fillMaxWidth(),
     ) {
-        SettingListItem(
-            label = stringResource(id = R.string.navigation_drawer_dropdown_action_sync_all_accounts),
-            onClick = onSyncAllAccountsClick,
-            icon = Icons.Outlined.Sync,
-        )
+        item {
+            SettingListItem(
+                label = stringResource(id = R.string.navigation_drawer_dropdown_action_sync_all_accounts),
+                onClick = onSyncAllAccountsClick,
+                icon = Icons.Outlined.Sync,
+            )
+        }
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/FolderSettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/FolderSettingList.kt
@@ -14,6 +14,7 @@ import net.thunderbird.feature.navigation.drawer.dropdown.R
 internal fun FolderSettingList(
     onManageFoldersClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    isUnifiedAccount: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -21,11 +22,13 @@ internal fun FolderSettingList(
             .padding(vertical = MainTheme.spacings.default)
             .fillMaxWidth(),
     ) {
-        SettingListItem(
-            label = stringResource(R.string.navigation_drawer_dropdown_action_manage_folders),
-            onClick = onManageFoldersClick,
-            icon = Icons.Outlined.FolderManaged,
-        )
+        if (isUnifiedAccount.not()) {
+            SettingListItem(
+                label = stringResource(R.string.navigation_drawer_dropdown_action_manage_folders),
+                onClick = onManageFoldersClick,
+                icon = Icons.Outlined.FolderManaged,
+            )
+        }
         SettingListItem(
             label = stringResource(id = R.string.navigation_drawer_dropdown_action_settings),
             onClick = onSettingsClick,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/FolderSettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/FolderSettingList.kt
@@ -1,11 +1,14 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.setting
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.common.window.WindowSizeClass
+import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.navigation.drawer.dropdown.R
@@ -17,22 +20,26 @@ internal fun FolderSettingList(
     isUnifiedAccount: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    SettingList(
         modifier = modifier
             .padding(vertical = MainTheme.spacings.default)
             .fillMaxWidth(),
     ) {
         if (isUnifiedAccount.not()) {
+            item {
+                SettingListItem(
+                    label = stringResource(R.string.navigation_drawer_dropdown_action_manage_folders),
+                    onClick = onManageFoldersClick,
+                    icon = Icons.Outlined.FolderManaged,
+                )
+            }
+        }
+        item {
             SettingListItem(
-                label = stringResource(R.string.navigation_drawer_dropdown_action_manage_folders),
-                onClick = onManageFoldersClick,
-                icon = Icons.Outlined.FolderManaged,
+                label = stringResource(id = R.string.navigation_drawer_dropdown_action_settings),
+                onClick = onSettingsClick,
+                icon = Icons.Outlined.Settings,
             )
         }
-        SettingListItem(
-            label = stringResource(id = R.string.navigation_drawer_dropdown_action_settings),
-            onClick = onSettingsClick,
-            icon = Icons.Outlined.Settings,
-        )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/FolderSettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/FolderSettingList.kt
@@ -1,11 +1,8 @@
 package net.thunderbird.feature.navigation.drawer.dropdown.ui.setting
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -14,7 +11,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.navigation.drawer.dropdown.R
 
 @Composable
-internal fun SettingList(
+internal fun FolderSettingList(
     onManageFoldersClick: () -> Unit,
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -22,18 +19,17 @@ internal fun SettingList(
     Column(
         modifier = modifier
             .padding(vertical = MainTheme.spacings.default)
-            .windowInsetsPadding(WindowInsets.navigationBars)
             .fillMaxWidth(),
     ) {
         SettingListItem(
             label = stringResource(R.string.navigation_drawer_dropdown_action_manage_folders),
             onClick = onManageFoldersClick,
-            imageVector = Icons.Outlined.FolderManaged,
+            icon = Icons.Outlined.FolderManaged,
         )
         SettingListItem(
             label = stringResource(id = R.string.navigation_drawer_dropdown_action_settings),
             onClick = onSettingsClick,
-            imageVector = Icons.Outlined.Settings,
+            icon = Icons.Outlined.Settings,
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/FolderSettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/FolderSettingList.kt
@@ -2,13 +2,9 @@ package net.thunderbird.feature.navigation.drawer.dropdown.ui.setting
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import app.k9mail.core.ui.compose.common.window.WindowSizeClass
-import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.navigation.drawer.dropdown.R

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingList.kt
@@ -10,7 +10,7 @@ import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
 
 @Composable
 internal fun SettingList(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     content: LazyGridScope.() -> Unit,
 ) {
     val windowSizeInfo = getWindowSizeInfo()

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingList.kt
@@ -1,0 +1,28 @@
+package net.thunderbird.feature.navigation.drawer.dropdown.ui.setting
+
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.common.window.WindowSizeClass
+import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
+
+@Composable
+internal fun SettingList(
+    modifier: Modifier,
+    content: LazyGridScope.() -> Unit,
+) {
+    val windowSizeInfo = getWindowSizeInfo()
+    val isLandscape = windowSizeInfo.screenWidth > windowSizeInfo.screenHeight
+    val useMultipleRows = isLandscape && windowSizeInfo.screenWidthSizeClass != WindowSizeClass.Compact
+
+    val rows = if (useMultipleRows) 2 else 1
+
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(rows),
+        modifier = modifier,
+    ) {
+        content()
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/setting/SettingListItem.kt
@@ -10,7 +10,7 @@ import app.k9mail.core.ui.compose.designsystem.organism.drawer.NavigationDrawerI
 internal fun SettingListItem(
     label: String,
     onClick: () -> Unit,
-    imageVector: ImageVector,
+    icon: ImageVector,
     modifier: Modifier = Modifier,
 ) {
     NavigationDrawerItem(
@@ -20,7 +20,7 @@ internal fun SettingListItem(
         selected = false,
         icon = {
             Icon(
-                imageVector = imageVector,
+                imageVector = icon,
             )
         },
     )

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/SideRailDrawerContent.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/SideRailDrawerContent.kt
@@ -1,4 +1,4 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui
+package net.thunderbird.feature.navigation.drawer.siderail.ui
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
@@ -16,12 +16,12 @@ import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Event
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.State
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountList
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountView
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.DRAWER_WIDTH
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getAdditionalWidth
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.folder.FolderList
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.setting.SettingList
+import net.thunderbird.feature.navigation.drawer.siderail.ui.account.SideRailAccountList
+import net.thunderbird.feature.navigation.drawer.siderail.ui.setting.SideRailSettingList
 
 @Composable
 internal fun SideRailDrawerContent(
@@ -53,7 +53,7 @@ internal fun SideRailDrawerContent(
                 AnimatedVisibility(
                     visible = state.config.showAccountSelector,
                 ) {
-                    AccountList(
+                    SideRailAccountList(
                         accounts = state.accounts,
                         selectedAccount = selectedAccount,
                         onAccountClick = { onEvent(Event.OnAccountClick(it)) },
@@ -76,7 +76,7 @@ internal fun SideRailDrawerContent(
                         modifier = Modifier.weight(1f),
                     )
                     DividerHorizontal()
-                    SettingList(
+                    SideRailSettingList(
                         onAccountSelectorClick = { onEvent(Event.OnAccountSelectorClick) },
                         onManageFoldersClick = { onEvent(Event.OnManageFoldersClick) },
                         showAccountSelector = state.config.showAccountSelector,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/SideRailDrawerContent.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/SideRailDrawerContent.kt
@@ -16,11 +16,11 @@ import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Event
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.State
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountView
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.DRAWER_WIDTH
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getAdditionalWidth
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.folder.FolderList
 import net.thunderbird.feature.navigation.drawer.siderail.ui.account.SideRailAccountList
+import net.thunderbird.feature.navigation.drawer.siderail.ui.account.SideRailAccountView
 import net.thunderbird.feature.navigation.drawer.siderail.ui.setting.SideRailSettingList
 
 @Composable
@@ -41,7 +41,7 @@ internal fun SideRailDrawerContent(
         val selectedAccount = state.accounts.firstOrNull { it.id == state.selectedAccountId }
         Column {
             selectedAccount?.let {
-                AccountView(
+                SideRailAccountView(
                     account = selectedAccount,
                     onClick = { onEvent(Event.OnAccountViewClick(selectedAccount)) },
                     showAvatar = state.config.showAccountSelector,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicator.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicator.kt
@@ -4,13 +4,15 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.calculateAccountColor
 
 @Composable
 internal fun SideRailAccountIndicator(
-    accountColor: Int,
+    accountColor: Color,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -19,7 +21,7 @@ internal fun SideRailAccountIndicator(
             .defaultMinSize(
                 minHeight = MainTheme.spacings.default,
             ),
-        color = calculateAccountColor(accountColor),
+        color = calculateAccountColor(accountColor.toArgb()),
         shape = MainTheme.shapes.medium,
     ) {}
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicator.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicator.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.calculateAccountColor
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.rememberCalculatedAccountColor
 
 @Composable
 internal fun SideRailAccountIndicator(
@@ -20,7 +20,7 @@ internal fun SideRailAccountIndicator(
             .defaultMinSize(
                 minHeight = MainTheme.spacings.default,
             ),
-        color = calculateAccountColor(accountColor),
+        color = rememberCalculatedAccountColor(accountColor),
         shape = MainTheme.shapes.medium,
     ) {}
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicator.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicator.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.calculateAccountColor
@@ -21,7 +20,7 @@ internal fun SideRailAccountIndicator(
             .defaultMinSize(
                 minHeight = MainTheme.spacings.default,
             ),
-        color = calculateAccountColor(accountColor.toArgb()),
+        color = calculateAccountColor(accountColor),
         shape = MainTheme.shapes.medium,
     ) {}
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicator.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountIndicator.kt
@@ -1,4 +1,4 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
+package net.thunderbird.feature.navigation.drawer.siderail.ui.account
 
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.width
@@ -6,9 +6,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.calculateAccountColor
 
 @Composable
-internal fun AccountIndicator(
+internal fun SideRailAccountIndicator(
     accountColor: Int,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountList.kt
@@ -1,9 +1,11 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui.account
+package net.thunderbird.feature.navigation.drawer.siderail.ui.account
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -13,20 +15,24 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import kotlinx.collections.immutable.ImmutableList
 import net.thunderbird.feature.navigation.drawer.dropdown.R
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountListItem
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.getDisplayCutOutHorizontalInsetPadding
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.setting.SettingItem
 
 @Composable
-internal fun AccountList(
+internal fun SideRailAccountList(
     accounts: ImmutableList<DisplayAccount>,
     selectedAccount: DisplayAccount?,
     onAccountClick: (DisplayAccount) -> Unit,
     onSyncAllAccountsClick: () -> Unit,
+    onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -64,6 +70,13 @@ internal fun AccountList(
                     icon = Icons.Outlined.Sync,
                     label = stringResource(id = R.string.navigation_drawer_dropdown_action_sync_all_accounts),
                     onClick = onSyncAllAccountsClick,
+                )
+                // Hack to compensate the column placement at an uneven coordinate, caused by the 1.dp divider.
+                Spacer(modifier = Modifier.height(7.dp))
+                SettingItem(
+                    icon = Icons.Outlined.Settings,
+                    label = stringResource(id = R.string.navigation_drawer_dropdown_action_settings),
+                    onClick = onSettingsClick,
                 )
             }
         }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountList.kt
@@ -21,15 +21,15 @@ import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import kotlinx.collections.immutable.ImmutableList
 import net.thunderbird.feature.navigation.drawer.dropdown.R
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.getDisplayCutOutHorizontalInsetPadding
 import net.thunderbird.feature.navigation.drawer.siderail.ui.setting.SideRailSettingItem
 
 @Composable
 internal fun SideRailAccountList(
-    accounts: ImmutableList<MailDisplayAccount>,
-    selectedAccount: MailDisplayAccount?,
-    onAccountClick: (MailDisplayAccount) -> Unit,
+    accounts: ImmutableList<DisplayAccount>,
+    selectedAccount: DisplayAccount?,
+    onAccountClick: (DisplayAccount) -> Unit,
     onSyncAllAccountsClick: () -> Unit,
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountList.kt
@@ -21,15 +21,15 @@ import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import kotlinx.collections.immutable.ImmutableList
 import net.thunderbird.feature.navigation.drawer.dropdown.R
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.getDisplayCutOutHorizontalInsetPadding
 import net.thunderbird.feature.navigation.drawer.siderail.ui.setting.SideRailSettingItem
 
 @Composable
 internal fun SideRailAccountList(
-    accounts: ImmutableList<DisplayAccount>,
-    selectedAccount: DisplayAccount?,
-    onAccountClick: (DisplayAccount) -> Unit,
+    accounts: ImmutableList<MailDisplayAccount>,
+    selectedAccount: MailDisplayAccount?,
+    onAccountClick: (MailDisplayAccount) -> Unit,
     onSyncAllAccountsClick: () -> Unit,
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountList.kt
@@ -22,9 +22,8 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 import kotlinx.collections.immutable.ImmutableList
 import net.thunderbird.feature.navigation.drawer.dropdown.R
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountListItem
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.getDisplayCutOutHorizontalInsetPadding
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.setting.SettingItem
+import net.thunderbird.feature.navigation.drawer.siderail.ui.setting.SideRailSettingItem
 
 @Composable
 internal fun SideRailAccountList(
@@ -56,7 +55,7 @@ internal fun SideRailAccountList(
                     items = accounts,
                     key = { account -> account.id },
                 ) { account ->
-                    AccountListItem(
+                    SideRailAccountListItem(
                         account = account,
                         onClick = { onAccountClick(account) },
                         selected = selectedAccount == account,
@@ -66,14 +65,14 @@ internal fun SideRailAccountList(
             Column(
                 modifier = Modifier.padding(vertical = MainTheme.spacings.oneHalf),
             ) {
-                SettingItem(
+                SideRailSettingItem(
                     icon = Icons.Outlined.Sync,
                     label = stringResource(id = R.string.navigation_drawer_dropdown_action_sync_all_accounts),
                     onClick = onSyncAllAccountsClick,
                 )
                 // Hack to compensate the column placement at an uneven coordinate, caused by the 1.dp divider.
                 Spacer(modifier = Modifier.height(7.dp))
-                SettingItem(
+                SideRailSettingItem(
                     icon = Icons.Outlined.Settings,
                     label = stringResource(id = R.string.navigation_drawer_dropdown_action_settings),
                     onClick = onSettingsClick,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItem.kt
@@ -7,13 +7,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.theme2.MainTheme
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountAvatar
 
 @Composable
 internal fun SideRailAccountListItem(
-    account: MailDisplayAccount,
-    onClick: (MailDisplayAccount) -> Unit,
+    account: DisplayAccount,
+    onClick: (DisplayAccount) -> Unit,
     selected: Boolean,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItem.kt
@@ -1,0 +1,31 @@
+package net.thunderbird.feature.navigation.drawer.siderail.ui.account
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountAvatar
+
+@Composable
+internal fun SideRailAccountListItem(
+    account: DisplayAccount,
+    onClick: (DisplayAccount) -> Unit,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.width(MainTheme.sizes.large)
+            .padding(vertical = MainTheme.spacings.half),
+        contentAlignment = Alignment.Center,
+    ) {
+        AccountAvatar(
+            account = account,
+            onClick = onClick,
+            selected = selected,
+        )
+    }
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountListItem.kt
@@ -7,13 +7,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.theme2.MainTheme
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountAvatar
 
 @Composable
 internal fun SideRailAccountListItem(
-    account: DisplayAccount,
-    onClick: (DisplayAccount) -> Unit,
+    account: MailDisplayAccount,
+    onClick: (MailDisplayAccount) -> Unit,
     selected: Boolean,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountView.kt
@@ -27,13 +27,13 @@ import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.theme2.MainTheme
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountAvatar
 
 @Suppress("LongMethod")
 @Composable
 internal fun SideRailAccountView(
-    account: DisplayAccount,
+    account: MailDisplayAccount,
     onClick: () -> Unit,
     showAvatar: Boolean,
     modifier: Modifier = Modifier,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountView.kt
@@ -1,0 +1,109 @@
+package net.thunderbird.feature.navigation.drawer.siderail.ui.account
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountAvatar
+
+@Suppress("LongMethod")
+@Composable
+internal fun SideRailAccountView(
+    account: DisplayAccount,
+    onClick: () -> Unit,
+    showAvatar: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth()
+            .height(intrinsicSize = IntrinsicSize.Max),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AnimatedVisibility(visible = showAvatar) {
+            Surface(
+                color = MainTheme.colors.surfaceContainer,
+                modifier = Modifier.fillMaxHeight(),
+            ) {
+                val horizontalInsetPadding = getDisplayCutOutHorizontalInsetPadding()
+
+                Box(
+                    modifier = Modifier
+                        .windowInsetsPadding(horizontalInsetPadding)
+                        .width(MainTheme.sizes.large),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    AccountAvatar(
+                        account = account,
+                        onClick = null,
+                        selected = false,
+                    )
+                }
+            }
+        }
+        Row(
+            modifier = modifier
+                .clickable(onClick = onClick)
+                .height(intrinsicSize = IntrinsicSize.Max)
+                .fillMaxWidth()
+                .defaultMinSize(minHeight = MainTheme.sizes.large)
+                .padding(
+                    top = MainTheme.spacings.double,
+                    start = MainTheme.spacings.double,
+                    end = MainTheme.spacings.triple,
+                    bottom = MainTheme.spacings.double,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SideRailAccountIndicator(
+                accountColor = account.color,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .padding(end = MainTheme.spacings.oneHalf),
+            )
+            Column(
+                verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+            ) {
+                TextBodyLarge(
+                    text = account.name,
+                    color = MainTheme.colors.onSurface,
+                )
+                if (account.name != account.email) {
+                    TextBodyMedium(
+                        text = account.email,
+                        color = MainTheme.colors.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun getDisplayCutOutHorizontalInsetPadding(): WindowInsets {
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    return WindowInsets.displayCutout.only(if (isRtl) WindowInsetsSides.Right else WindowInsetsSides.Left)
+}

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/account/SideRailAccountView.kt
@@ -27,13 +27,16 @@ import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.account.AccountAvatar
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountColor
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.common.getDisplayAccountName
 
 @Suppress("LongMethod")
 @Composable
 internal fun SideRailAccountView(
-    account: MailDisplayAccount,
+    account: DisplayAccount,
     onClick: () -> Unit,
     showAvatar: Boolean,
     modifier: Modifier = Modifier,
@@ -78,8 +81,11 @@ internal fun SideRailAccountView(
                 ),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            val color = getDisplayAccountColor(account)
+            val name = getDisplayAccountName(account)
+
             SideRailAccountIndicator(
-                accountColor = account.color,
+                accountColor = color,
                 modifier = Modifier
                     .fillMaxHeight()
                     .padding(end = MainTheme.spacings.oneHalf),
@@ -88,10 +94,10 @@ internal fun SideRailAccountView(
                 verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
             ) {
                 TextBodyLarge(
-                    text = account.name,
+                    text = name,
                     color = MainTheme.colors.onSurface,
                 )
-                if (account.name != account.email) {
+                if (account is MailDisplayAccount && account.name != account.email) {
                     TextBodyMedium(
                         text = account.email,
                         color = MainTheme.colors.onSurfaceVariant,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingItem.kt
@@ -1,4 +1,4 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui.setting
+package net.thunderbird.feature.navigation.drawer.siderail.ui.setting
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -14,7 +14,7 @@ import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
 import app.k9mail.core.ui.compose.theme2.MainTheme
 
 @Composable
-internal fun SettingItem(
+internal fun SideRailSettingItem(
     icon: ImageVector,
     label: String,
     onClick: () -> Unit,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingList.kt
@@ -1,4 +1,4 @@
-package net.thunderbird.feature.navigation.drawer.dropdown.ui.setting
+package net.thunderbird.feature.navigation.drawer.siderail.ui.setting
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -12,11 +12,13 @@ import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.navigation.drawer.dropdown.R
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.setting.SettingListItem
 
 @Composable
-internal fun SettingList(
+internal fun SideRailSettingList(
+    onAccountSelectorClick: () -> Unit,
     onManageFoldersClick: () -> Unit,
-    onSettingsClick: () -> Unit,
+    showAccountSelector: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -31,9 +33,17 @@ internal fun SettingList(
             imageVector = Icons.Outlined.FolderManaged,
         )
         SettingListItem(
-            label = stringResource(id = R.string.navigation_drawer_dropdown_action_settings),
-            onClick = onSettingsClick,
-            imageVector = Icons.Outlined.Settings,
+            label = if (showAccountSelector) {
+                stringResource(R.string.navigation_drawer_dropdown_action_hide_accounts)
+            } else {
+                stringResource(R.string.navigation_drawer_dropdown_action_show_accounts)
+            },
+            onClick = onAccountSelectorClick,
+            imageVector = if (showAccountSelector) {
+                Icons.Outlined.ChevronLeft
+            } else {
+                Icons.Outlined.ChevronRight
+            },
         )
     }
 }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingList.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/setting/SideRailSettingList.kt
@@ -30,7 +30,7 @@ internal fun SideRailSettingList(
         SettingListItem(
             label = stringResource(R.string.navigation_drawer_dropdown_action_manage_folders),
             onClick = onManageFoldersClick,
-            imageVector = Icons.Outlined.FolderManaged,
+            icon = Icons.Outlined.FolderManaged,
         )
         SettingListItem(
             label = if (showAccountSelector) {
@@ -39,7 +39,7 @@ internal fun SideRailSettingList(
                 stringResource(R.string.navigation_drawer_dropdown_action_show_accounts)
             },
             onClick = onAccountSelectorClick,
-            imageVector = if (showAccountSelector) {
+            icon = if (showAccountSelector) {
                 Icons.Outlined.ChevronLeft
             } else {
                 Icons.Outlined.ChevronRight

--- a/feature/navigation/drawer/dropdown/src/main/res/values/strings.xml
+++ b/feature/navigation/drawer/dropdown/src/main/res/values/strings.xml
@@ -2,11 +2,12 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_dropdown_action_settings">Settings</string>
     <string name="navigation_drawer_dropdown_avount_view_selection_title">Account list</string>
+    <string name="navigation_drawer_dropdown_unified_account_title">Unified Account</string>
     <string name="navigation_drawer_dropdown_action_manage_folders">Manage folders</string>
     <string name="navigation_drawer_dropdown_action_sync_all_accounts">Sync all accounts</string>
     <string name="navigation_drawer_dropdown_action_show_accounts">Show accounts</string>
     <string name="navigation_drawer_dropdown_action_hide_accounts">Hide accounts</string>
-    <string name="navigation_drawer_dropdown_unified_inbox_title">Unified Inbox</string>
+    <string name="navigation_drawer_dropdown_unified_inbox_title">Inbox</string>
     <!-- This is displayed as the unread count of a folder in the folder drawer when the number of unread messages exceeds 99. Space is extremely limited. Keep this as short as possible. -->
     <string name="navigation_drawer_dropdown_folder_item_badge_count_greater_than_99">99+</string>
     <!-- This is displayed as the unread count of a folder in the folder drawer when the number of unread messages exceeds 1000. Space is extremely limited. Keep this as short as possible. -->

--- a/feature/navigation/drawer/dropdown/src/main/res/values/strings.xml
+++ b/feature/navigation/drawer/dropdown/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="navigation_drawer_dropdown_action_settings">Settings</string>
+    <string name="navigation_drawer_dropdown_avount_view_selection_title">Account list</string>
     <string name="navigation_drawer_dropdown_action_manage_folders">Manage folders</string>
     <string name="navigation_drawer_dropdown_action_sync_all_accounts">Sync all accounts</string>
     <string name="navigation_drawer_dropdown_action_show_accounts">Show accounts</string>

--- a/feature/navigation/drawer/dropdown/src/main/res/values/strings.xml
+++ b/feature/navigation/drawer/dropdown/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="navigation_drawer_dropdown_unified_account_title">Unified Account</string>
     <string name="navigation_drawer_dropdown_action_manage_folders">Manage folders</string>
     <string name="navigation_drawer_dropdown_action_sync_all_accounts">Sync all accounts</string>
+    <string name="navigation_drawer_dropdown_action_add_account">Add account</string>
     <string name="navigation_drawer_dropdown_action_show_accounts">Show accounts</string>
     <string name="navigation_drawer_dropdown_action_hide_accounts">Hide accounts</string>
     <string name="navigation_drawer_dropdown_unified_inbox_title">Inbox</string>

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/UnifiedFolderRepositoryTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/UnifiedFolderRepositoryTest.kt
@@ -26,7 +26,7 @@ internal class UnifiedFolderRepositoryTest {
         )
         val folderType = UnifiedDisplayFolderType.INBOX
 
-        val result = testSubject.getDisplayUnifiedFolderFlow(folderType).first()
+        val result = testSubject.getUnifiedDisplayFolderFlow(folderType).first()
 
         assertThat(result).isEqualTo(
             UnifiedDisplayFolder(

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/UnifiedFolderRepositoryTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/UnifiedFolderRepositoryTest.kt
@@ -6,8 +6,8 @@ import assertk.assertions.isEqualTo
 import kotlin.test.Test
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 import net.thunderbird.feature.search.api.MessageSearchField
 import net.thunderbird.feature.search.api.SearchAttribute
 
@@ -24,12 +24,12 @@ internal class UnifiedFolderRepositoryTest {
         val testSubject = UnifiedFolderRepository(
             messageCountsProvider = messageCountsProvider,
         )
-        val folderType = DisplayUnifiedFolderType.INBOX
+        val folderType = UnifiedDisplayFolderType.INBOX
 
         val result = testSubject.getDisplayUnifiedFolderFlow(folderType).first()
 
         assertThat(result).isEqualTo(
-            DisplayUnifiedFolder(
+            UnifiedDisplayFolder(
                 id = "unified_inbox",
                 unifiedType = folderType,
                 unreadMessageCount = 2,

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeUnifiedFolderRepository.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeUnifiedFolderRepository.kt
@@ -2,13 +2,13 @@ package net.thunderbird.feature.navigation.drawer.dropdown.domain.usecase
 
 import kotlinx.coroutines.flow.Flow
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UnifiedFolderRepository
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 
 internal class FakeUnifiedFolderRepository(
-    private val displayUnifiedFolderFlow: Flow<DisplayUnifiedFolder>,
+    private val displayUnifiedFolderFlow: Flow<UnifiedDisplayFolder>,
 ) : UnifiedFolderRepository {
-    override fun getDisplayUnifiedFolderFlow(unifiedFolderType: DisplayUnifiedFolderType): Flow<DisplayUnifiedFolder> {
+    override fun getDisplayUnifiedFolderFlow(unifiedFolderType: UnifiedDisplayFolderType): Flow<UnifiedDisplayFolder> {
         return displayUnifiedFolderFlow
     }
 }

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeUnifiedFolderRepository.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeUnifiedFolderRepository.kt
@@ -8,7 +8,7 @@ import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedD
 internal class FakeUnifiedFolderRepository(
     private val displayUnifiedFolderFlow: Flow<UnifiedDisplayFolder>,
 ) : UnifiedFolderRepository {
-    override fun getDisplayUnifiedFolderFlow(unifiedFolderType: UnifiedDisplayFolderType): Flow<UnifiedDisplayFolder> {
+    override fun getUnifiedDisplayFolderFlow(unifiedFolderType: UnifiedDisplayFolderType): Flow<UnifiedDisplayFolder> {
         return displayUnifiedFolderFlow
     }
 }

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayFoldersForAccountTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayFoldersForAccountTest.kt
@@ -8,10 +8,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccountFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData
 import app.k9mail.legacy.ui.folder.DisplayFolder as LegacyDisplayFolder
 
@@ -105,16 +105,16 @@ internal class GetDisplayFoldersForAccountTest {
             starredMessageCount = 0,
         )
 
-        val DISPLAY_UNIFIED_FOLDER = DisplayUnifiedFolder(
+        val DISPLAY_UNIFIED_FOLDER = UnifiedDisplayFolder(
             id = "unified_inbox",
-            unifiedType = DisplayUnifiedFolderType.INBOX,
+            unifiedType = UnifiedDisplayFolderType.INBOX,
             unreadMessageCount = 2,
             starredMessageCount = 2,
         )
 
-        val DISPLAY_UNIFIED_FOLDER_2 = DisplayUnifiedFolder(
+        val DISPLAY_UNIFIED_FOLDER_2 = UnifiedDisplayFolder(
             id = "unified_inbox",
-            unifiedType = DisplayUnifiedFolderType.INBOX,
+            unifiedType = UnifiedDisplayFolderType.INBOX,
             unreadMessageCount = 3,
             starredMessageCount = 3,
         )
@@ -122,14 +122,14 @@ internal class GetDisplayFoldersForAccountTest {
         val DISPLAY_UNIFIED_FOLDERS = listOf(DISPLAY_UNIFIED_FOLDER)
 
         val DISPLAY_ACCOUNT_FOLDERS = listOf<DisplayFolder>(
-            DisplayAccountFolder(
+            MailDisplayFolder(
                 accountId = ACCOUNT_ID_RAW,
                 folder = FakeData.FOLDER,
                 isInTopGroup = false,
                 unreadMessageCount = 0,
                 starredMessageCount = 0,
             ),
-            DisplayAccountFolder(
+            MailDisplayFolder(
                 accountId = ACCOUNT_ID_RAW,
                 folder = FakeData.FOLDER.copy(
                     id = 2,
@@ -141,7 +141,7 @@ internal class GetDisplayFoldersForAccountTest {
             ),
         )
 
-        val DISPLAY_ACCOUNT_FOLDERS_2 = DISPLAY_ACCOUNT_FOLDERS + DisplayAccountFolder(
+        val DISPLAY_ACCOUNT_FOLDERS_2 = DISPLAY_ACCOUNT_FOLDERS + MailDisplayFolder(
             accountId = ACCOUNT_ID_RAW,
             folder = FakeData.FOLDER.copy(
                 id = 3,

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayTreeFolderTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayTreeFolderTest.kt
@@ -7,11 +7,11 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderType
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccountFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 
 class GetDisplayTreeFolderTest {
 
@@ -52,7 +52,7 @@ class GetDisplayTreeFolderTest {
     fun `should create tree from display unified folder`() {
         // arrange
         val unifiedFolder = createDisplayUnifiedFolder(
-            unifiedFolderType = DisplayUnifiedFolderType.INBOX,
+            unifiedFolderType = UnifiedDisplayFolderType.INBOX,
             unreadMessageCount = 5,
             starredMessageCount = 2,
         )
@@ -84,7 +84,7 @@ class GetDisplayTreeFolderTest {
     fun `should create tree from unified folders and regular folders`() {
         // arrange
         val unifiedFolder = createDisplayUnifiedFolder(
-            unifiedFolderType = DisplayUnifiedFolderType.INBOX,
+            unifiedFolderType = UnifiedDisplayFolderType.INBOX,
             unreadMessageCount = 3,
             starredMessageCount = 1,
         )
@@ -173,7 +173,7 @@ class GetDisplayTreeFolderTest {
                 nestedWeird.starredMessageCount,
             children = persistentListOf(
                 DisplayTreeFolder(
-                    displayFolder = DisplayAccountFolder(
+                    displayFolder = MailDisplayFolder(
                         accountId = "accountId",
                         folder = Folder(id = 1, name = "Inbox", type = FolderType.REGULAR, isLocalOnly = false),
                         isInTopGroup = true,
@@ -186,7 +186,7 @@ class GetDisplayTreeFolderTest {
                     children = persistentListOf(),
                 ),
                 DisplayTreeFolder(
-                    displayFolder = DisplayAccountFolder(
+                    displayFolder = MailDisplayFolder(
                         accountId = "accountId",
                         folder = Folder(id = 2, name = "", type = FolderType.REGULAR, isLocalOnly = false),
                         isInTopGroup = true,
@@ -198,7 +198,7 @@ class GetDisplayTreeFolderTest {
                     totalStarredCount = 4,
                     children = persistentListOf(
                         DisplayTreeFolder(
-                            displayFolder = DisplayAccountFolder(
+                            displayFolder = MailDisplayFolder(
                                 accountId = "placeholder",
                                 folder = Folder(
                                     id = 1L,
@@ -215,7 +215,7 @@ class GetDisplayTreeFolderTest {
                             totalStarredCount = 2,
                             children = persistentListOf(
                                 DisplayTreeFolder(
-                                    displayFolder = DisplayAccountFolder(
+                                    displayFolder = MailDisplayFolder(
                                         accountId = "accountId",
                                         folder = Folder(
                                             id = 3,
@@ -237,7 +237,7 @@ class GetDisplayTreeFolderTest {
                     ),
                 ),
                 DisplayTreeFolder(
-                    displayFolder = DisplayAccountFolder(
+                    displayFolder = MailDisplayFolder(
                         accountId = "placeholder",
                         folder = Folder(id = 2, name = "valid1", type = FolderType.REGULAR, isLocalOnly = false),
                         isInTopGroup = true,
@@ -249,7 +249,7 @@ class GetDisplayTreeFolderTest {
                     totalStarredCount = 3,
                     children = persistentListOf(
                         DisplayTreeFolder(
-                            displayFolder = DisplayAccountFolder(
+                            displayFolder = MailDisplayFolder(
                                 accountId = "placeholder",
                                 folder = Folder(
                                     id = 3L,
@@ -266,7 +266,7 @@ class GetDisplayTreeFolderTest {
                             totalStarredCount = 3,
                             children = persistentListOf(
                                 DisplayTreeFolder(
-                                    displayFolder = DisplayAccountFolder(
+                                    displayFolder = MailDisplayFolder(
                                         accountId = "accountId",
                                         folder = Folder(
                                             id = 4,
@@ -431,8 +431,8 @@ class GetDisplayTreeFolderTest {
             unreadMessageCount: Int,
             starredMessageCount: Int,
             accountId: String = "accountId",
-        ): DisplayAccountFolder {
-            return DisplayAccountFolder(
+        ): MailDisplayFolder {
+            return MailDisplayFolder(
                 accountId = accountId,
                 folder = Folder(
                     id = folderId,
@@ -447,11 +447,11 @@ class GetDisplayTreeFolderTest {
         }
 
         fun createDisplayUnifiedFolder(
-            unifiedFolderType: DisplayUnifiedFolderType,
+            unifiedFolderType: UnifiedDisplayFolderType,
             unreadMessageCount: Int,
             starredMessageCount: Int,
-        ): DisplayUnifiedFolder {
-            return DisplayUnifiedFolder(
+        ): UnifiedDisplayFolder {
+            return UnifiedDisplayFolder(
                 id = unifiedFolderType.name.lowercase(),
                 unifiedType = unifiedFolderType,
                 unreadMessageCount = unreadMessageCount,

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewKtTest.kt
@@ -42,7 +42,7 @@ internal class DrawerViewKtTest : ComposeTest() {
 
         assertThat(counter).isEqualTo(verifyCounter)
 
-        viewModel.effect(Effect.OpenAccount(FakeData.DISPLAY_ACCOUNT.id))
+        viewModel.effect(Effect.OpenAccount(FakeData.MAIL_DISPLAY_ACCOUNT.id))
 
         verifyCounter.openAccountCount++
         assertThat(counter).isEqualTo(verifyCounter)

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewKtTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewKtTest.kt
@@ -34,6 +34,7 @@ internal class DrawerViewKtTest : ComposeTest() {
                 openUnifiedFolder = { counter.openUnifiedFolderCount++ },
                 openManageFolders = { counter.openManageFoldersCount++ },
                 openSettings = { counter.openSettingsCount++ },
+                openAddAccount = { counter.openAddAccountCount++ },
                 closeDrawer = { counter.closeDrawerCount++ },
                 featureFlagProvider = FakeFeatureFlagProvider(isEnabled = true),
                 viewModel = viewModel,
@@ -66,6 +67,9 @@ internal class DrawerViewKtTest : ComposeTest() {
 
         verifyCounter.closeDrawerCount++
         viewModel.effect(Effect.CloseDrawer)
+
+        verifyCounter.openAddAccountCount++
+        viewModel.effect(Effect.OpenAddAccount)
     }
 
     @Test
@@ -85,6 +89,7 @@ internal class DrawerViewKtTest : ComposeTest() {
                 openUnifiedFolder = { },
                 openManageFolders = { },
                 openSettings = { },
+                openAddAccount = { },
                 closeDrawer = { },
                 featureFlagProvider = FakeFeatureFlagProvider(isEnabled = true),
                 viewModel = viewModel,
@@ -123,6 +128,7 @@ internal class DrawerViewKtTest : ComposeTest() {
                 openUnifiedFolder = {},
                 openManageFolders = {},
                 openSettings = {},
+                openAddAccount = {},
                 closeDrawer = {},
                 featureFlagProvider = FakeFeatureFlagProvider(isEnabled = true),
                 viewModel = viewModel,
@@ -157,6 +163,7 @@ internal class DrawerViewKtTest : ComposeTest() {
         var openUnifiedFolderCount: Int = 0,
         var openManageFoldersCount: Int = 0,
         var openSettingsCount: Int = 0,
+        var openAddAccountCount: Int = 0,
         var closeDrawerCount: Int = 0,
     )
 }

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
@@ -316,6 +316,7 @@ internal class DrawerViewModelTest {
             selectedAccountId = displayAccounts[0].id,
             folders = displayFoldersMap[displayAccounts[0].id]!!.toImmutableList(),
             selectedFolderId = displayFoldersMap[displayAccounts[0].id]!![0].id,
+            selectedFolder = displayFoldersMap[displayAccounts[0].id]!![0],
         )
         val testSubject = createTestSubject(
             displayAccountsFlow = getDisplayAccountsFlow,
@@ -327,6 +328,9 @@ internal class DrawerViewModelTest {
 
         val displayFolders = displayFoldersMap[displayAccounts[0].id] ?: emptyList()
         testSubject.event(Event.OnFolderClick(displayFolders[1]))
+
+        // Consume the state update
+        turbines.awaitStateItem()
 
         assertThat(turbines.awaitEffectItem()).isEqualTo(
             Effect.OpenFolder(
@@ -355,6 +359,7 @@ internal class DrawerViewModelTest {
                 selectedAccountId = displayAccounts[0].id,
                 folders = displayFoldersMap[displayAccounts[0].id]!!.toImmutableList(),
                 selectedFolderId = displayFoldersMap[displayAccounts[0].id]!![0].id,
+                selectedFolder = displayFoldersMap[displayAccounts[0].id]!![0],
             )
             val testSubject = createTestSubject(
                 displayAccountsFlow = getDisplayAccountsFlow,
@@ -366,6 +371,9 @@ internal class DrawerViewModelTest {
 
             val displayFolders = displayFoldersMap[displayAccounts[0].id] ?: emptyList()
             testSubject.event(Event.OnFolderClick(displayFolders[1]))
+
+            // Consume the state update
+            turbines.awaitStateItem()
 
             assertThat(turbines.awaitEffectItem()).isEqualTo(Effect.OpenUnifiedFolder)
 

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
@@ -23,16 +23,16 @@ import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawerExternalContract.DrawerConfig
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UseCase
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccountFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolder
-import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayUnifiedFolderType
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolderType
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Effect
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Event
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.State
-import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.DISPLAY_ACCOUNT
+import net.thunderbird.feature.navigation.drawer.dropdown.ui.FakeData.MAIL_DISPLAY_ACCOUNT
 import org.junit.Rule
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
@@ -71,12 +71,12 @@ internal class DrawerViewModelTest {
     @Test
     fun `should change loading state when OnSyncAccount event is received`() = runMviTest {
         val initialState = State(
-            accounts = listOf(DISPLAY_ACCOUNT).toImmutableList(),
-            selectedAccountId = DISPLAY_ACCOUNT.id,
+            accounts = listOf(MAIL_DISPLAY_ACCOUNT).toImmutableList(),
+            selectedAccountId = MAIL_DISPLAY_ACCOUNT.id,
         )
         val testSubject = createTestSubject(
             initialState = initialState,
-            displayAccountsFlow = flow { emit(listOf(DISPLAY_ACCOUNT)) },
+            displayAccountsFlow = flow { emit(listOf(MAIL_DISPLAY_ACCOUNT)) },
             syncAccountFlow = flow {
                 delay(25)
                 emit(Result.success(Unit))
@@ -220,7 +220,7 @@ internal class DrawerViewModelTest {
 
     @Test
     fun `should set selected account to null when no accounts are present`() = runTest {
-        val getDisplayAccountsFlow = MutableStateFlow(emptyList<DisplayAccount>())
+        val getDisplayAccountsFlow = MutableStateFlow(emptyList<MailDisplayAccount>())
         val testSubject = createTestSubject(
             displayAccountsFlow = getDisplayAccountsFlow,
         )
@@ -461,7 +461,7 @@ internal class DrawerViewModelTest {
     private fun createTestSubject(
         initialState: State = State(),
         drawerConfigFlow: Flow<DrawerConfig> = flow { emit(createDrawerConfig()) },
-        displayAccountsFlow: Flow<List<DisplayAccount>> = flow { emit(emptyList()) },
+        displayAccountsFlow: Flow<List<MailDisplayAccount>> = flow { emit(emptyList()) },
         displayFoldersFlow: Flow<Map<String, List<DisplayFolder>>> = flow { emit(emptyMap()) },
         displayTreeFolder: DisplayTreeFolder = DisplayTreeFolder(
             displayFolder = null,
@@ -508,8 +508,8 @@ internal class DrawerViewModelTest {
         email: String = "test@example.com",
         unreadCount: Int = 0,
         starredCount: Int = 0,
-    ): DisplayAccount {
-        return DisplayAccount(
+    ): MailDisplayAccount {
+        return MailDisplayAccount(
             id = id,
             name = name,
             email = email,
@@ -519,7 +519,7 @@ internal class DrawerViewModelTest {
         )
     }
 
-    private fun createDisplayAccountList(count: Int): List<DisplayAccount> {
+    private fun createDisplayAccountList(count: Int): List<MailDisplayAccount> {
         return List(count) { index ->
             createDisplayAccount(
                 id = "uuid-$index",
@@ -534,7 +534,7 @@ internal class DrawerViewModelTest {
         type: FolderType = FolderType.REGULAR,
         unreadCount: Int = 0,
         starredCount: Int = 0,
-    ): DisplayAccountFolder {
+    ): MailDisplayFolder {
         val folder = Folder(
             id = id,
             name = name,
@@ -542,7 +542,7 @@ internal class DrawerViewModelTest {
             isLocalOnly = false,
         )
 
-        return DisplayAccountFolder(
+        return MailDisplayFolder(
             accountId = accountId,
             folder = folder,
             isInTopGroup = false,
@@ -551,7 +551,7 @@ internal class DrawerViewModelTest {
         )
     }
 
-    private fun createDisplayFolderList(count: Int): List<DisplayAccountFolder> {
+    private fun createDisplayFolderList(count: Int): List<MailDisplayFolder> {
         return List(count) { index ->
             createDisplayFolder(
                 id = index.toLong() + 100,
@@ -561,11 +561,11 @@ internal class DrawerViewModelTest {
 
     private fun createDisplayUnifiedFolder(
         id: String = "unified_inbox",
-        unifiedType: DisplayUnifiedFolderType = DisplayUnifiedFolderType.INBOX,
+        unifiedType: UnifiedDisplayFolderType = UnifiedDisplayFolderType.INBOX,
         unreadCount: Int = 0,
         starredCount: Int = 0,
-    ): DisplayUnifiedFolder {
-        return DisplayUnifiedFolder(
+    ): UnifiedDisplayFolder {
+        return UnifiedDisplayFolder(
             id = id,
             unifiedType = unifiedType,
             unreadMessageCount = unreadCount,

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
@@ -395,7 +395,7 @@ internal class DrawerViewModelTest {
             ).thenReturn(flowOf(Unit))
 
             val testSubject = createTestSubject(
-                initialState = State(config = drawerConfigWithAccountSelectorDisabled),
+                initialState = State(config = drawerConfigWithAccountSelectorDisabled, showAccountSelection = false),
                 saveDrawerConfig = saveDrawerConfig,
                 drawerConfigFlow = flowOf(drawerConfigWithAccountSelectorDisabled),
             )
@@ -406,6 +406,9 @@ internal class DrawerViewModelTest {
             advanceUntilIdle()
             verify(saveDrawerConfig, times(1)).invoke(captor.capture())
             assertThat(captor.firstValue).isEqualTo(drawerConfigWithAccountSelectorEnabled)
+
+            // Verify that showAccountSelection is toggled after the delay
+            assertThat(testSubject.state.value.showAccountSelection).isEqualTo(true)
         }
 
     @Suppress("MaxLineLength")
@@ -421,7 +424,7 @@ internal class DrawerViewModelTest {
             ).thenReturn(flowOf(Unit))
 
             val testSubject = createTestSubject(
-                initialState = State(config = drawerConfigWithAccountSelectorEnabled),
+                initialState = State(config = drawerConfigWithAccountSelectorEnabled, showAccountSelection = false),
                 saveDrawerConfig = saveDrawerConfig,
                 drawerConfigFlow = flowOf(drawerConfigWithAccountSelectorEnabled),
             )
@@ -432,6 +435,9 @@ internal class DrawerViewModelTest {
             advanceUntilIdle()
             verify(saveDrawerConfig, times(1)).invoke(captor.capture())
             assertThat(captor.firstValue).isEqualTo(drawerConfigWithAccountSelectorDisabled)
+
+            // Verify that showAccountSelection is toggled after the delay
+            assertThat(testSubject.state.value.showAccountSelection).isEqualTo(true)
         }
 
     @Test
@@ -478,7 +484,7 @@ internal class DrawerViewModelTest {
             initialState = initialState,
             getDrawerConfig = { drawerConfigFlow },
             getDisplayAccounts = { displayAccountsFlow },
-            getDisplayFoldersForAccount = { accountId, _ ->
+            getDisplayFoldersForAccount = { accountId ->
                 displayFoldersFlow.map { it[accountId] ?: emptyList() }
             },
             getDisplayTreeFolder = { folders, maxDepth ->

--- a/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/SideRailDrawer.kt
+++ b/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/SideRailDrawer.kt
@@ -79,6 +79,7 @@ class SideRailDrawer(
     override fun selectUnifiedInbox() {
         drawerState.update {
             it.copy(
+                selectedAccountUuid = "unified_account",
                 selectedFolderId = DisplayUnifiedFolderType.INBOX.id,
             )
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -745,13 +745,17 @@ open class MessageList :
     }
 
     fun openRealAccount(accountId: String) {
-        val account = accountManager.getAccount(accountId) ?: return
-        val folderId = defaultFolderProvider.getDefaultFolder(account)
+        if (accountId == "unified_account") {
+            openUnifiedInbox()
+        } else {
+            val account = accountManager.getAccount(accountId) ?: return
+            val folderId = defaultFolderProvider.getDefaultFolder(account)
 
-        val search = LocalMessageSearch()
-        search.addAllowedFolder(folderId)
-        search.addAccountUuid(account.uuid)
-        actionDisplaySearch(this, search, noThreading = false, newTask = false)
+            val search = LocalMessageSearch()
+            search.addAllowedFolder(folderId)
+            search.addAccountUuid(account.uuid)
+            actionDisplaySearch(this, search, noThreading = false, newTask = false)
+        }
     }
 
     private fun performSearch(search: LocalMessageSearch) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -70,6 +70,7 @@ import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawer
 import net.thunderbird.feature.navigation.drawer.dropdown.DropDownDrawer
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayAccount
 import net.thunderbird.feature.navigation.drawer.siderail.SideRailDrawer
 import net.thunderbird.feature.search.LocalMessageSearch
 import net.thunderbird.feature.search.SearchAccount
@@ -753,7 +754,7 @@ open class MessageList :
     }
 
     fun openRealAccount(accountId: String) {
-        if (accountId == "unified_account") {
+        if (accountId == UnifiedDisplayAccount.UNIFIED_ACCOUNT_ID) {
             openUnifiedInbox()
         } else {
             val account = accountManager.getAccount(accountId) ?: return

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -659,6 +659,7 @@ open class MessageList :
                 navigationDrawer = DropDownDrawer(
                     parent = this,
                     openAccount = { accountId -> openRealAccount(accountId) },
+                    openAddAccount = { launchAddAccountScreen() },
                     openFolder = { accountId, folderId -> openFolder(accountId, folderId) },
                     openUnifiedFolder = { openUnifiedInbox() },
                     openManageFolders = { launchManageFoldersScreen() },
@@ -742,6 +743,13 @@ open class MessageList :
         }
 
         ManageFoldersActivity.launch(this, account!!)
+    }
+
+    private fun launchAddAccountScreen() {
+        FeatureLauncherActivity.launch(
+            context = this,
+            target = FeatureLauncherTarget.AccountSetup,
+        )
     }
 
     fun openRealAccount(accountId: String) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1504,7 +1504,6 @@ open class MessageList :
                     !generalSettingsManager.getSettings().isShowUnifiedInbox -> drawer.deselect()
 
                 search.id == SearchAccount.UNIFIED_INBOX -> drawer.selectUnifiedInbox()
-                else -> drawer.deselect()
             }
         } ?: logger.warn(TAG) { "Couldn't select folder for $accountUuid as LocalSearch is null." }
     }


### PR DESCRIPTION
Resolves #9189

Depends on #9358

This changes the drawer ui to a true dropdown ui solution, hidden behind a feature flag.

## Main Features

1. **Unified Folder Support**: 
   - Added a unified account view that aggregates content from multiple accounts
   - Implemented a unified inbox that shows messages from all accounts in one place

2. **Drawer Layout Improvements**:
   - Added support for two drawer UI modes: dropdown drawer and side rail drawer to keep changes minimal when the feature flag is not enabled
   - Improved folder selection and navigation between accounts
   - Enhanced the account list view with better selection states

3. **UI/UX Enhancements**:
   - Fixed selection state for nested folders
   - Improved avatar color selection for dark mode

## Technical Changes

1. **Architecture**:
   - Created a dedicated repository for unified folders (`UnifiedFolderRepository`)
   - Implemented search functionality to support unified inbox views
   - Added proper message counting for unified folders
   - Created new domain entities: `UnifiedDisplayAccount`, `UnifiedDisplayFolder`, and `UnifiedDisplayFolderType`

2. **Bug Fixes**:
   - Fixed issues with folder selection in nested folders
   - Fixed account selection to only trigger when the account is different
   - Removed deselect functionality that was preventing folders from being selected
   - Fixed management of folders when unified account is shown

3. **Feature Flags**:
   - Added feature flags to control the drawer functionality:
     - `enable_dropdown_drawer`: Controls the overall drawer feature (dropdown vs. side rail)
     - `enable_dropdown_drawer_ui`: Controls the UI mode (dropdown with expandable folders vs. side rail with expandable folders)
     
| Name       | Screenshot                                  |
|-----------------------|----------------------------------------------------|
| Unified Account          | <img src="https://github.com/user-attachments/assets/33cd82fa-ef7a-464e-bae1-7242f11b5e59" alt="Unified Account" width="300" /> |
| Account List          | <img src="https://github.com/user-attachments/assets/5adc9c2b-7600-40c4-a732-8f4bc09789d1" alt="Account List" width="300" /> |
| Account View         | <img src="https://github.com/user-attachments/assets/8d538380-252b-4a3d-a1fa-da0fff41394e" alt="Account View" width="300" /> |
| Account View with nested selection         | <img src="https://github.com/user-attachments/assets/65c7b47b-4299-4b4b-bc97-a6f2369e95af" alt="Account View" width="300" /> |
