### PR TITLE
Uplift: fix back button not closing app when message list is in inbox after returning from another folder and pressing back

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1453,11 +1453,11 @@ open class MessageList :
         this.search = search
         singleFolderMode = false
 
+        val folderIds = search.folderIds
         if (search.searchAllAccounts()) {
             val accountUuids = search.accountUuids
             if (accountUuids.size == 1) {
                 account = accountManager.getAccount(accountUuids.elementAt(0))
-                val folderIds = search.folderIds
                 singleFolderMode = folderIds.size == 1
             } else {
                 account = null
@@ -1466,7 +1466,7 @@ open class MessageList :
             if (account == null && search.accountUuids.size == 1) {
                 account = accountManager.getAccount(search.accountUuids.elementAt(0))
             }
-            singleFolderMode = true
+            singleFolderMode = folderIds.size == 1
         }
 
         configureDrawer()


### PR DESCRIPTION
Uplift #9472 to beta. 

The changes on #9472 supersede the changes on #9433, correctly fixing the navigate back issue without crashing the app when trying to open a Threaded view.