### PR TITLE
chore(notification): add notification sender compat

### DIFF
--- a/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/SecretDebugSettingsScreenPreview.kt
+++ b/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/SecretDebugSettingsScreenPreview.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import app.k9mail.core.ui.compose.common.koin.koinPreview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.flowOf
 import net.thunderbird.core.common.resources.StringsResourceManager
 import net.thunderbird.core.outcome.Outcome
@@ -16,6 +17,8 @@ import net.thunderbird.feature.mail.account.api.BaseAccount
 import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
 import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
 import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationEvent
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationReceiver
 import net.thunderbird.feature.notification.api.sender.NotificationSender
 
 @PreviewLightDark
@@ -46,6 +49,10 @@ private fun SecretDebugSettingsScreenPreview() {
                         notification: Notification,
                     ): Flow<Outcome<Success<Notification>, Failure<Notification>>> =
                         error("not implemented")
+                },
+                notificationReceiver = object : InAppNotificationReceiver {
+                    override val events: SharedFlow<InAppNotificationEvent>
+                        get() = error("not implemented")
                 },
             )
         }

--- a/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/inject/FeatureDebugSettingsModule.kt
+++ b/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/inject/FeatureDebugSettingsModule.kt
@@ -13,6 +13,7 @@ val featureDebugSettingsModule = module {
             stringsResourceManager = get(),
             accountManager = get(),
             notificationSender = get(),
+            notificationReceiver = get(),
         )
     }
 }

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSectionViewModel.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/notification/DebugNotificationSectionViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.thunderbird.core.common.resources.StringsResourceManager
@@ -27,12 +28,14 @@ import net.thunderbird.feature.notification.api.content.MailNotification
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.content.PushServiceNotification
 import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationReceiver
 import net.thunderbird.feature.notification.api.sender.NotificationSender
 
 internal class DebugNotificationSectionViewModel(
     private val stringsResourceManager: StringsResourceManager,
     private val accountManager: AccountManager<BaseAccount>,
     private val notificationSender: NotificationSender,
+    private val notificationReceiver: InAppNotificationReceiver,
     private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BaseViewModel<State, Event, Effect>(initialState = State()), DebugNotificationSectionContract.ViewModel {
@@ -75,6 +78,18 @@ internal class DebugNotificationSectionViewModel(
                     )
                 }
             }
+        }
+
+        viewModelScope.launch {
+            notificationReceiver
+                .events
+                .collectLatest { event ->
+                    updateState { state ->
+                        state.copy(
+                            notificationStatusLog = state.notificationStatusLog + " In-app notification event: $event",
+                        )
+                    }
+                }
         }
     }
 

