### PR TITLE
chore(java-compat): add a FeatureFlagProvider.provide(String) version for Java compatibility

### DIFF
--- a/core/featureflag/build.gradle.kts
+++ b/core/featureflag/build.gradle.kts
@@ -5,3 +5,11 @@ plugins {
 android {
     namespace = "net.thunderbird.core.featureflag"
 }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.androidx.annotation)
+        }
+    }
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/compat/FeatureFlagProviderCompat.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/compat/FeatureFlagProviderCompat.kt
@@ -1,0 +1,29 @@
+@file:JvmName("FeatureFlagProviderCompat")
+
+package net.thunderbird.core.featureflag.compat
+
+import androidx.annotation.Discouraged
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.FeatureFlagProvider
+import net.thunderbird.core.featureflag.FeatureFlagResult
+import net.thunderbird.core.featureflag.toFeatureFlagKey
+
+/**
+ * Provides a feature flag result based on a string key, primarily for Java compatibility.
+ *
+ * This function acts as a bridge for Java code to access the Kotlin-idiomatic `provide`
+ * function that expects a [FeatureFlagKey], as value classes are not compatible with Java
+ * code.
+ *
+ * **Note:** This function is discouraged for use in Kotlin code. Prefer using the
+ * [FeatureFlagProvider.provide(key: FeatureFlagKey)][FeatureFlagProvider.provide]
+ * function directly in Kotlin.
+ *
+ * @receiver The [FeatureFlagProvider] instance to query.
+ * @param key The string representation of the feature flag key.
+ * @return The [FeatureFlagResult] corresponding to the given key.
+ */
+@Discouraged(message = "This function should be only used within Java files.")
+fun FeatureFlagProvider.provide(key: String): FeatureFlagResult {
+    return provide(key.toFeatureFlagKey())
+}


### PR DESCRIPTION
Part of #9312.

We will need to call the `FeatureFlagProvider.provide(key)` function within a few Java files to enable the in-app notifications.

As our `FeatureFlagKey` is a value class, the `provide` function isn't available within any Java file, as value classes are not exposed to Java.

We can remove this later when upgrading Kotlin to 2.2 by using the experimental `@JvmExposeBoxed` annotation.