### PR TITLE
feat: introduce secret debug screen

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(projects.feature.mail.account.api)
     implementation(projects.feature.migration.provider)
     implementation(projects.feature.notification.api)
+    implementation(projects.feature.notification.impl)
     implementation(projects.feature.widget.messageList)
 
     implementation(projects.mail.protocols.imap)

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/feature/AppCommonFeatureModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/feature/AppCommonFeatureModule.kt
@@ -3,11 +3,13 @@ package net.thunderbird.app.common.feature
 import app.k9mail.feature.launcher.FeatureLauncherExternalContract
 import app.k9mail.feature.launcher.di.featureLauncherModule
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawerExternalContract
+import net.thunderbird.feature.notification.impl.inject.featureNotificationModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 internal val appCommonFeatureModule = module {
     includes(featureLauncherModule)
+    includes(featureNotificationModule)
 
     factory<FeatureLauncherExternalContract.AccountSetupFinishedLauncher> {
         AccountSetupFinishedLauncher(

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/PreviewWithThemeLightDark.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/PreviewWithThemeLightDark.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.theme2.MainTheme
 
 /**
@@ -35,8 +36,8 @@ fun PreviewWithThemeLightDark(
     useRow: Boolean = false,
     useScrim: Boolean = false,
     scrimAlpha: Float = 0.8f,
-    scrimPadding: PaddingValues = PaddingValues(MainTheme.spacings.triple),
-    arrangement: Arrangement.HorizontalOrVertical = Arrangement.spacedBy(MainTheme.spacings.triple),
+    scrimPadding: PaddingValues = PaddingValues(24.dp),
+    arrangement: Arrangement.HorizontalOrVertical = Arrangement.spacedBy(24.dp),
     content: @Composable () -> Unit,
 ) {
     val movableContent = remember {

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/PreviewWithThemeLightDark.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/PreviewWithThemeLightDark.kt
@@ -31,7 +31,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
  * @see app.k9mail.core.ui.compose.theme2.default.defaultThemeSpacings for MainTheme.spacings
  */
 @Composable
-fun PreviewWithThemeLightDark(
+fun PreviewWithThemesLightDark(
     modifier: Modifier = Modifier,
     useRow: Boolean = false,
     useScrim: Boolean = false,
@@ -42,14 +42,14 @@ fun PreviewWithThemeLightDark(
 ) {
     val movableContent = remember {
         movableContentOf {
-            ThemePreview(
+            PreviewWithThemeLightDark(
                 themeType = PreviewThemeType.THUNDERBIRD,
                 useScrim = useScrim,
                 scrimAlpha = scrimAlpha,
                 scrimPadding = scrimPadding,
                 content = content,
             )
-            ThemePreview(
+            PreviewWithThemeLightDark(
                 themeType = PreviewThemeType.K9MAIL,
                 useScrim = useScrim,
                 scrimAlpha = scrimAlpha,
@@ -76,12 +76,13 @@ fun PreviewWithThemeLightDark(
     }
 }
 
+@Suppress("ModifierMissing")
 @Composable
-private fun ThemePreview(
-    themeType: PreviewThemeType,
-    useScrim: Boolean,
-    scrimAlpha: Float,
-    scrimPadding: PaddingValues,
+fun PreviewWithThemeLightDark(
+    themeType: PreviewThemeType = PreviewThemeType.THUNDERBIRD,
+    useScrim: Boolean = false,
+    scrimAlpha: Float = 0f,
+    scrimPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable (() -> Unit),
 ) {
     val movableContent = remember { movableContentOf { content() } }

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/BasicDialogPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/BasicDialogPreview.kt
@@ -29,7 +29,7 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
 @PreviewLightDarkLandscape
 @Composable
 private fun BasicDialogPreview() {
-    PreviewWithThemeLightDark(
+    PreviewWithThemesLightDark(
         useRow = true,
         useScrim = true,
         scrimPadding = PaddingValues(32.dp),
@@ -115,7 +115,7 @@ private fun BasicDialogPreview() {
 @PreviewLightDarkLandscape
 @Composable
 private fun PreviewOnlySupportingText() {
-    PreviewWithThemeLightDark(
+    PreviewWithThemesLightDark(
         useRow = true,
         useScrim = true,
         scrimPadding = PaddingValues(32.dp),

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/BasicDialogPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/BasicDialogPreview.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.PreviewLightDarkLandscape
-import app.k9mail.core.ui.compose.designsystem.PreviewWithThemeLightDark
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextHeadlineSmall
 import app.k9mail.core.ui.compose.theme2.MainTheme
@@ -32,8 +32,8 @@ private fun BasicDialogPreview() {
     PreviewWithThemeLightDark(
         useRow = true,
         useScrim = true,
-        scrimPadding = PaddingValues(MainTheme.spacings.quadruple),
-        arrangement = Arrangement.spacedBy(MainTheme.spacings.triple),
+        scrimPadding = PaddingValues(32.dp),
+        arrangement = Arrangement.spacedBy(24.dp),
     ) {
         BasicDialogContent(
             headline = {
@@ -118,8 +118,8 @@ private fun PreviewOnlySupportingText() {
     PreviewWithThemeLightDark(
         useRow = true,
         useScrim = true,
-        scrimPadding = PaddingValues(MainTheme.spacings.quadruple),
-        arrangement = Arrangement.spacedBy(MainTheme.spacings.triple),
+        scrimPadding = PaddingValues(32.dp),
+        arrangement = Arrangement.spacedBy(24.dp),
     ) {
         BasicDialogContent(
             headline = {

--- a/feature/debug-settings/build.gradle.kts
+++ b/feature/debug-settings/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "net.thunderbird.feature.debug.settings"
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
+dependencies {
+    implementation(projects.core.ui.compose.designsystem)
+    implementation(projects.core.ui.compose.navigation)
+    implementation(projects.core.common)
+    implementation(projects.core.outcome)
+    implementation(projects.feature.mail.account.api)
+    implementation(projects.feature.notification.api)
+}

--- a/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/DebugSectionPreview.kt
+++ b/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/DebugSectionPreview.kt
@@ -1,0 +1,24 @@
+package net.thunderbird.feature.debug.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyLarge
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+@PreviewLightDark
+@Composable
+private fun DebugSectionPreview() {
+    PreviewWithThemesLightDark {
+        Box(modifier = Modifier.padding(MainTheme.spacings.triple)) {
+            DebugSection(
+                title = "Debug section",
+            ) {
+                TextBodyLarge("Content")
+            }
+        }
+    }
+}

--- a/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/SecretDebugSettingsScreenPreview.kt
+++ b/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/SecretDebugSettingsScreenPreview.kt
@@ -1,0 +1,60 @@
+package net.thunderbird.feature.debug.settings
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import app.k9mail.core.ui.compose.common.koin.koinPreview
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import net.thunderbird.core.common.resources.StringsResourceManager
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.debug.settings.notification.DebugNotificationSectionViewModel
+import net.thunderbird.feature.mail.account.api.AccountManager
+import net.thunderbird.feature.mail.account.api.BaseAccount
+import net.thunderbird.feature.notification.api.command.NotificationCommand.CommandOutcome.Failure
+import net.thunderbird.feature.notification.api.command.NotificationCommand.CommandOutcome.Success
+import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.api.sender.NotificationSender
+
+@PreviewLightDark
+@Composable
+private fun SecretDebugSettingsScreenPreview() {
+    koinPreview {
+        single<DebugNotificationSectionViewModel> {
+            DebugNotificationSectionViewModel(
+                stringsResourceManager = object : StringsResourceManager {
+                    override fun stringResource(resourceId: Int): String = "fake"
+
+                    override fun stringResource(resourceId: Int, vararg formatArgs: Any?): String = "fake"
+                },
+                accountManager = object : AccountManager<BaseAccount> {
+                    override fun getAccounts(): List<BaseAccount> = listOf()
+                    override fun getAccountsFlow(): Flow<List<BaseAccount>> = flowOf(listOf())
+                    override fun getAccount(accountUuid: String): BaseAccount? = null
+                    override fun getAccountFlow(accountUuid: String): Flow<BaseAccount?> = flowOf(null)
+                    override fun moveAccount(
+                        account: BaseAccount,
+                        newPosition: Int,
+                    ) = Unit
+
+                    override fun saveAccount(account: BaseAccount) = Unit
+                },
+                notificationSender = object : NotificationSender {
+                    override fun send(
+                        notification: Notification,
+                    ): Flow<Outcome<Success<Notification>, Failure<Notification>>> =
+                        error("not implemented")
+                },
+            )
+        }
+    } WithContent {
+        PreviewWithThemesLightDark {
+            SecretDebugSettingsScreen(
+                onNavigateBack = { },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}

--- a/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/inject/FeatureDebugSettingsModule.kt
+++ b/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/inject/FeatureDebugSettingsModule.kt
@@ -1,0 +1,18 @@
+package net.thunderbird.feature.debug.settings.inject
+
+import net.thunderbird.feature.debug.settings.navigation.DefaultSecretDebugSettingsNavigation
+import net.thunderbird.feature.debug.settings.navigation.SecretDebugSettingsNavigation
+import net.thunderbird.feature.debug.settings.notification.DebugNotificationSectionViewModel
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val featureDebugSettingsModule = module {
+    single<SecretDebugSettingsNavigation> { DefaultSecretDebugSettingsNavigation() }
+    viewModel {
+        DebugNotificationSectionViewModel(
+            stringsResourceManager = get(),
+            accountManager = get(),
+            notificationSender = get(),
+        )
+    }
+}

--- a/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSectionPreview.kt
+++ b/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSectionPreview.kt
@@ -1,0 +1,78 @@
+package net.thunderbird.feature.debug.settings.notification
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemeLightDark
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.collections.immutable.toPersistentList
+import net.thunderbird.feature.mail.account.api.BaseAccount
+import net.thunderbird.feature.notification.api.content.MailNotification
+
+@OptIn(ExperimentalUuidApi::class)
+@PreviewLightDark
+@Composable
+private fun DebugNotificationSectionPreview() {
+    PreviewWithThemeLightDark {
+        val accounts = remember {
+            List(size = 10) {
+                object : BaseAccount {
+                    override val uuid: String = Uuid.random().toString()
+                    override val name: String? = "Account $it"
+                    override val email: String = "account-$it@mail.com"
+                }
+            }.toPersistentList()
+        }
+        var state by remember {
+            mutableStateOf(
+                DebugNotificationSectionContract.State(
+                    accounts = accounts,
+                    selectedAccount = accounts.first(),
+                ),
+            )
+        }
+        DebugNotificationSection(
+            state = state,
+            modifier = Modifier.padding(MainTheme.spacings.triple),
+            onAccountSelect = { state = state.copy(selectedAccount = it) },
+        )
+    }
+}
+
+@OptIn(ExperimentalUuidApi::class)
+@PreviewLightDark
+@Composable
+private fun PreviewSingleMailNotification() {
+    PreviewWithThemeLightDark {
+        val accounts = remember {
+            List(size = 10) {
+                object : BaseAccount {
+                    override val uuid: String = Uuid.random().toString()
+                    override val name: String? = "Account $it"
+                    override val email: String = "account-$it@mail.com"
+                }
+            }.toPersistentList()
+        }
+        var state by remember {
+            mutableStateOf(
+                DebugNotificationSectionContract.State(
+                    accounts = accounts,
+                    selectedAccount = accounts.first(),
+                    selectedSystemNotificationType = MailNotification.NewMail.SingleMail::class,
+                ),
+            )
+        }
+        DebugNotificationSection(
+            state = state,
+            modifier = Modifier.padding(MainTheme.spacings.triple),
+            onAccountSelect = { state = state.copy(selectedAccount = it) },
+        )
+    }
+}

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/DebugSection.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/DebugSection.kt
@@ -1,0 +1,49 @@
+package net.thunderbird.feature.debug.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.DividerHorizontal
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleLarge
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+@Composable
+internal fun DebugSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    DebugSection(
+        title = { TextTitleLarge(title) },
+        modifier = modifier,
+        content = content,
+    )
+}
+
+@Composable
+internal fun DebugSubSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    DebugSection(
+        title = { TextTitleMedium(title) },
+        modifier = modifier,
+        content = content,
+    )
+}
+
+@Composable
+internal fun DebugSection(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(modifier = modifier) {
+        title()
+        DividerHorizontal(modifier = Modifier.padding(vertical = MainTheme.spacings.double))
+        content()
+    }
+}

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/SecretDebugSettingsScreen.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/SecretDebugSettingsScreen.kt
@@ -1,0 +1,45 @@
+package net.thunderbird.feature.debug.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonIcon
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.compose.designsystem.organism.TopAppBar
+import app.k9mail.core.ui.compose.designsystem.template.Scaffold
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.debug.settings.notification.DebugNotificationSection
+
+@Composable
+fun SecretDebugSettingsScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = stringResource(R.string.debug_settings_screen_title),
+                navigationIcon = {
+                    ButtonIcon(
+                        onClick = onNavigateBack,
+                        imageVector = Icons.Outlined.ArrowBack,
+                    )
+                },
+            )
+        },
+        modifier = modifier,
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(MainTheme.spacings.double),
+        ) {
+            DebugNotificationSection()
+        }
+    }
+}

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/navigation/SecretDebugSettingsNavigation.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/navigation/SecretDebugSettingsNavigation.kt
@@ -1,0 +1,31 @@
+package net.thunderbird.feature.debug.settings.navigation
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraphBuilder
+import app.k9mail.core.ui.compose.navigation.Navigation
+import app.k9mail.core.ui.compose.navigation.deepLinkComposable
+import net.thunderbird.feature.debug.settings.BuildConfig
+import net.thunderbird.feature.debug.settings.SecretDebugSettingsScreen
+import net.thunderbird.feature.debug.settings.navigation.SecretDebugSettingsRoute.Notification
+
+interface SecretDebugSettingsNavigation : Navigation<SecretDebugSettingsRoute>
+
+internal class DefaultSecretDebugSettingsNavigation : SecretDebugSettingsNavigation {
+    override fun registerRoutes(
+        navGraphBuilder: NavGraphBuilder,
+        onBack: () -> Unit,
+        onFinish: (SecretDebugSettingsRoute) -> Unit,
+    ) {
+        if (BuildConfig.DEBUG) {
+            with(navGraphBuilder) {
+                deepLinkComposable<Notification>(Notification.basePath) {
+                    SecretDebugSettingsScreen(
+                        onNavigateBack = onBack,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/navigation/SecretDebugSettingsRoute.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/navigation/SecretDebugSettingsRoute.kt
@@ -1,0 +1,17 @@
+package net.thunderbird.feature.debug.settings.navigation
+
+import app.k9mail.core.ui.compose.navigation.Route
+import kotlinx.serialization.Serializable
+
+sealed interface SecretDebugSettingsRoute : Route {
+    @Serializable
+    data object Notification : SecretDebugSettingsRoute {
+        override val basePath: String = "$SECRET_DEBUG_SETTINGS/notification"
+
+        override fun route(): String = basePath
+    }
+
+    companion object {
+        const val SECRET_DEBUG_SETTINGS = "app://secret_debug_settings"
+    }
+}

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSection.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSection.kt
@@ -1,0 +1,270 @@
+package net.thunderbird.feature.debug.settings.notification
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import app.k9mail.core.ui.compose.common.mvi.observeWithoutEffect
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonFilled
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
+import app.k9mail.core.ui.compose.designsystem.molecule.input.SelectInput
+import app.k9mail.core.ui.compose.designsystem.molecule.input.TextInput
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import kotlin.reflect.KClass
+import kotlinx.collections.immutable.ImmutableList
+import net.thunderbird.feature.debug.settings.DebugSection
+import net.thunderbird.feature.debug.settings.DebugSubSection
+import net.thunderbird.feature.debug.settings.R
+import net.thunderbird.feature.debug.settings.notification.DebugNotificationSectionContract.Event
+import net.thunderbird.feature.debug.settings.notification.DebugNotificationSectionContract.ViewModel
+import net.thunderbird.feature.mail.account.api.BaseAccount
+import net.thunderbird.feature.notification.api.content.MailNotification
+import net.thunderbird.feature.notification.api.content.Notification
+import org.koin.androidx.compose.koinViewModel
+
+private const val UUID_MAX_CHAR_DISPLAY = 4
+
+@Composable
+internal fun DebugNotificationSection(
+    modifier: Modifier = Modifier,
+    viewModel: ViewModel = koinViewModel<DebugNotificationSectionViewModel>(),
+) {
+    val (state, dispatchEvent) = viewModel.observeWithoutEffect()
+
+    DebugNotificationSection(
+        state = state.value,
+        modifier = modifier,
+        onAccountSelect = { account ->
+            dispatchEvent(Event.SelectAccount(account))
+        },
+        onOptionChange = { notificationType ->
+            dispatchEvent(Event.SelectNotificationType(notificationType))
+        },
+        onTriggerSystemNotificationClick = { dispatchEvent(Event.TriggerSystemNotification) },
+        onTriggerInAppNotificationClick = { dispatchEvent(Event.TriggerInAppNotification) },
+        onSenderChange = { dispatchEvent(Event.OnSenderChange(it)) },
+        onSubjectChange = { dispatchEvent(Event.OnSubjectChange(it)) },
+        onSummaryChange = { dispatchEvent(Event.OnSummaryChange(it)) },
+        onPreviewChange = { dispatchEvent(Event.OnPreviewChange(it)) },
+        onClearStatusLog = { dispatchEvent(Event.ClearStatusLog) },
+    )
+}
+
+@Composable
+internal fun DebugNotificationSection(
+    state: DebugNotificationSectionContract.State,
+    modifier: Modifier = Modifier,
+    onAccountSelect: (BaseAccount) -> Unit = {},
+    onOptionChange: (KClass<out Notification>) -> Unit = {},
+    onTriggerSystemNotificationClick: () -> Unit = {},
+    onTriggerInAppNotificationClick: () -> Unit = {},
+    onSenderChange: (String) -> Unit = {},
+    onSubjectChange: (String) -> Unit = {},
+    onSummaryChange: (String) -> Unit = {},
+    onPreviewChange: (String) -> Unit = {},
+    onClearStatusLog: () -> Unit = {},
+) {
+    DebugSection(
+        title = stringResource(R.string.debug_settings_notifications_title),
+        modifier = modifier,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.quadruple),
+        ) {
+            CommonNotificationInformation(state, onAccountSelect)
+            SystemNotificationSection(
+                state = state,
+                onOptionChange = onOptionChange,
+                onClick = onTriggerSystemNotificationClick,
+                onSenderChange = onSenderChange,
+                onSubjectChange = onSubjectChange,
+                onSummaryChange = onSummaryChange,
+                onPreviewChange = onPreviewChange,
+            )
+            InAppNotificationSection(
+                selectedNotificationType = state.selectedInAppNotificationType,
+                options = state.inAppNotificationTypes,
+                onOptionChange = onOptionChange,
+                onClick = onTriggerInAppNotificationClick,
+            )
+            NotificationStatusLog(state.notificationStatusLog, onClearStatusLog)
+        }
+    }
+}
+
+@Composable
+private fun CommonNotificationInformation(
+    state: DebugNotificationSectionContract.State,
+    onAccountSelect: (BaseAccount) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    DebugSubSection(
+        title = stringResource(R.string.debug_settings_notifications_common_notification_information),
+        modifier = modifier.padding(start = MainTheme.spacings.double),
+    ) {
+        val loadingText = stringResource(R.string.debug_settings_notifications_loading)
+        SelectInput(
+            options = state.accounts,
+            selectedOption = state.selectedAccount,
+            onOptionChange = { account ->
+                account?.let(onAccountSelect)
+            },
+            optionToStringTransformation = { account ->
+                account?.let { account ->
+                    val uuidStart = account.uuid.take(UUID_MAX_CHAR_DISPLAY)
+                    val uuidEnd = account.uuid.take(UUID_MAX_CHAR_DISPLAY)
+                    val accountDisplay = account.name ?: account.email
+                    "$uuidStart..$uuidEnd - $accountDisplay"
+                } ?: loadingText
+            },
+        )
+    }
+}
+
+@Composable
+private fun SystemNotificationSection(
+    state: DebugNotificationSectionContract.State,
+    onOptionChange: (KClass<out Notification>) -> Unit,
+    onClick: () -> Unit,
+    onSenderChange: (String) -> Unit,
+    onSubjectChange: (String) -> Unit,
+    onSummaryChange: (String) -> Unit,
+    onPreviewChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    DebugSubSection(
+        title = stringResource(R.string.debug_settings_notifications_system_notification),
+        modifier = modifier.padding(start = MainTheme.spacings.double),
+    ) {
+        Column {
+            TriggerNotificationSection(
+                selectedNotificationType = state.selectedSystemNotificationType,
+                options = state.systemNotificationTypes,
+                onOptionChange = onOptionChange,
+                onClick = onClick,
+            )
+            AnimatedVisibility(state.selectedSystemNotificationType == MailNotification.NewMail.SingleMail::class) {
+                Column {
+                    TextInput(
+                        onTextChange = onSenderChange,
+                        text = state.singleNotificationData.sender,
+                        label = stringResource(R.string.debug_settings_notifications_single_mail_sender),
+                    )
+                    TextInput(
+                        onTextChange = onSubjectChange,
+                        text = state.singleNotificationData.subject,
+                        label = stringResource(R.string.debug_settings_notifications_single_mail_subject),
+                    )
+                    TextInput(
+                        onTextChange = onSummaryChange,
+                        text = state.singleNotificationData.summary,
+                        label = stringResource(R.string.debug_settings_notifications_single_mail_summary),
+                    )
+                    TextInput(
+                        onTextChange = onPreviewChange,
+                        text = state.singleNotificationData.preview,
+                        label = stringResource(R.string.debug_settings_notifications_single_mail_preview),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InAppNotificationSection(
+    selectedNotificationType: KClass<out Notification>?,
+    options: ImmutableList<KClass<out Notification>>,
+    onOptionChange: (KClass<out Notification>) -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    DebugSubSection(
+        title = stringResource(R.string.debug_settings_notifications_in_app_notification),
+        modifier = modifier.padding(start = MainTheme.spacings.double),
+    ) {
+        TriggerNotificationSection(
+            selectedNotificationType = selectedNotificationType,
+            options = options,
+            onOptionChange = onOptionChange,
+            onClick = onClick,
+        )
+    }
+}
+
+@Composable
+private fun TriggerNotificationSection(
+    selectedNotificationType: KClass<out Notification>?,
+    options: ImmutableList<KClass<out Notification>>,
+    onOptionChange: (KClass<out Notification>) -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.oneHalf),
+        modifier = modifier,
+    ) {
+        val selectedOption = remember(selectedNotificationType, options) {
+            selectedNotificationType ?: options.firstOrNull()
+        }
+        val loadingText = stringResource(R.string.debug_settings_notifications_loading)
+        SelectInput(
+            options = options,
+            selectedOption = selectedOption,
+            onOptionChange = { it?.let(onOptionChange) },
+            optionToStringTransformation = { kClass -> kClass?.realName ?: loadingText },
+        )
+
+        ButtonFilled(
+            text = stringResource(R.string.debug_settings_notifications_trigger_notification),
+            onClick = onClick,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.NotificationStatusLog(
+    notificationStatusLog: ImmutableList<String>,
+    onClearStatusLog: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = notificationStatusLog.isNotEmpty(),
+        modifier = modifier.padding(start = MainTheme.spacings.double),
+    ) {
+        DebugSubSection(
+            title = stringResource(R.string.debug_settings_notification_status_log),
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                TextBodyMedium(
+                    text = buildAnnotatedString {
+                        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                            appendLine(stringResource(R.string.debug_settings_notifications_status))
+                        }
+                        notificationStatusLog.forEach { status ->
+                            appendLine(status)
+                        }
+                    },
+                )
+                ButtonText(
+                    text = stringResource(R.string.debug_settings_notifications_clear_status_log),
+                    onClick = onClearStatusLog,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                )
+            }
+        }
+    }
+}

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSectionContract.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSectionContract.kt
@@ -1,0 +1,50 @@
+package net.thunderbird.feature.debug.settings.notification
+
+import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
+import kotlin.reflect.KClass
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import net.thunderbird.feature.mail.account.api.BaseAccount
+import net.thunderbird.feature.notification.api.content.Notification
+
+internal interface DebugNotificationSectionContract {
+
+    interface ViewModel : UnidirectionalViewModel<State, Event, Effect>
+
+    data class State(
+        val accounts: ImmutableList<BaseAccount> = persistentListOf(),
+        val selectedAccount: BaseAccount? = null,
+        val notificationStatusLog: ImmutableList<String> = persistentListOf("Ready to send notification"),
+        val selectedSystemNotificationType: KClass<out Notification>? = null,
+        val selectedInAppNotificationType: KClass<out Notification>? = null,
+        val folderName: String? = null,
+        val singleNotificationData: MailSingleNotificationData = MailSingleNotificationData.Undefined,
+        val systemNotificationTypes: ImmutableList<KClass<out Notification>> = persistentListOf(),
+        val inAppNotificationTypes: ImmutableList<KClass<out Notification>> = persistentListOf(),
+    ) {
+        data class MailSingleNotificationData(
+            val sender: String = "",
+            val subject: String = "",
+            val summary: String = "",
+            val preview: String = "",
+        ) {
+            companion object {
+                val Undefined = MailSingleNotificationData()
+            }
+        }
+    }
+
+    sealed interface Event {
+        data class SelectAccount(val account: BaseAccount) : Event
+        data class SelectNotificationType(val notificationType: KClass<out Notification>) : Event
+        data object TriggerSystemNotification : Event
+        data object TriggerInAppNotification : Event
+        data class OnSenderChange(val sender: String) : Event
+        data class OnSubjectChange(val subject: String) : Event
+        data class OnSummaryChange(val summary: String) : Event
+        data class OnPreviewChange(val preview: String) : Event
+        data object ClearStatusLog : Event
+    }
+
+    sealed interface Effect
+}

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSectionViewModel.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSectionViewModel.kt
@@ -1,0 +1,303 @@
+package net.thunderbird.feature.debug.settings.notification
+
+import androidx.lifecycle.viewModelScope
+import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
+import kotlin.random.Random
+import kotlin.reflect.KClass
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import net.thunderbird.core.common.resources.StringsResourceManager
+import net.thunderbird.feature.debug.settings.R
+import net.thunderbird.feature.debug.settings.notification.DebugNotificationSectionContract.Effect
+import net.thunderbird.feature.debug.settings.notification.DebugNotificationSectionContract.Event
+import net.thunderbird.feature.debug.settings.notification.DebugNotificationSectionContract.State
+import net.thunderbird.feature.mail.account.api.AccountManager
+import net.thunderbird.feature.mail.account.api.BaseAccount
+import net.thunderbird.feature.notification.api.NotificationGroup
+import net.thunderbird.feature.notification.api.NotificationGroupKey
+import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.content.AuthenticationErrorNotification
+import net.thunderbird.feature.notification.api.content.CertificateErrorNotification
+import net.thunderbird.feature.notification.api.content.FailedToCreateNotification
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.content.MailNotification
+import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.api.content.PushServiceNotification
+import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.sender.NotificationSender
+
+internal class DebugNotificationSectionViewModel(
+    private val stringsResourceManager: StringsResourceManager,
+    private val accountManager: AccountManager<BaseAccount>,
+    private val notificationSender: NotificationSender,
+    private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : BaseViewModel<State, Event, Effect>(initialState = State()), DebugNotificationSectionContract.ViewModel {
+
+    init {
+        viewModelScope.launch(ioDispatcher) {
+            val accounts = accountManager.getAccounts()
+            withContext(mainDispatcher) {
+                updateState {
+                    val systemNotificationTypes = buildList {
+                        add(AuthenticationErrorNotification::class)
+                        add(CertificateErrorNotification::class)
+                        add(FailedToCreateNotification::class)
+                        add(MailNotification.Fetching::class)
+                        add(MailNotification.NewMail.SingleMail::class)
+                        add(MailNotification.NewMail.SummaryMail::class)
+                        add(MailNotification.SendFailed::class)
+                        add(MailNotification.Sending::class)
+                        add(PushServiceNotification.AlarmPermissionMissing::class)
+                        add(PushServiceNotification.Initializing::class)
+                        add(PushServiceNotification.Listening::class)
+                        add(PushServiceNotification.WaitBackgroundSync::class)
+                        add(PushServiceNotification.WaitNetwork::class)
+                    }.toPersistentList()
+
+                    val inAppNotificationTypes = buildList {
+                        add(AuthenticationErrorNotification::class)
+                        add(CertificateErrorNotification::class)
+                        add(FailedToCreateNotification::class)
+                        add(MailNotification.SendFailed::class)
+                        add(PushServiceNotification.AlarmPermissionMissing::class)
+                    }.toPersistentList()
+                    State(
+                        accounts = accounts.toPersistentList(),
+                        selectedAccount = accounts.first(),
+                        systemNotificationTypes = systemNotificationTypes,
+                        inAppNotificationTypes = inAppNotificationTypes,
+                        selectedSystemNotificationType = systemNotificationTypes.first(),
+                        selectedInAppNotificationType = inAppNotificationTypes.first(),
+                    )
+                }
+            }
+        }
+    }
+
+    override fun event(event: Event) {
+        when (event) {
+            is Event.TriggerSystemNotification -> viewModelScope.launch {
+                if (state.value.selectedSystemNotificationType == null) {
+                    updateState {
+                        it.copy(selectedSystemNotificationType = state.value.systemNotificationTypes.first())
+                    }
+                }
+                triggerNotification(
+                    notification = requireNotNull(buildNotification(state.value.selectedSystemNotificationType)),
+                )
+            }
+
+            is Event.TriggerInAppNotification -> viewModelScope.launch {
+                if (state.value.selectedInAppNotificationType == null) {
+                    updateState {
+                        it.copy(selectedInAppNotificationType = state.value.inAppNotificationTypes.first())
+                    }
+                }
+                triggerNotification(
+                    notification = requireNotNull(buildNotification(state.value.selectedInAppNotificationType)),
+                )
+            }
+
+            is Event.SelectAccount -> updateState { state ->
+                state.copy(selectedAccount = event.account)
+            }
+
+            is Event.SelectNotificationType -> viewModelScope.launch {
+                buildNotification(event.notificationType)
+            }
+
+            is Event.OnSenderChange -> updateState {
+                it.copy(singleNotificationData = it.singleNotificationData.copy(sender = event.sender))
+            }
+
+            is Event.OnSubjectChange -> updateState {
+                it.copy(singleNotificationData = it.singleNotificationData.copy(subject = event.subject))
+            }
+
+            is Event.OnSummaryChange -> updateState {
+                it.copy(singleNotificationData = it.singleNotificationData.copy(summary = event.summary))
+            }
+
+            is Event.OnPreviewChange -> updateState {
+                it.copy(singleNotificationData = it.singleNotificationData.copy(preview = event.preview))
+            }
+
+            Event.ClearStatusLog -> updateState { it.copy(notificationStatusLog = persistentListOf()) }
+        }
+    }
+
+    private suspend fun triggerNotification(
+        notification: Notification,
+    ) {
+        notification.let { notification ->
+            notificationSender
+                .send(notification)
+                .collect { result ->
+                    updateState {
+                        it.copy(notificationStatusLog = it.notificationStatusLog + "Result: $result")
+                    }
+                }
+        }
+    }
+
+    private suspend fun buildNotification(notificationType: KClass<out Notification>?): Notification? {
+        updateState {
+            it.copy(
+                notificationStatusLog = it.notificationStatusLog +
+                    stringsResourceManager.stringResource(
+                        R.string.debug_settings_notifications_preparing_notification,
+                        notificationType?.realName,
+                    ),
+            )
+        }
+
+        val state = state.value
+        val selectedAccount = state.selectedAccount ?: return null
+        val accountDisplay = selectedAccount.name ?: selectedAccount.email
+
+        val notification = buildNotification(
+            notificationType = notificationType,
+            notificationId = NotificationId(Random.nextInt()),
+            selectedAccount = selectedAccount,
+            accountDisplay = accountDisplay,
+            state = state,
+        )
+
+        updateState { state ->
+            state.copy(
+                selectedSystemNotificationType = (notification as? SystemNotification)?.let { it::class }
+                    ?: state.selectedSystemNotificationType,
+                selectedInAppNotificationType = (notification as? InAppNotification)?.let { it::class }
+                    ?: state.selectedInAppNotificationType,
+            )
+        }
+
+        return notification
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    private suspend fun buildNotification(
+        notificationType: KClass<out Notification>?,
+        notificationId: NotificationId,
+        selectedAccount: BaseAccount,
+        accountDisplay: String,
+        state: State,
+    ): Notification? = when (notificationType) {
+        AuthenticationErrorNotification::class -> AuthenticationErrorNotification(
+            id = notificationId,
+            accountUuid = selectedAccount.uuid,
+            accountDisplayName = accountDisplay,
+        )
+
+        CertificateErrorNotification::class -> CertificateErrorNotification(
+            id = notificationId,
+            accountUuid = selectedAccount.uuid,
+            accountDisplayName = accountDisplay,
+        )
+
+        FailedToCreateNotification::class -> FailedToCreateNotification(
+            id = notificationId,
+            accountUuid = selectedAccount.uuid,
+            failedNotification = AuthenticationErrorNotification(
+                id = notificationId,
+                accountUuid = selectedAccount.uuid,
+                accountDisplayName = accountDisplay,
+            ),
+        )
+
+        MailNotification.Fetching::class -> MailNotification.Fetching(
+            id = notificationId,
+            accountUuid = selectedAccount.uuid,
+            accountDisplayName = accountDisplay,
+            folderName = state.folderName,
+        )
+
+        MailNotification.NewMail.SingleMail::class -> state.buildSingleMailNotification(
+            notificationId = notificationId,
+            selectedAccount = selectedAccount,
+            accountDisplay = accountDisplay,
+        )
+
+        MailNotification.NewMail.SummaryMail::class -> MailNotification.NewMail.SummaryMail(
+            id = notificationId,
+            accountUuid = selectedAccount.uuid,
+            accountDisplayName = accountDisplay,
+            messagesNotificationChannelSuffix = "",
+            newMessageCount = 10,
+            additionalMessagesCount = 10,
+            group = NotificationGroup(
+                key = NotificationGroupKey("key"),
+                summary = "",
+            ),
+        )
+
+        MailNotification.SendFailed::class -> MailNotification.SendFailed(
+            id = notificationId,
+            accountUuid = selectedAccount.uuid,
+            exception = Exception("What a failure"),
+        )
+
+        MailNotification.Sending::class -> MailNotification.Sending(
+            id = notificationId,
+            accountUuid = selectedAccount.uuid,
+            accountDisplayName = accountDisplay,
+        )
+
+        PushServiceNotification.AlarmPermissionMissing::class -> PushServiceNotification.AlarmPermissionMissing(
+            id = notificationId,
+        )
+
+        PushServiceNotification.Initializing::class -> PushServiceNotification.Initializing(
+            id = notificationId,
+        )
+
+        PushServiceNotification.Listening::class -> PushServiceNotification.Listening(
+            id = notificationId,
+        )
+
+        PushServiceNotification.WaitBackgroundSync::class -> PushServiceNotification.WaitBackgroundSync(
+            id = notificationId,
+        )
+
+        PushServiceNotification.WaitNetwork::class -> PushServiceNotification.WaitNetwork(
+            id = notificationId,
+        )
+
+        else -> null
+    }
+
+    private fun State.buildSingleMailNotification(
+        notificationId: NotificationId,
+        selectedAccount: BaseAccount,
+        accountDisplay: String,
+    ): MailNotification.NewMail.SingleMail? = MailNotification.NewMail.SingleMail(
+        id = notificationId,
+        accountUuid = selectedAccount.uuid,
+        accountName = accountDisplay,
+        messagesNotificationChannelSuffix = "",
+        summary = singleNotificationData.summary,
+        sender = singleNotificationData.sender,
+        subject = singleNotificationData.subject,
+        preview = singleNotificationData.preview,
+        group = null,
+    )
+
+    private operator fun ImmutableList<String>.plus(other: String): ImmutableList<String> =
+        (this.toMutableList() + other).toPersistentList()
+}
+
+internal val KClass<out Notification>.realName: String
+    get() {
+        val clazz = java
+
+        return clazz.name
+            .replace(clazz.`package`?.name.orEmpty(), "")
+            .removePrefix(".")
+            .replace("$", ".")
+    }

--- a/feature/debug-settings/src/main/res/values/strings.xml
+++ b/feature/debug-settings/src/main/res/values/strings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="debug_settings_screen_title">Secret Debug Settings Screen</string>
+    <string name="debug_settings_notifications_loading">Loading…</string>
+    <string name="debug_settings_notifications_trigger_notification">Trigger notification</string>
+    <string name="debug_settings_notifications_single_mail_sender">Sender</string>
+    <string name="debug_settings_notifications_single_mail_subject">Subject</string>
+    <string name="debug_settings_notifications_single_mail_summary">Summary</string>
+    <string name="debug_settings_notifications_single_mail_preview">Preview</string>
+    <string name="debug_settings_notifications_common_notification_information">Common notification information</string>
+    <string name="debug_settings_notifications_in_app_notification">In-App notification</string>
+    <string name="debug_settings_notifications_title">Notifications</string>
+    <string name="debug_settings_notifications_system_notification">System notification</string>
+    <string name="debug_settings_notifications_preparing_notification">Preparing notification %1$s</string>
+    <string name="debug_settings_notification_status_log">Notification status log</string>
+    <string name="debug_settings_notifications_status">"Status: "</string>
+    <string name="debug_settings_notifications_clear_status_log">Clear status log</string>
+</resources>

--- a/feature/debug-settings/src/release/kotlin/net/thunderbird/feature/debug/settings/inject/FeatureDebugSettingsModule.kt
+++ b/feature/debug-settings/src/release/kotlin/net/thunderbird/feature/debug/settings/inject/FeatureDebugSettingsModule.kt
@@ -1,0 +1,6 @@
+package net.thunderbird.feature.debug.settings.inject
+
+import org.koin.dsl.module
+
+val featureDebugSettingsModule = module {
+}

--- a/feature/launcher/build.gradle.kts
+++ b/feature/launcher/build.gradle.kts
@@ -22,4 +22,6 @@ dependencies {
     implementation(libs.androidx.activity.compose)
 
     testImplementation(projects.core.ui.compose.testing)
+
+    implementation(projects.feature.debugSettings)
 }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherTarget.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherTarget.kt
@@ -8,6 +8,7 @@ import app.k9mail.feature.account.setup.navigation.AccountSetupRoute
 import app.k9mail.feature.funding.api.FundingRoute
 import app.k9mail.feature.onboarding.main.navigation.OnboardingRoute
 import net.thunderbird.feature.account.settings.api.AccountSettingsRoute
+import net.thunderbird.feature.debug.settings.navigation.SecretDebugSettingsRoute
 
 sealed class FeatureLauncherTarget(
     val deepLinkUri: Uri,
@@ -36,5 +37,9 @@ sealed class FeatureLauncherTarget(
     data object Onboarding : FeatureLauncherTarget(
         deepLinkUri = OnboardingRoute.Onboarding().route().toUri(),
         flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK,
+    )
+
+    data object SecretDebugSettings : FeatureLauncherTarget(
+        deepLinkUri = SecretDebugSettingsRoute.Notification.route().toUri(),
     )
 }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/di/FeatureLauncherModule.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/di/FeatureLauncherModule.kt
@@ -4,6 +4,7 @@ import app.k9mail.feature.account.edit.featureAccountEditModule
 import app.k9mail.feature.account.setup.featureAccountSetupModule
 import app.k9mail.feature.onboarding.main.featureOnboardingModule
 import app.k9mail.feature.settings.import.featureSettingsImportModule
+import net.thunderbird.feature.debug.settings.inject.featureDebugSettingsModule
 import org.koin.dsl.module
 
 val featureLauncherModule = module {
@@ -12,5 +13,6 @@ val featureLauncherModule = module {
         featureSettingsImportModule,
         featureAccountSetupModule,
         featureAccountEditModule,
+        featureDebugSettingsModule,
     )
 }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
@@ -14,6 +14,7 @@ import app.k9mail.feature.launcher.FeatureLauncherExternalContract.AccountSetupF
 import app.k9mail.feature.onboarding.main.navigation.OnboardingNavigation
 import app.k9mail.feature.onboarding.main.navigation.OnboardingRoute
 import net.thunderbird.feature.account.settings.api.AccountSettingsNavigation
+import net.thunderbird.feature.debug.settings.navigation.SecretDebugSettingsNavigation
 import org.koin.compose.koinInject
 
 @Composable
@@ -27,6 +28,7 @@ fun FeatureLauncherNavHost(
     accountSetupNavigation: AccountSetupNavigation = koinInject(),
     onboardingNavigation: OnboardingNavigation = koinInject(),
     fundingNavigation: FundingNavigation = koinInject(),
+    secretDebugSettingsNavigation: SecretDebugSettingsNavigation = koinInject(),
 ) {
     val activity = LocalActivity.current as ComponentActivity
 
@@ -73,6 +75,12 @@ fun FeatureLauncherNavHost(
         )
 
         fundingNavigation.registerRoutes(
+            navGraphBuilder = this,
+            onBack = onBack,
+            onFinish = { onBack() },
+        )
+
+        secretDebugSettingsNavigation.registerRoutes(
             navGraphBuilder = this,
             onBack = onBack,
             onFinish = { onBack() },

--- a/feature/mail/message/list/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/dialog/ChooseArchiveFolderDialogContentPreview.kt
+++ b/feature/mail/message/list/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/dialog/ChooseArchiveFolderDialogContentPreview.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.PreviewLightDarkLandscape
-import app.k9mail.core.ui.compose.designsystem.PreviewWithThemeLightDark
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.mail.folder.api.FolderType
@@ -63,7 +63,7 @@ private class ChooseArchiveFolderDialogContentParamsCol :
 private fun ChooseArchiveFolderDialogContentPreview(
     @PreviewParameter(ChooseArchiveFolderDialogContentParamsCol::class) state: State.ChooseArchiveFolder,
 ) {
-    PreviewWithThemeLightDark(
+    PreviewWithThemesLightDark(
         useRow = true,
         useScrim = true,
         scrimPadding = PaddingValues(32.dp),

--- a/feature/mail/message/list/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/dialog/CreateNewArchiveFolderDialogContentPreview.kt
+++ b/feature/mail/message/list/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/dialog/CreateNewArchiveFolderDialogContentPreview.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.PreviewLightDarkLandscape
-import app.k9mail.core.ui.compose.designsystem.PreviewWithThemeLightDark
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.theme2.MainTheme
 
@@ -67,7 +67,7 @@ private class CreateArchiveFolderPreviewParamsCollection :
 private fun CreateNewArchiveFolderDialogContentPreview(
     @PreviewParameter(CreateArchiveFolderPreviewParamsCollection::class) params: CreateArchiveFolderPreviewParams,
 ) {
-    PreviewWithThemeLightDark(
+    PreviewWithThemesLightDark(
         useRow = true,
         useScrim = true,
         scrimPadding = PaddingValues(32.dp),

--- a/feature/mail/message/list/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/dialog/EmailCantBeArchivedDialogButtonsPreview.kt
+++ b/feature/mail/message/list/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/dialog/EmailCantBeArchivedDialogButtonsPreview.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.PreviewLightDarkLandscape
-import app.k9mail.core.ui.compose.designsystem.PreviewWithThemeLightDark
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
 import app.k9mail.core.ui.compose.designsystem.atom.Surface
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.theme2.MainTheme
@@ -24,7 +24,7 @@ import net.thunderbird.feature.mail.message.list.R
 @PreviewLightDarkLandscape
 @Composable
 private fun EmailCantBeArchivedDialogButtonsPreview() {
-    PreviewWithThemeLightDark(
+    PreviewWithThemesLightDark(
         useRow = true,
         useScrim = true,
         scrimPadding = PaddingValues(32.dp),

--- a/feature/notification/api/build.gradle.kts
+++ b/feature/notification/api/build.gradle.kts
@@ -17,5 +17,5 @@ android {
 
 compose.resources {
     publicResClass = false
-    packageOfResClass = "net.thunderbird.feature.notification.resources"
+    packageOfResClass = "net.thunderbird.feature.notification.resources.api"
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/NotificationChannel.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/NotificationChannel.kt
@@ -1,12 +1,12 @@
 package net.thunderbird.feature.notification.api
 
-import net.thunderbird.feature.notification.resources.Res
-import net.thunderbird.feature.notification.resources.notification_channel_messages_description
-import net.thunderbird.feature.notification.resources.notification_channel_messages_title
-import net.thunderbird.feature.notification.resources.notification_channel_miscellaneous_description
-import net.thunderbird.feature.notification.resources.notification_channel_miscellaneous_title
-import net.thunderbird.feature.notification.resources.notification_channel_push_description
-import net.thunderbird.feature.notification.resources.notification_channel_push_title
+import net.thunderbird.feature.notification.resources.api.Res
+import net.thunderbird.feature.notification.resources.api.notification_channel_messages_description
+import net.thunderbird.feature.notification.resources.api.notification_channel_messages_title
+import net.thunderbird.feature.notification.resources.api.notification_channel_miscellaneous_description
+import net.thunderbird.feature.notification.resources.api.notification_channel_miscellaneous_title
+import net.thunderbird.feature.notification.resources.api.notification_channel_push_description
+import net.thunderbird.feature.notification.resources.api.notification_channel_push_title
 import org.jetbrains.compose.resources.StringResource
 
 /**

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/AuthenticationErrorNotification.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/AuthenticationErrorNotification.kt
@@ -4,9 +4,9 @@ import net.thunderbird.feature.notification.api.NotificationChannel
 import net.thunderbird.feature.notification.api.NotificationId
 import net.thunderbird.feature.notification.api.NotificationSeverity
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
-import net.thunderbird.feature.notification.resources.Res
-import net.thunderbird.feature.notification.resources.notification_authentication_error_text
-import net.thunderbird.feature.notification.resources.notification_authentication_error_title
+import net.thunderbird.feature.notification.resources.api.Res
+import net.thunderbird.feature.notification.resources.api.notification_authentication_error_text
+import net.thunderbird.feature.notification.resources.api.notification_authentication_error_title
 import org.jetbrains.compose.resources.getString
 
 /**
@@ -27,7 +27,7 @@ data class AuthenticationErrorNotification private constructor(
         NotificationAction.UpdateServerSettings,
     )
 
-    override val lockscreenNotification: SystemNotification = copy(contentText = null)
+    override val lockscreenNotification: SystemNotification get() = copy(contentText = null)
 
     companion object {
         /**

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/CertificateErrorNotification.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/CertificateErrorNotification.kt
@@ -4,9 +4,9 @@ import net.thunderbird.feature.notification.api.NotificationChannel
 import net.thunderbird.feature.notification.api.NotificationId
 import net.thunderbird.feature.notification.api.NotificationSeverity
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
-import net.thunderbird.feature.notification.resources.Res
-import net.thunderbird.feature.notification.resources.notification_certificate_error_public
-import net.thunderbird.feature.notification.resources.notification_certificate_error_text
+import net.thunderbird.feature.notification.resources.api.Res
+import net.thunderbird.feature.notification.resources.api.notification_certificate_error_public
+import net.thunderbird.feature.notification.resources.api.notification_certificate_error_text
 import org.jetbrains.compose.resources.getString
 
 /**
@@ -26,7 +26,7 @@ data class CertificateErrorNotification private constructor(
     override val severity: NotificationSeverity = NotificationSeverity.Fatal
     override val actions: Set<NotificationAction> = setOf(NotificationAction.UpdateServerSettings)
 
-    override val lockscreenNotification: SystemNotification = copy(
+    override val lockscreenNotification: SystemNotification get() = copy(
         contentText = lockScreenTitle,
     )
 

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/FailedToCreateNotification.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/FailedToCreateNotification.kt
@@ -3,9 +3,9 @@ package net.thunderbird.feature.notification.api.content
 import net.thunderbird.feature.notification.api.NotificationChannel
 import net.thunderbird.feature.notification.api.NotificationId
 import net.thunderbird.feature.notification.api.NotificationSeverity
-import net.thunderbird.feature.notification.resources.Res
-import net.thunderbird.feature.notification.resources.notification_notify_error_text
-import net.thunderbird.feature.notification.resources.notification_notify_error_title
+import net.thunderbird.feature.notification.resources.api.Res
+import net.thunderbird.feature.notification.resources.api.notification_notify_error_text
+import net.thunderbird.feature.notification.resources.api.notification_notify_error_title
 import org.jetbrains.compose.resources.getString
 
 /**

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/MailNotification.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/MailNotification.kt
@@ -1,21 +1,20 @@
 package net.thunderbird.feature.notification.api.content
 
 import net.thunderbird.core.common.exception.rootCauseMassage
-import net.thunderbird.feature.notification.api.LockscreenNotificationAppearance
 import net.thunderbird.feature.notification.api.NotificationChannel
 import net.thunderbird.feature.notification.api.NotificationGroup
 import net.thunderbird.feature.notification.api.NotificationId
 import net.thunderbird.feature.notification.api.NotificationSeverity
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
-import net.thunderbird.feature.notification.resources.Res
-import net.thunderbird.feature.notification.resources.notification_additional_messages
-import net.thunderbird.feature.notification.resources.notification_bg_send_ticker
-import net.thunderbird.feature.notification.resources.notification_bg_send_title
-import net.thunderbird.feature.notification.resources.notification_bg_sync_text
-import net.thunderbird.feature.notification.resources.notification_bg_sync_ticker
-import net.thunderbird.feature.notification.resources.notification_bg_sync_title
-import net.thunderbird.feature.notification.resources.notification_new_messages_title
-import net.thunderbird.feature.notification.resources.send_failure_subject
+import net.thunderbird.feature.notification.resources.api.Res
+import net.thunderbird.feature.notification.resources.api.notification_additional_messages
+import net.thunderbird.feature.notification.resources.api.notification_bg_send_ticker
+import net.thunderbird.feature.notification.resources.api.notification_bg_send_title
+import net.thunderbird.feature.notification.resources.api.notification_bg_sync_text
+import net.thunderbird.feature.notification.resources.api.notification_bg_sync_ticker
+import net.thunderbird.feature.notification.resources.api.notification_bg_sync_title
+import net.thunderbird.feature.notification.resources.api.notification_new_messages_title
+import net.thunderbird.feature.notification.resources.api.send_failure_subject
 import org.jetbrains.compose.resources.getPluralString
 import org.jetbrains.compose.resources.getString
 
@@ -34,7 +33,7 @@ sealed class MailNotification : AppNotification(), SystemNotification {
         override val contentText: String?,
         override val channel: NotificationChannel,
     ) : MailNotification() {
-        override val lockscreenNotification: SystemNotification = copy(contentText = null)
+        override val lockscreenNotification: SystemNotification get() = copy(contentText = null)
 
         companion object {
             /**
@@ -83,7 +82,7 @@ sealed class MailNotification : AppNotification(), SystemNotification {
         override val contentText: String?,
         override val channel: NotificationChannel,
     ) : MailNotification() {
-        override val lockscreenNotification: SystemNotification = copy(contentText = null)
+        override val lockscreenNotification: SystemNotification get() = copy(contentText = null)
 
         companion object {
             /**
@@ -118,7 +117,7 @@ sealed class MailNotification : AppNotification(), SystemNotification {
         override val channel: NotificationChannel,
     ) : MailNotification(), InAppNotification {
         override val severity: NotificationSeverity = NotificationSeverity.Critical
-        override val lockscreenNotification: SystemNotification = copy(contentText = null)
+        override val lockscreenNotification: SystemNotification get() = copy(contentText = null)
         override val actions: Set<NotificationAction> = setOf(
             NotificationAction.Retry,
         )
@@ -157,7 +156,7 @@ sealed class MailNotification : AppNotification(), SystemNotification {
         abstract val accountUuid: String
         abstract val messagesNotificationChannelSuffix: String
 
-        override val channel: NotificationChannel = NotificationChannel.Messages(
+        override val channel: NotificationChannel get() = NotificationChannel.Messages(
             accountUuid = accountUuid,
             suffix = messagesNotificationChannelSuffix,
         )
@@ -194,7 +193,6 @@ sealed class MailNotification : AppNotification(), SystemNotification {
             val subject: String,
             val preview: String,
             override val group: NotificationGroup?,
-            override val lockscreenNotificationAppearance: LockscreenNotificationAppearance,
         ) : NewMail() {
             override val title: String = sender
             override val contentText: String = subject

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/PushServiceNotification.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/PushServiceNotification.kt
@@ -4,15 +4,15 @@ import net.thunderbird.feature.notification.api.NotificationChannel
 import net.thunderbird.feature.notification.api.NotificationId
 import net.thunderbird.feature.notification.api.NotificationSeverity
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
-import net.thunderbird.feature.notification.resources.Res
-import net.thunderbird.feature.notification.resources.push_info_disable_push_action
-import net.thunderbird.feature.notification.resources.push_notification_grant_alarm_permission
-import net.thunderbird.feature.notification.resources.push_notification_info
-import net.thunderbird.feature.notification.resources.push_notification_state_alarm_permission_missing
-import net.thunderbird.feature.notification.resources.push_notification_state_initializing
-import net.thunderbird.feature.notification.resources.push_notification_state_listening
-import net.thunderbird.feature.notification.resources.push_notification_state_wait_background_sync
-import net.thunderbird.feature.notification.resources.push_notification_state_wait_network
+import net.thunderbird.feature.notification.resources.api.Res
+import net.thunderbird.feature.notification.resources.api.push_info_disable_push_action
+import net.thunderbird.feature.notification.resources.api.push_notification_grant_alarm_permission
+import net.thunderbird.feature.notification.resources.api.push_notification_info
+import net.thunderbird.feature.notification.resources.api.push_notification_state_alarm_permission_missing
+import net.thunderbird.feature.notification.resources.api.push_notification_state_initializing
+import net.thunderbird.feature.notification.resources.api.push_notification_state_listening
+import net.thunderbird.feature.notification.resources.api.push_notification_state_wait_background_sync
+import net.thunderbird.feature.notification.resources.api.push_notification_state_wait_network
 import org.jetbrains.compose.resources.getString
 
 /**

--- a/feature/notification/impl/build.gradle.kts
+++ b/feature/notification/impl/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.core.common)
             implementation(projects.core.outcome)
+            implementation(projects.core.logging.api)
             implementation(projects.feature.notification.api)
         }
     }
@@ -18,5 +19,5 @@ android {
 
 compose.resources {
     publicResClass = false
-    packageOfResClass = "net.thunderbird.feature.notification.resources"
+    packageOfResClass = "net.thunderbird.feature.notification.resources.impl"
 }

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/InAppNotificationCommand.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/InAppNotificationCommand.kt
@@ -1,5 +1,6 @@
 package net.thunderbird.feature.notification.impl.command
 
+import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.command.NotificationCommand
 import net.thunderbird.feature.notification.api.command.NotificationCommand.CommandOutcome.Failure
@@ -16,10 +17,14 @@ import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
  * @param notifier The [NotificationNotifier] responsible for actually displaying the notification.
  */
 internal class InAppNotificationCommand(
+    private val logger: Logger,
     notification: InAppNotification,
     notifier: NotificationNotifier<InAppNotification>,
 ) : NotificationCommand<InAppNotification>(notification, notifier) {
     override fun execute(): Outcome<Success<InAppNotification>, Failure<InAppNotification>> {
-        TODO("Implementation on GitHub Issue #9245")
+        logger.debug {
+            "TODO: Implementation on GitHub Issue #9245. Notification = $notification."
+        }
+        return Outcome.success(data = Success(command = this))
     }
 }

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
@@ -1,5 +1,6 @@
 package net.thunderbird.feature.notification.impl.command
 
+import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.notification.api.command.NotificationCommand
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.content.Notification
@@ -11,6 +12,7 @@ import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNoti
  * A factory for creating a set of notification commands based on a given notification.
  */
 internal class NotificationCommandFactory(
+    private val logger: Logger,
     private val systemNotificationNotifier: SystemNotificationNotifier,
     private val inAppNotificationNotifier: InAppNotificationNotifier,
 ) {
@@ -28,6 +30,7 @@ internal class NotificationCommandFactory(
         if (notification is SystemNotification) {
             commands.add(
                 SystemNotificationCommand(
+                    logger = logger,
                     notification = notification,
                     notifier = systemNotificationNotifier,
                 ),
@@ -37,6 +40,7 @@ internal class NotificationCommandFactory(
         if (notification is InAppNotification) {
             commands.add(
                 InAppNotificationCommand(
+                    logger = logger,
                     notification = notification,
                     notifier = inAppNotificationNotifier,
                 ),

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/SystemNotificationCommand.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/SystemNotificationCommand.kt
@@ -1,5 +1,6 @@
 package net.thunderbird.feature.notification.impl.command
 
+import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.command.NotificationCommand
 import net.thunderbird.feature.notification.api.command.NotificationCommand.CommandOutcome.Failure
@@ -14,10 +15,14 @@ import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
  * @param notifier The notifier responsible for displaying the notification.
  */
 internal class SystemNotificationCommand(
+    private val logger: Logger,
     notification: SystemNotification,
     notifier: NotificationNotifier<SystemNotification>,
 ) : NotificationCommand<SystemNotification>(notification, notifier) {
     override fun execute(): Outcome<Success<SystemNotification>, Failure<SystemNotification>> {
-        TODO("Implementation on GitHub Issue #9245")
+        logger.debug {
+            "TODO: Implementation on GitHub Issue #9245. Notification = $notification."
+        }
+        return Outcome.success(data = Success(command = this))
     }
 }

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
@@ -1,0 +1,27 @@
+package net.thunderbird.feature.notification.impl.inject
+
+import net.thunderbird.feature.notification.api.sender.NotificationSender
+import net.thunderbird.feature.notification.impl.command.NotificationCommandFactory
+import net.thunderbird.feature.notification.impl.receiver.InAppNotificationNotifier
+import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNotifier
+import net.thunderbird.feature.notification.impl.sender.DefaultNotificationSender
+import org.koin.dsl.module
+
+val featureNotificationModule = module {
+    factory { SystemNotificationNotifier() }
+    factory { InAppNotificationNotifier() }
+
+    factory<NotificationCommandFactory> {
+        NotificationCommandFactory(
+            logger = get(),
+            systemNotificationNotifier = get(),
+            inAppNotificationNotifier = get(),
+        )
+    }
+
+    single<NotificationSender> {
+        DefaultNotificationSender(
+            commandFactory = get(),
+        )
+    }
+}

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
@@ -17,7 +17,10 @@ val settingsUiModule = module {
     viewModel { SettingsViewModel(accountManager = get()) }
 
     viewModel {
-        GeneralSettingsViewModel(logFileWriter = get(), syncDebugFileLogSink = get<FileLogSink>(named("syncDebug")))
+        GeneralSettingsViewModel(
+            logFileWriter = get(),
+            syncDebugFileLogSink = get<FileLogSink>(named("syncDebug")),
+        )
     }
     factory {
         GeneralSettingsDataStore(

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
@@ -10,6 +10,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceScreen
 import app.k9mail.feature.telemetry.api.TelemetryManager
+import com.fsck.k9.ui.BuildConfig
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.extensions.withArguments
 import com.fsck.k9.ui.observe
@@ -69,6 +70,19 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
                     parentPreference.removePreference(fontSizePreferenceScreen)
                 }
             }
+
+        findPreference<Preference>("debug_secret_debug_screen")?.apply {
+            if (!BuildConfig.DEBUG) {
+                remove()
+                onPreferenceClickListener = null
+            } else {
+                onPreferenceClickListener = Preference.OnPreferenceClickListener { preference ->
+                    viewModel.onOpenSecretDebugScreen(requireContext())
+
+                    true
+                }
+            }
+        }
 
         initializeDataCollection()
 
@@ -147,6 +161,7 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
             .also { snackbar = it }
             .show()
     }
+
     private fun formatFileExportUriString(): String {
         val now = Calendar.getInstance()
         return String.format(

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsViewModel.kt
@@ -1,8 +1,12 @@
 package com.fsck.k9.ui.settings.general
 
+import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.k9mail.feature.launcher.FeatureLauncherActivity
+import app.k9mail.feature.launcher.FeatureLauncherTarget
+import com.fsck.k9.ui.BuildConfig
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -15,8 +19,7 @@ import net.thunderbird.core.logging.legacy.Log
 class GeneralSettingsViewModel(
     private val logFileWriter: LogFileWriter,
     private val syncDebugFileLogSink: FileLogSink,
-) :
-    ViewModel() {
+) : ViewModel() {
     private var snackbarJob: Job? = null
     private val uiStateFlow = MutableStateFlow<GeneralSettingsUiState>(GeneralSettingsUiState.Idle)
     val uiState: Flow<GeneralSettingsUiState> = uiStateFlow
@@ -68,6 +71,12 @@ class GeneralSettingsViewModel(
 
     private fun sendUiState(uiState: GeneralSettingsUiState) {
         uiStateFlow.value = uiState
+    }
+
+    fun onOpenSecretDebugScreen(context: Context) {
+        if (BuildConfig.DEBUG) {
+            FeatureLauncherActivity.launch(context = context, target = FeatureLauncherTarget.SecretDebugSettings)
+        }
     }
 
     companion object {

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <string name="debug_sync_export_logs_title">Export Sync logs</string>
     <string name="debug_export_logs_success">Export successful. Logs might contain sensitive information. Be careful who you send them to.</string>
     <string name="debug_export_logs_failure">Export failed.</string>
+    <string name="debug_open_secret_debug_screen">Open Secret debug screen</string>
 
     <string name="message_list_load_more_messages_action">Load more messages</string>
     <string name="message_to_fmt">To:<xliff:g id="counterParty">%s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/general_settings.xml
@@ -554,6 +554,10 @@
             android:title="@string/debug_enable_sensitive_logging_title"
             />
 
+        <Preference
+            android:key="debug_secret_debug_screen"
+            android:title="@string/debug_open_secret_debug_screen" />
+
     </PreferenceScreen>
 
 </PreferenceScreen>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -248,6 +248,10 @@ include(
     ":quality:konsist",
 )
 
+include(
+    ":feature:debug-settings",
+)
+
 check(JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     """
         Java 17+ is required to build Thunderbird for Android.


### PR DESCRIPTION
Changeset split from #9415
Part of #9245.

- Introduce the Secret Debug Screen, enabling notification testing
- Fixes Previews that use `PreviewWithThemesLightDark` being unable to render because of using `MainTheme` outside the `CompositionLocal`
- Rename `PreviewWithThemeLightDark` to `PreviewWithThemesLightDark`
- Rename `ThemePreview` to `PreviewWithThemeLightDark`