--- a/feature/notification/api/build.gradle.kts
+++ b/feature/notification/api/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.internal.config.LanguageFeature
 
 plugins {
     id(ThunderbirdPlugins.Library.kmpCompose)
+    alias(libs.plugins.dev.mokkery)
 }
 
 kotlin {

--- a/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/action/icon/NotificationActionIcons.android.kt
+++ b/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/action/icon/NotificationActionIcons.android.kt
@@ -1,0 +1,44 @@
+package net.thunderbird.feature.notification.api.ui.action.icon
+
+import net.thunderbird.feature.notification.api.R
+import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+
+internal actual val NotificationActionIcons.Reply: NotificationIcon
+    get() = NotificationIcon(
+        systemNotificationIcon = R.drawable.ic_reply,
+    )
+
+internal actual val NotificationActionIcons.MarkAsRead: NotificationIcon
+    get() = NotificationIcon(
+        systemNotificationIcon = R.drawable.ic_mark_email_read,
+    )
+
+internal actual val NotificationActionIcons.Delete: NotificationIcon
+    get() = NotificationIcon(
+        systemNotificationIcon = R.drawable.ic_delete,
+    )
+
+internal actual val NotificationActionIcons.MarkAsSpam: NotificationIcon
+    get() = NotificationIcon(
+        systemNotificationIcon = R.drawable.ic_report,
+    )
+
+internal actual val NotificationActionIcons.Archive: NotificationIcon
+    get() = NotificationIcon(
+        systemNotificationIcon = R.drawable.ic_archive,
+    )
+
+internal actual val NotificationActionIcons.UpdateServerSettings: NotificationIcon
+    get() = NotificationIcon(
+        systemNotificationIcon = R.drawable.ic_settings,
+    )
+
+internal actual val NotificationActionIcons.Retry: NotificationIcon
+    get() = NotificationIcon(
+        systemNotificationIcon = R.drawable.ic_refresh,
+    )
+
+internal actual val NotificationActionIcons.DisablePushAction: NotificationIcon
+    get() = NotificationIcon(
+        systemNotificationIcon = R.drawable.ic_settings,
+    )

--- a/feature/notification/api/src/commonMain/composeResources/values/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values/strings.xml
@@ -45,4 +45,15 @@
 
     <string name="push_info_disable_push_action">Disable Push</string>
 
+    <string name="notification_action_reply">Reply</string>
+    <string name="notification_action_mark_as_read">Mark Read</string>
+    <string name="notification_action_mark_all_as_read">Mark All Read</string>
+    <string name="notification_action_delete">Delete</string>
+    <string name="notification_action_delete_all">Delete All</string>
+    <string name="notification_action_archive">Archive</string>
+    <string name="notification_action_archive_all">Archive All</string>
+    <string name="notification_action_spam">Spam</string>
+    <string name="notification_action_retry">Retry</string>
+    <string name="notification_action_update_server_settings">Update Server Settings</string>
+
 </resources>

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/NotificationRegistry.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/NotificationRegistry.kt
@@ -1,0 +1,61 @@
+package net.thunderbird.feature.notification.api
+
+import net.thunderbird.feature.notification.api.content.Notification
+
+/**
+ * A registry for managing notifications and their corresponding IDs.
+ *
+ * It establishes and maintains the correlation between a [Notification] object
+ * and its unique [NotificationId].
+ * This can also be used to track which notifications are currently being displayed
+ * to the user.
+ */
+interface NotificationRegistry {
+    /**
+     * A [Map] off all the current notifications, associated with their IDs,
+     * being displayed to the user.
+     */
+    val registrar: Map<NotificationId, Notification>
+
+    /**
+     * Retrieves a [Notification] object based on its [notificationId].
+     *
+     * @param notificationId The ID of the notification to retrieve.
+     * @return The [Notification] object associated with the given [notificationId],
+     * or `null` if no such notification exists.
+     */
+    operator fun get(notificationId: NotificationId): Notification?
+
+    /**
+     * Retrieves the [NotificationId] associated with the given [notification].
+     *
+     * @param notification The notification for which to retrieve the ID.
+     * @return The [NotificationId] if the notification is registered, or `null` otherwise.
+     */
+    operator fun get(notification: Notification): NotificationId?
+
+    /**
+     * Registers a notification and returns its unique ID.
+     *
+     * If the provided [notification] is already registered, this function will effectively
+     * return its known [NotificationId].
+     *
+     * @param notification The [Notification] object to register.
+     * @return The unique [NotificationId] assigned to the registered notification.
+     */
+    suspend fun register(notification: Notification): NotificationId
+
+    /**
+     * Unregisters a [Notification] by its [NotificationId].
+     *
+     * @param notificationId The ID of the notification to unregister.
+     */
+    fun unregister(notificationId: NotificationId)
+
+    /**
+     * Unregisters a previously registered notification.
+     *
+     * @param notification The [Notification] object to unregister.
+     */
+    fun unregister(notification: Notification)
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/NotificationSeverity.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/NotificationSeverity.kt
@@ -12,7 +12,7 @@ package net.thunderbird.feature.notification.api
  * For [Temporary] and [Warning], user action might be recommended or optional.
  * For [Information], no user action is usually needed.
  */
-enum class NotificationSeverity {
+enum class NotificationSeverity(val dismissable: Boolean) {
     /**
      * Completely blocks the user from performing essential tasks or accessing core functionality.
      *
@@ -24,7 +24,7 @@ enum class NotificationSeverity {
      *     - Retry
      *     - Provide other credentials
      */
-    Fatal,
+    Fatal(dismissable = false),
 
     /**
      * Prevents the user from completing specific core actions or causes significant disruption to functionality.
@@ -36,7 +36,7 @@ enum class NotificationSeverity {
      * - **Notification Actions:**
      *    - Retry
      */
-    Critical,
+    Critical(dismissable = false),
 
     /**
      * Causes a temporary disruption or delay to functionality, which may resolve on its own.
@@ -48,7 +48,7 @@ enum class NotificationSeverity {
      * - **Notification Message:** You are offline, the message will be sent later.
      * - **Notification Actions:** N/A
      */
-    Temporary,
+    Temporary(dismissable = true),
 
     /**
      * Alerts the user to a potential issue or limitation that may affect functionality if not addressed.
@@ -61,7 +61,7 @@ enum class NotificationSeverity {
      * - **Notification Actions:**
      *    - Manage Storage
      */
-    Warning,
+    Warning(dismissable = true),
 
     /**
      * Provides status or context without impacting functionality or requiring action.
@@ -72,5 +72,5 @@ enum class NotificationSeverity {
      * - **Notification Message:** Last time email synchronization succeeded
      * - **Notification Actions:** N/A
      */
-    Information,
+    Information(dismissable = true),
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/NotificationCommandException.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/NotificationCommandException.kt
@@ -1,0 +1,6 @@
+package net.thunderbird.feature.notification.api.command
+
+class NotificationCommandException @JvmOverloads constructor(
+    override val message: String?,
+    override val cause: Throwable? = null,
+) : Exception(message, cause)

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/AppNotification.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/AppNotification.kt
@@ -49,7 +49,7 @@ sealed interface Notification {
  * @property actions A set of actions that can be performed on the notification. Defaults to an empty set.
  * @see Notification
  */
-sealed class AppNotification : Notification {
+abstract class AppNotification : Notification {
     override val accessibilityText: String = title
 
     @OptIn(ExperimentalTime::class)

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/AppNotification.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/AppNotification.kt
@@ -70,7 +70,7 @@ abstract class AppNotification : Notification {
  * @see SystemNotificationStyle
  * @see net.thunderbird.feature.notification.api.ui.style.systemNotificationStyle
  */
-sealed interface SystemNotification : Notification {
+interface SystemNotification : Notification {
     val subText: String? get() = null
     val channel: NotificationChannel
     val group: NotificationGroup? get() = null
@@ -112,6 +112,6 @@ sealed interface SystemNotification : Notification {
  * @see InAppNotificationStyle
  * @see net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyle
  */
-sealed interface InAppNotification : Notification {
+interface InAppNotification : Notification {
     val inAppNotificationStyle: InAppNotificationStyle get() = InAppNotificationStyle.Undefined
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/PushServiceNotification.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/PushServiceNotification.kt
@@ -3,6 +3,8 @@ package net.thunderbird.feature.notification.api.content
 import net.thunderbird.feature.notification.api.NotificationChannel
 import net.thunderbird.feature.notification.api.NotificationSeverity
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.api.ui.action.icon.DisablePushAction
+import net.thunderbird.feature.notification.api.ui.action.icon.NotificationActionIcons
 import net.thunderbird.feature.notification.api.ui.icon.AlarmPermissionMissing
 import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
 import net.thunderbird.feature.notification.api.ui.icon.NotificationIcons
@@ -168,7 +170,9 @@ sealed class PushServiceNotification : AppNotification(), SystemNotification {
  * @return A set of [NotificationAction] instances.
  */
 private suspend fun buildNotificationActions(): Set<NotificationAction> = setOf(
+    NotificationAction.Tap,
     NotificationAction.CustomAction(
-        message = getString(resource = Res.string.push_info_disable_push_action),
+        title = getString(resource = Res.string.push_info_disable_push_action),
+        icon = NotificationActionIcons.DisablePushAction,
     ),
 )

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/receiver/InAppNotificationReceiver.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/receiver/InAppNotificationReceiver.kt
@@ -1,0 +1,19 @@
+package net.thunderbird.feature.notification.api.receiver
+
+import kotlinx.coroutines.flow.SharedFlow
+import net.thunderbird.feature.notification.api.content.InAppNotification
+
+/**
+ * Interface for receiving in-app notification events.
+ *
+ * This interface provides a [SharedFlow] of [InAppNotificationEvent]s that can be observed
+ * by UI components or other parts of the application to react to in-app notifications.
+ */
+interface InAppNotificationReceiver {
+    val events: SharedFlow<InAppNotificationEvent>
+}
+
+sealed interface InAppNotificationEvent {
+    data class Show(val notification: InAppNotification) : InAppNotificationEvent
+    data class Dismiss(val notification: InAppNotification) : InAppNotificationEvent
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/receiver/compat/InAppNotificationReceiverCompat.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/receiver/compat/InAppNotificationReceiverCompat.kt
@@ -1,0 +1,46 @@
+package net.thunderbird.feature.notification.api.receiver.compat
+
+import androidx.annotation.Discouraged
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationEvent
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationReceiver
+
+/**
+ * A compatibility class for [InAppNotificationReceiver] that allows Java classes to observe notification events.
+ *
+ * This class is discouraged for use in Kotlin code. Use [InAppNotificationReceiver] directly instead.
+ *
+ * @param notificationReceiver The [InAppNotificationReceiver] instance to delegate to.
+ * @param listener A callback function that will be invoked when a new [InAppNotificationEvent] is received.
+ * @param mainImmediateDispatcher The [CoroutineDispatcher] to use for observing events.
+ */
+@Discouraged("Only for usage within a Java class. Use InAppNotificationReceiver instead.")
+class InAppNotificationReceiverCompat(
+    private val notificationReceiver: InAppNotificationReceiver,
+    listener: OnReceiveEventListener,
+    mainImmediateDispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
+) : InAppNotificationReceiver by notificationReceiver, DisposableHandle {
+    private val scope = CoroutineScope(SupervisorJob() + mainImmediateDispatcher)
+
+    init {
+        scope.launch {
+            events.collect { event ->
+                listener.onReceiveEvent(event)
+            }
+        }
+    }
+
+    override fun dispose() {
+        scope.cancel()
+    }
+
+    fun interface OnReceiveEventListener {
+        fun onReceiveEvent(event: InAppNotificationEvent)
+    }
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompat.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompat.kt
@@ -1,0 +1,50 @@
+package net.thunderbird.feature.notification.api.sender.compat
+
+import androidx.annotation.Discouraged
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
+import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.api.sender.NotificationSender
+
+/**
+ * A compatibility layer for sending notifications from Java code.
+ *
+ * This class wraps [NotificationSender] and provides a Java-friendly API for sending notifications
+ * and receiving results via a callback interface.
+ *
+ * It is marked as [Discouraged] because it is intended only for use within Java classes.
+ * Kotlin code should use [NotificationSender] directly.
+ *
+ * @property notificationSender The underlying [NotificationSender] instance.
+ * @property mainImmediateDispatcher The [CoroutineDispatcher] used for launching coroutines.
+ */
+@Discouraged("Only for usage within a Java class. Use NotificationSender instead.")
+class NotificationSenderCompat @JvmOverloads constructor(
+    private val notificationSender: NotificationSender,
+    mainImmediateDispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
+) : NotificationSender by notificationSender, DisposableHandle {
+    private val scope = CoroutineScope(SupervisorJob() + mainImmediateDispatcher)
+
+    fun send(notification: Notification, onResultListener: OnResultListener) {
+        send(notification)
+            .onEach { outcome -> onResultListener.onResult(outcome) }
+            .launchIn(scope)
+    }
+
+    override fun dispose() {
+        scope.cancel()
+    }
+
+    fun interface OnResultListener {
+        fun onResult(outcome: Outcome<Success<Notification>, Failure<Notification>>)
+    }
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/action/NotificationAction.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/action/NotificationAction.kt
@@ -1,50 +1,125 @@
 package net.thunderbird.feature.notification.api.ui.action
 
+import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.ui.action.icon.Archive
+import net.thunderbird.feature.notification.api.ui.action.icon.Delete
+import net.thunderbird.feature.notification.api.ui.action.icon.MarkAsRead
+import net.thunderbird.feature.notification.api.ui.action.icon.MarkAsSpam
+import net.thunderbird.feature.notification.api.ui.action.icon.NotificationActionIcons
+import net.thunderbird.feature.notification.api.ui.action.icon.Reply
+import net.thunderbird.feature.notification.api.ui.action.icon.Retry
+import net.thunderbird.feature.notification.api.ui.action.icon.UpdateServerSettings
+import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+import net.thunderbird.feature.notification.resources.api.Res
+import net.thunderbird.feature.notification.resources.api.notification_action_archive
+import net.thunderbird.feature.notification.resources.api.notification_action_delete
+import net.thunderbird.feature.notification.resources.api.notification_action_mark_as_read
+import net.thunderbird.feature.notification.resources.api.notification_action_reply
+import net.thunderbird.feature.notification.resources.api.notification_action_retry
+import net.thunderbird.feature.notification.resources.api.notification_action_spam
+import net.thunderbird.feature.notification.resources.api.notification_action_update_server_settings
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.getString
+
 /**
  * Represents the various actions that can be performed on a notification.
  */
-sealed interface NotificationAction {
+sealed class NotificationAction {
+    abstract val icon: NotificationIcon?
+    protected abstract val titleResource: StringResource?
+
+    open suspend fun resolveTitle(): String? = titleResource?.let { getString(it) }
+
+    /**
+     * Action to open the notification. This is the default action when a notification is tapped.
+     *
+     * This action typically does not have an icon or title displayed on the notification itself,
+     * as it's implied by tapping the notification content.
+     *
+     * All [SystemNotification] will have this action implicitly, even if not specified in the
+     * [SystemNotification.actions] set.
+     */
+    data object Tap : NotificationAction() {
+        override val icon: NotificationIcon? = null
+        override val titleResource: StringResource? = null
+    }
+
     /**
      * Action to reply to the email message associated with the notification.
      */
-    data object Reply : NotificationAction
+    data object Reply : NotificationAction() {
+        override val icon: NotificationIcon = NotificationActionIcons.Reply
+
+        override val titleResource: StringResource = Res.string.notification_action_reply
+    }
 
     /**
      * Action to mark the email message associated with the notification as read.
      */
-    data object MarkAsRead : NotificationAction
+    data object MarkAsRead : NotificationAction() {
+        override val icon: NotificationIcon = NotificationActionIcons.MarkAsRead
+
+        override val titleResource: StringResource = Res.string.notification_action_mark_as_read
+    }
 
     /**
      * Action to delete the email message associated with the notification.
      */
-    data object Delete : NotificationAction
+    data object Delete : NotificationAction() {
+        override val icon: NotificationIcon = NotificationActionIcons.Delete
+
+        override val titleResource: StringResource = Res.string.notification_action_delete
+    }
 
     /**
      * Action to mark the email message associated with the notification as spam.
      */
-    data object MarkAsSpam : NotificationAction
+    data object MarkAsSpam : NotificationAction() {
+        override val icon: NotificationIcon = NotificationActionIcons.MarkAsSpam
+
+        override val titleResource: StringResource = Res.string.notification_action_spam
+    }
 
     /**
      * Action to archive the email message associated with the notification.
      */
-    data object Archive : NotificationAction
+    data object Archive : NotificationAction() {
+        override val icon: NotificationIcon = NotificationActionIcons.Archive
+
+        override val titleResource: StringResource = Res.string.notification_action_archive
+    }
 
     /**
      * Action to prompt the user to update server settings, typically when authentication fails.
      */
-    data object UpdateServerSettings : NotificationAction
+    data object UpdateServerSettings : NotificationAction() {
+        override val icon: NotificationIcon = NotificationActionIcons.UpdateServerSettings
+
+        override val titleResource: StringResource = Res.string.notification_action_update_server_settings
+    }
 
     /**
      * Action to retry a failed operation, such as sending a message or fetching new messages.
      */
-    data object Retry : NotificationAction
+    data object Retry : NotificationAction() {
+        override val icon: NotificationIcon = NotificationActionIcons.Retry
+
+        override val titleResource: StringResource = Res.string.notification_action_retry
+    }
 
     /**
      * Represents a custom notification action.
      *
      * This can be used for actions that are not predefined and require a specific message.
      *
-     * @property message The text to be displayed for this custom action.
+     * @property title The text to be displayed for this custom action.
      */
-    data class CustomAction(val message: String) : NotificationAction
+    data class CustomAction(
+        val title: String,
+        override val icon: NotificationIcon? = null,
+    ) : NotificationAction() {
+        override val titleResource: StringResource get() = error("Custom Action must not supply a title resource")
+
+        override suspend fun resolveTitle(): String = title
+    }
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/action/icon/NotificationActionIcons.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/action/icon/NotificationActionIcons.kt
@@ -1,0 +1,14 @@
+package net.thunderbird.feature.notification.api.ui.action.icon
+
+import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+
+internal object NotificationActionIcons
+
+internal expect val NotificationActionIcons.Reply: NotificationIcon
+internal expect val NotificationActionIcons.MarkAsRead: NotificationIcon
+internal expect val NotificationActionIcons.Delete: NotificationIcon
+internal expect val NotificationActionIcons.MarkAsSpam: NotificationIcon
+internal expect val NotificationActionIcons.Archive: NotificationIcon
+internal expect val NotificationActionIcons.UpdateServerSettings: NotificationIcon
+internal expect val NotificationActionIcons.Retry: NotificationIcon
+internal expect val NotificationActionIcons.DisablePushAction: NotificationIcon

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/icon/NotificationIcon.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/icon/NotificationIcon.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
  * @property inAppNotificationIcon The icon to be used for in-app notifications.
  */
 data class NotificationIcon(
-    private val systemNotificationIcon: SystemNotificationIcon? = null,
-    private val inAppNotificationIcon: ImageVector? = null,
+    val systemNotificationIcon: SystemNotificationIcon? = null,
+    val inAppNotificationIcon: ImageVector? = null,
 ) {
 
     init {

--- a/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/fake/FakeNotification.kt
+++ b/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/fake/FakeNotification.kt
@@ -1,0 +1,60 @@
+package net.thunderbird.feature.notification.api.fake
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import net.thunderbird.feature.notification.api.NotificationChannel
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.content.AppNotification
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+
+data class FakeNotification(
+    override val title: String = "fake title",
+    override val contentText: String? = "fake content",
+    override val severity: NotificationSeverity = NotificationSeverity.Information,
+    override val icon: NotificationIcon = NotificationIcon(
+        inAppNotificationIcon = ImageVector.Builder(
+            defaultWidth = 0.dp,
+            defaultHeight = 0.dp,
+            viewportWidth = 0f,
+            viewportHeight = 0f,
+        ).build(),
+    ),
+    override val channel: NotificationChannel = NotificationChannel.Messages(
+        accountUuid = "",
+        suffix = "",
+    ),
+) : AppNotification(), SystemNotification, InAppNotification
+
+data class FakeSystemOnlyNotification(
+    override val title: String = "fake title",
+    override val contentText: String? = "fake content",
+    override val severity: NotificationSeverity = NotificationSeverity.Information,
+    override val icon: NotificationIcon = NotificationIcon(
+        inAppNotificationIcon = ImageVector.Builder(
+            defaultWidth = 0.dp,
+            defaultHeight = 0.dp,
+            viewportWidth = 0f,
+            viewportHeight = 0f,
+        ).build(),
+    ),
+    override val channel: NotificationChannel = NotificationChannel.Messages(
+        accountUuid = "",
+        suffix = "",
+    ),
+) : AppNotification(), SystemNotification
+
+data class FakeInAppOnlyNotification(
+    override val title: String = "fake title",
+    override val contentText: String? = "fake content",
+    override val severity: NotificationSeverity = NotificationSeverity.Information,
+    override val icon: NotificationIcon = NotificationIcon(
+        inAppNotificationIcon = ImageVector.Builder(
+            defaultWidth = 0.dp,
+            defaultHeight = 0.dp,
+            viewportWidth = 0f,
+            viewportHeight = 0f,
+        ).build(),
+    ),
+) : AppNotification(), InAppNotification

--- a/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/receiver/compat/InAppNotificationReceiverCompatTest.kt
+++ b/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/receiver/compat/InAppNotificationReceiverCompatTest.kt
@@ -1,0 +1,86 @@
+package net.thunderbird.feature.notification.api.receiver.compat
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import dev.mokkery.matcher.any
+import dev.mokkery.spy
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.content.AppNotification
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationEvent
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationReceiver
+import net.thunderbird.feature.notification.api.receiver.compat.InAppNotificationReceiverCompat.OnReceiveEventListener
+import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+
+class InAppNotificationReceiverCompatTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `onReceiveEvent should be triggered when an event is received into InAppNotificationReceiver`() = runTest {
+        // Arrange
+        val inAppNotificationReceiver = FakeInAppNotificationReceiver()
+        val eventsTriggered = mutableListOf<InAppNotificationEvent>()
+        val expectedEvents = List(size = 100) { index ->
+            val title = "notification $index"
+            when {
+                index % 2 == 0 -> {
+                    InAppNotificationEvent.Show(FakeNotification(title = title))
+                }
+
+                else -> InAppNotificationEvent.Dismiss(FakeNotification(title = title))
+            }
+        }.toTypedArray()
+        val onReceiveEventListener = spy<OnReceiveEventListener>(
+            OnReceiveEventListener { event ->
+                eventsTriggered += event
+            },
+        )
+        InAppNotificationReceiverCompat(
+            notificationReceiver = inAppNotificationReceiver,
+            listener = onReceiveEventListener,
+            mainImmediateDispatcher = UnconfinedTestDispatcher(),
+        )
+
+        // Act
+        expectedEvents.forEach { event -> inAppNotificationReceiver.trigger(event) }
+
+        // Assert
+        verify(exactly(100)) {
+            onReceiveEventListener.onReceiveEvent(event = any())
+        }
+        assertThat(eventsTriggered).containsExactlyInAnyOrder(elements = expectedEvents)
+    }
+
+    private class FakeInAppNotificationReceiver : InAppNotificationReceiver {
+        private val _events = MutableSharedFlow<InAppNotificationEvent>()
+        override val events: SharedFlow<InAppNotificationEvent> = _events.asSharedFlow()
+
+        suspend fun trigger(event: InAppNotificationEvent) {
+            _events.emit(event)
+        }
+    }
+
+    data class FakeNotification(
+        override val title: String = "fake title",
+        override val contentText: String? = "fake content",
+        override val severity: NotificationSeverity = NotificationSeverity.Information,
+        override val icon: NotificationIcon = NotificationIcon(
+            inAppNotificationIcon = ImageVector.Builder(
+                defaultWidth = 0.dp,
+                defaultHeight = 0.dp,
+                viewportWidth = 0f,
+                viewportHeight = 0f,
+            ).build(),
+        ),
+    ) : AppNotification(), InAppNotification
+}

--- a/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompatTest.kt
+++ b/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompatTest.kt
@@ -1,0 +1,106 @@
+package net.thunderbird.feature.notification.api.sender.compat
+
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import dev.mokkery.matcher.any
+import dev.mokkery.spy
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.command.NotificationCommand
+import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
+import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.command.NotificationCommandException
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.fake.FakeInAppOnlyNotification
+import net.thunderbird.feature.notification.api.fake.FakeNotification
+import net.thunderbird.feature.notification.api.fake.FakeSystemOnlyNotification
+import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
+import net.thunderbird.feature.notification.api.sender.NotificationSender
+
+class NotificationSenderCompatTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `send should call listener callback whenever a result is received`() {
+        // Arrange
+        val expectedResults = listOf<Outcome<Success<Notification>, Failure<Notification>>>(
+            Outcome.success(Success(FakeInAppNotificationCommand())),
+            Outcome.success(Success(FakeSystemNotificationCommand())),
+            Outcome.failure(
+                error = Failure(
+                    command = FakeSystemNotificationCommand(),
+                    throwable = NotificationCommandException("What an issue?"),
+                ),
+            ),
+        ).toTypedArray()
+        val sender = FakeNotificationSender(results = expectedResults.asFlow())
+        val actualResults = mutableListOf<Outcome<Success<Notification>, Failure<Notification>>>()
+        val listener = spy(
+            NotificationSenderCompat.OnResultListener { outcome ->
+                actualResults += outcome
+            },
+        )
+        val testSubject = NotificationSenderCompat(
+            notificationSender = sender,
+            mainImmediateDispatcher = UnconfinedTestDispatcher(),
+        )
+
+        // Act
+        testSubject.send(notification = FakeNotification(), listener)
+
+        // Assert
+        verify(exactly(expectedResults.size)) {
+            listener.onResult(outcome = any())
+        }
+        assertThat(actualResults).containsExactlyInAnyOrder(elements = expectedResults)
+    }
+
+    private class FakeNotificationSender(
+        private val results: Flow<Outcome<Success<Notification>, Failure<Notification>>>,
+    ) : NotificationSender {
+        override fun send(notification: Notification): Flow<Outcome<Success<Notification>, Failure<Notification>>> =
+            results
+    }
+
+    private class FakeInAppNotificationNotifier : NotificationNotifier<InAppNotification> {
+        override suspend fun show(
+            id: NotificationId,
+            notification: InAppNotification,
+        ) = Unit
+
+        override fun dispose() = Unit
+    }
+
+    private class FakeInAppNotificationCommand(
+        notification: InAppNotification = FakeInAppOnlyNotification(),
+        notifier: NotificationNotifier<InAppNotification> = FakeInAppNotificationNotifier(),
+    ) : NotificationCommand<InAppNotification>(notification, notifier) {
+        override suspend fun execute(): Outcome<Success<InAppNotification>, Failure<InAppNotification>> =
+            error("not implemented")
+    }
+
+    private class FakeSystemNotificationNotifier : NotificationNotifier<SystemNotification> {
+        override suspend fun show(
+            id: NotificationId,
+            notification: SystemNotification,
+        ) = Unit
+
+        override fun dispose() = Unit
+    }
+
+    private class FakeSystemNotificationCommand(
+        notification: SystemNotification = FakeSystemOnlyNotification(),
+        notifier: NotificationNotifier<SystemNotification> = FakeSystemNotificationNotifier(),
+    ) : NotificationCommand<SystemNotification>(notification, notifier) {
+        override suspend fun execute(): Outcome<Success<SystemNotification>, Failure<SystemNotification>> =
+            error("not implemented")
+    }
+}

--- a/feature/notification/api/src/jvmMain/kotlin/net/thunderbird/feature/notification/api/ui/action/icon/NotificationActionIcons.jvm.kt
+++ b/feature/notification/api/src/jvmMain/kotlin/net/thunderbird/feature/notification/api/ui/action/icon/NotificationActionIcons.jvm.kt
@@ -1,0 +1,14 @@
+package net.thunderbird.feature.notification.api.ui.action.icon
+
+import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+
+private const val ERROR_MESSAGE = "Can't send notifications from a jvm library. Use android library or app instead."
+
+internal actual val NotificationActionIcons.Reply: NotificationIcon get() = error(ERROR_MESSAGE)
+internal actual val NotificationActionIcons.MarkAsRead: NotificationIcon get() = error(ERROR_MESSAGE)
+internal actual val NotificationActionIcons.Delete: NotificationIcon get() = error(ERROR_MESSAGE)
+internal actual val NotificationActionIcons.MarkAsSpam: NotificationIcon get() = error(ERROR_MESSAGE)
+internal actual val NotificationActionIcons.Archive: NotificationIcon get() = error(ERROR_MESSAGE)
+internal actual val NotificationActionIcons.UpdateServerSettings: NotificationIcon get() = error(ERROR_MESSAGE)
+internal actual val NotificationActionIcons.Retry: NotificationIcon get() = error(ERROR_MESSAGE)
+internal actual val NotificationActionIcons.DisablePushAction: NotificationIcon get() = error(ERROR_MESSAGE)

--- a/feature/notification/impl/build.gradle.kts
+++ b/feature/notification/impl/build.gradle.kts
@@ -1,11 +1,13 @@
 plugins {
     id(ThunderbirdPlugins.Library.kmpCompose)
+    alias(libs.plugins.dev.mokkery)
 }
 
 kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(projects.core.common)
+            implementation(projects.core.featureflag)
             implementation(projects.core.outcome)
             implementation(projects.core.logging.api)
             implementation(projects.feature.notification.api)

--- a/feature/notification/impl/build.gradle.kts
+++ b/feature/notification/impl/build.gradle.kts
@@ -10,6 +10,15 @@ kotlin {
             implementation(projects.core.logging.api)
             implementation(projects.feature.notification.api)
         }
+        commonTest.dependencies {
+            implementation(projects.core.logging.testing)
+        }
+        androidUnitTest.dependencies {
+            implementation(libs.androidx.test.core)
+            implementation(libs.mockito.core)
+            implementation(libs.mockito.kotlin)
+            implementation(libs.robolectric)
+        }
     }
 }
 

--- a/feature/notification/impl/src/androidMain/AndroidManifest.xml
+++ b/feature/notification/impl/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+</manifest>

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.android.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.android.kt
@@ -1,18 +1,28 @@
 package net.thunderbird.feature.notification.impl.inject
 
 import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
+import net.thunderbird.feature.notification.impl.intent.action.AlarmPermissionMissingNotificationTapActionIntentCreator
 import net.thunderbird.feature.notification.impl.intent.action.DefaultNotificationActionIntentCreator
 import net.thunderbird.feature.notification.impl.intent.action.NotificationActionIntentCreator
+import net.thunderbird.feature.notification.impl.receiver.AndroidSystemNotificationNotifier
+import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNotifier
 import net.thunderbird.feature.notification.impl.ui.action.DefaultSystemNotificationActionCreator
 import net.thunderbird.feature.notification.impl.ui.action.NotificationActionCreator
 import org.koin.android.ext.koin.androidApplication
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.koin.dsl.onClose
 
 internal actual val platformFeatureNotificationModule: Module = module {
-    single<List<NotificationActionIntentCreator<*>>>(named<NotificationActionIntentCreator.TypeQualifier>()) {
+    single<List<NotificationActionIntentCreator<*, *>>>(named<NotificationActionIntentCreator.TypeQualifier>()) {
         listOf(
+            AlarmPermissionMissingNotificationTapActionIntentCreator(
+                context = androidApplication(),
+                logger = get(),
+            ),
+            // The Default implementation must always be the last.
             DefaultNotificationActionIntentCreator(
                 logger = get(),
                 applicationContext = androidApplication(),
@@ -25,5 +35,15 @@ internal actual val platformFeatureNotificationModule: Module = module {
             logger = get(),
             actionIntentCreators = get(named<NotificationActionIntentCreator.TypeQualifier>()),
         )
+    }
+
+    single<NotificationNotifier<SystemNotification>>(named<SystemNotificationNotifier>()) {
+        AndroidSystemNotificationNotifier(
+            logger = get(),
+            applicationContext = androidApplication(),
+            notificationActionCreator = get(named(NotificationActionCreator.TypeQualifier.System)),
+        )
+    }.onClose { notifier ->
+        notifier?.dispose()
     }
 }

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.android.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.android.kt
@@ -1,0 +1,29 @@
+package net.thunderbird.feature.notification.impl.inject
+
+import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.impl.intent.action.DefaultNotificationActionIntentCreator
+import net.thunderbird.feature.notification.impl.intent.action.NotificationActionIntentCreator
+import net.thunderbird.feature.notification.impl.ui.action.DefaultSystemNotificationActionCreator
+import net.thunderbird.feature.notification.impl.ui.action.NotificationActionCreator
+import org.koin.android.ext.koin.androidApplication
+import org.koin.core.module.Module
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+internal actual val platformFeatureNotificationModule: Module = module {
+    single<List<NotificationActionIntentCreator<*>>>(named<NotificationActionIntentCreator.TypeQualifier>()) {
+        listOf(
+            DefaultNotificationActionIntentCreator(
+                logger = get(),
+                applicationContext = androidApplication(),
+            ),
+        )
+    }
+
+    single<NotificationActionCreator<SystemNotification>>(named(NotificationActionCreator.TypeQualifier.System)) {
+        DefaultSystemNotificationActionCreator(
+            logger = get(),
+            actionIntentCreators = get(named<NotificationActionIntentCreator.TypeQualifier>()),
+        )
+    }
+}

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/AlarmPermissionMissingNotificationTapActionIntentCreator.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/AlarmPermissionMissingNotificationTapActionIntentCreator.kt
@@ -1,0 +1,53 @@
+package net.thunderbird.feature.notification.impl.intent.action
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.annotation.RequiresApi
+import androidx.core.app.PendingIntentCompat
+import androidx.core.net.toUri
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.api.content.PushServiceNotification
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+
+private const val TAG = "AlarmPermissionMissingNotificationIntentCreator"
+
+class AlarmPermissionMissingNotificationTapActionIntentCreator(
+    private val context: Context,
+    private val logger: Logger,
+) : NotificationActionIntentCreator<PushServiceNotification.AlarmPermissionMissing, NotificationAction.Tap> {
+    override fun accept(notification: Notification, action: NotificationAction): Boolean =
+        Build.VERSION.SDK_INT > Build.VERSION_CODES.S &&
+            notification is PushServiceNotification.AlarmPermissionMissing
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    override fun create(
+        notification: PushServiceNotification.AlarmPermissionMissing,
+        action: NotificationAction.Tap,
+    ): PendingIntent {
+        logger.debug(TAG) { "create() called with: notification = $notification" }
+        val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+            data = "package:${context.packageName}".toUri()
+        }
+
+        return requireNotNull(
+            PendingIntentCompat.getActivity(
+                /* context = */
+                context,
+                /* requestCode = */
+                1,
+                /* intent = */
+                intent,
+                /* flags = */
+                0,
+                /* isMutable = */
+                false,
+            ),
+        ) {
+            "Could not create PendingIntent for AlarmPermissionMissing Notification."
+        }
+    }
+}

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/DefaultNotificationActionIntentCreator.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/DefaultNotificationActionIntentCreator.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.content.Context
 import androidx.core.app.PendingIntentCompat
 import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
 
 private const val TAG = "DefaultNotificationActionIntentCreator"
@@ -21,11 +22,11 @@ private const val TAG = "DefaultNotificationActionIntentCreator"
 internal class DefaultNotificationActionIntentCreator(
     private val logger: Logger,
     private val applicationContext: Context,
-) : NotificationActionIntentCreator<NotificationAction> {
-    override fun accept(action: NotificationAction): Boolean = true
+) : NotificationActionIntentCreator<Notification, NotificationAction> {
+    override fun accept(notification: Notification, action: NotificationAction): Boolean = true
 
-    override fun create(action: NotificationAction): PendingIntent? {
-        logger.debug(TAG) { "create() called with: action = $action" }
+    override fun create(notification: Notification, action: NotificationAction): PendingIntent? {
+        logger.debug(TAG) { "create() called with: notification = $notification, action = $action" }
         val packageManager = applicationContext.packageManager
         val launchIntent = requireNotNull(
             packageManager.getLaunchIntentForPackage(applicationContext.packageName),

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/DefaultNotificationActionIntentCreator.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/DefaultNotificationActionIntentCreator.kt
@@ -1,0 +1,49 @@
+package net.thunderbird.feature.notification.impl.intent.action
+
+import android.app.PendingIntent
+import android.content.Context
+import androidx.core.app.PendingIntentCompat
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+
+private const val TAG = "DefaultNotificationActionIntentCreator"
+
+/**
+ * A default implementation of [NotificationActionIntentCreator] that creates a [PendingIntent]
+ * to launch the application when a notification action is triggered.
+ *
+ * This creator accepts any [NotificationAction] and always attempts to create a launch intent
+ * for the current application.
+ *
+ * @property logger The logger instance for logging debug messages.
+ * @property applicationContext The application context used to access system services like PackageManager.
+ */
+internal class DefaultNotificationActionIntentCreator(
+    private val logger: Logger,
+    private val applicationContext: Context,
+) : NotificationActionIntentCreator<NotificationAction> {
+    override fun accept(action: NotificationAction): Boolean = true
+
+    override fun create(action: NotificationAction): PendingIntent? {
+        logger.debug(TAG) { "create() called with: action = $action" }
+        val packageManager = applicationContext.packageManager
+        val launchIntent = requireNotNull(
+            packageManager.getLaunchIntentForPackage(applicationContext.packageName),
+        ) {
+            "Could not retrieve the launch intent from ${applicationContext.packageName}"
+        }
+
+        return PendingIntentCompat.getActivity(
+            /* context = */
+            applicationContext,
+            /* requestCode = */
+            1,
+            /* intent = */
+            launchIntent,
+            /* flags = */
+            0,
+            /* isMutable = */
+            false,
+        )
+    }
+}

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/NotificationActionIntentCreator.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/NotificationActionIntentCreator.kt
@@ -1,0 +1,32 @@
+package net.thunderbird.feature.notification.impl.intent.action
+
+import android.app.PendingIntent
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+
+/**
+ * Interface for creating a [PendingIntent] for a given [NotificationAction].
+ *
+ * This interface is used to decouple the creation of [PendingIntent]s from the notification creation logic.
+ * Implementations of this interface should be registered in the Koin graph using the [TypeQualifier].
+ *
+ * @param TNotificationAction The type of [NotificationAction] this creator can handle.
+ */
+internal interface NotificationActionIntentCreator<in TNotificationAction : NotificationAction> {
+    /**
+     * Determines whether this [NotificationActionIntentCreator] can create an intent for the given [action].
+     *
+     * @param action The [NotificationAction] to check.
+     * @return `true` if this creator can handle the [action], `false` otherwise.
+     */
+    fun accept(action: NotificationAction): Boolean
+
+    /**
+     * Creates a [PendingIntent] for the given notification action.
+     *
+     * @param action The notification action to create an intent for.
+     * @return The created [PendingIntent], or `null` if the action is not supported or an error occurs.
+     */
+    fun create(action: TNotificationAction): PendingIntent?
+
+    object TypeQualifier
+}

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/NotificationActionIntentCreator.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/intent/action/NotificationActionIntentCreator.kt
@@ -1,6 +1,7 @@
 package net.thunderbird.feature.notification.impl.intent.action
 
 import android.app.PendingIntent
+import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
 
 /**
@@ -11,14 +12,17 @@ import net.thunderbird.feature.notification.api.ui.action.NotificationAction
  *
  * @param TNotificationAction The type of [NotificationAction] this creator can handle.
  */
-internal interface NotificationActionIntentCreator<in TNotificationAction : NotificationAction> {
+internal interface NotificationActionIntentCreator<
+    in TNotification : Notification,
+    in TNotificationAction : NotificationAction,
+    > {
     /**
      * Determines whether this [NotificationActionIntentCreator] can create an intent for the given [action].
      *
      * @param action The [NotificationAction] to check.
      * @return `true` if this creator can handle the [action], `false` otherwise.
      */
-    fun accept(action: NotificationAction): Boolean
+    fun accept(notification: Notification, action: NotificationAction): Boolean
 
     /**
      * Creates a [PendingIntent] for the given notification action.
@@ -26,7 +30,7 @@ internal interface NotificationActionIntentCreator<in TNotificationAction : Noti
      * @param action The notification action to create an intent for.
      * @return The created [PendingIntent], or `null` if the action is not supported or an error occurs.
      */
-    fun create(action: TNotificationAction): PendingIntent?
+    fun create(notification: TNotification, action: TNotificationAction): PendingIntent?
 
     object TypeQualifier
 }

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/receiver/AndroidSystemNotificationNotifier.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/receiver/AndroidSystemNotificationNotifier.kt
@@ -1,0 +1,111 @@
+package net.thunderbird.feature.notification.impl.receiver
+
+import android.app.Notification
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import kotlin.time.ExperimentalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.api.ui.style.SystemNotificationStyle
+import net.thunderbird.feature.notification.impl.ui.action.NotificationActionCreator
+
+private const val TAG = "AndroidSystemNotificationNotifier"
+
+@OptIn(ExperimentalTime::class)
+internal class AndroidSystemNotificationNotifier(
+    private val logger: Logger,
+    private val applicationContext: Context,
+    private val notificationActionCreator: NotificationActionCreator<SystemNotification>,
+) : SystemNotificationNotifier {
+    private val notificationManager: NotificationManagerCompat = NotificationManagerCompat.from(applicationContext)
+
+    override suspend fun show(
+        id: NotificationId,
+        notification: SystemNotification,
+    ) {
+        logger.debug(TAG) { "show() called with: id = $id, notification = $notification" }
+        val androidNotification = notification.toAndroidNotification()
+        notificationManager.notify(id.value, androidNotification)
+    }
+
+    override fun dispose() {
+        logger.debug(TAG) { "dispose() called" }
+    }
+
+    private suspend fun SystemNotification.toAndroidNotification(): Notification {
+        logger.debug(TAG) { "toAndroidNotification() called with systemNotification = $this" }
+        val systemNotification = this
+        return NotificationCompat
+            .Builder(applicationContext, channel.id)
+            .apply {
+                setSmallIcon(
+                    checkNotNull(icon.systemNotificationIcon) {
+                        "A icon is required to display a system notification"
+                    },
+                )
+                setContentTitle(title)
+                setTicker(accessibilityText)
+                contentText?.let(::setContentText)
+                subText?.let(::setSubText)
+                setOngoing(severity.dismissable.not())
+                setWhen(createdAt.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds())
+                asLockscreenNotification()?.let { lockscreenNotification ->
+                    if (lockscreenNotification.notification != systemNotification) {
+                        setPublicVersion(lockscreenNotification.notification.toAndroidNotification())
+                    }
+                }
+
+                val tapAction = notificationActionCreator.create(
+                    notification = systemNotification,
+                    action = NotificationAction.Tap,
+                )
+                setContentIntent(tapAction.pendingIntent)
+
+                setNotificationStyle(notification = systemNotification)
+
+                if (actions.isNotEmpty()) {
+                    for (action in actions) {
+                        val notificationAction = notificationActionCreator
+                            .create(notification = systemNotification, action)
+
+                        addAction(
+                            /* icon = */
+                            notificationAction.icon ?: 0,
+                            /* title = */
+                            notificationAction.title,
+                            /* intent = */
+                            notificationAction.pendingIntent,
+                        )
+                    }
+                }
+            }
+            .build()
+    }
+
+    private fun NotificationCompat.Builder.setNotificationStyle(
+        notification: SystemNotification,
+    ) {
+        when (val style = notification.systemNotificationStyle) {
+            is SystemNotificationStyle.BigTextStyle -> setStyle(
+                NotificationCompat.BigTextStyle().bigText(style.text),
+            )
+
+            is SystemNotificationStyle.InboxStyle -> {
+                val inboxStyle = NotificationCompat.InboxStyle()
+                    .setBigContentTitle(style.bigContentTitle)
+                    .setSummaryText(style.summary)
+
+                style.lines.forEach(inboxStyle::addLine)
+
+                setStyle(inboxStyle)
+            }
+
+            SystemNotificationStyle.Undefined -> Unit
+        }
+    }
+}

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/ui/action/AndroidNotificationAction.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/ui/action/AndroidNotificationAction.kt
@@ -1,0 +1,18 @@
+package net.thunderbird.feature.notification.impl.ui.action
+
+import android.app.PendingIntent
+import androidx.annotation.DrawableRes
+
+/**
+ * Represents an action that can be performed on an Android notification.
+ *
+ * @property icon The drawable resource ID for the action's icon.
+ * @property title The title of the action.
+ * @property pendingIntent The [PendingIntent] to be executed when the action is triggered.
+ */
+data class AndroidNotificationAction(
+    @DrawableRes
+    val icon: Int?,
+    val title: String?,
+    val pendingIntent: PendingIntent?,
+)

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/ui/action/DefaultSystemNotificationActionCreator.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/ui/action/DefaultSystemNotificationActionCreator.kt
@@ -1,6 +1,7 @@
 package net.thunderbird.feature.notification.impl.ui.action
 
 import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.content.SystemNotification
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
 import net.thunderbird.feature.notification.impl.intent.action.NotificationActionIntentCreator
@@ -9,7 +10,7 @@ private const val TAG = "DefaultSystemNotificationActionCreator"
 
 internal class DefaultSystemNotificationActionCreator(
     private val logger: Logger,
-    private val actionIntentCreators: List<NotificationActionIntentCreator<NotificationAction>>,
+    private val actionIntentCreators: List<NotificationActionIntentCreator<Notification, NotificationAction>>,
 ) : NotificationActionCreator<SystemNotification> {
     override suspend fun create(
         notification: SystemNotification,
@@ -17,8 +18,8 @@ internal class DefaultSystemNotificationActionCreator(
     ): AndroidNotificationAction {
         logger.debug(TAG) { "create() called with: notification = $notification, action = $action" }
         val intent = actionIntentCreators
-            .first { it.accept(action) }
-            .create(action)
+            .first { it.accept(notification, action) }
+            .create(notification, action)
 
         return AndroidNotificationAction(
             icon = action.icon?.systemNotificationIcon,

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/ui/action/DefaultSystemNotificationActionCreator.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/ui/action/DefaultSystemNotificationActionCreator.kt
@@ -1,0 +1,29 @@
+package net.thunderbird.feature.notification.impl.ui.action
+
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.impl.intent.action.NotificationActionIntentCreator
+
+private const val TAG = "DefaultSystemNotificationActionCreator"
+
+internal class DefaultSystemNotificationActionCreator(
+    private val logger: Logger,
+    private val actionIntentCreators: List<NotificationActionIntentCreator<NotificationAction>>,
+) : NotificationActionCreator<SystemNotification> {
+    override suspend fun create(
+        notification: SystemNotification,
+        action: NotificationAction,
+    ): AndroidNotificationAction {
+        logger.debug(TAG) { "create() called with: notification = $notification, action = $action" }
+        val intent = actionIntentCreators
+            .first { it.accept(action) }
+            .create(action)
+
+        return AndroidNotificationAction(
+            icon = action.icon?.systemNotificationIcon,
+            title = action.resolveTitle(),
+            pendingIntent = intent,
+        )
+    }
+}

--- a/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/ui/action/NotificationActionCreator.kt
+++ b/feature/notification/impl/src/androidMain/kotlin/net/thunderbird/feature/notification/impl/ui/action/NotificationActionCreator.kt
@@ -1,0 +1,25 @@
+package net.thunderbird.feature.notification.impl.ui.action
+
+import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+
+/**
+ * Interface responsible for creating Android-specific notification actions ([AndroidNotificationAction])
+ * from generic notification actions ([NotificationAction]).
+ *
+ * This allows decoupling the core notification logic from the Android platform specifics.
+ *
+ * @param TNotification The type of [Notification] this creator can handle.
+ */
+interface NotificationActionCreator<TNotification : Notification> {
+    /**
+     * Creates an [AndroidNotificationAction] for the given [notification] and [action].
+     *
+     * @param notification The notification to create the action for.
+     * @param action The action to create.
+     * @return The created [AndroidNotificationAction].
+     */
+    suspend fun create(notification: TNotification, action: NotificationAction): AndroidNotificationAction
+
+    enum class TypeQualifier { System, InApp }
+}

--- a/feature/notification/impl/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/impl/intent/action/DefaultNotificationActionIntentCreatorTest.kt
+++ b/feature/notification/impl/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/impl/intent/action/DefaultNotificationActionIntentCreatorTest.kt
@@ -1,0 +1,132 @@
+package net.thunderbird.feature.notification.impl.intent.action
+
+import android.app.Application
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.core.app.PendingIntentCompat
+import androidx.test.core.app.ApplicationProvider
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DefaultNotificationActionIntentCreatorTest {
+    private val application: Application = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `accept should return true for any type of notification action`() {
+        // Arrange
+        val multipleActions = listOf(
+            NotificationAction.Tap,
+            NotificationAction.Reply,
+            NotificationAction.MarkAsRead,
+            NotificationAction.Delete,
+            NotificationAction.MarkAsSpam,
+            NotificationAction.Archive,
+            NotificationAction.UpdateServerSettings,
+            NotificationAction.Retry,
+            NotificationAction.CustomAction(title = "Custom Action 1"),
+            NotificationAction.CustomAction(title = "Custom Action 2"),
+            NotificationAction.CustomAction(title = "Custom Action 3"),
+        )
+        val testSubject = createTestSubject()
+
+        // Act
+        val accepted = multipleActions.fold(initial = true) { accepted, action ->
+            accepted and testSubject.accept(action)
+        }
+
+        // Assert
+        assertThat(accepted).isTrue()
+    }
+
+    @Test
+    fun `create should return PendingIntent for any type of notification action`() {
+        // Arrange
+        mockStatic(PendingIntentCompat::class.java).use { pendingIntentCompat ->
+            // Arrange (cont.)
+            val expectedIntent = Intent(Intent.ACTION_MAIN).apply {
+                addCategory(Intent.CATEGORY_LAUNCHER)
+                setPackage(application.packageName)
+            }
+            val mockedPackageManager = mock<PackageManager> {
+                on {
+                    getLaunchIntentForPackage(eq(application.packageName))
+                } doReturn expectedIntent
+            }
+            val context = spy(application) {
+                on { packageManager } doReturn mockedPackageManager
+            }
+
+            pendingIntentCompat
+                .`when`<PendingIntent> {
+                    PendingIntentCompat.getActivity(
+                        /* context = */
+                        any(),
+                        /* requestCode = */
+                        any(),
+                        /* intent = */
+                        any(),
+                        /* flags = */
+                        any(),
+                        /* isMutable = */
+                        eq(false),
+                    )
+                }
+                .thenReturn(mock<PendingIntent>())
+
+            val intentCaptor = argumentCaptor<Intent>()
+            val testSubject = createTestSubject(context)
+
+            // Act
+            testSubject.create(NotificationAction.Tap)
+
+            // Assert
+            pendingIntentCompat.verify {
+                PendingIntentCompat.getActivity(
+                    /* context = */
+                    eq(context),
+                    /* requestCode = */
+                    eq(1),
+                    /* intent = */
+                    intentCaptor.capture(),
+                    /* flags = */
+                    eq(0),
+                    /* isMutable = */
+                    eq(false),
+                )
+            }
+            assertThat(intentCaptor.firstValue).all {
+                prop(Intent::getAction).isEqualTo(Intent.ACTION_MAIN)
+                prop(Intent::getPackage).isEqualTo(application.packageName)
+                transform { intent -> intent.hasCategory(Intent.CATEGORY_LAUNCHER) }
+                    .isTrue()
+            }
+        }
+    }
+
+    private fun createTestSubject(
+        context: Context = application,
+    ): DefaultNotificationActionIntentCreator {
+        return DefaultNotificationActionIntentCreator(
+            logger = TestLogger(),
+            applicationContext = context,
+        )
+    }
+}

--- a/feature/notification/impl/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/impl/intent/action/DefaultNotificationActionIntentCreatorTest.kt
+++ b/feature/notification/impl/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/impl/intent/action/DefaultNotificationActionIntentCreatorTest.kt
@@ -14,6 +14,7 @@ import assertk.assertions.isTrue
 import assertk.assertions.prop
 import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.impl.fake.FakeNotification
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mockStatic
@@ -49,7 +50,7 @@ class DefaultNotificationActionIntentCreatorTest {
 
         // Act
         val accepted = multipleActions.fold(initial = true) { accepted, action ->
-            accepted and testSubject.accept(action)
+            accepted and testSubject.accept(notification = FakeNotification(), action)
         }
 
         // Assert
@@ -95,7 +96,7 @@ class DefaultNotificationActionIntentCreatorTest {
             val testSubject = createTestSubject(context)
 
             // Act
-            testSubject.create(NotificationAction.Tap)
+            testSubject.create(notification = FakeNotification(), action = NotificationAction.Tap)
 
             // Assert
             pendingIntentCompat.verify {

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/DefaultNotificationRegistry.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/DefaultNotificationRegistry.kt
@@ -1,0 +1,60 @@
+package net.thunderbird.feature.notification.impl
+
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.NotificationRegistry
+import net.thunderbird.feature.notification.api.content.Notification
+
+@OptIn(ExperimentalAtomicApi::class)
+class DefaultNotificationRegistry : NotificationRegistry {
+    private val mutex = Mutex()
+
+    // We use a MutableMap<Notification, NotificationId>, rather than MutableMap<NotificationId, Notification>,
+    // allowing for quick lookups (O(1) on average for MutableMap) to check if a notification is already present
+    // during registration.
+    private val _registrar = mutableMapOf<Notification, NotificationId>()
+    private val rawId = AtomicInt(value = 0)
+
+    override val registrar: Map<NotificationId, Notification> get() = _registrar
+        .entries
+        .associate { (notification, notificationId) -> notificationId to notification }
+
+    override fun get(notificationId: NotificationId): Notification? {
+        return _registrar
+            .entries
+            .firstOrNull { (_, value) -> value == notificationId }
+            ?.key
+    }
+
+    override fun get(notification: Notification): NotificationId? {
+        return _registrar[notification]
+    }
+
+    override suspend fun register(notification: Notification): NotificationId {
+        return mutex.withLock {
+            val existingNotificationId = get(notification)
+            if (existingNotificationId != null) {
+                return@withLock existingNotificationId
+            }
+
+            val id = rawId.incrementAndFetch()
+            val notificationId = NotificationId(id)
+            _registrar.put(notification, notificationId)
+
+            notificationId
+        }
+    }
+
+    override fun unregister(notificationId: NotificationId) {
+        val notification = get(notificationId)
+        _registrar.remove(notification)
+    }
+
+    override fun unregister(notification: Notification) {
+        _registrar.remove(notification)
+    }
+}

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/InAppNotificationCommand.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/InAppNotificationCommand.kt
@@ -1,10 +1,16 @@
 package net.thunderbird.feature.notification.impl.command
 
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.FeatureFlagProvider
+import net.thunderbird.core.featureflag.FeatureFlagResult
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.notification.api.NotificationRegistry
 import net.thunderbird.feature.notification.api.command.NotificationCommand
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
+
+private const val TAG = "InAppNotificationCommand"
 
 /**
  * A command that handles in-app notifications.
@@ -16,13 +22,42 @@ import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
  */
 internal class InAppNotificationCommand(
     private val logger: Logger,
+    private val featureFlagProvider: FeatureFlagProvider,
+    private val notificationRegistry: NotificationRegistry,
     notification: InAppNotification,
     notifier: NotificationNotifier<InAppNotification>,
 ) : NotificationCommand<InAppNotification>(notification, notifier) {
+    private val isFeatureFlagEnabled: Boolean
+        get() = featureFlagProvider
+            .provide(FeatureFlagKey.DisplayInAppNotifications) == FeatureFlagResult.Enabled
+
     override suspend fun execute(): Outcome<Success<InAppNotification>, Failure<InAppNotification>> {
-        logger.debug {
-            "TODO: Implementation on GitHub Issue #9245. Notification = $notification."
+        logger.debug(TAG) { "execute() called with: notification = $notification" }
+        return when {
+            isFeatureFlagEnabled.not() ->
+                Outcome.failure(
+                    error = Failure(
+                        command = this,
+                        throwable = NotificationCommandException(
+                            message = "${FeatureFlagKey.DisplayInAppNotifications.key} feature flag is not enabled",
+                        ),
+                    ),
+                )
+
+            canExecuteCommand() -> {
+                notifier.show(id = notificationRegistry.register(notification), notification = notification)
+                Outcome.success(Success(command = this))
+            }
+
+            else -> {
+                Outcome.failure(Failure(command = this, throwable = Exception("Can't execute command.")))
+            }
         }
-        return Outcome.success(data = Success(command = this))
     }
+
+    // TODO(#9392): Verify if the app is on foreground. IF it isn't, then should fail
+    //  executing the command
+    // TODO(#9420): If the app is on background and the severity is Fatal or Critical, we should
+    //  let the command execute, but store it in a database instead of triggering the show notification logic.
+    private fun canExecuteCommand(): Boolean = true
 }

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandException.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandException.kt
@@ -1,0 +1,6 @@
+package net.thunderbird.feature.notification.impl.command
+
+class NotificationCommandException @JvmOverloads constructor(
+    override val message: String?,
+    override val cause: Throwable? = null,
+) : Exception(message, cause)

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
@@ -8,7 +8,6 @@ import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.content.SystemNotification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
-import net.thunderbird.feature.notification.impl.receiver.InAppNotificationNotifier
 import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNotifier
 
 /**

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
@@ -8,7 +8,6 @@ import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.content.SystemNotification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
-import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNotifier
 
 /**
  * A factory for creating a set of notification commands based on a given notification.
@@ -17,7 +16,7 @@ internal class NotificationCommandFactory(
     private val logger: Logger,
     private val featureFlagProvider: FeatureFlagProvider,
     private val notificationRegistry: NotificationRegistry,
-    private val systemNotificationNotifier: SystemNotificationNotifier,
+    private val systemNotificationNotifier: NotificationNotifier<SystemNotification>,
     private val inAppNotificationNotifier: NotificationNotifier<InAppNotification>,
 ) {
     /**

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
@@ -35,6 +35,8 @@ internal class NotificationCommandFactory(
             commands.add(
                 SystemNotificationCommand(
                     logger = logger,
+                    featureFlagProvider = featureFlagProvider,
+                    notificationRegistry = notificationRegistry,
                     notification = notification,
                     notifier = systemNotificationNotifier,
                 ),

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/NotificationCommandFactory.kt
@@ -1,10 +1,13 @@
 package net.thunderbird.feature.notification.impl.command
 
+import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.notification.api.NotificationRegistry
 import net.thunderbird.feature.notification.api.command.NotificationCommand
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 import net.thunderbird.feature.notification.impl.receiver.InAppNotificationNotifier
 import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNotifier
 
@@ -13,8 +16,10 @@ import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNoti
  */
 internal class NotificationCommandFactory(
     private val logger: Logger,
+    private val featureFlagProvider: FeatureFlagProvider,
+    private val notificationRegistry: NotificationRegistry,
     private val systemNotificationNotifier: SystemNotificationNotifier,
-    private val inAppNotificationNotifier: InAppNotificationNotifier,
+    private val inAppNotificationNotifier: NotificationNotifier<InAppNotification>,
 ) {
     /**
      * Creates a set of [NotificationCommand]s for the given [notification].
@@ -41,6 +46,8 @@ internal class NotificationCommandFactory(
             commands.add(
                 InAppNotificationCommand(
                     logger = logger,
+                    featureFlagProvider = featureFlagProvider,
+                    notificationRegistry = notificationRegistry,
                     notification = notification,
                     notifier = inAppNotificationNotifier,
                 ),

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/SystemNotificationCommand.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/SystemNotificationCommand.kt
@@ -1,10 +1,19 @@
 package net.thunderbird.feature.notification.impl.command
 
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.FeatureFlagProvider
+import net.thunderbird.core.featureflag.FeatureFlagResult
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.notification.api.NotificationRegistry
+import net.thunderbird.feature.notification.api.NotificationSeverity
 import net.thunderbird.feature.notification.api.command.NotificationCommand
+import net.thunderbird.feature.notification.api.command.NotificationCommandException
+import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.content.SystemNotification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
+
+private const val TAG = "SystemNotificationCommand"
 
 /**
  * Command for displaying system notifications.
@@ -14,13 +23,64 @@ import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
  */
 internal class SystemNotificationCommand(
     private val logger: Logger,
+    private val featureFlagProvider: FeatureFlagProvider,
+    private val notificationRegistry: NotificationRegistry,
     notification: SystemNotification,
     notifier: NotificationNotifier<SystemNotification>,
+    private val isAppInBackground: () -> Boolean = {
+        // TODO(#9391): Verify if the app is backgrounded.
+        false
+    },
 ) : NotificationCommand<SystemNotification>(notification, notifier) {
+
+    private val isFeatureFlagEnabled: Boolean
+        get() = featureFlagProvider
+            .provide(FeatureFlagKey.UseNotificationSenderForSystemNotifications) == FeatureFlagResult.Enabled
+
     override suspend fun execute(): Outcome<Success<SystemNotification>, Failure<SystemNotification>> {
-        logger.debug {
-            "TODO: Implementation on GitHub Issue #9245. Notification = $notification."
+        logger.debug(TAG) { "execute() called" }
+        return when {
+            isFeatureFlagEnabled.not() ->
+                Outcome.failure(
+                    error = Failure(
+                        command = this,
+                        throwable = NotificationCommandException(
+                            message = "${FeatureFlagKey.UseNotificationSenderForSystemNotifications.key} feature flag" +
+                                "is not enabled",
+                        ),
+                    ),
+                )
+
+            canExecuteCommand() -> {
+                notifier.show(
+                    id = notificationRegistry.register(notification),
+                    notification = notification,
+                )
+                Outcome.success(Success(command = this))
+            }
+
+            else -> {
+                Outcome.failure(
+                    error = Failure(
+                        command = this,
+                        throwable = NotificationCommandException("Can't execute command."),
+                    ),
+                )
+            }
         }
-        return Outcome.success(data = Success(command = this))
+    }
+
+    private fun canExecuteCommand(): Boolean {
+        val shouldAlwaysShow = when (notification.severity) {
+            NotificationSeverity.Fatal, NotificationSeverity.Critical -> true
+            else -> false
+        }
+
+        return when {
+            shouldAlwaysShow -> true
+            isAppInBackground() -> true
+            notification !is InAppNotification -> true
+            else -> false
+        }
     }
 }

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
@@ -1,6 +1,8 @@
 package net.thunderbird.feature.notification.impl.inject
 
+import net.thunderbird.feature.notification.api.NotificationRegistry
 import net.thunderbird.feature.notification.api.sender.NotificationSender
+import net.thunderbird.feature.notification.impl.DefaultNotificationRegistry
 import net.thunderbird.feature.notification.impl.command.NotificationCommandFactory
 import net.thunderbird.feature.notification.impl.receiver.InAppNotificationNotifier
 import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNotifier
@@ -24,4 +26,6 @@ val featureNotificationModule = module {
             commandFactory = get(),
         )
     }
+
+    single<NotificationRegistry> { DefaultNotificationRegistry() }
 }

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
@@ -7,9 +7,14 @@ import net.thunderbird.feature.notification.impl.command.NotificationCommandFact
 import net.thunderbird.feature.notification.impl.receiver.InAppNotificationNotifier
 import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNotifier
 import net.thunderbird.feature.notification.impl.sender.DefaultNotificationSender
+import org.koin.core.module.Module
 import org.koin.dsl.module
 
+internal expect val platformFeatureNotificationModule: Module
+
 val featureNotificationModule = module {
+    includes(platformFeatureNotificationModule)
+
     factory { SystemNotificationNotifier() }
     factory { InAppNotificationNotifier() }
 

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
@@ -23,8 +23,6 @@ val featureNotificationModule = module {
 
     single<NotificationRegistry> { DefaultNotificationRegistry() }
 
-    factory { SystemNotificationNotifier() }
-
     single { InAppNotificationEventBus() }
         .bind(InAppNotificationReceiver::class)
 
@@ -41,7 +39,7 @@ val featureNotificationModule = module {
             logger = get(),
             featureFlagProvider = get(),
             notificationRegistry = get(),
-            systemNotificationNotifier = get(),
+            systemNotificationNotifier = get(named<SystemNotificationNotifier>()),
             inAppNotificationNotifier = get(named<InAppNotificationNotifier>()),
         )
     }

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
@@ -1,6 +1,8 @@
 package net.thunderbird.feature.notification.impl.inject
 
 import net.thunderbird.feature.notification.api.NotificationRegistry
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 import net.thunderbird.feature.notification.api.sender.NotificationSender
 import net.thunderbird.feature.notification.impl.DefaultNotificationRegistry
 import net.thunderbird.feature.notification.impl.command.NotificationCommandFactory
@@ -8,6 +10,7 @@ import net.thunderbird.feature.notification.impl.receiver.InAppNotificationNotif
 import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNotifier
 import net.thunderbird.feature.notification.impl.sender.DefaultNotificationSender
 import org.koin.core.module.Module
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 internal expect val platformFeatureNotificationModule: Module
@@ -16,13 +19,17 @@ val featureNotificationModule = module {
     includes(platformFeatureNotificationModule)
 
     factory { SystemNotificationNotifier() }
-    factory { InAppNotificationNotifier() }
+    factory<NotificationNotifier<InAppNotification>>(named<InAppNotificationNotifier>()) {
+        InAppNotificationNotifier()
+    }
 
     factory<NotificationCommandFactory> {
         NotificationCommandFactory(
             logger = get(),
+            featureFlagProvider = get(),
+            notificationRegistry = get(),
             systemNotificationNotifier = get(),
-            inAppNotificationNotifier = get(),
+            inAppNotificationNotifier = get(named<InAppNotificationNotifier>()),
         )
     }
 

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.kt
@@ -2,15 +2,18 @@ package net.thunderbird.feature.notification.impl.inject
 
 import net.thunderbird.feature.notification.api.NotificationRegistry
 import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationReceiver
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 import net.thunderbird.feature.notification.api.sender.NotificationSender
 import net.thunderbird.feature.notification.impl.DefaultNotificationRegistry
 import net.thunderbird.feature.notification.impl.command.NotificationCommandFactory
+import net.thunderbird.feature.notification.impl.receiver.InAppNotificationEventBus
 import net.thunderbird.feature.notification.impl.receiver.InAppNotificationNotifier
 import net.thunderbird.feature.notification.impl.receiver.SystemNotificationNotifier
 import net.thunderbird.feature.notification.impl.sender.DefaultNotificationSender
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 internal expect val platformFeatureNotificationModule: Module
@@ -18,9 +21,19 @@ internal expect val platformFeatureNotificationModule: Module
 val featureNotificationModule = module {
     includes(platformFeatureNotificationModule)
 
+    single<NotificationRegistry> { DefaultNotificationRegistry() }
+
     factory { SystemNotificationNotifier() }
-    factory<NotificationNotifier<InAppNotification>>(named<InAppNotificationNotifier>()) {
-        InAppNotificationNotifier()
+
+    single { InAppNotificationEventBus() }
+        .bind(InAppNotificationReceiver::class)
+
+    single<NotificationNotifier<InAppNotification>>(named<InAppNotificationNotifier>()) {
+        InAppNotificationNotifier(
+            logger = get(),
+            notificationRegistry = get(),
+            inAppNotificationEventBus = get(),
+        )
     }
 
     factory<NotificationCommandFactory> {
@@ -38,6 +51,4 @@ val featureNotificationModule = module {
             commandFactory = get(),
         )
     }
-
-    single<NotificationRegistry> { DefaultNotificationRegistry() }
 }

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/receiver/InAppNotificationEventBus.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/receiver/InAppNotificationEventBus.kt
@@ -1,0 +1,31 @@
+package net.thunderbird.feature.notification.impl.receiver
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationEvent
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationReceiver
+
+/**
+ * An event bus for in-app notifications.
+ *
+ * This interface extends [InAppNotificationReceiver] to allow listening for notification events,
+ * and adds a [publish] method to send new notification events.
+ */
+internal interface InAppNotificationEventBus : InAppNotificationReceiver {
+    /**
+     * Publishes an in-app notification event to the event bus.
+     *
+     * @param event The [InAppNotificationEvent] to be published.
+     */
+    suspend fun publish(event: InAppNotificationEvent)
+}
+
+internal fun InAppNotificationEventBus(): InAppNotificationEventBus = object : InAppNotificationEventBus {
+    private val _events = MutableSharedFlow<InAppNotificationEvent>(replay = 1)
+    override val events: SharedFlow<InAppNotificationEvent> = _events.asSharedFlow()
+
+    override suspend fun publish(event: InAppNotificationEvent) {
+        _events.emit(event)
+    }
+}

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/receiver/InAppNotificationNotifier.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/receiver/InAppNotificationNotifier.kt
@@ -1,22 +1,34 @@
 package net.thunderbird.feature.notification.impl.receiver
 
+import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.NotificationRegistry
 import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.receiver.InAppNotificationEvent
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
+
+private const val TAG = "InAppNotificationNotifier"
 
 /**
  * This notifier is responsible for taking a [InAppNotification] data object and
  * presenting it to the user in a suitable way.
- *
- * **Note:** The current implementation is a placeholder and needs to be completed
- * as part of GitHub Issue #9245.
  */
-internal class InAppNotificationNotifier : NotificationNotifier<InAppNotification> {
+internal class InAppNotificationNotifier(
+    private val logger: Logger,
+    private val notificationRegistry: NotificationRegistry,
+    private val inAppNotificationEventBus: InAppNotificationEventBus,
+) : NotificationNotifier<InAppNotification> {
+
     override suspend fun show(id: NotificationId, notification: InAppNotification) {
-        TODO("Implementation on GitHub Issue #9245")
+        logger.debug(TAG) { "show() called with: id = $id, notification = $notification" }
+        if (notificationRegistry.registrar.containsKey(id)) {
+            inAppNotificationEventBus.publish(
+                event = InAppNotificationEvent.Show(notification),
+            )
+        }
     }
 
     override fun dispose() {
-        TODO("Implementation on GitHub Issue #9245")
+        logger.debug(TAG) { "dispose() called" }
     }
 }

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/receiver/SystemNotificationNotifier.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/receiver/SystemNotificationNotifier.kt
@@ -1,6 +1,5 @@
 package net.thunderbird.feature.notification.impl.receiver
 
-import net.thunderbird.feature.notification.api.NotificationId
 import net.thunderbird.feature.notification.api.content.SystemNotification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 
@@ -11,12 +10,4 @@ import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
  * **Note:** The current implementation is a placeholder and needs to be completed
  * as part of GitHub Issue #9245.
  */
-internal class SystemNotificationNotifier : NotificationNotifier<SystemNotification> {
-    override suspend fun show(id: NotificationId, notification: SystemNotification) {
-        TODO("Implementation on GitHub Issue #9245")
-    }
-
-    override fun dispose() {
-        TODO("Implementation on GitHub Issue #9245")
-    }
-}
+internal interface SystemNotificationNotifier : NotificationNotifier<SystemNotification>

--- a/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/DefaultNotificationRegistryTest.kt
+++ b/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/DefaultNotificationRegistryTest.kt
@@ -1,0 +1,193 @@
+package net.thunderbird.feature.notification.impl
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.containsAtLeast
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.content.AppNotification
+import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+
+@Suppress("MaxLineLength")
+class DefaultNotificationRegistryTest {
+    @Test
+    fun `register should return NotificationId given notification`() = runTest {
+        // Arrange
+        val notification = FakeNotification()
+        val registry = DefaultNotificationRegistry()
+
+        // Act
+        val notificationId = registry.register(notification)
+
+        // Assert
+        assertThat(registry[notificationId])
+            .isNotNull()
+            .isEqualTo(notification)
+    }
+
+    @Test
+    fun `register should return same NotificationId when registering the same notification multiple times`() = runTest {
+        // Arrange
+        val notification = FakeNotification()
+        val registry = DefaultNotificationRegistry()
+
+        // Act
+        val notificationId1 = registry.register(notification)
+        val notificationId2 = registry.register(notification)
+
+        // Assert
+        assertThat(notificationId1)
+            .isEqualTo(notificationId2)
+        assertThat(registry[notificationId1])
+            .isNotNull()
+            .isEqualTo(notification)
+        assertThat(registry[notificationId2])
+            .isNotNull()
+            .isEqualTo(notification)
+    }
+
+    @Test
+    fun `register should not register duplicated notifications when running concurrently`() = runTest {
+        // Arrange
+        val notificationSize = 100
+        val registerTries = 50
+        val notifications = List(size = notificationSize) { index ->
+            FakeNotification(
+                title = "fake notification $index",
+            )
+        }
+        val expectedNotificationIds = List(size = notificationSize) { index ->
+            NotificationId(value = index + 1)
+        }
+        val registry = DefaultNotificationRegistry()
+
+        // Act
+        List(size = registerTries) {
+            thread(start = true) {
+                notifications.forEach { notification ->
+                    runBlocking {
+                        registry.register(notification)
+                    }
+                }
+            }
+        }.forEach {
+            it.join()
+        }
+
+        // Assert
+        val registrar = registry.registrar
+        assertThat(registrar).hasSize(notificationSize)
+        assertThat(registrar)
+            .containsAtLeast(elements = expectedNotificationIds.zip(notifications).toTypedArray())
+    }
+
+    @Test
+    fun `operator get Notification should return NotificationId when notification is in the registrar`() = runTest {
+        // Arrange
+        val notification = FakeNotification()
+        val registry = DefaultNotificationRegistry()
+        registry.register(notification)
+
+        // Act
+        val notificationId = registry[notification]
+
+        // Assert
+        assertThat(notificationId).isNotNull()
+    }
+
+    @Test
+    fun `operator get Notification should return null when notification is NOT in the registrar`() = runTest {
+        // Arrange
+        val notification = FakeNotification()
+        val notRegisteredNotification = FakeNotification(title = "that is not registered!!")
+        val registry = DefaultNotificationRegistry()
+        registry.register(notification)
+
+        // Act
+        val notificationId = registry[notRegisteredNotification]
+
+        // Assert
+        assertThat(notificationId).isNull()
+    }
+
+    @Test
+    fun `operator get NotificationId should return Notification when notification is in the registrar`() = runTest {
+        // Arrange
+        val notification = FakeNotification()
+        val registry = DefaultNotificationRegistry()
+        val notificationId = registry.register(notification)
+
+        // Act
+        val registrarNotification = registry[notificationId]
+
+        // Assert
+        assertThat(registrarNotification).isNotNull()
+    }
+
+    @Test
+    fun `operator get NotificationId should return null when notification is NOT in the registrar`() = runTest {
+        // Arrange
+        val registry = DefaultNotificationRegistry()
+        val notification = FakeNotification()
+        registry.register(notification)
+
+        // Act
+        val notificationId = registry[NotificationId(value = Int.MAX_VALUE)]
+
+        // Assert
+        assertThat(notificationId).isNull()
+    }
+
+    @Test
+    fun `unregister should remove notification from registrar when given a notification object and Notification is in registrar`() =
+        runTest {
+            // Arrange
+            val registry = DefaultNotificationRegistry()
+            val notification = FakeNotification()
+            registry.register(notification)
+
+            // Act
+            registry.unregister(notification)
+
+            // Assert
+            assertThat(registry[notification]).isNull()
+        }
+
+    @Test
+    fun `unregister should remove notification from registrar when given a notification id and Notification is in registrar`() =
+        runTest {
+            // Arrange
+            val registry = DefaultNotificationRegistry()
+            val notification = FakeNotification()
+            val notificationId = registry.register(notification)
+
+            // Act
+            registry.unregister(notificationId)
+
+            // Assert
+            assertThat(registry[notification]).isNull()
+        }
+
+    data class FakeNotification(
+        override val title: String = "fake title",
+        override val contentText: String? = "fake content",
+        override val severity: NotificationSeverity = NotificationSeverity.Information,
+        override val icon: NotificationIcon = NotificationIcon(
+            inAppNotificationIcon = ImageVector.Builder(
+                defaultWidth = 0.dp,
+                defaultHeight = 0.dp,
+                viewportWidth = 0f,
+                viewportHeight = 0f,
+            ).build(),
+        ),
+    ) : AppNotification()
+}

--- a/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/DefaultNotificationRegistryTest.kt
+++ b/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/DefaultNotificationRegistryTest.kt
@@ -1,7 +1,5 @@
 package net.thunderbird.feature.notification.impl
 
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.containsAtLeast
 import assertk.assertions.hasSize
@@ -13,9 +11,7 @@ import kotlin.test.Test
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.feature.notification.api.NotificationId
-import net.thunderbird.feature.notification.api.NotificationSeverity
-import net.thunderbird.feature.notification.api.content.AppNotification
-import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+import net.thunderbird.feature.notification.impl.fake.FakeNotification
 
 @Suppress("MaxLineLength")
 class DefaultNotificationRegistryTest {
@@ -176,18 +172,4 @@ class DefaultNotificationRegistryTest {
             // Assert
             assertThat(registry[notification]).isNull()
         }
-
-    data class FakeNotification(
-        override val title: String = "fake title",
-        override val contentText: String? = "fake content",
-        override val severity: NotificationSeverity = NotificationSeverity.Information,
-        override val icon: NotificationIcon = NotificationIcon(
-            inAppNotificationIcon = ImageVector.Builder(
-                defaultWidth = 0.dp,
-                defaultHeight = 0.dp,
-                viewportWidth = 0f,
-                viewportHeight = 0f,
-            ).build(),
-        ),
-    ) : AppNotification()
 }

--- a/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/InAppNotificationCommandTest.kt
+++ b/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/InAppNotificationCommandTest.kt
@@ -12,7 +12,6 @@ import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
 import kotlin.random.Random
 import kotlin.test.Test
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.FeatureFlagProvider
@@ -28,7 +27,6 @@ import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 import net.thunderbird.feature.notification.impl.fake.FakeNotification
-import net.thunderbird.feature.notification.impl.fake.FakeSystemOnlyNotification
 
 @Suppress("MaxLineLength")
 class InAppNotificationCommandTest {

--- a/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/InAppNotificationCommandTest.kt
+++ b/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/InAppNotificationCommandTest.kt
@@ -1,0 +1,177 @@
+package net.thunderbird.feature.notification.impl.command
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import dev.mokkery.matcher.any
+import dev.mokkery.spy
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.FeatureFlagProvider
+import net.thunderbird.core.featureflag.FeatureFlagResult
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.NotificationRegistry
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
+import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
+import net.thunderbird.feature.notification.impl.fake.FakeNotification
+import net.thunderbird.feature.notification.impl.fake.FakeSystemOnlyNotification
+
+@Suppress("MaxLineLength")
+class InAppNotificationCommandTest {
+    @Test
+    fun `execute should return Failure when display_in_app_notifications feature flag is Disabled`() =
+        runTest {
+            // Arrange
+            val testSubject = createTestSubject(
+                featureFlagProvider = { key ->
+                    when (key) {
+                        FeatureFlagKey.DisplayInAppNotifications -> FeatureFlagResult.Disabled
+                        else -> FeatureFlagResult.Enabled
+                    }
+                },
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Failure<Failure<InAppNotification>>>()
+                .prop("error") { it.error }
+                .all {
+                    prop(Failure<InAppNotification>::command)
+                        .isEqualTo(testSubject)
+                    prop(Failure<InAppNotification>::throwable)
+                        .isInstanceOf<NotificationCommandException>()
+                        .hasMessage(
+                            "${FeatureFlagKey.DisplayInAppNotifications.key} feature flag is not enabled",
+                        )
+                }
+        }
+
+    @Test
+    fun `execute should return Failure when display_in_app_notifications feature flag is Unavailable`() =
+        runTest {
+            // Arrange
+            val testSubject = createTestSubject(
+                featureFlagProvider = { key ->
+                    when (key) {
+                        FeatureFlagKey.DisplayInAppNotifications -> FeatureFlagResult.Unavailable
+                        else -> FeatureFlagResult.Enabled
+                    }
+                },
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Failure<Failure<InAppNotification>>>()
+                .prop("error") { it.error }
+                .all {
+                    prop(Failure<InAppNotification>::command)
+                        .isEqualTo(testSubject)
+                    prop(Failure<InAppNotification>::throwable)
+                        .isInstanceOf<NotificationCommandException>()
+                        .hasMessage(
+                            "${FeatureFlagKey.DisplayInAppNotifications.key} feature flag is not enabled",
+                        )
+                }
+        }
+
+    @Test
+    fun `execute should return Success when display_in_app_notifications feature flag is Enabled`() =
+        runTest {
+            // Arrange
+            val notification = FakeNotification(
+                severity = NotificationSeverity.Information,
+            )
+            val notifier = spy(FakeNotifier())
+            val testSubject = createTestSubject(
+                notification = notification,
+                notifier = notifier,
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Success<Success<InAppNotification>>>()
+                .prop("data") { it.data }
+                .all {
+                    prop(Success<InAppNotification>::command)
+                        .isEqualTo(testSubject)
+                }
+
+            verifySuspend(exactly(1)) {
+                notifier.show(id = any(), notification)
+            }
+        }
+
+    private fun createTestSubject(
+        notification: InAppNotification = FakeNotification(),
+        featureFlagProvider: FeatureFlagProvider = FeatureFlagProvider { FeatureFlagResult.Enabled },
+        notifier: NotificationNotifier<InAppNotification> = FakeNotifier(),
+        notificationRegistry: NotificationRegistry = FakeNotificationRegistry(),
+    ): InAppNotificationCommand {
+        val logger = TestLogger()
+        return InAppNotificationCommand(
+            logger = logger,
+            featureFlagProvider = featureFlagProvider,
+            notificationRegistry = notificationRegistry,
+            notification = notification,
+            notifier = notifier,
+        )
+    }
+}
+
+private open class FakeNotificationRegistry : NotificationRegistry {
+    override val registrar: Map<NotificationId, Notification>
+        get() = TODO("Not yet implemented")
+
+    override fun get(notificationId: NotificationId): Notification? {
+        TODO("Not yet implemented")
+    }
+
+    override fun get(notification: Notification): NotificationId? {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun register(notification: Notification): NotificationId {
+        return NotificationId(value = Random.nextInt())
+    }
+
+    override fun unregister(notificationId: NotificationId) {
+        TODO("Not yet implemented")
+    }
+
+    override fun unregister(notification: Notification) {
+        TODO("Not yet implemented")
+    }
+}
+
+private open class FakeNotifier : NotificationNotifier<InAppNotification> {
+    override suspend fun show(
+        id: NotificationId,
+        notification: InAppNotification,
+    ) = Unit
+
+    override fun dispose() = Unit
+}

--- a/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/SystemNotificationCommandTest.kt
+++ b/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/SystemNotificationCommandTest.kt
@@ -1,0 +1,311 @@
+package net.thunderbird.feature.notification.impl.command
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import dev.mokkery.matcher.any
+import dev.mokkery.spy
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.FeatureFlagProvider
+import net.thunderbird.core.featureflag.FeatureFlagResult
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.NotificationRegistry
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
+import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.command.NotificationCommandException
+import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
+import net.thunderbird.feature.notification.impl.fake.FakeNotification
+import net.thunderbird.feature.notification.impl.fake.FakeSystemOnlyNotification
+
+@Suppress("MaxLineLength")
+class SystemNotificationCommandTest {
+    @Test
+    fun `execute should return Failure when use_notification_sender_for_system_notifications feature flag is Disabled`() =
+        runTest {
+            // Arrange
+            val testSubject = createTestSubject(
+                featureFlagProvider = { key ->
+                    when (key) {
+                        FeatureFlagKey.UseNotificationSenderForSystemNotifications -> FeatureFlagResult.Disabled
+                        else -> FeatureFlagResult.Enabled
+                    }
+                },
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Failure<Failure<SystemNotification>>>()
+                .prop("error") { it.error }
+                .all {
+                    prop(Failure<SystemNotification>::command)
+                        .isEqualTo(testSubject)
+                    prop(Failure<SystemNotification>::throwable)
+                        .isInstanceOf<NotificationCommandException>()
+                        .hasMessage(
+                            "${FeatureFlagKey.UseNotificationSenderForSystemNotifications.key} feature flag" +
+                                "is not enabled",
+                        )
+                }
+        }
+
+    @Test
+    fun `execute should return Failure when use_notification_sender_for_system_notifications feature flag is Unavailable`() =
+        runTest {
+            // Arrange
+            val testSubject = createTestSubject(
+                featureFlagProvider = { key ->
+                    when (key) {
+                        FeatureFlagKey.UseNotificationSenderForSystemNotifications -> FeatureFlagResult.Unavailable
+                        else -> FeatureFlagResult.Enabled
+                    }
+                },
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Failure<Failure<SystemNotification>>>()
+                .prop("error") { it.error }
+                .all {
+                    prop(Failure<SystemNotification>::command)
+                        .isEqualTo(testSubject)
+                    prop(Failure<SystemNotification>::throwable)
+                        .isInstanceOf<NotificationCommandException>()
+                        .hasMessage(
+                            "${FeatureFlagKey.UseNotificationSenderForSystemNotifications.key} feature flag" +
+                                "is not enabled",
+                        )
+                }
+        }
+
+    @Test
+    fun `execute should return Failure when the app is in the foreground, notification is also InApp and severity is not Fatal or Critical`() =
+        runTest {
+            // Arrange
+            val notification = FakeNotification(
+                severity = NotificationSeverity.Information,
+            )
+            val testSubject = createTestSubject(
+                notification = notification,
+                // TODO(#9391): Verify if the app is backgrounded.
+                isAppInBackground = { false },
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Failure<Failure<SystemNotification>>>()
+                .prop("error") { it.error }
+                .all {
+                    prop(Failure<SystemNotification>::command)
+                        .isEqualTo(testSubject)
+                    prop(Failure<SystemNotification>::throwable)
+                        .isInstanceOf<NotificationCommandException>()
+                        .hasMessage("Can't execute command.")
+                }
+        }
+
+    @Test
+    fun `execute should return Success when the app is in the background`() =
+        runTest {
+            // Arrange
+            val notification = FakeNotification(
+                severity = NotificationSeverity.Information,
+            )
+            val notifier = spy(FakeNotifier())
+            val testSubject = createTestSubject(
+                notification = notification,
+                // TODO(#9391): Verify if the app is backgrounded.
+                isAppInBackground = { true },
+                notifier = notifier,
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Success<Success<SystemNotification>>>()
+                .prop("data") { it.data }
+                .all {
+                    prop(Success<SystemNotification>::command)
+                        .isEqualTo(testSubject)
+                }
+
+            verifySuspend(exactly(1)) {
+                notifier.show(any(), notification)
+            }
+        }
+
+    @Test
+    fun `execute should return Success when the notification severity is Fatal`() =
+        runTest {
+            // Arrange
+            val notification = FakeNotification(
+                severity = NotificationSeverity.Fatal,
+            )
+            val notifier = spy(FakeNotifier())
+            val testSubject = createTestSubject(
+                notification = notification,
+                // TODO(#9391): Verify if the app is backgrounded.
+                isAppInBackground = { false },
+                notifier = notifier,
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Success<Success<SystemNotification>>>()
+                .prop("data") { it.data }
+                .all {
+                    prop(Success<SystemNotification>::command)
+                        .isEqualTo(testSubject)
+                }
+
+            verifySuspend(exactly(1)) {
+                notifier.show(any(), notification)
+            }
+        }
+
+    @Test
+    fun `execute should return Success when the notification severity is Critical`() =
+        runTest {
+            // Arrange
+            val notification = FakeNotification(
+                severity = NotificationSeverity.Critical,
+            )
+            val notifier = spy(FakeNotifier())
+            val testSubject = createTestSubject(
+                notification = notification,
+                // TODO(#9391): Verify if the app is backgrounded.
+                isAppInBackground = { false },
+                notifier = notifier,
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Success<Success<SystemNotification>>>()
+                .prop("data") { it.data }
+                .all {
+                    prop(Success<SystemNotification>::command)
+                        .isEqualTo(testSubject)
+                }
+
+            verifySuspend(exactly(1)) {
+                notifier.show(any(), notification)
+            }
+        }
+
+    @Test
+    fun `execute should return Success when the notification the app is not in background and notification is not an in-app notification`() =
+        runTest {
+            // Arrange
+            val notification = FakeSystemOnlyNotification(
+                severity = NotificationSeverity.Information,
+            )
+            val notifier = spy(FakeNotifier())
+            val testSubject = createTestSubject(
+                notification = notification,
+                // TODO(#9391): Verify if the app is backgrounded.
+                isAppInBackground = { false },
+                notifier = notifier,
+            )
+
+            // Act
+            val outcome = testSubject.execute()
+
+            // Assert
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Success<Success<SystemNotification>>>()
+                .prop("data") { it.data }
+                .all {
+                    prop(Success<SystemNotification>::command)
+                        .isEqualTo(testSubject)
+                }
+
+            verifySuspend(exactly(1)) {
+                notifier.show(any(), notification)
+            }
+        }
+
+    private fun createTestSubject(
+        notification: SystemNotification = FakeNotification(),
+        featureFlagProvider: FeatureFlagProvider = FeatureFlagProvider { FeatureFlagResult.Enabled },
+        notifier: NotificationNotifier<SystemNotification> = FakeNotifier(),
+        notificationRegistry: NotificationRegistry = FakeNotificationRegistry(),
+        isAppInBackground: () -> Boolean = {
+            // TODO(#9391): Verify if the app is backgrounded.
+            false
+        },
+    ): SystemNotificationCommand {
+        val logger = TestLogger()
+        return SystemNotificationCommand(
+            logger = logger,
+            featureFlagProvider = featureFlagProvider,
+            notificationRegistry = notificationRegistry,
+            notification = notification,
+            notifier = notifier,
+            isAppInBackground = isAppInBackground,
+        )
+    }
+}
+
+private open class FakeNotificationRegistry : NotificationRegistry {
+    override val registrar: Map<NotificationId, Notification>
+        get() = TODO("Not yet implemented")
+
+    override fun get(notificationId: NotificationId): Notification? {
+        TODO("Not yet implemented")
+    }
+
+    override fun get(notification: Notification): NotificationId? {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun register(notification: Notification): NotificationId {
+        return NotificationId(value = Random.nextInt())
+    }
+
+    override fun unregister(notificationId: NotificationId) {
+        TODO("Not yet implemented")
+    }
+
+    override fun unregister(notification: Notification) {
+        TODO("Not yet implemented")
+    }
+}
+
+private open class FakeNotifier : NotificationNotifier<SystemNotification> {
+    override suspend fun show(
+        id: NotificationId,
+        notification: SystemNotification,
+    ) = Unit
+
+    override fun dispose() = Unit
+}

--- a/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/fake/FakeNotification.kt
+++ b/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/fake/FakeNotification.kt
@@ -1,0 +1,60 @@
+package net.thunderbird.feature.notification.impl.fake
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import net.thunderbird.feature.notification.api.NotificationChannel
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.content.AppNotification
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.content.SystemNotification
+import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+
+data class FakeNotification(
+    override val title: String = "fake title",
+    override val contentText: String? = "fake content",
+    override val severity: NotificationSeverity = NotificationSeverity.Information,
+    override val icon: NotificationIcon = NotificationIcon(
+        inAppNotificationIcon = ImageVector.Builder(
+            defaultWidth = 0.dp,
+            defaultHeight = 0.dp,
+            viewportWidth = 0f,
+            viewportHeight = 0f,
+        ).build(),
+    ),
+    override val channel: NotificationChannel = NotificationChannel.Messages(
+        accountUuid = "",
+        suffix = "",
+    ),
+) : AppNotification(), SystemNotification, InAppNotification
+
+data class FakeSystemOnlyNotification(
+    override val title: String = "fake title",
+    override val contentText: String? = "fake content",
+    override val severity: NotificationSeverity = NotificationSeverity.Information,
+    override val icon: NotificationIcon = NotificationIcon(
+        inAppNotificationIcon = ImageVector.Builder(
+            defaultWidth = 0.dp,
+            defaultHeight = 0.dp,
+            viewportWidth = 0f,
+            viewportHeight = 0f,
+        ).build(),
+    ),
+    override val channel: NotificationChannel = NotificationChannel.Messages(
+        accountUuid = "",
+        suffix = "",
+    ),
+) : AppNotification(), SystemNotification
+
+data class FakeInAppOnlyNotification(
+    override val title: String = "fake title",
+    override val contentText: String? = "fake content",
+    override val severity: NotificationSeverity = NotificationSeverity.Information,
+    override val icon: NotificationIcon = NotificationIcon(
+        inAppNotificationIcon = ImageVector.Builder(
+            defaultWidth = 0.dp,
+            defaultHeight = 0.dp,
+            viewportWidth = 0f,
+            viewportHeight = 0f,
+        ).build(),
+    ),
+) : AppNotification(), InAppNotification

--- a/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/receiver/InAppNotificationNotifierTest.kt
+++ b/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/receiver/InAppNotificationNotifierTest.kt
@@ -1,0 +1,73 @@
+package net.thunderbird.feature.notification.impl.receiver
+
+import dev.mokkery.matcher.any
+import dev.mokkery.spy
+import dev.mokkery.verify.VerifyMode.Companion.exactly
+import dev.mokkery.verifySuspend
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.NotificationRegistry
+import net.thunderbird.feature.notification.api.content.Notification
+import net.thunderbird.feature.notification.impl.fake.FakeInAppOnlyNotification
+
+class InAppNotificationNotifierTest {
+    @Test
+    fun `show should not publish event when notification is already present in NotificationRegistry`() = runTest {
+        // Arrange
+        val notificationId = NotificationId(value = 1)
+        val notification = FakeInAppOnlyNotification()
+        val registrar = mapOf(notificationId to notification)
+        val eventBus = spy(InAppNotificationEventBus())
+        val testSubject = createTestSubject(registrar, eventBus)
+
+        // Act
+        testSubject.show(notificationId, notification)
+
+        // Assert
+        verifySuspend(exactly(1)) {
+            eventBus.publish(any())
+        }
+    }
+
+    @Test
+    fun `show should publish event when notification is not present in NotificationRegistry`() = runTest {
+        // Arrange
+        val notificationId = NotificationId(value = Int.MAX_VALUE)
+        val notification = FakeInAppOnlyNotification()
+        val registrar = buildMap<NotificationId, Notification> {
+            repeat(times = 100) { index ->
+                put(NotificationId(index), FakeInAppOnlyNotification(title = "fake title $index"))
+            }
+        }
+        val eventBus = spy(InAppNotificationEventBus())
+        val testSubject = createTestSubject(registrar, eventBus)
+
+        // Act
+        testSubject.show(notificationId, notification)
+
+        // Assert
+        verifySuspend(exactly(0)) {
+            eventBus.publish(any())
+        }
+    }
+
+    private fun createTestSubject(
+        registrar: Map<NotificationId, Notification>,
+        eventBus: InAppNotificationEventBus,
+    ): InAppNotificationNotifier {
+        return InAppNotificationNotifier(
+            logger = TestLogger(),
+            notificationRegistry = object : NotificationRegistry {
+                override val registrar: Map<NotificationId, Notification> = registrar
+                override fun get(notificationId: NotificationId): Notification? = error("Not yet implemented")
+                override fun get(notification: Notification): NotificationId? = error("Not yet implemented")
+                override suspend fun register(notification: Notification): NotificationId = error("Not yet implemented")
+                override fun unregister(notificationId: NotificationId) = error("Not yet implemented")
+                override fun unregister(notification: Notification) = error("Not yet implemented")
+            },
+            inAppNotificationEventBus = eventBus,
+        )
+    }
+}

--- a/feature/notification/impl/src/jvmMain/java/net/thunderbird/feature/notification/impl/inject/NotificationModule.jvm.kt
+++ b/feature/notification/impl/src/jvmMain/java/net/thunderbird/feature/notification/impl/inject/NotificationModule.jvm.kt
@@ -1,5 +1,0 @@
-package net.thunderbird.feature.notification.impl.inject
-
-import org.koin.dsl.module
-
-internal actual val platformFeatureNotificationModule = module { }

--- a/feature/notification/impl/src/jvmMain/java/net/thunderbird/feature/notification/impl/inject/NotificationModule.jvm.kt
+++ b/feature/notification/impl/src/jvmMain/java/net/thunderbird/feature/notification/impl/inject/NotificationModule.jvm.kt
@@ -1,0 +1,5 @@
+package net.thunderbird.feature.notification.impl.inject
+
+import org.koin.dsl.module
+
+internal actual val platformFeatureNotificationModule = module { }

--- a/feature/notification/impl/src/jvmMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.jvm.kt
+++ b/feature/notification/impl/src/jvmMain/kotlin/net/thunderbird/feature/notification/impl/inject/NotificationModule.jvm.kt
@@ -1,0 +1,5 @@
+package net.thunderbird.feature.notification.impl.inject
+
+import org.koin.dsl.module
+
+internal actual val platformFeatureNotificationModule = module { }


### PR DESCRIPTION
Depends on #9500, #9506, #9507, #9508.

Part of #9312.

We need to create notifications from Java code, so we must enable the new Notification API to be used without a coroutine.

This pull request aims to address this issue by introducing the `NotificationSenderCompat`, which should only be used within Java code.