### PR TITLE
fix: migration test is missing a logger setup

### DIFF
--- a/legacy/storage/src/test/java/com/fsck/k9/storage/RobolectricTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/RobolectricTest.kt
@@ -1,6 +1,9 @@
 package com.fsck.k9.storage
 
 import android.app.Application
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.logging.testing.TestLogger
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -12,4 +15,21 @@ import org.robolectric.annotation.Config
 @Config(application = EmptyApplication::class)
 abstract class RobolectricTest
 
-class EmptyApplication : Application()
+/**
+ * Only used for Robolectric tests that do not require an instance of our [Application] class.
+ *
+ * This class sets up the static [Log.logger] to a [TestLogger] instance, allowing tests to log messages without
+ * needing a full application context.
+ */
+class EmptyApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        Log.logger = logger
+    }
+
+    companion object {
+        val logger: Logger = TestLogger()
+    }
+}


### PR DESCRIPTION
The migration tests fail with missing logger setup.
