### PR TITLE
Extend scroll on welcome and new account screens in landscape mode.

### DIFF
--- a/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/padding/CalculateResponsivePadding.kt
+++ b/core/ui/compose/common/src/main/kotlin/app/k9mail/core/ui/compose/common/padding/CalculateResponsivePadding.kt
@@ -1,0 +1,20 @@
+package app.k9mail.core.ui.compose.common.padding
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import app.k9mail.core.ui.compose.common.window.WindowSizeClass
+import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
+
+@Composable
+fun calculateResponsiveWidthPadding(): PaddingValues {
+    val windowSizeInfo = getWindowSizeInfo()
+    val horizontalPadding = when (windowSizeInfo.screenWidthSizeClass) {
+        WindowSizeClass.Compact -> 0.dp
+
+        WindowSizeClass.Medium -> (windowSizeInfo.screenWidth - WindowSizeClass.COMPACT_MAX_WIDTH.dp) / 2
+
+        WindowSizeClass.Expanded -> (windowSizeInfo.screenWidth - WindowSizeClass.MEDIUM_MAX_WIDTH.dp) / 2
+    }
+    return PaddingValues(horizontal = horizontalPadding)
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContentPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContentPreview.kt
@@ -1,6 +1,7 @@
 package app.k9mail.core.ui.compose.designsystem.template
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
@@ -13,10 +14,10 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 internal fun ResponsiveContentPreview() {
     PreviewWithTheme {
         Surface {
-            ResponsiveContent {
+            ResponsiveContent { contentPadding ->
                 Surface(
                     color = MainTheme.colors.info,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().padding(contentPadding),
                 ) {}
             }
         }

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveWidthContainerPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveWidthContainerPreview.kt
@@ -1,6 +1,7 @@
 package app.k9mail.core.ui.compose.designsystem.template
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.common.annotation.PreviewDevices
@@ -14,10 +15,12 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 internal fun ResponsiveWidthContainerPreview() {
     PreviewWithTheme {
         Surface {
-            ResponsiveWidthContainer {
+            ResponsiveWidthContainer { contentPadding ->
                 Surface(
                     color = MainTheme.colors.error,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(contentPadding),
                 ) {
                     TextBodyLarge("Hello, World!")
                 }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/LazyColumnWithHeaderFooter.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/LazyColumnWithHeaderFooter.kt
@@ -1,6 +1,7 @@
 package app.k9mail.core.ui.compose.designsystem.template
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
@@ -10,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 
 /**
  * The [LazyColumnWithHeaderFooter] composable creates a [LazyColumn] with header and footer items.
@@ -25,6 +27,7 @@ import androidx.compose.ui.unit.Density
 fun LazyColumnWithHeaderFooter(
     modifier: Modifier = Modifier,
     state: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     header: @Composable () -> Unit = {},
@@ -34,6 +37,7 @@ fun LazyColumnWithHeaderFooter(
     LazyColumn(
         modifier = modifier,
         state = state,
+        contentPadding = contentPadding,
         verticalArrangement = verticalArrangementWithHeaderFooter(verticalArrangement),
         horizontalAlignment = horizontalAlignment,
     ) {

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContent.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContent.kt
@@ -1,13 +1,14 @@
 package app.k9mail.core.ui.compose.designsystem.template
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import app.k9mail.core.ui.compose.common.padding.calculateResponsiveWidthPadding
 import app.k9mail.core.ui.compose.common.window.WindowSizeClass
 import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
@@ -25,7 +26,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 @Composable
 fun ResponsiveContent(
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+    content: @Composable (PaddingValues) -> Unit,
 ) {
     val windowSizeClass = getWindowSizeInfo()
 
@@ -39,21 +40,21 @@ fun ResponsiveContent(
 @Composable
 private fun CompactContent(
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+    content: @Composable (PaddingValues) -> Unit,
 ) {
     Box(
         modifier = Modifier
             .fillMaxSize()
             .then(modifier),
     ) {
-        content()
+        content(calculateResponsiveWidthPadding())
     }
 }
 
 @Composable
 private fun MediumContent(
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+    content: @Composable (PaddingValues) -> Unit,
 ) {
     Box(
         modifier = Modifier
@@ -61,18 +62,14 @@ private fun MediumContent(
             .then(modifier),
         contentAlignment = Alignment.TopCenter,
     ) {
-        Box(
-            modifier = Modifier.requiredWidth(WindowSizeClass.COMPACT_MAX_WIDTH.dp),
-        ) {
-            content()
-        }
+        content(calculateResponsiveWidthPadding())
     }
 }
 
 @Composable
 private fun ExpandedContent(
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+    content: @Composable (PaddingValues) -> Unit,
 ) {
     when (getWindowSizeInfo().screenHeightSizeClass) {
         WindowSizeClass.Compact -> MediumContent(modifier, content)
@@ -84,10 +81,9 @@ private fun ExpandedContent(
                 contentAlignment = Alignment.TopCenter,
             ) {
                 Surface(
-                    modifier = Modifier.requiredWidth(WindowSizeClass.MEDIUM_MAX_WIDTH.dp),
                     tonalElevation = MainTheme.elevations.level1,
                 ) {
-                    content()
+                    content(calculateResponsiveWidthPadding())
                 }
             }
         }
@@ -101,11 +97,10 @@ private fun ExpandedContent(
             ) {
                 Surface(
                     modifier = Modifier
-                        .requiredWidth(WindowSizeClass.MEDIUM_MAX_WIDTH.dp)
                         .requiredHeight(WindowSizeClass.MEDIUM_MAX_HEIGHT.dp),
                     tonalElevation = MainTheme.elevations.level1,
                 ) {
-                    content()
+                    content(calculateResponsiveWidthPadding())
                 }
             }
         }

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContentWithSurface.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveContentWithSurface.kt
@@ -1,5 +1,6 @@
 package app.k9mail.core.ui.compose.designsystem.template
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
@@ -16,9 +17,9 @@ fun ResponsiveContentWithSurface(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    ResponsiveContent {
+    ResponsiveContent { contentPadding ->
         Surface(
-            modifier = modifier,
+            modifier = modifier.padding(contentPadding),
             color = MainTheme.colors.surface,
         ) {
             content()

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveWidthContainer.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/template/ResponsiveWidthContainer.kt
@@ -1,17 +1,12 @@
 package app.k9mail.core.ui.compose.designsystem.template
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import app.k9mail.core.ui.compose.common.window.WindowSizeClass
-import app.k9mail.core.ui.compose.common.window.WindowSizeClass.Compact
-import app.k9mail.core.ui.compose.common.window.WindowSizeClass.Expanded
-import app.k9mail.core.ui.compose.common.window.WindowSizeClass.Medium
-import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
+import app.k9mail.core.ui.compose.common.padding.calculateResponsiveWidthPadding
 
 /**
  * A container that adjusts its width depending on the screen size.
@@ -35,28 +30,14 @@ import app.k9mail.core.ui.compose.common.window.getWindowSizeInfo
 @Composable
 fun ResponsiveWidthContainer(
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+    content: @Composable (paddingValues: PaddingValues) -> Unit,
 ) {
-    val windowSizeInfo = getWindowSizeInfo()
-
-    val responsiveModifier = when (windowSizeInfo.screenWidthSizeClass) {
-        Compact -> Modifier.fillMaxWidth()
-
-        Medium -> Modifier.requiredWidth(WindowSizeClass.COMPACT_MAX_WIDTH.dp)
-
-        Expanded -> Modifier.requiredWidth(WindowSizeClass.MEDIUM_MAX_WIDTH.dp)
-    }
-
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .then(modifier),
         contentAlignment = Alignment.TopCenter,
     ) {
-        Box(
-            modifier = responsiveModifier,
-        ) {
-            content()
-        }
+        content(calculateResponsiveWidthPadding())
     }
 }

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
@@ -39,7 +39,7 @@ internal fun PreferenceViewWithDialog(
         },
         modifier = modifier,
     ) { innerPadding ->
-        ResponsiveWidthContainer {
+        ResponsiveWidthContainer { horizontalPadding ->
             PreferenceList(
                 preferences = preferences,
                 onItemClick = { index, _ ->
@@ -47,7 +47,9 @@ internal fun PreferenceViewWithDialog(
                     showDialog = true
                 },
                 onPreferenceChange = onPreferenceChange,
-                modifier = Modifier.padding(innerPadding),
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .padding(horizontalPadding),
             )
         }
     }

--- a/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
+++ b/core/ui/compose/preference/src/main/kotlin/net/thunderbird/core/ui/compose/preference/ui/PreferenceViewWithDialog.kt
@@ -39,7 +39,7 @@ internal fun PreferenceViewWithDialog(
         },
         modifier = modifier,
     ) { innerPadding ->
-        ResponsiveWidthContainer { horizontalPadding ->
+        ResponsiveWidthContainer { contentPadding ->
             PreferenceList(
                 preferences = preferences,
                 onItemClick = { index, _ ->
@@ -49,7 +49,7 @@ internal fun PreferenceViewWithDialog(
                 onPreferenceChange = onPreferenceChange,
                 modifier = Modifier
                     .padding(innerPadding)
-                    .padding(horizontalPadding),
+                    .padding(contentPadding),
             )
         }
     }

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/AppTitleTopHeader.kt
@@ -30,7 +30,7 @@ fun AppTitleTopHeader(
                 bottom = MainTheme.spacings.default,
             )
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -38,6 +38,7 @@ fun AppTitleTopHeader(
                     start = MainTheme.spacings.half,
                     end = MainTheme.spacings.quadruple,
                 )
+                .padding(contentPadding)
                 .then(modifier),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/ContentListView.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/ContentListView.kt
@@ -27,11 +27,12 @@ fun ContentListView(
             .padding(contentPadding)
             .fillMaxWidth()
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .imePadding(),
+            contentPadding = contentPadding,
             horizontalAlignment = horizontalAlignment,
             verticalArrangement = verticalArrangement,
         ) {

--- a/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/WizardNavigationBar.kt
+++ b/feature/account/common/src/main/kotlin/app/k9mail/feature/account/common/ui/WizardNavigationBar.kt
@@ -27,7 +27,7 @@ fun WizardNavigationBar(
         modifier = Modifier
             .fillMaxWidth()
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         Row(
             modifier = Modifier
                 .padding(
@@ -36,6 +36,7 @@ fun WizardNavigationBar(
                     end = MainTheme.spacings.quadruple,
                     bottom = MainTheme.spacings.double,
                 )
+                .padding(contentPadding)
                 .fillMaxWidth(),
             horizontalArrangement = getHorizontalArrangement(state),
         ) {

--- a/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/save/SaveServerSettingsContent.kt
+++ b/feature/account/edit/src/main/kotlin/app/k9mail/feature/account/edit/ui/server/settings/save/SaveServerSettingsContent.kt
@@ -24,7 +24,7 @@ fun SaveServerSettingsContent(
             .testTagAsResourceId("SaveServerSettingsContent")
             .padding(contentPadding)
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         ContentLoadingErrorView(
             state = state,
             loading = {
@@ -42,7 +42,7 @@ fun SaveServerSettingsContent(
                     message = stringResource(id = R.string.account_edit_save_server_settings_success_message),
                 )
             },
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().padding(contentPadding),
         )
     }
 }

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContent.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorContent.kt
@@ -34,9 +34,9 @@ internal fun ServerCertificateErrorContent(
     state: State,
     scrollState: ScrollState,
 ) {
-    ResponsiveWidthContainer(modifier = Modifier.padding(innerPadding)) {
+    ResponsiveWidthContainer(modifier = Modifier.padding(innerPadding)) { contentPadding ->
         Column(
-            modifier = Modifier.verticalScroll(scrollState),
+            modifier = Modifier.verticalScroll(scrollState).padding(contentPadding),
         ) {
             CertificateErrorOverview(state)
 

--- a/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreen.kt
+++ b/feature/account/server/certificate/src/main/kotlin/app/k9mail/feature/account/server/certificate/ui/ServerCertificateErrorScreen.kt
@@ -88,8 +88,8 @@ private fun ButtonBar(
                     top = MainTheme.spacings.half,
                     bottom = MainTheme.spacings.half,
                 ),
-        ) {
-            Column(modifier = Modifier.animateContentSize()) {
+        ) { contentPadding ->
+            Column(modifier = Modifier.animateContentSize().padding(contentPadding)) {
                 ButtonFilled(
                     text = stringResource(R.string.account_server_certificate_button_back),
                     onClick = { dispatch(Event.OnBackClicked) },

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContent.kt
@@ -35,11 +35,12 @@ internal fun IncomingServerSettingsContent(
             .padding(contentPadding)
             .fillMaxWidth()
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .imePadding(),
+            contentPadding = contentPadding,
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContent.kt
@@ -35,11 +35,12 @@ internal fun OutgoingServerSettingsContent(
             .padding(contentPadding)
             .fillMaxWidth()
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .imePadding(),
+            contentPadding = contentPadding,
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {

--- a/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationContent.kt
+++ b/feature/account/server/validation/src/main/kotlin/app/k9mail/feature/account/server/validation/ui/ServerValidationContent.kt
@@ -45,11 +45,12 @@ internal fun ServerValidationContent(
             .padding(contentPadding)
             .fillMaxWidth()
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .imePadding(),
+            contentPadding = contentPadding,
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.double, Alignment.CenterVertically),
         ) {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContent.kt
@@ -48,7 +48,7 @@ internal fun AccountAutoDiscoveryContent(
             .fillMaxSize()
             .testTagAsResourceId("AccountAutoDiscoveryContent")
             .then(modifier),
-    ) {
+    ) { paddingValues ->
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {
@@ -56,6 +56,7 @@ internal fun AccountAutoDiscoveryContent(
                 modifier = Modifier
                     .weight(1f)
                     .verticalScroll(scrollState)
+                    .padding(paddingValues)
                     .imePadding(),
             ) {
                 AppTitleTopHeader(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/createaccount/CreateAccountContent.kt
@@ -24,7 +24,7 @@ internal fun CreateAccountContent(
             .padding(contentPadding)
             .testTagAsResourceId("CreateAccountContent")
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         ContentLoadingErrorView(
             state = state,
             loading = {
@@ -42,7 +42,7 @@ internal fun CreateAccountContent(
                     message = stringResource(R.string.account_setup_create_account_created),
                 )
             },
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().padding(contentPadding),
         )
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContent.kt
@@ -44,11 +44,12 @@ internal fun DisplayOptionsContent(
             .consumeWindowInsets(contentPadding)
             .padding(contentPadding)
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .imePadding(),
+            contentPadding = contentPadding,
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/sync/SyncOptionsContent.kt
@@ -47,11 +47,12 @@ internal fun SyncOptionsContent(
             .consumeWindowInsets(contentPadding)
             .padding(contentPadding)
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .imePadding(),
+            contentPadding = contentPadding,
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
         ) {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersContent.kt
@@ -33,8 +33,8 @@ fun SpecialFoldersContent(
             .testTagAsResourceId("SpecialFoldersContent")
             .padding(contentPadding)
             .then(modifier),
-    ) {
-        Column {
+    ) { contentPadding ->
+        Column(Modifier.padding(contentPadding)) {
             AppTitleTopHeader(
                 title = brandName,
             )

--- a/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContent.kt
+++ b/feature/funding/googleplay/src/main/kotlin/app/k9mail/feature/funding/googleplay/ui/contribution/ContributionContent.kt
@@ -27,14 +27,15 @@ internal fun ContributionContent(
         modifier = modifier
             .testTagAsResourceId("ContributionContent")
             .padding(contentPadding),
-    ) {
+    ) { contentPadding ->
         val scrollState = rememberScrollState()
 
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = MainTheme.spacings.quadruple)
-                .verticalScroll(scrollState),
+                .verticalScroll(scrollState)
+                .padding(contentPadding),
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.triple),
         ) {

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/PermissionDeniedContent.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/PermissionDeniedContent.kt
@@ -24,12 +24,13 @@ internal fun PermissionDeniedContent(
 ) {
     ResponsiveContent(
         modifier = Modifier.testTagAsResourceId("PermissionDeniedContent"),
-    ) {
+    ) { contentPadding ->
         Column(
             verticalArrangement = Arrangement.Center,
             modifier = Modifier
                 .fillMaxHeight()
-                .padding(MainTheme.spacings.double),
+                .padding(MainTheme.spacings.double)
+                .padding(contentPadding),
         ) {
             TextTitleLarge(text = stringResource(R.string.migration_qrcode_permission_denied_title))
             Spacer(modifier = Modifier.height(MainTheme.spacings.double))

--- a/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreen.kt
+++ b/feature/onboarding/migration/thunderbird/src/main/kotlin/app/k9mail/feature/onboarding/migration/thunderbird/TbOnboardingMigrationScreen.kt
@@ -62,11 +62,12 @@ internal fun TbOnboardingMigrationScreen(
         modifier = Modifier
             .fillMaxSize()
             .then(modifier),
-    ) {
+    ) { contentPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(scrollState),
+                .verticalScroll(scrollState)
+                .padding(contentPadding),
         ) {
             AppTitleTopHeader(
                 title = brandNameProvider.brandName,

--- a/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
+++ b/feature/onboarding/permissions/src/main/kotlin/app/k9mail/feature/onboarding/permissions/ui/PermissionsContent.kt
@@ -53,13 +53,14 @@ internal fun PermissionsContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(innerPadding),
-        ) {
+        ) { contentPadding ->
             Column(
                 verticalArrangement = Arrangement.SpaceBetween,
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
                     .fillMaxHeight()
-                    .verticalScroll(state = scrollState),
+                    .verticalScroll(state = scrollState)
+                    .padding(contentPadding),
             ) {
                 HeaderArea(brandName = brandName)
 
@@ -152,7 +153,7 @@ private fun BottomBar(
     ) {
         ResponsiveWidthContainer(
             modifier = Modifier.fillMaxWidth(),
-        ) {
+        ) { contentPadding ->
             Row(
                 modifier = Modifier
                     .padding(
@@ -161,7 +162,8 @@ private fun BottomBar(
                         top = MainTheme.spacings.default,
                         bottom = MainTheme.spacings.double,
                     )
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .padding(contentPadding),
                 horizontalArrangement = Arrangement.End,
             ) {
                 Crossfade(

--- a/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
+++ b/feature/onboarding/welcome/src/main/kotlin/app/k9mail/feature/onboarding/welcome/ui/WelcomeContent.kt
@@ -47,9 +47,10 @@ internal fun WelcomeContent(
     Surface(
         modifier = modifier,
     ) {
-        ResponsiveContent {
+        ResponsiveContent { contentPadding ->
             LazyColumnWithHeaderFooter(
                 modifier = Modifier.fillMaxSize(),
+                contentPadding = contentPadding,
                 verticalArrangement = Arrangement.SpaceEvenly,
                 header = {
                     WelcomeHeaderSection(title = appName)


### PR DESCRIPTION
Fixes https://github.com/thunderbird/thunderbird-android/issues/9366

This pull request provides an alternative solution to https://github.com/thunderbird/thunderbird-android/pull/9396, which used proxy scroll for the scrollable child. I've marked it as a _draft_ for now.

Thanks to @rafaeltonholo for the detailed code review and comments.

This approach offers a concise, lightweight, and elegant alternative to the previous solution.

**Details:**
The changes now apply to both screens: **Welcome** and **New Account** in **landscape mode**.

1. For `Column`, we no longer need `ResponsiveWidthContainer`.
It has been replaced by a modifier extension function called `responsiveWidthPadding()`.

2. For `LazyColumn`, the same applies - `ResponsiveContent` is no longer needed.
I introduced a new function called `calculateResponsiveWidthPadding()`.

From a design perspective, the UI remains visually the same. However, the scrollable areas on both the left and right sides have been extended, allowing users to scroll the content even when it's smaller than the screen.

Sample video:
<details><summary>Demo:</summary>
<p>


https://github.com/user-attachments/assets/f6028b63-8610-44e9-8c17-b1ec4443194e



</p>
</details> 
