### PR TITLE
chore(quality): add Kover to calculate the test code coverage

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -5,11 +5,6 @@ plugins {
     id("thunderbird.quality.badging")
 }
 
-val testCoverageEnabled: Boolean by extra
-if (testCoverageEnabled) {
-    apply(plugin = "jacoco")
-}
-
 android {
     namespace = "com.fsck.k9"
 
@@ -97,8 +92,9 @@ android {
 
         debug {
             applicationIdSuffix = ".debug"
-            enableUnitTestCoverage = testCoverageEnabled
-            enableAndroidTestCoverage = testCoverageEnabled
+
+            enableUnitTestCoverage = true
+            enableAndroidTestCoverage = true
 
             isMinifyEnabled = false
         }

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -5,11 +5,6 @@ plugins {
     id("thunderbird.quality.badging")
 }
 
-val testCoverageEnabled: Boolean by extra
-if (testCoverageEnabled) {
-    apply(plugin = "jacoco")
-}
-
 android {
     namespace = "net.thunderbird.android"
 
@@ -91,6 +86,9 @@ android {
         debug {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-SNAPSHOT"
+
+            enableUnitTestCoverage = true
+            enableAndroidTestCoverage = true
 
             isMinifyEnabled = false
             isShrinkResources = false

--- a/build-plugin/build.gradle.kts
+++ b/build-plugin/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(plugin(libs.plugins.dependency.check))
     implementation(plugin(libs.plugins.detekt))
     implementation(plugin(libs.plugins.spotless))
+    implementation(plugin(libs.plugins.kover))
 
     implementation(libs.diff.utils)
     compileOnly(libs.android.tools.common)

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.compose.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("thunderbird.app.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.kover")
     id("thunderbird.quality.spotless")
 }
 

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.kover")
     id("thunderbird.quality.spotless")
 }
 

--- a/build-plugin/src/main/kotlin/thunderbird.app.jvm.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.jvm.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("application")
     id("org.jetbrains.kotlin.jvm")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.kover")
     id("thunderbird.quality.spotless")
 }
 

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.kover")
     id("thunderbird.quality.spotless")
 }
 

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.kover")
     id("thunderbird.quality.spotless")
 }
 

--- a/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     `java-library`
     id("org.jetbrains.kotlin.jvm")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.kover")
     id("thunderbird.quality.spotless")
 }
 

--- a/build-plugin/src/main/kotlin/thunderbird.library.kmp.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.kmp.compose.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.kover")
     id("thunderbird.quality.spotless")
 }
 

--- a/build-plugin/src/main/kotlin/thunderbird.library.kmp.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.kmp.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("thunderbird.quality.detekt.typed")
+    id("thunderbird.quality.kover")
     id("thunderbird.quality.spotless")
 }
 

--- a/build-plugin/src/main/kotlin/thunderbird.quality.kover.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.quality.kover.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("org.jetbrains.kotlinx.kover")
+}
+
+kover {
+    reports {
+        filters {
+            excludes {
+                annotatedBy("androidx.compose.ui.tooling.preview.Preview")
+            }
+        }
+
+        verify {
+            rule("line-coverage") {
+                minBound(50)
+            }
+        }
+    }
+}

--- a/build-plugin/src/main/kotlin/thunderbird.quality.kover.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.quality.kover.gradle.kts
@@ -12,7 +12,7 @@ kover {
 
         verify {
             rule("line-coverage") {
-                minBound(50)
+                minBound(0)
             }
         }
     }

--- a/build-plugin/src/main/kotlin/thunderbird.quality.kover.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.quality.kover.gradle.kts
@@ -2,7 +2,15 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
+/**
+ * To enable Kover provide the `enableKover` property by adding `./gradlew koverHtmlReport -PenableKover`.
+ */
+
 kover {
+    if (!hasProperty("enableKover")) {
+        disable()
+    }
+
     reports {
         filters {
             excludes {

--- a/build-plugin/src/main/kotlin/thunderbird.quality.kover.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.quality.kover.gradle.kts
@@ -6,7 +6,13 @@ kover {
     reports {
         filters {
             excludes {
-                annotatedBy("androidx.compose.ui.tooling.preview.Preview")
+                annotatedBy(
+                    "androidx.compose.ui.tooling.preview.Preview",
+                    "androidx.compose.ui.tooling.preview.PreviewLightDark",
+                    "app.k9mail.core.ui.compose.common.annotation.PreviewDevices",
+                    "app.k9mail.core.ui.compose.common.annotation.PreviewDevicesWithBackground",
+                    "app.k9mail.core.ui.compose.designsystem.PreviewLightDarkLandscape",
+                )
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,17 +12,12 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.jetbrains.compose) apply false
 
-    id("thunderbird.quality.spotless.root")
     id("thunderbird.dependency.check")
+    id("thunderbird.quality.spotless.root")
+    id("thunderbird.quality.kover")
 }
 
-val propertyTestCoverage: String? by extra
-
 allprojects {
-    extra.apply {
-        set("testCoverageEnabled", propertyTestCoverage != null)
-    }
-
     tasks.withType<Test> {
         testLogging {
             exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,7 @@ kotlinxCollectionsImmutable = "0.4.0"
 kotlinxDateTime = "0.7.0"
 kotlinxIoCore = "0.7.0"
 kotlinxSerialization = "1.8.1"
+kover = "0.9.1"
 ktlint = "1.5.0"
 ktor = "3.1.3"
 kxml2 = "1.0"
@@ -124,6 +125,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinBom" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlinBom" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinBom" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinBom" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "kotlinKsp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }
 dev-mokkery = { id = "dev.mokkery", version.ref = "mokkery" }

--- a/mail/common/build.gradle.kts
+++ b/mail/common/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
     alias(libs.plugins.android.lint)
 }
 
-val testCoverageEnabled: Boolean by extra
-if (testCoverageEnabled) {
-    apply(plugin = "jacoco")
-}
-
 dependencies {
     api(libs.jetbrains.annotations)
 

--- a/mail/protocols/imap/build.gradle.kts
+++ b/mail/protocols/imap/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
     alias(libs.plugins.android.lint)
 }
 
-val testCoverageEnabled: Boolean by extra
-if (testCoverageEnabled) {
-    apply(plugin = "jacoco")
-}
-
 dependencies {
     api(projects.mail.common)
     implementation(projects.core.common)

--- a/mail/protocols/pop3/build.gradle.kts
+++ b/mail/protocols/pop3/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
     alias(libs.plugins.android.lint)
 }
 
-val testCoverageEnabled: Boolean by extra
-if (testCoverageEnabled) {
-    apply(plugin = "jacoco")
-}
-
 dependencies {
     api(projects.mail.common)
     implementation(projects.core.common)

--- a/mail/protocols/smtp/build.gradle.kts
+++ b/mail/protocols/smtp/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
     alias(libs.plugins.android.lint)
 }
 
-val testCoverageEnabled: Boolean by extra
-if (testCoverageEnabled) {
-    apply(plugin = "jacoco")
-}
-
 dependencies {
     api(projects.mail.common)
     implementation(projects.core.common)

--- a/mail/testing/build.gradle.kts
+++ b/mail/testing/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
     alias(libs.plugins.android.lint)
 }
 
-val testCoverageEnabled: Boolean by extra
-if (testCoverageEnabled) {
-    apply(plugin = "jacoco")
-}
-
 dependencies {
     api(projects.mail.common)
     api(projects.core.common)


### PR DESCRIPTION
This is a simple setup to just enable Kover and allow us to generate code coverage reportings.

Resolves #9503


