### PR TITLE
feat(notifications): add banner global notification

### DIFF
--- a/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/page/organism/items/BannerItems.kt
+++ b/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/page/organism/items/BannerItems.kt
@@ -1,8 +1,10 @@
 package net.thunderbird.ui.catalog.ui.page.organism.items
 
 import androidx.compose.foundation.lazy.grid.LazyGridScope
+import net.thunderbird.ui.catalog.ui.page.organism.items.banners.bannerGlobal
 import net.thunderbird.ui.catalog.ui.page.organism.items.banners.bannerInline
 
 fun LazyGridScope.bannerItems() {
+    bannerGlobal()
     bannerInline()
 }

--- a/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/page/organism/items/banners/BannerInline.kt
+++ b/app-ui-catalog/src/main/kotlin/net/thunderbird/ui/catalog/ui/page/organism/items/banners/BannerInline.kt
@@ -1,0 +1,74 @@
+package net.thunderbird.ui.catalog.ui.page.organism.items.banners
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.molecule.notification.NotificationActionButton
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.ErrorBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.InfoBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.SuccessBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.WarningBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.ui.catalog.ui.page.common.list.fullSpanItem
+import net.thunderbird.ui.catalog.ui.page.common.list.sectionHeaderItem
+import net.thunderbird.ui.catalog.ui.page.common.list.sectionSubtitleItem
+
+fun LazyGridScope.bannerGlobal() {
+    sectionHeaderItem("Banner Global")
+    errorBannerGlobal()
+    infoBannerGlobal()
+    warningBannerGlobal()
+    successBannerGlobal()
+}
+
+fun LazyGridScope.errorBannerGlobal() {
+    sectionSubtitleItem("Error")
+    fullSpanItem {
+        ErrorBannerGlobalNotificationCard(
+            text = "Notification Text",
+            action = {
+                NotificationActionButton(text = "Action 1", onClick = {})
+            },
+            modifier = Modifier.padding(MainTheme.spacings.double),
+        )
+    }
+}
+
+fun LazyGridScope.infoBannerGlobal() {
+    sectionSubtitleItem("Information")
+    fullSpanItem {
+        InfoBannerGlobalNotificationCard(
+            text = "Notification Text",
+            action = {
+                NotificationActionButton(text = "Action 1", onClick = {})
+            },
+            modifier = Modifier.padding(MainTheme.spacings.double),
+        )
+    }
+}
+
+fun LazyGridScope.warningBannerGlobal() {
+    sectionSubtitleItem("Warning")
+    fullSpanItem {
+        WarningBannerGlobalNotificationCard(
+            text = "Notification Text",
+            action = {
+                NotificationActionButton(text = "Action 1", onClick = {})
+            },
+            modifier = Modifier.padding(MainTheme.spacings.double),
+        )
+    }
+}
+
+fun LazyGridScope.successBannerGlobal() {
+    sectionSubtitleItem("Success")
+    fullSpanItem {
+        SuccessBannerGlobalNotificationCard(
+            text = "Notification Text",
+            action = {
+                NotificationActionButton(text = "Action 1", onClick = {})
+            },
+            modifier = Modifier.padding(MainTheme.spacings.double),
+        )
+    }
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/BannerGlobalNotificationCardPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/BannerGlobalNotificationCardPreview.kt
@@ -1,0 +1,68 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
+import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.compose.designsystem.atom.icon.outlined.Warning
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.BannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+@PreviewLightDark
+@Composable
+private fun BannerGlobalNotificationCardStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            BannerGlobalNotificationCard(
+                icon = { Icon(imageVector = Icons.Outlined.Warning) },
+                text = "Offline. No internet connection found.",
+                action = {
+                    ButtonText(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun BannerGlobalNotificationCardAnnotatedStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            BannerGlobalNotificationCard(
+                icon = { Icon(imageVector = Icons.Outlined.Warning) },
+                text = buildAnnotatedString {
+                    withStyle(SpanStyle(fontWeight = FontWeight.Black)) {
+                        append("Offline. ")
+                    }
+                    append("No internet connection found.")
+                },
+                action = {
+                    ButtonText(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/ErrorBannerGlobalNotificationCardPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/ErrorBannerGlobalNotificationCardPreview.kt
@@ -1,0 +1,63 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
+import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.designsystem.molecule.notification.NotificationActionButton
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.ErrorBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+@PreviewLightDark
+@Composable
+private fun ErrorBannerGlobalNotificationCardStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            ErrorBannerGlobalNotificationCard(
+                text = "Offline. No internet connection found.",
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ErrorBannerGlobalNotificationCardAnnotatedStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            ErrorBannerGlobalNotificationCard(
+                text = buildAnnotatedString {
+                    withStyle(SpanStyle(fontWeight = FontWeight.Black)) {
+                        append("Offline. ")
+                    }
+                    append("No internet connection found.")
+                },
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/InfoBannerGlobalNotificationCardPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/InfoBannerGlobalNotificationCardPreview.kt
@@ -1,0 +1,120 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
+import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.designsystem.molecule.notification.NotificationActionButton
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.InfoBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+@PreviewLightDark
+@Composable
+private fun InfoBannerGlobalNotificationCardStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            InfoBannerGlobalNotificationCard(
+                text = "Offline. No internet connection found.",
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun InfoBannerGlobalNotificationCardNoActionPreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            InfoBannerGlobalNotificationCard(
+                text = "Offline. No internet connection found.",
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun InfoBannerGlobalNotificationCardLongTextPreview(
+    @PreviewParameter(LoremIpsum::class) text: String,
+) {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            InfoBannerGlobalNotificationCard(
+                text = text,
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun InfoBannerGlobalNotificationCardLongNoActionTextPreview(
+    @PreviewParameter(LoremIpsum::class) text: String,
+) {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            InfoBannerGlobalNotificationCard(
+                text = text,
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun InfoBannerGlobalNotificationCardAnnotatedStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            InfoBannerGlobalNotificationCard(
+                text = buildAnnotatedString {
+                    withStyle(SpanStyle(fontWeight = FontWeight.Black)) {
+                        append("Offline. ")
+                    }
+                    append("No internet connection found.")
+                },
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/SuccessBannerGlobalNotificationCardPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/SuccessBannerGlobalNotificationCardPreview.kt
@@ -1,0 +1,120 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
+import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.designsystem.molecule.notification.NotificationActionButton
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.SuccessBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+@PreviewLightDark
+@Composable
+private fun SuccessBannerGlobalNotificationCardStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            SuccessBannerGlobalNotificationCard(
+                text = "What an awesome notification, isn't it?",
+                action = {
+                    NotificationActionButton(
+                        text = "Action",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SuccessBannerGlobalNotificationCardNoActionPreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            SuccessBannerGlobalNotificationCard(
+                text = "What an awesome notification, isn't it?",
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SuccessBannerGlobalNotificationCardLongTextPreview(
+    @PreviewParameter(LoremIpsum::class) text: String,
+) {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            SuccessBannerGlobalNotificationCard(
+                text = text,
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SuccessBannerGlobalNotificationCardLongNoActionTextPreview(
+    @PreviewParameter(LoremIpsum::class) text: String,
+) {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            SuccessBannerGlobalNotificationCard(
+                text = text,
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SuccessBannerGlobalNotificationCardAnnotatedStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            SuccessBannerGlobalNotificationCard(
+                text = buildAnnotatedString {
+                    withStyle(SpanStyle(fontWeight = FontWeight.Black)) {
+                        append("Offline. ")
+                    }
+                    append("No internet connection found.")
+                },
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}

--- a/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/WarningBannerGlobalNotificationCardPreview.kt
+++ b/core/ui/compose/designsystem/src/debug/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/WarningBannerGlobalNotificationCardPreview.kt
@@ -1,0 +1,120 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import app.k9mail.core.ui.compose.designsystem.PreviewWithThemesLightDark
+import app.k9mail.core.ui.compose.designsystem.atom.Surface
+import app.k9mail.core.ui.compose.designsystem.molecule.notification.NotificationActionButton
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.WarningBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+@PreviewLightDark
+@Composable
+private fun WarningBannerGlobalNotificationCardStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            WarningBannerGlobalNotificationCard(
+                text = "Offline. No internet connection found.",
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun WarningBannerGlobalNotificationCardNoActionPreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            WarningBannerGlobalNotificationCard(
+                text = "Offline. No internet connection found.",
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun WarningBannerGlobalNotificationCardLongTextPreview(
+    @PreviewParameter(LoremIpsum::class) text: String,
+) {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            WarningBannerGlobalNotificationCard(
+                text = text,
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun WarningBannerGlobalNotificationCardLongNoActionTextPreview(
+    @PreviewParameter(LoremIpsum::class) text: String,
+) {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            WarningBannerGlobalNotificationCard(
+                text = text,
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun WarningBannerGlobalNotificationCardAnnotatedStringTitlePreview() {
+    PreviewWithThemesLightDark {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            WarningBannerGlobalNotificationCard(
+                text = buildAnnotatedString {
+                    withStyle(SpanStyle(fontWeight = FontWeight.Black)) {
+                        append("Offline. ")
+                    }
+                    append("No internet connection found.")
+                },
+                action = {
+                    NotificationActionButton(
+                        text = "Retry",
+                        onClick = {},
+                    )
+                },
+                modifier = Modifier.padding(top = MainTheme.spacings.quadruple),
+            )
+        }
+    }
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/BannerNotificationCardDefaults.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/BannerNotificationCardDefaults.kt
@@ -32,7 +32,7 @@ object BannerNotificationCardDefaults {
     /**
      * The default behaviour for the [BannerInlineNotificationCard]
      */
-    val behaviour = BannerInlineNotificationCardBehaviour.Expanded
+    val bannerInlineBehaviour = BannerInlineNotificationCardBehaviour.Expanded
 
     /**
      * Creates a [CardColors] for an error banner inline notification card.

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/BannerNotificationCardDefaults.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/BannerNotificationCardDefaults.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.dp
 import app.k9mail.core.ui.compose.designsystem.atom.card.CardColors
 import app.k9mail.core.ui.compose.designsystem.atom.card.CardDefaults
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.BannerGlobalNotificationCard
 import app.k9mail.core.ui.compose.designsystem.organism.banner.inline.BannerInlineNotificationCard
 import app.k9mail.core.ui.compose.designsystem.organism.banner.inline.BannerInlineNotificationCardBehaviour
 import app.k9mail.core.ui.compose.theme2.MainTheme
@@ -18,6 +20,9 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
  * Contains the default values used by [BannerInlineNotificationCard] and [BannerGlobalNotificationCard] types
  */
 object BannerNotificationCardDefaults {
+    /** The default shape of the [BannerGlobalNotificationCard] */
+    val bannerGlobalShape: Shape = RectangleShape
+
     /** The default shape of the [BannerInlineNotificationCard] */
     val bannerInlineShape: Shape
         @ReadOnlyComposable

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/BannerGlobalNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/BannerGlobalNotificationCard.kt
@@ -1,0 +1,118 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
+import app.k9mail.core.ui.compose.designsystem.atom.card.CardColors
+import app.k9mail.core.ui.compose.designsystem.atom.card.CardFilled
+import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleSmall
+import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificationCardDefaults
+import app.k9mail.core.ui.compose.theme2.LocalContentColor
+import app.k9mail.core.ui.compose.theme2.MainTheme
+
+/**
+ * Used to maintain the user’s awareness of a persistent irregular state of the application,
+ * without disrupting other elements of the flow.
+ *
+ * @param icon The icon to display on the left side of the card.
+ * @param text The text to display in the card.
+ * @param modifier The modifier to apply to this layout node.
+ * @param colors The colors to use for the card.
+ * @param shape The shape of the card.
+ * @param action The action to display on the right side of the card.
+ */
+@Composable
+internal fun BannerGlobalNotificationCard(
+    icon: @Composable () -> Unit,
+    text: CharSequence,
+    modifier: Modifier = Modifier,
+    colors: CardColors = BannerNotificationCardDefaults.warningCardColors(),
+    shape: Shape = BannerNotificationCardDefaults.bannerGlobalShape,
+    action: (@Composable () -> Unit)? = null,
+) {
+    BannerGlobalNotificationCard(
+        icon = icon,
+        text = {
+            when (text) {
+                is String -> TextTitleSmall(
+                    text = text,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                is AnnotatedString -> TextTitleSmall(
+                    text = text,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                else -> TextTitleSmall(
+                    text = text.toString(),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+        colors = colors,
+        shape = shape,
+        modifier = modifier,
+        action = action,
+    )
+}
+
+/**
+ * Displays a header notification card.
+ *
+ * @param icon The icon to display on the left side of the card.
+ * @param text The text to display in the card.
+ * @param modifier The modifier to apply to this layout node.
+ * @param colors The colors to use for the card.
+ * @param shape The shape of the card.
+ * @param action The action to display on the right side of the card.
+ *
+ * @see BannerGlobalNotificationCard
+ */
+@Composable
+private fun BannerGlobalNotificationCard(
+    icon: @Composable () -> Unit,
+    text: @Composable () -> Unit,
+    colors: CardColors,
+    shape: Shape,
+    modifier: Modifier = Modifier,
+    action: (@Composable () -> Unit)? = null,
+) {
+    CardFilled(
+        modifier = modifier,
+        shape = shape,
+        colors = colors,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = MainTheme.sizes.bannerGlobalHeight)
+                .padding(horizontal = MainTheme.spacings.default),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
+        ) {
+            icon()
+            Box(
+                modifier = Modifier.weight(1f),
+            ) {
+                text()
+            }
+            CompositionLocalProvider(LocalContentColor provides colors.contentColor) {
+                action?.invoke()
+            }
+        }
+    }
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/ErrorBannerGlobalNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/ErrorBannerGlobalNotificationCard.kt
@@ -1,0 +1,29 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificationCardDefaults
+
+/**
+ * Displays an error banner global notification card.
+ *
+ * @param text The text to display in the notification card.
+ * @param action The composable function to display as the action button.
+ * @param modifier The modifier to apply to this layout node.
+ */
+@Composable
+fun ErrorBannerGlobalNotificationCard(
+    text: CharSequence,
+    action: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BannerGlobalNotificationCard(
+        icon = { Icon(imageVector = Icons.Outlined.Report) },
+        text = text,
+        action = action,
+        modifier = modifier,
+        colors = BannerNotificationCardDefaults.errorCardColors(),
+    )
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/InfoBannerGlobalNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/InfoBannerGlobalNotificationCard.kt
@@ -1,0 +1,29 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificationCardDefaults
+
+/**
+ * Displays an info banner global notification card.
+ *
+ * @param text The text to display in the notification card.
+ * @param action The composable function to display as the action button.
+ * @param modifier The modifier to apply to this layout node.
+ */
+@Composable
+fun InfoBannerGlobalNotificationCard(
+    text: CharSequence,
+    modifier: Modifier = Modifier,
+    action: (@Composable () -> Unit)? = null,
+) {
+    BannerGlobalNotificationCard(
+        icon = { Icon(imageVector = Icons.Outlined.Info) },
+        text = text,
+        action = action,
+        modifier = modifier,
+        colors = BannerNotificationCardDefaults.infoCardColors(),
+    )
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/SuccessBannerGlobalNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/SuccessBannerGlobalNotificationCard.kt
@@ -1,0 +1,29 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificationCardDefaults
+
+/**
+ * Displays a success banner global notification card.
+ *
+ * @param text The text to display in the notification card.
+ * @param action The composable function to display as the action button.
+ * @param modifier The modifier to apply to this layout node.
+ */
+@Composable
+fun SuccessBannerGlobalNotificationCard(
+    text: CharSequence,
+    modifier: Modifier = Modifier,
+    action: (@Composable () -> Unit)? = null,
+) {
+    BannerGlobalNotificationCard(
+        icon = { Icon(imageVector = Icons.Outlined.CheckCircle) },
+        text = text,
+        action = action,
+        modifier = modifier,
+        colors = BannerNotificationCardDefaults.successCardColors(),
+    )
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/WarningBannerGlobalNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/global/WarningBannerGlobalNotificationCard.kt
@@ -1,0 +1,30 @@
+package app.k9mail.core.ui.compose.designsystem.organism.banner.global
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icon
+import app.k9mail.core.ui.compose.designsystem.atom.icon.Icons
+import app.k9mail.core.ui.compose.designsystem.atom.icon.outlined.Warning
+import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificationCardDefaults
+
+/**
+ * Displays a warning banner global notification card.
+ *
+ * @param text The text to display in the notification card.
+ * @param action The composable function to display as the action button.
+ * @param modifier The modifier to apply to this layout node.
+ */
+@Composable
+fun WarningBannerGlobalNotificationCard(
+    text: CharSequence,
+    modifier: Modifier = Modifier,
+    action: (@Composable () -> Unit)? = null,
+) {
+    BannerGlobalNotificationCard(
+        icon = { Icon(imageVector = Icons.Outlined.Warning) },
+        text = text,
+        action = action,
+        modifier = modifier,
+        colors = BannerNotificationCardDefaults.warningCardColors(),
+    )
+}

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/BannerInlineNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/BannerInlineNotificationCard.kt
@@ -51,7 +51,7 @@ internal fun BannerInlineNotificationCard(
     colors: CardColors = BannerNotificationCardDefaults.errorCardColors(),
     border: BorderStroke = BannerNotificationCardDefaults.errorCardBorder(),
     shape: Shape = BannerNotificationCardDefaults.bannerInlineShape,
-    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.behaviour,
+    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.bannerInlineBehaviour,
 ) {
     val maxLines = when (behaviour) {
         BannerInlineNotificationCardBehaviour.Clipped -> 2

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/ErrorBannerInlineNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/ErrorBannerInlineNotificationCard.kt
@@ -16,7 +16,7 @@ import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificatio
  *  typically buttons, laid out in a [RowScope].
  * @param modifier Optional [Modifier] to be applied to the composable.
  * @param behaviour Optional [BannerInlineNotificationCardBehaviour] to customize the appearance
- *  and behavior of the notification card. Defaults to [BannerNotificationCardDefaults.behaviour].
+ *  and behavior of the notification card. Defaults to [BannerNotificationCardDefaults.bannerInlineBehaviour].
  */
 @Composable
 fun ErrorBannerInlineNotificationCard(
@@ -24,7 +24,7 @@ fun ErrorBannerInlineNotificationCard(
     supportingText: CharSequence,
     actions: @Composable RowScope.() -> Unit,
     modifier: Modifier = Modifier,
-    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.behaviour,
+    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.bannerInlineBehaviour,
 ) {
     BannerInlineNotificationCard(
         icon = { Icon(imageVector = Icons.Outlined.Report) },

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/InfoBannerInlineNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/InfoBannerInlineNotificationCard.kt
@@ -16,7 +16,7 @@ import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificatio
  *  typically buttons, laid out in a [RowScope].
  * @param modifier Optional [Modifier] to be applied to the composable.
  * @param behaviour Optional [BannerInlineNotificationCardBehaviour] to customize the appearance
- *  and behavior of the notification card. Defaults to [BannerNotificationCardDefaults.behaviour].
+ *  and behavior of the notification card. Defaults to [BannerNotificationCardDefaults.bannerInlineBehaviour].
  */
 @Composable
 fun InfoBannerInlineNotificationCard(
@@ -24,7 +24,7 @@ fun InfoBannerInlineNotificationCard(
     supportingText: CharSequence,
     actions: @Composable RowScope.() -> Unit,
     modifier: Modifier = Modifier,
-    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.behaviour,
+    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.bannerInlineBehaviour,
 ) {
     BannerInlineNotificationCard(
         icon = { Icon(imageVector = Icons.Outlined.Info) },

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/SuccessBannerInlineNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/SuccessBannerInlineNotificationCard.kt
@@ -16,7 +16,7 @@ import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificatio
  *  typically buttons, laid out in a [RowScope].
  * @param modifier Optional [Modifier] to be applied to the composable.
  * @param behaviour Optional [BannerInlineNotificationCardBehaviour] to customize the appearance
- *  and behavior of the notification card. Defaults to [BannerNotificationCardDefaults.behaviour].
+ *  and behavior of the notification card. Defaults to [BannerNotificationCardDefaults.bannerInlineBehaviour].
  */
 @Composable
 fun SuccessBannerInlineNotificationCard(
@@ -24,7 +24,7 @@ fun SuccessBannerInlineNotificationCard(
     supportingText: CharSequence,
     actions: @Composable RowScope.() -> Unit,
     modifier: Modifier = Modifier,
-    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.behaviour,
+    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.bannerInlineBehaviour,
 ) {
     BannerInlineNotificationCard(
         icon = { Icon(imageVector = Icons.Outlined.CheckCircle) },

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/WarningBannerInlineNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/WarningBannerInlineNotificationCard.kt
@@ -17,7 +17,7 @@ import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificatio
  *  typically buttons, laid out in a [RowScope].
  * @param modifier Optional [Modifier] to be applied to the composable.
  * @param behaviour Optional [BannerInlineNotificationCardBehaviour] to customize the appearance
- *  and behavior of the notification card. Defaults to [BannerNotificationCardDefaults.behaviour].
+ *  and behavior of the notification card. Defaults to [BannerNotificationCardDefaults.bannerInlineBehaviour].
  */
 @Composable
 fun WarningBannerInlineNotificationCard(
@@ -25,7 +25,7 @@ fun WarningBannerInlineNotificationCard(
     supportingText: CharSequence,
     actions: @Composable RowScope.() -> Unit,
     modifier: Modifier = Modifier,
-    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.behaviour,
+    behaviour: BannerInlineNotificationCardBehaviour = BannerNotificationCardDefaults.bannerInlineBehaviour,
 ) {
     BannerInlineNotificationCard(
         icon = { Icon(imageVector = Icons.Outlined.Warning) },

--- a/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/ThemeSizes.kt
+++ b/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/ThemeSizes.kt
@@ -22,6 +22,7 @@ data class ThemeSizes(
     val topBarHeight: Dp,
     val bottomBarHeight: Dp,
     val bottomBarHeightWithFab: Dp,
+    val bannerGlobalHeight: Dp,
 )
 
 internal val LocalThemeSizes = staticCompositionLocalOf<ThemeSizes> {

--- a/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/default/DefaultThemeSizes.kt
+++ b/core/ui/compose/theme2/common/src/main/kotlin/app/k9mail/core/ui/compose/theme2/default/DefaultThemeSizes.kt
@@ -20,4 +20,5 @@ val defaultThemeSizes = ThemeSizes(
     topBarHeight = 64.dp,
     bottomBarHeight = 80.dp,
     bottomBarHeightWithFab = 72.dp,
+    bannerGlobalHeight = 48.dp,
 )


### PR DESCRIPTION
Depends on #9528.
Resolve #9530.

- Add the outlined version of `CheckCircle`
- Add `BannerGlobalNotificationCard` as a base type for `BannerGlobalNotification`s

### Previews
#### Error
<img width="1234" height="696" alt="image" src="https://github.com/user-attachments/assets/7bffa0f1-f750-4ce6-bee2-8300efa6c327" />

#### Info
<img width="1246" height="346" alt="image" src="https://github.com/user-attachments/assets/b32d9c16-e825-4f35-9b08-5325311c95c5" />

#### Success
<img width="1241" height="692" alt="image" src="https://github.com/user-attachments/assets/44e41d3a-fa00-481f-88be-b10de85f1954" />

#### Warning
<img width="1239" height="685" alt="image" src="https://github.com/user-attachments/assets/f43b49d7-cd82-47ba-8971-e87dd51978ef" />

### App UI-Catalog
| Thunderbird Theme | K9 Theme |
| -------------------- | ---------- |
| <video src="https://github.com/user-attachments/assets/48daae21-7cc5-45e1-99ec-9adffd7b2107" /> | <video src="https://github.com/user-attachments/assets/3e4df18f-c334-4b70-9511-0ff5a7f0ced0" /> |



