### PR TITLE
fix(test): do not use loopback IP for IMAP connectivity test

### DIFF
--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
@@ -663,7 +663,7 @@ class RealImapConnectionTest {
 
     @Test(expected = IOException::class)
     fun `open() with connection error should throw`() {
-        val settings = createImapSettings(host = "127.1.2.3")
+        val settings = createImapSettings(host = "192.0.2.123")
         val imapConnection = createImapConnection(settings, socketFactory, oAuth2TokenProvider)
 
         imapConnection.open()


### PR DESCRIPTION
When running a local IMAP server on the development host, the `open() with connection error should throw` IMAP test will succeed connecting to the IMAP server, thus making the test fail.

This patch changes the use of a loopback IP address (127.1.2.3) to a non-routable RFC-5737 TEST-NET-1 address (192.0.2.123).

Fixes: https://github.com/thunderbird/thunderbird-android/issues/9400
