### PR TITLE
fix(db): migration tests access db table fields that are not present …

### DIFF
--- a/core/android/common/src/main/kotlin/app/k9mail/core/android/common/database/CursorExtensions.kt
+++ b/core/android/common/src/main/kotlin/app/k9mail/core/android/common/database/CursorExtensions.kt
@@ -11,17 +11,17 @@ fun <T> Cursor.map(block: (Cursor) -> T): List<T> {
 
 fun Cursor.getStringOrNull(columnName: String): String? {
     val columnIndex = getColumnIndex(columnName)
-    return if (isNull(columnIndex)) null else getString(columnIndex)
+    return if (columnIndex == -1 || isNull(columnIndex)) null else getString(columnIndex)
 }
 
 fun Cursor.getIntOrNull(columnName: String): Int? {
     val columnIndex = getColumnIndex(columnName)
-    return if (isNull(columnIndex)) null else getInt(columnIndex)
+    return if (columnIndex == -1 || isNull(columnIndex)) null else getInt(columnIndex)
 }
 
 fun Cursor.getLongOrNull(columnName: String): Long? {
     val columnIndex = getColumnIndex(columnName)
-    return if (isNull(columnIndex)) null else getLong(columnIndex)
+    return if (columnIndex == -1 || isNull(columnIndex)) null else getLong(columnIndex)
 }
 
 fun Cursor.getStringOrThrow(columnName: String): String {


### PR DESCRIPTION
This fixes the migration tests trying to access databse table fields that are not present and causing the `CursorWindow` errors.

Fixes #9466



