### PR TITLE
fix: resolve #9338 – Download Complete message was covered by navigation bar...

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -228,7 +228,7 @@ open class MessageList :
 
         ViewCompat.setOnApplyWindowInsetsListener(container) { v, windowsInsets ->
             val insets = windowsInsets.getInsets(displayCutout() or navigationBars())
-            v.setPadding(insets.left, 0, insets.right, 0)
+            v.setPadding(insets.left, 0, insets.right, insets.bottom)
 
             windowsInsets
         }


### PR DESCRIPTION
This PR fixes issue #9338 by adjusting the position of the “Download Complete message” so it’s no longer hidden by the navigation bar on some devices.
The root cause was the lack of proper handling of Window Insets—the system UI areas like the navigation bar that can overlap app content.