### PR TITLE
fix(message-list): back button not closing app when message list is in inbox after returning from another folder and pressing back

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1466,6 +1466,7 @@ open class MessageList :
             if (account == null && search.accountUuids.size == 1) {
                 account = accountManager.getAccount(search.accountUuids.elementAt(0))
             }
+            singleFolderMode = true
         }
 
         configureDrawer()


### PR DESCRIPTION
Fixes #9407
| Before fix | After fix |
| --------- | ---------|
| <video src="https://github.com/user-attachments/assets/b1565548-7962-4c24-92f3-4fbc1c422cd7"/> | <video src="https://github.com/user-attachments/assets/1faad30b-96bf-458d-9561-9bf1d5a9e652"/> |

