### PR TITLE
Chore update feature flags

### DIFF
--- a/app-thunderbird/src/beta/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/beta/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -12,11 +12,11 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
             FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = true),
-            FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = false),
+            FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = true),
             FeatureFlag("disable_font_size_config".toFeatureFlagKey(), enabled = true),
             FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = true),
-            FeatureFlag("enable_dropdown_drawer_ui".toFeatureFlagKey(), enabled = false),
+            FeatureFlag("enable_dropdown_drawer_ui".toFeatureFlagKey(), enabled = true),
             FeatureFlag(FeatureFlagKey.DisplayInAppNotifications, enabled = true),
             FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = false),
         )

--- a/app-thunderbird/src/daily/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/daily/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -12,7 +12,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
             FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = true),
-            FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = false),
+            FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = true),
             FeatureFlag("disable_font_size_config".toFeatureFlagKey(), enabled = true),
             FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = true),

--- a/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -11,11 +11,11 @@ import net.thunderbird.core.featureflag.toFeatureFlagKey
 class TbFeatureFlagFactory : FeatureFlagFactory {
     override fun createFeatureCatalog(): List<FeatureFlag> {
         return listOf(
-            FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = false),
+            FeatureFlag("archive_marks_as_read".toFeatureFlagKey(), enabled = true),
             FeatureFlag("new_account_settings".toFeatureFlagKey(), enabled = false),
-            FeatureFlag("disable_font_size_config".toFeatureFlagKey(), enabled = false),
-            FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = false),
-            FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = false),
+            FeatureFlag("disable_font_size_config".toFeatureFlagKey(), enabled = true),
+            FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = true),
+            FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer_ui".toFeatureFlagKey(), enabled = false),
             FeatureFlag(FeatureFlagKey.DisplayInAppNotifications, enabled = false),
             FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = false),


### PR DESCRIPTION
This updates the feature flags to the state of our current release version 11.

And enables new account settings on daily.

The new account settings and drawer ui are enabled for beta.
