### PR TITLE
fix: resolve #8446 – In folders, contact pictures function as check boxes or toggle buttons

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -371,6 +371,14 @@ class MessageListAdapter internal constructor(
         val isActive = isActiveMessage(messageListItem)
 
         if (appearance.showContactPicture) {
+            holder.contactPictureClickArea.isSelected = isSelected
+
+            holder.contactPictureClickArea.contentDescription = if (isSelected) {
+                res.getString(R.string.swipe_action_deselect)
+            } else {
+                res.getString(R.string.swipe_action_select)
+            }
+
             if (isSelected) {
                 holder.contactPicture.isVisible = false
                 holder.selected.isVisible = true

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -372,19 +372,17 @@ class MessageListAdapter internal constructor(
 
         if (appearance.showContactPicture) {
             holder.contactPictureClickArea.isSelected = isSelected
-
-            holder.contactPictureClickArea.contentDescription = if (isSelected) {
-                res.getString(R.string.swipe_action_deselect)
-            } else {
-                res.getString(R.string.swipe_action_select)
-            }
-
             if (isSelected) {
                 holder.contactPicture.isVisible = false
                 holder.selected.isVisible = true
             } else {
                 holder.selected.isVisible = false
                 holder.contactPicture.isVisible = true
+            }
+            holder.contactPictureClickArea.contentDescription = if (isSelected) {
+                res.getString(R.string.swipe_action_deselect)
+            } else {
+                res.getString(R.string.swipe_action_select)
             }
         }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewHolder.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewHolder.kt
@@ -13,6 +13,7 @@ class MessageViewHolder(view: View) : MessageListViewHolder(view) {
 
     val selected: View = view.findViewById(R.id.selected)
     val contactPicture: ImageView = view.findViewById(R.id.contact_picture)
+    val contactPictureClickArea: View = view.findViewById(R.id.contact_picture_click_area)
     val subject: MaterialTextView = view.findViewById(R.id.subject)
     val preview: MaterialTextView = view.findViewById(R.id.preview)
     val date: MaterialTextView = view.findViewById(R.id.date)


### PR DESCRIPTION
Now the contact photo has proper accessibility feedback through TalkBack.

If the e-mail is unselected, it says:
“Select. Double tap to activate.”

If the e-mail is selected, it says:
“Selected. Deselect. Double tap to activate.”

This makes it clear to visually impaired users what the current selection state is, and what action will occur on interaction.

The contact photo now behaves similarly to the star icon, which already provides accessible feedback regarding whether the message is starred or not.

In the video, you can see the current behavior (main branch) versus the improved behavior (with my fix applied).
https://github.com/user-attachments/assets/88f7d1e7-ae06-43bf-a41d-3ba555d09f38
