### PR TITLE
Uplift - Handle UTF8 strings sent using literal syntax

### DIFF
--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandRefreshFolderList.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandRefreshFolderList.kt
@@ -36,8 +36,8 @@ internal class CommandRefreshFolderList(
 }
 
 private fun List<FolderListItem>.toLegacyFolderList(): List<LegacyFolderListItem> {
-    return this.filterNot { it.oldServerId == null }
-        .map { LegacyFolderListItem(it.oldServerId!!, it.name, it.type) }
+    return this
+        .map { LegacyFolderListItem(it.serverId, it.name, it.type) }
 }
 
 private data class LegacyFolderListItem(

--- a/backend/imap/src/test/java/com/fsck/k9/backend/imap/TestImapStore.kt
+++ b/backend/imap/src/test/java/com/fsck/k9/backend/imap/TestImapStore.kt
@@ -33,7 +33,6 @@ class TestImapStore : ImapStore {
                 serverId = folder.serverId,
                 name = "irrelevant",
                 type = FolderType.REGULAR,
-                oldServerId = null,
             )
         }
     }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/FolderListItem.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/FolderListItem.kt
@@ -6,5 +6,4 @@ data class FolderListItem(
     val serverId: String,
     val name: String,
     val type: FolderType,
-    val oldServerId: String?,
 )

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/FolderNameCodec.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/FolderNameCodec.kt
@@ -8,8 +8,13 @@ import java.nio.charset.StandardCharsets
 internal class FolderNameCodec {
     private val modifiedUtf7Charset = CharsetProvider().charsetForName("X-RFC-3501")
     private val asciiCharset = StandardCharsets.US_ASCII
+    var acceptUtf8Encoding = false
 
     fun encode(folderName: String): String {
+        if (acceptUtf8Encoding) {
+            return folderName
+        }
+
         val byteBuffer = modifiedUtf7Charset.encode(folderName)
         val bytes = ByteArray(byteBuffer.limit())
         byteBuffer.get(bytes)
@@ -18,6 +23,10 @@ internal class FolderNameCodec {
     }
 
     fun decode(encodedFolderName: String): String {
+        if (acceptUtf8Encoding) {
+            return encodedFolderName
+        }
+
         val decoder = modifiedUtf7Charset.newDecoder().onMalformedInput(CodingErrorAction.REPORT)
         val byteBuffer = ByteBuffer.wrap(encodedFolderName.toByteArray(asciiCharset))
         val charBuffer = decoder.decode(byteBuffer)

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.kt
@@ -19,6 +19,8 @@ internal interface ImapConnection {
 
     fun close()
 
+    fun canSendUTF8QuotedStrings(): Boolean
+
     @Throws(IOException::class, MessagingException::class)
     fun hasCapability(capability: String): Boolean
 

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderFetcher.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderFetcher.kt
@@ -50,10 +50,9 @@ class ImapFolderFetcher internal constructor(
         return try {
             store.getFolders()
                 .asSequence()
-                .filterNot { it.oldServerId == null }
                 .map { folder ->
                     RemoteFolder(
-                        serverId = FolderServerId(folder.oldServerId!!),
+                        serverId = FolderServerId(folder.serverId),
                         displayName = folder.name,
                         type = folder.type,
                     )

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapResponseParser.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapResponseParser.java
@@ -22,14 +22,15 @@ class ImapResponseParser {
     private boolean utf8Accept;
     private FolderNameCodec folderNameCodec;
 
-    public ImapResponseParser(PeekableInputStream in) {
+    public ImapResponseParser(PeekableInputStream in, FolderNameCodec folderNameCodec) {
         this.inputStream = in;
         this.utf8Accept = false;
-        this.folderNameCodec = new FolderNameCodec();
+        this.folderNameCodec = folderNameCodec;
     }
 
     public void setUtf8Accepted(final boolean yes) {
         utf8Accept = yes;
+        folderNameCodec.setAcceptUtf8Encoding(yes);
     }
 
     public ImapResponse readResponse() throws IOException {
@@ -417,7 +418,7 @@ class ImapResponseParser {
             read += count;
         }
 
-        return new String(data, "US-ASCII");
+        return new String(data, "UTF8");
     }
 
     private String parseQuoted() throws IOException {

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -98,11 +98,7 @@ internal class RealImapFolder(
     @get:Throws(MessagingException::class)
     private val encodedName: String
         get() {
-            return if (connection?.isUtf8AcceptCapable == true) {
-                prefixedName
-            } else {
-                folderNameCodec.encode(prefixedName)
-            }
+            return folderNameCodec.encode(prefixedName)
         }
 
     @Throws(MessagingException::class, IOException::class)
@@ -311,11 +307,7 @@ internal class RealImapFolder(
 
         val uids = messages.map { it.uid.toLong() }.toSet()
         val encodedDestinationFolderName =
-            if (connection!!.isUtf8AcceptCapable) {
-                folder.prefixedName
-            } else {
-                folderNameCodec.encode(folder.prefixedName)
-            }
+            folderNameCodec.encode(folder.prefixedName)
         val escapedDestinationFolderName = ImapUtility.encodeString(encodedDestinationFolderName)
 
         return try {
@@ -351,11 +343,7 @@ internal class RealImapFolder(
 
         val uids = messages.map { it.uid.toLong() }.toSet()
         val encodedDestinationFolderName =
-            if (connection!!.isUtf8AcceptCapable) {
-                folder.prefixedName
-            } else {
-                folderNameCodec.encode(folder.prefixedName)
-            }
+            folderNameCodec.encode(folder.prefixedName)
         val escapedDestinationFolderName = ImapUtility.encodeString(encodedDestinationFolderName)
 
         return try {

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderFetcherTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderFetcherTest.kt
@@ -60,49 +60,41 @@ class ImapFolderFetcherTest {
                     serverId = "INBOX",
                     name = "INBOX",
                     type = FolderType.INBOX,
-                    oldServerId = "INBOX",
                 ),
                 FolderListItem(
                     serverId = "[Gmail]/All Mail",
                     name = "[Gmail]/All Mail",
                     type = FolderType.ARCHIVE,
-                    oldServerId = "[Gmail]/All Mail",
                 ),
                 FolderListItem(
                     serverId = "[Gmail]/Drafts",
                     name = "[Gmail]/Drafts",
                     type = FolderType.DRAFTS,
-                    oldServerId = "[Gmail]/Drafts",
                 ),
                 FolderListItem(
                     serverId = "[Gmail]/Important",
                     name = "[Gmail]/Important",
                     type = FolderType.REGULAR,
-                    oldServerId = "[Gmail]/Important",
                 ),
                 FolderListItem(
                     serverId = "[Gmail]/Sent Mail",
                     name = "[Gmail]/Sent Mail",
                     type = FolderType.SENT,
-                    oldServerId = "[Gmail]/Sent Mail",
                 ),
                 FolderListItem(
                     serverId = "[Gmail]/Spam",
                     name = "[Gmail]/Spam",
                     type = FolderType.SPAM,
-                    oldServerId = "[Gmail]/Spam",
                 ),
                 FolderListItem(
                     serverId = "[Gmail]/Starred",
                     name = "[Gmail]/Starred",
                     type = FolderType.REGULAR,
-                    oldServerId = "[Gmail]/Starred",
                 ),
                 FolderListItem(
                     serverId = "[Gmail]/Trash",
                     name = "[Gmail]/Trash",
                     type = FolderType.TRASH,
-                    oldServerId = "[Gmail]/Trash",
                 ),
             )
         }
@@ -151,38 +143,6 @@ class ImapFolderFetcherTest {
                 type = FolderType.TRASH,
             ),
         )
-        assertThat(fakeImapStore.hasOpenConnections).isFalse()
-    }
-
-    @Test
-    fun `folder without oldServerId should be ignored`() {
-        fakeImapStore.getFoldersAction = {
-            listOf(
-                FolderListItem(
-                    serverId = "ünicode",
-                    name = "ünicode",
-                    type = FolderType.REGULAR,
-                    oldServerId = null,
-                ),
-                FolderListItem(
-                    serverId = "INBOX",
-                    name = "INBOX",
-                    type = FolderType.INBOX,
-                    oldServerId = "INBOX",
-                ),
-            )
-        }
-
-        val folders = folderFetcher.getFolders(serverSettings, authStateStorage = null)
-
-        assertThat(folders).containsExactly(
-            RemoteFolder(
-                serverId = FolderServerId("INBOX"),
-                displayName = "INBOX",
-                type = FolderType.INBOX,
-            ),
-        )
-
         assertThat(fakeImapStore.hasOpenConnections).isFalse()
     }
 

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseHelper.java
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseHelper.java
@@ -21,9 +21,14 @@ public class ImapResponseHelper {
     }
 
     public static ImapResponse createImapResponse(String response) throws IOException {
+        return createImapResponse(response, false);
+    }
+
+    public static ImapResponse createImapResponse(String response, boolean utf8) throws IOException {
         String input = response + "\r\n";
         PeekableInputStream inputStream = new PeekableInputStream(new ByteArrayInputStream(input.getBytes()));
-        ImapResponseParser parser = new ImapResponseParser(inputStream);
+        ImapResponseParser parser = new ImapResponseParser(inputStream, new FolderNameCodec());
+        parser.setUtf8Accepted(utf8);
 
         return parser.readResponse();
     }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.kt
@@ -472,6 +472,18 @@ class ImapResponseParserTest {
     }
 
     @Test
+    fun `readResponse() with LIST response containing folder name with literal UTF8`() {
+        val parser = createParserWithResponses("""* LIST (\hasnochildren) "/" {18}""" + "\r\nИсходящие")
+
+        parser.setUtf8Accepted(true)
+        val response = parser.readResponse()
+
+        assertThat(response).hasSize(4)
+        assertThat(response).index(3).isEqualTo("Исходящие")
+        assertThatAllInputWasConsumed()
+    }
+
+    @Test
     fun `readResponse() with LIST response containing folder name with parentheses should throw`() {
         val parser = createParserWithResponses("""* LIST (\NoInferiors) "/" Root/Folder/Subfolder()""")
 
@@ -595,7 +607,7 @@ class ImapResponseParserTest {
         val byteArrayInputStream = ByteArrayInputStream(response.toByteArray(Charsets.UTF_8))
         peekableInputStream = PeekableInputStream(byteArrayInputStream)
 
-        return ImapResponseParser(peekableInputStream)
+        return ImapResponseParser(peekableInputStream, FolderNameCodec())
     }
 
     private fun assertThatAllInputWasConsumed() {

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.kt
@@ -1185,6 +1185,7 @@ class RealImapConnectionTest {
             settings,
             socketFactory,
             oAuth2TokenProvider,
+            FolderNameCodec(),
             connectionGeneration,
             SOCKET_CONNECT_TIMEOUT,
             SOCKET_READ_TIMEOUT,

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
@@ -380,6 +380,25 @@ class RealImapFolderTest {
     }
 
     @Test
+    fun `moveMessages() with MOVE and UTF8=ACCEPT extensions`() {
+        val folderNameCodec = FolderNameCodec()
+        folderNameCodec.acceptUtf8Encoding = true
+        val sourceFolder = RealImapFolder(internalImapStore, testConnectionManager, "Folder", folderNameCodec)
+        prepareImapFolderForOpen(OpenMode.READ_WRITE)
+        imapConnection.stub {
+            on { hasCapability(Capabilities.MOVE) } doReturn true
+        }
+        val destinationFolder = createFolder("la vache dit møø")
+        val messages = listOf(createImapMessage("1"))
+        setupMoveResponses("x OK [COPYUID 23 1 101] Success")
+        sourceFolder.open(OpenMode.READ_WRITE)
+
+        val uidMapping = sourceFolder.moveMessages(messages, destinationFolder)
+
+        assertCommandWithIdsIssued("UID MOVE 1 \"la vache dit møø\"")
+    }
+
+    @Test
     fun moveMessages_shouldCopyMessages() {
         val sourceFolder = createFolder("Folder")
         prepareImapFolderForOpen(OpenMode.READ_WRITE)

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapConnection.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapConnection.kt
@@ -38,6 +38,10 @@ internal open class TestImapConnection(val timeout: Long, override val connectio
         isConnected = false
     }
 
+    override fun canSendUTF8QuotedStrings(): Boolean {
+        return false // to be mocked where appropriate
+    }
+
     override fun hasCapability(capability: String): Boolean {
         throw UnsupportedOperationException("not implemented")
     }


### PR DESCRIPTION
Uplift #9241 to beta

[Approval Request]

Original Issue/Pull request: #9241

Regression caused by (issue #): N/A

User impact if declined: User will face malformed folder names when server supports UTF-8

Testing completed (on daily, etc.): daily and main

Risk to taking this patch (and alternatives if risky): Not known yet.