### PR TITLE
Catch I/O errors in sendContinuation()

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.kt
@@ -832,15 +832,20 @@ internal class RealImapConnection(
     @Synchronized
     @Throws(IOException::class)
     override fun sendContinuation(continuation: String) {
-        val outputStream = checkNotNull(imapOutputStream)
+        try {
+            val outputStream = checkNotNull(imapOutputStream)
 
-        outputStream.write(continuation.toByteArray())
-        outputStream.write('\r'.code)
-        outputStream.write('\n'.code)
-        outputStream.flush()
+            outputStream.write(continuation.toByteArray())
+            outputStream.write('\r'.code)
+            outputStream.write('\n'.code)
+            outputStream.flush()
 
-        if (K9MailLib.isDebug() && K9MailLib.DEBUG_PROTOCOL_IMAP) {
-            Log.v("%s>>> %s", logId, continuation)
+            if (K9MailLib.isDebug() && K9MailLib.DEBUG_PROTOCOL_IMAP) {
+                Log.v("%s>>> %s", logId, continuation)
+            }
+        } catch (e: IOException) {
+            close()
+            throw e
         }
     }
 

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolderIdler.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolderIdler.kt
@@ -85,6 +85,8 @@ internal class RealImapFolderIdler(
                 doneSent = false
             }
 
+            connection.setSocketDefaultReadTimeout()
+
             val tag = connection.sendCommand("IDLE", false)
 
             synchronized(this) {
@@ -142,6 +144,8 @@ internal class RealImapFolderIdler(
             }
         } while (!stopIdle)
 
+        connection.setSocketDefaultReadTimeout()
+
         return result
     }
 
@@ -170,7 +174,12 @@ internal class RealImapFolderIdler(
             if (connection.isConnected) {
                 doneSent = true
                 connection.setSocketDefaultReadTimeout()
-                connection.sendContinuation("DONE")
+                try {
+                    connection.sendContinuation("DONE")
+                } catch (e: IOException) {
+                    Log.v(e, "%s: IOException while sending DONE", logTag)
+                    throw e
+                }
             }
         }
     }


### PR DESCRIPTION
Catch IOException in sendContinuation() similar to the other send / receive methods.
This fixes broken IMAP push on network loss/regain on the authors phone.
Log that exception in sendDone().
Also reset read timeout after IDLE.

This fixes broken IMAP IDLE on my phone (Pixel 6 Pro w/ Android 16). IMAP IDLE is reproducably broken if the home wifi is left for about an hour (mobile data on) then the phone returns. Unfortunately I have not been able to log the issue as the log's history is always way too short. But unpatched K-9 Mail this IMAP IDLE breaks every time; with this patch it so far has not broken (about 5 "events" were it should have and did break -- I was running both versions in parallel).