### PR TITLE
Add proxy scroll to AccountAutoDiscoveryContent

### DIFF
--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/scroll/ScrollModifier.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/scroll/ScrollModifier.kt
@@ -1,0 +1,56 @@
+package app.k9mail.core.ui.compose.common.scroll
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.splineBasedDecay
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.input.pointer.util.addPointerInputChange
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+fun Modifier.proxyScroll(
+    coroutineScope: CoroutineScope,
+    scrollState: ScrollState,
+    onCancelFling: () -> Unit,
+    onCreateFling: (Job) -> Unit,
+): Modifier {
+    val velocityTracker = VelocityTracker()
+    return pointerInput(Unit) {
+        val decay = splineBasedDecay<Float>(this)
+        detectVerticalDragGestures(
+            onDragStart = {
+                velocityTracker.resetTracking()
+                onCancelFling()
+            },
+            onDragEnd = {
+                onCancelFling()
+                val velocity = -velocityTracker.calculateVelocity().y
+                velocityTracker.resetTracking()
+                onCreateFling(
+                    coroutineScope.launch {
+                        var previous = 0f
+                        val animatable = Animatable(0f)
+                        animatable.animateDecay(
+                            initialVelocity = velocity,
+                            animationSpec = decay,
+                        ) {
+                            val delta = value - previous
+                            previous = value
+                            coroutineScope.launch { scrollState.scrollBy(delta) }
+                        }
+                    },
+                )
+            },
+            onVerticalDrag = { change, dragAmount ->
+                coroutineScope.launch { scrollState.scrollBy(-dragAmount) }
+                velocityTracker.addPointerInputChange(change)
+                change.consume()
+            },
+        )
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/thunderbird/thunderbird-android/issues/9366

**Details:**
One way to enable scrolling outside the actual scrolling column is to capture vertical drag gestures and manually scroll the inner content.

1. First, we catch vertical drag events and call `scrollBy()` with the drag amount. However, the content stops immediately after lifting the finger, without inertia.
2. Next, we use a decay animation to simulate natural scrolling. `VelocityTracker` calculates the initial movement speed. However, if the user tries to scroll the inner content while the manual scroll is still in progress, a glitch occurs due to two simultaneous scroll events.
3. Finally, we use `NestedScrollConnection` to cancel the simulated natural scrolling.

**Test:**
We can highlight two areas for testing:
- The outer box
- The inner (scrollable) column

by using different background colors via the `background()` method.

**Sample video:**
<details><summary>Demo</summary>
<p>


https://github.com/user-attachments/assets/551d2307-889b-4fc1-8f63-602f76e05cd3



</p>
</details> 
