### PR TITLE
feat(notifications): add in-app notification host state

### DIFF
--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/DisplayInAppNotificationFlag.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/DisplayInAppNotificationFlag.kt
@@ -1,0 +1,14 @@
+package net.thunderbird.feature.notification.api.ui.host
+
+import kotlinx.collections.immutable.toPersistentSet
+
+enum class DisplayInAppNotificationFlag {
+    BannerGlobalNotifications,
+    BannerInlineNotifications,
+    SnackbarNotifications,
+    ;
+
+    companion object {
+        val AllNotifications = DisplayInAppNotificationFlag.entries.toPersistentSet()
+    }
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/InAppNotificationHostStateHolder.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/InAppNotificationHostStateHolder.kt
@@ -1,0 +1,141 @@
+package net.thunderbird.feature.notification.api.ui.host
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerGlobalVisual
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerInlineVisual
+import net.thunderbird.feature.notification.api.ui.host.visual.InAppNotificationHostState
+import net.thunderbird.feature.notification.api.ui.host.visual.InAppNotificationVisual
+import net.thunderbird.feature.notification.api.ui.host.visual.SnackbarVisual
+
+@Stable
+class InAppNotificationHostStateHolder(private val enabled: ImmutableSet<DisplayInAppNotificationFlag>) {
+    private val internalState =
+        MutableStateFlow<InAppNotificationHostStateImpl>(value = InAppNotificationHostStateImpl())
+    internal val currentInAppNotificationHostState: StateFlow<InAppNotificationHostState> = internalState.asStateFlow()
+
+    fun showInAppNotification(
+        notification: InAppNotification,
+    ) {
+        val newData = notification.toInAppNotificationData()
+        // TODO(#9572): If global is already present, show the one with the highest priority
+        //              show the previous one back once the higher priority has fixed and the
+        //              other wasn't
+        internalState.update {
+            newData.bannerGlobalVisual.showIfNeeded(
+                ifFlagEnabled = DisplayInAppNotificationFlag.BannerGlobalNotifications,
+                select = { bannerGlobalVisual },
+                transformIfDifferent = { copy(bannerGlobalVisual = it) },
+            )
+        }
+        internalState.update {
+            newData.bannerInlineVisuals.showIfNeeded()
+        }
+        internalState.update {
+            newData.snackbarVisual.showIfNeeded(
+                ifFlagEnabled = DisplayInAppNotificationFlag.SnackbarNotifications,
+                select = { snackbarVisual },
+                transformIfDifferent = { copy(snackbarVisual = it) },
+            )
+        }
+    }
+
+    private fun ImmutableSet<BannerInlineVisual>.showIfNeeded(): InAppNotificationHostStateImpl {
+        if (!isEnabled(flag = DisplayInAppNotificationFlag.BannerInlineNotifications)) {
+            return internalState.value
+        }
+        val new = this
+        val current = internalState.value
+
+        return if (!current.bannerInlineVisuals.containsAll(new)) {
+            current.copy(
+                bannerInlineVisuals = (current.bannerInlineVisuals + new).toPersistentSet(),
+            )
+        } else {
+            current
+        }
+    }
+
+    private inline fun <TVisual : InAppNotificationVisual> TVisual?.showIfNeeded(
+        ifFlagEnabled: DisplayInAppNotificationFlag,
+        select: InAppNotificationHostStateImpl.() -> TVisual?,
+        transformIfDifferent: InAppNotificationHostStateImpl.(TVisual) -> InAppNotificationHostStateImpl,
+    ): InAppNotificationHostStateImpl {
+        if (!isEnabled(ifFlagEnabled)) {
+            return internalState.value
+        }
+        val new = this
+        val current = internalState.value
+        return if (new != null && new != current.select()) {
+            current.transformIfDifferent(new)
+        } else {
+            current
+        }
+    }
+
+    /**
+     * Dismisses the given in-app notification visual.
+     *
+     * This function is responsible for removing the specified notification visual
+     * from the display.
+     *
+     * @param visual The [InAppNotificationVisual] to dismiss.
+     */
+    fun dismiss(visual: InAppNotificationVisual) {
+        internalState.update { current ->
+            current.copy(
+                bannerGlobalVisual = visual.nullIfDifferent(otherwise = current.bannerGlobalVisual),
+                bannerInlineVisuals = (visual as? BannerInlineVisual)?.let { bannerInlineVisual ->
+                    (current.bannerInlineVisuals - bannerInlineVisual).toPersistentSet()
+                } ?: current.bannerInlineVisuals,
+                snackbarVisual = visual.nullIfDifferent(otherwise = current.snackbarVisual),
+            )
+        }
+    }
+
+    private inline fun <reified T : InAppNotificationVisual> InAppNotificationVisual?.nullIfDifferent(
+        otherwise: T?,
+    ): T? {
+        val current = (this as? T?) ?: otherwise
+        return if (this == current) null else otherwise
+    }
+
+    private fun isEnabled(flag: DisplayInAppNotificationFlag): Boolean {
+        return enabled.any { it == flag } || enabled == DisplayInAppNotificationFlag.AllNotifications
+    }
+
+    private data class InAppNotificationHostStateImpl(
+        override val bannerGlobalVisual: BannerGlobalVisual? = null,
+        override val bannerInlineVisuals: ImmutableSet<BannerInlineVisual> = persistentSetOf(),
+        override val snackbarVisual: SnackbarVisual? = null,
+        private val onDismissVisual: (InAppNotificationVisual) -> Unit = {},
+    ) : InAppNotificationHostState
+
+    private fun InAppNotification.toInAppNotificationData(): InAppNotificationHostState =
+        InAppNotificationHostStateImpl(
+            bannerGlobalVisual = BannerGlobalVisual.from(notification = this),
+            bannerInlineVisuals = BannerInlineVisual.from(notification = this).toPersistentSet(),
+            snackbarVisual = SnackbarVisual.from(notification = this),
+        )
+
+    override fun toString(): String {
+        return "InAppNotificationHostState(" +
+            "enabled=$enabled, currentInAppNotificationData=${currentInAppNotificationHostState.value})"
+    }
+}
+
+@Composable
+fun rememberInAppNotificationHostState(
+    enabled: ImmutableSet<DisplayInAppNotificationFlag> = DisplayInAppNotificationFlag.AllNotifications,
+): InAppNotificationHostStateHolder {
+    return remember { InAppNotificationHostStateHolder(enabled) }
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/visual/InAppNotificationHostState.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/visual/InAppNotificationHostState.kt
@@ -1,0 +1,35 @@
+package net.thunderbird.feature.notification.api.ui.host.visual
+
+import androidx.compose.runtime.Stable
+import kotlinx.collections.immutable.ImmutableSet
+
+/**
+ * Defines the visual representation of in-app notifications.
+ *
+ * This interface holds the visual data for different types of in-app notifications
+ * that can be displayed to the user. It allows for a structured way to manage
+ * and present notification information.
+ */
+@Stable
+internal interface InAppNotificationHostState {
+    /**
+     * The visual representation of a global banner notification.
+     *
+     * This property holds a [BannerGlobalVisual] object if a global banner is
+     * currently active, or `null` if no global banner is being shown.
+     */
+    val bannerGlobalVisual: BannerGlobalVisual?
+
+    /**
+     * A set of inline banner visuals that are currently active.
+     */
+    val bannerInlineVisuals: ImmutableSet<BannerInlineVisual>
+
+    /**
+     * The visual representation of a snackbar notification.
+     *
+     * This property holds a [SnackbarVisual] object if a snackbar notification
+     * is currently active, or `null` if no snackbar is being displayed.
+     */
+    val snackbarVisual: SnackbarVisual?
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/visual/InAppNotificationVisual.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/visual/InAppNotificationVisual.kt
@@ -1,0 +1,221 @@
+package net.thunderbird.feature.notification.api.ui.host.visual
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.util.fastFilter
+import kotlin.time.Duration
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toPersistentList
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerInlineVisual.Companion.MAX_SUPPORTING_TEXT_LENGTH
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerInlineVisual.Companion.MAX_TITLE_LENGTH
+import net.thunderbird.feature.notification.api.ui.style.InAppNotificationStyle
+
+sealed interface InAppNotificationVisual
+
+/**
+ * Represents the visual appearance of a [InAppNotificationStyle.BannerGlobalNotification].
+ *
+ * @property message The text content to be displayed in the banner global. This can be any CharSequence,
+ *   allowing for formatted text.
+ * @property severity The [NotificationSeverity] of the notification, indicating its importance or type.
+ *   Used to determine which BannerGlobal visual style to use.
+ * @property action An optional [NotificationAction] that the user can perform in response to the notification.
+ *   If null, no action is available.
+ * @property priority An integer representing the priority of the notification. Higher values typically indicate
+ *   higher priority. Used to determine which notification to display, in case of multiples
+ *   [InAppNotificationStyle.BannerGlobalNotification].
+ * @see InAppNotificationVisual
+ * @see InAppNotificationStyle.BannerGlobalNotification
+ */
+@Stable
+data class BannerGlobalVisual(
+    val message: CharSequence,
+    val severity: NotificationSeverity,
+    val action: NotificationAction?,
+    val priority: Int,
+) : InAppNotificationVisual {
+    internal companion object {
+        /**
+         * Creates a [BannerGlobalVisual] from an [InAppNotification].
+         *
+         * This function attempts to convert an [InAppNotification] into a [BannerGlobalVisual].
+         * It expects the notification to have a style of [InAppNotificationStyle.BannerGlobalNotification].
+         *
+         * It performs the following checks:
+         * - The `contentText` of the notification must not be null.
+         * - The notification must have zero or one action.
+         *
+         * If the notification has a matching style and passes all checks, a [BannerGlobalVisual] is created.
+         * Otherwise, this function returns `null`.
+         *
+         * @param notification The [InAppNotification] to convert.
+         * @return A [BannerGlobalVisual] if the conversion is successful, `null` otherwise.
+         * @throws IllegalStateException fails the check validations.
+         */
+        fun from(notification: InAppNotification): BannerGlobalVisual? =
+            notification.toVisuals<InAppNotificationStyle.BannerGlobalNotification, BannerGlobalVisual> { style ->
+                BannerGlobalVisual(
+                    message = checkNotNull(notification.contentText) {
+                        "A notification with a BannerGlobalNotification style must have a contentText not null"
+                    },
+                    severity = notification.severity,
+                    action = notification
+                        .actions
+                        .let { actions ->
+                            check(actions.size in 0..1) {
+                                "A notification with a BannerGlobalNotification style must have at zero or one action"
+                            }
+                            actions.toPersistentList()
+                        }
+                        .firstOrNull(),
+                    priority = style.priority,
+                )
+            }.singleOrNull()
+    }
+}
+
+/**
+ * Represents the visual appearance of a [InAppNotificationStyle.BannerInlineNotification].
+ *
+ * @property title The title of the notification.
+ * @property supportingText The main content/message of the notification.
+ * @property severity The [NotificationSeverity] of the notification, indicating its importance or type.
+ *   Used to determine which BannerGlobal visual style to use.
+ * @property actions An immutable list of [NotificationAction] objects representing actions
+ *  the user can take in response to the notification.
+ * @see InAppNotificationVisual
+ * @see InAppNotificationStyle.BannerInlineNotification
+ */
+@Stable
+data class BannerInlineVisual(
+    val title: CharSequence,
+    val supportingText: CharSequence,
+    val severity: NotificationSeverity,
+    val actions: ImmutableList<NotificationAction>,
+) : InAppNotificationVisual {
+    internal companion object {
+        internal const val MAX_TITLE_LENGTH = 100
+        internal const val MAX_SUPPORTING_TEXT_LENGTH = 200
+
+        /**
+         * Creates a [BannerInlineVisual] from an [InAppNotification].
+         *
+         * This function attempts to convert an [InAppNotification] into a [BannerInlineVisual].
+         * It expects the notification to have a style of [InAppNotificationStyle.BannerInlineNotification].
+         *
+         * It performs the following checks:
+         * - The `title` of the notification must have at least 1 and at most [MAX_TITLE_LENGTH] chars.
+         * - The `contentText` of the notification must not be null and have at least 1 and at most
+         *   [MAX_SUPPORTING_TEXT_LENGTH] chars.
+         * - The notification must have 1 or 2 actions.
+         *
+         * If the notification has a matching style and passes all checks, a [BannerInlineVisual] is created.
+         * Otherwise, this function returns an empty list.
+         *
+         * @param notification The [InAppNotification] to convert.
+         * @return A list containing a [BannerInlineVisual] if the conversion is successful, an empty list otherwise.
+         * @throws IllegalStateException if any of the validation checks fail.
+         */
+        fun from(notification: InAppNotification): List<BannerInlineVisual> =
+            notification.toVisuals<InAppNotificationStyle.BannerInlineNotification, BannerInlineVisual> { style ->
+                BannerInlineVisual(
+                    title = checkTitle(notification.title),
+                    supportingText = checkContentText(notification.contentText),
+                    severity = notification.severity,
+                    actions = notification
+                        .actions
+                        .let { actions ->
+                            check(actions.size in 1..2) {
+                                "A notification with a BannerInlineNotification style must have at one or two actions"
+                            }
+                            actions.toPersistentList()
+                        },
+                )
+            }
+
+        private fun checkTitle(title: String): String {
+            check(title.length in 1..MAX_TITLE_LENGTH) {
+                "A notification with a BannerInlineNotification style must have a title length of 1 to " +
+                    "$MAX_TITLE_LENGTH characters."
+            }
+            return title
+        }
+
+        private fun checkContentText(contentText: String?): String {
+            checkNotNull(contentText) {
+                "A notification with a BannerInlineNotification style must have a contentText not null"
+            }
+            check(contentText.length in 1..MAX_SUPPORTING_TEXT_LENGTH) {
+                "A notification with a BannerInlineNotification style must have a contentText length of 1 to " +
+                    "$MAX_SUPPORTING_TEXT_LENGTH characters."
+            }
+            return contentText
+        }
+    }
+}
+
+/**
+ * Represents the visual appearance of a [InAppNotificationStyle.SnackbarNotification].
+ *
+ * @property message The text message to be displayed in the snackbar.
+ * @property action An optional [NotificationAction] that the user can perform. This is typically a
+ *   single action like "Undo" or "Dismiss". If null, no action button is shown.
+ * @property duration The [Duration] for which the snackbar will be visible.
+ * @see InAppNotificationVisual
+ * @see InAppNotificationStyle.SnackbarNotification
+ */
+@Stable
+data class SnackbarVisual(
+    val message: String,
+    val action: NotificationAction?,
+    val duration: Duration,
+) : InAppNotificationVisual {
+    internal companion object {
+        /**
+         * Creates a [SnackbarVisual] from an [InAppNotification].
+         *
+         * This function attempts to convert an [InAppNotification] into a [SnackbarVisual].
+         * It expects the notification to have a style of [InAppNotificationStyle.SnackbarNotification].
+         *
+         * It performs the following checks:
+         * - The `contentText` of the notification must not be null.
+         * - The notification must have exactly one action.
+         *
+         * If the notification has a matching style and passes all checks, a [SnackbarVisual] is created.
+         * Otherwise, this function returns `null`.
+         *
+         * @param notification The [InAppNotification] to convert.
+         * @return A [SnackbarVisual] if the conversion is successful, `null` otherwise.
+         * @throws IllegalStateException if `contentText` is null or if the number of actions is not 1
+         * when the style is [InAppNotificationStyle.SnackbarNotification].
+         */
+        fun from(notification: InAppNotification): SnackbarVisual? =
+            notification.toVisuals<InAppNotificationStyle.SnackbarNotification, SnackbarVisual> { style ->
+                SnackbarVisual(
+                    message = checkNotNull(notification.contentText) {
+                        "A notification with a SnackbarNotification style must have a contentText not null"
+                    },
+                    action = checkNotNull(notification.actions.singleOrNull()) {
+                        "A notification with a SnackbarNotification style must have exactly one action"
+                    },
+                    duration = style.duration,
+                )
+            }.singleOrNull()
+    }
+}
+
+private inline fun <
+    reified TStyle : InAppNotificationStyle,
+    reified TVisual : InAppNotificationVisual,
+    > InAppNotification.toVisuals(
+    transform: (TStyle) -> TVisual,
+): List<TVisual> {
+    return inAppNotificationStyles
+        .fastFilter { style -> style is TStyle }
+        .map { style ->
+            check(style is TStyle)
+            transform(style)
+        }
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
@@ -27,7 +27,9 @@ sealed interface InAppNotificationStyle {
     /**
      * @see InAppNotificationStyleBuilder.bannerGlobal
      */
-    data object BannerGlobalNotification : InAppNotificationStyle
+    data class BannerGlobalNotification(
+        val priority: Int,
+    ) : InAppNotificationStyle
 
     /**
      * @see [InAppNotificationStyleBuilder.snackbar]

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
@@ -37,11 +37,6 @@ sealed interface InAppNotificationStyle {
     ) : InAppNotificationStyle
 
     /**
-     * @see [InAppNotificationStyleBuilder.bottomSheet]
-     */
-    data object BottomSheetNotification : InAppNotificationStyle
-
-    /**
      * @see [InAppNotificationStyleBuilder.dialog]
      */
     data object DialogNotification : InAppNotificationStyle

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InAppNotificationStyleBuilder.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InAppNotificationStyleBuilder.kt
@@ -68,9 +68,9 @@ class InAppNotificationStyleBuilder internal constructor() {
      * a [DialogNotification] in these cases)
      */
     @NotificationStyleMarker
-    fun bannerGlobal() {
+    fun bannerGlobal(priority: Int = 0) {
         checkSingleStyleEntry<BannerGlobalNotification>()
-        styles += BannerGlobalNotification
+        styles += BannerGlobalNotification(priority = priority)
     }
 
     /**

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InAppNotificationStyleBuilder.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InAppNotificationStyleBuilder.kt
@@ -6,6 +6,7 @@ import net.thunderbird.feature.notification.api.ui.style.InAppNotificationStyle
 import net.thunderbird.feature.notification.api.ui.style.InAppNotificationStyle.BannerGlobalNotification
 import net.thunderbird.feature.notification.api.ui.style.InAppNotificationStyle.BannerInlineNotification
 import net.thunderbird.feature.notification.api.ui.style.InAppNotificationStyle.DialogNotification
+import net.thunderbird.feature.notification.api.ui.style.InAppNotificationStyle.SnackbarNotification
 import net.thunderbird.feature.notification.api.ui.style.NotificationStyleMarker
 
 /**
@@ -89,28 +90,8 @@ class InAppNotificationStyleBuilder internal constructor() {
      */
     @NotificationStyleMarker
     fun snackbar(duration: Duration = 10.seconds) {
-        checkSingleStyleEntry<InAppNotificationStyle.SnackbarNotification>()
-        styles += InAppNotificationStyle.SnackbarNotification(duration)
-    }
-
-    /**
-     * Use to inform the user about a required permission needed to enable or complete a key feature of the app.
-     *
-     * ### USAGE GUIDELINES
-     *
-     * #### Use for:
-     * - Requesting background activity permission from the user
-     * - Clearly and succinctly explaining why the permission is needed and how it affects the app experience
-     *
-     * #### Do not use for:
-     * - Displaying errors
-     * - Requesting contacts permission, as it does not critically impact app functionality
-     * - Requesting notification permission, which should follow the system-standard prompt or alternative pattern
-     */
-    @NotificationStyleMarker
-    fun bottomSheet() {
-        checkSingleStyleEntry<InAppNotificationStyle.BottomSheetNotification>()
-        styles += InAppNotificationStyle.BottomSheetNotification
+        checkSingleStyleEntry<SnackbarNotification>()
+        styles += SnackbarNotification(duration)
     }
 
     /**

--- a/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/host/InAppNotificationHostStateHolderTest.kt
+++ b/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/host/InAppNotificationHostStateHolderTest.kt
@@ -1,0 +1,896 @@
+package net.thunderbird.feature.notification.api.ui.host
+
+import app.cash.turbine.test
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.hasMessage
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import kotlin.test.Test
+import kotlin.test.assertFails
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerGlobalVisual
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerInlineVisual
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerInlineVisual.Companion.MAX_SUPPORTING_TEXT_LENGTH
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerInlineVisual.Companion.MAX_TITLE_LENGTH
+import net.thunderbird.feature.notification.api.ui.host.visual.InAppNotificationHostState
+import net.thunderbird.feature.notification.api.ui.host.visual.SnackbarVisual
+import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyles
+import net.thunderbird.feature.notification.testing.fake.FakeInAppOnlyNotification
+import net.thunderbird.feature.notification.testing.fake.ui.action.createFakeNotificationAction
+
+@Suppress("MaxLineLength", "LargeClass")
+class InAppNotificationHostStateHolderTest {
+    @Test
+    fun `showInAppNotification should show bannerGlobal when InAppNotification has BannerGlobalNotification style and BannerGlobalNotifications is enabled`() =
+        runTest {
+            // Arrange
+            val expectedContentText = "expected text"
+            val expectedAction = createFakeNotificationAction()
+            val expectedSeverity = NotificationSeverity.Warning
+            val notification = FakeInAppOnlyNotification(
+                contentText = expectedContentText,
+                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                actions = setOf(expectedAction),
+                severity = expectedSeverity,
+            )
+            val flags = persistentSetOf(DisplayInAppNotificationFlag.BannerGlobalNotifications)
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            testSubject.showInAppNotification(notification)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::bannerGlobalVisual)
+                    .isNotNull()
+                    .all {
+                        prop(BannerGlobalVisual::message)
+                            .isEqualTo(expectedContentText)
+                        prop(BannerGlobalVisual::action)
+                            .isEqualTo(expectedAction)
+                        prop(BannerGlobalVisual::severity)
+                            .isEqualTo(expectedSeverity)
+                    }
+            }
+        }
+
+    @Test
+    fun `showInAppNotification should show bannerGlobal when InAppNotification has BannerGlobalNotification style and AllNotifications is enabled`() =
+        runTest {
+            // Arrange
+            val expectedContentText = "expected text"
+            val expectedAction = createFakeNotificationAction()
+            val expectedSeverity = NotificationSeverity.Warning
+            val notification = FakeInAppOnlyNotification(
+                contentText = expectedContentText,
+                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                actions = setOf(expectedAction),
+                severity = expectedSeverity,
+            )
+            val flags = DisplayInAppNotificationFlag.AllNotifications
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            testSubject.showInAppNotification(notification)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::bannerGlobalVisual)
+                    .isNotNull()
+                    .all {
+                        prop(BannerGlobalVisual::message)
+                            .isEqualTo(expectedContentText)
+                        prop(BannerGlobalVisual::action)
+                            .isEqualTo(expectedAction)
+                        prop(BannerGlobalVisual::severity)
+                            .isEqualTo(expectedSeverity)
+                    }
+            }
+        }
+
+    @Test
+    fun `showInAppNotification should not show bannerGlobal when InAppNotification has BannerGlobalNotification style but BannerGlobalNotifications is disabled`() =
+        runTest {
+            // Arrange
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                contentText = "not important in this test case",
+                actions = setOf(createFakeNotificationAction()),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            testSubject.showInAppNotification(notification)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::bannerGlobalVisual)
+                    .isNull()
+            }
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has BannerGlobalNotification style but has multiple actions`() =
+        runTest {
+            // Arrange
+            val expectedMessage = "A notification with a BannerGlobalNotification style must have at zero or one action"
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                actions = setOf(
+                    createFakeNotificationAction(title = "fake action 1"),
+                    createFakeNotificationAction(title = "fake action 2"),
+                ),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has BannerGlobalNotification style but no contentText is configured`() =
+        runTest {
+            // Arrange
+            val expectedMessage =
+                "A notification with a BannerGlobalNotification style must have a contentText not null"
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                contentText = null,
+                actions = setOf(createFakeNotificationAction()),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification should show bannerInline when InAppNotification has BannerInlineNotification style and BannerInlineNotifications is enabled`() =
+        runTest {
+            // Arrange
+            val expectedContentText = "expected text"
+            val expectedAction = createFakeNotificationAction()
+            val expectedSeverity = NotificationSeverity.Warning
+            val notification = FakeInAppOnlyNotification(
+                contentText = expectedContentText,
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                actions = setOf(expectedAction),
+                severity = expectedSeverity,
+            )
+            val flags = persistentSetOf(DisplayInAppNotificationFlag.BannerInlineNotifications)
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            testSubject.showInAppNotification(notification)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::bannerInlineVisuals)
+                    .all {
+                        isNotEmpty()
+                        hasSize(1)
+                        transform { it.single() }
+                            .all {
+                                prop(BannerInlineVisual::supportingText)
+                                    .isEqualTo(expectedContentText)
+                                prop(BannerInlineVisual::actions).all {
+                                    hasSize(1)
+                                    contains(expectedAction)
+                                }
+                                prop(BannerInlineVisual::severity)
+                                    .isEqualTo(expectedSeverity)
+                            }
+                    }
+            }
+        }
+
+    @Test
+    fun `showInAppNotification should show bannerInline when InAppNotification has BannerInlineNotification style and AllNotifications is enabled`() =
+        runTest {
+            // Arrange
+            val expectedContentText = "expected text"
+            val expectedAction = createFakeNotificationAction()
+            val expectedSeverity = NotificationSeverity.Warning
+            val notification = FakeInAppOnlyNotification(
+                contentText = expectedContentText,
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                actions = setOf(expectedAction),
+                severity = expectedSeverity,
+            )
+            val flags = DisplayInAppNotificationFlag.AllNotifications
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            testSubject.showInAppNotification(notification)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::bannerInlineVisuals)
+                    .all {
+                        isNotEmpty()
+                        hasSize(1)
+                        transform { it.single() }
+                            .all {
+                                prop(BannerInlineVisual::supportingText)
+                                    .isEqualTo(expectedContentText)
+                                prop(BannerInlineVisual::actions).all {
+                                    hasSize(1)
+                                    contains(expectedAction)
+                                }
+                                prop(BannerInlineVisual::severity)
+                                    .isEqualTo(expectedSeverity)
+                            }
+                    }
+            }
+        }
+
+    @Test
+    fun `showInAppNotification should not show bannerInline when InAppNotification has BannerInlineNotification style but BannerInlineNotifications is disabled`() =
+        runTest {
+            // Arrange
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                contentText = "not important in this test case",
+                actions = setOf(createFakeNotificationAction()),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            testSubject.showInAppNotification(notification)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::bannerInlineVisuals)
+                    .isEmpty()
+            }
+        }
+
+    @Test
+    fun `showInAppNotification should not show duplicated banner inline notifications`() = runTest {
+        // Arrange
+        val expectedContentText = "expected text"
+        val expectedAction = createFakeNotificationAction()
+        val expectedSeverity = NotificationSeverity.Warning
+        val notification = FakeInAppOnlyNotification(
+            contentText = expectedContentText,
+            inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+            actions = setOf(expectedAction),
+            severity = expectedSeverity,
+        )
+        val flags = DisplayInAppNotificationFlag.AllNotifications
+        val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+        // Act
+        repeat(times = 100) {
+            testSubject.showInAppNotification(notification)
+        }
+
+        // Assert
+        testSubject.currentInAppNotificationHostState.test {
+            val state = awaitItem()
+            assertThat(state)
+                .prop(InAppNotificationHostState::bannerInlineVisuals)
+                .all {
+                    isNotEmpty()
+                    hasSize(1)
+                    transform { it.single() }
+                        .all {
+                            prop(BannerInlineVisual::supportingText)
+                                .isEqualTo(expectedContentText)
+                            prop(BannerInlineVisual::actions).all {
+                                hasSize(1)
+                                contains(expectedAction)
+                            }
+                            prop(BannerInlineVisual::severity)
+                                .isEqualTo(expectedSeverity)
+                        }
+                }
+        }
+    }
+
+    @Test
+    fun `showInAppNotification should show multiple bannerInlines when different BannerInlineNotification are triggered`() =
+        runTest {
+            // Arrange
+            fun getSeverity(index: Int): NotificationSeverity = when (index) {
+                in 0..<25 -> NotificationSeverity.Critical
+                in 25..<50 -> NotificationSeverity.Information
+                in 50..<75 -> NotificationSeverity.Temporary
+                else -> NotificationSeverity.Fatal
+            }
+
+            fun getAction(index: Int): NotificationAction = when (index) {
+                in 0..<25 -> createFakeNotificationAction(title = "fake action 1")
+                in 25..<50 -> createFakeNotificationAction(title = "fake action 2")
+                in 50..<75 -> createFakeNotificationAction(title = "fake action 3")
+                else -> createFakeNotificationAction(title = "fake action 4")
+            }
+
+            val expectedSize = 100
+            val notifications = List(size = expectedSize) { index ->
+                FakeInAppOnlyNotification(
+                    title = "fake title $index",
+                    contentText = "fake notification $index",
+                    inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                    actions = setOf(getAction(index)),
+                    severity = getSeverity(index),
+                )
+            }
+            val flags = DisplayInAppNotificationFlag.AllNotifications
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            notifications.forEach { notification ->
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::bannerInlineVisuals)
+                    .all {
+                        isNotEmpty()
+                        hasSize(expectedSize)
+                        given { visuals ->
+                            visuals.forEachIndexed { index, visual ->
+                                assertThat(visual).all {
+                                    prop(BannerInlineVisual::title)
+                                        .isEqualTo("fake title $index")
+                                    prop(BannerInlineVisual::supportingText)
+                                        .isEqualTo("fake notification $index")
+                                    prop(BannerInlineVisual::severity)
+                                        .isEqualTo(getSeverity(index))
+                                    prop(BannerInlineVisual::actions).all {
+                                        hasSize(1)
+                                        containsExactly(getAction(index))
+                                    }
+                                }
+                            }
+                        }
+                    }
+            }
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has BannerInlineNotification style but no action is configured`() =
+        runTest {
+            // Arrange
+            val expectedMessage = "A notification with a BannerInlineNotification style must have at one or two actions"
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                contentText = "not important in this test case",
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has BannerInlineNotification style with an empty title`() =
+        runTest {
+            // Arrange
+            val expectedMessage =
+                "A notification with a BannerInlineNotification style must have a title length of 1 to " +
+                    "$MAX_TITLE_LENGTH characters."
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                title = "", // empty
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has BannerInlineNotification style with a title longer than 100 chars`() =
+        runTest {
+            // Arrange
+            val expectedMessage =
+                "A notification with a BannerInlineNotification style must have a title length of 1 to " +
+                    "$MAX_TITLE_LENGTH characters."
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                title = "*".repeat(101),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has BannerInlineNotification style with a null contentText`() =
+        runTest {
+            // Arrange
+            val expectedMessage =
+                "A notification with a BannerInlineNotification style must have a contentText not null"
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                title = "fake title",
+                contentText = null,
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has BannerInlineNotification style with an empty contentText`() =
+        runTest {
+            // Arrange
+            val expectedMessage =
+                "A notification with a BannerInlineNotification style must have a contentText length " +
+                    "of 1 to $MAX_SUPPORTING_TEXT_LENGTH characters."
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                title = "fake title",
+                contentText = "", // empty
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has BannerInlineNotification style with a contentText longer than 200 chars`() =
+        runTest {
+            // Arrange
+            val expectedMessage =
+                "A notification with a BannerInlineNotification style must have a contentText length of " +
+                    "1 to $MAX_SUPPORTING_TEXT_LENGTH characters."
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                title = "fake title",
+                contentText = "*".repeat(201),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has BannerInlineNotification style with more than 2 actions`() =
+        runTest {
+            // Arrange
+            val expectedMessage = "A notification with a BannerInlineNotification style must have at one or two actions"
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                contentText = "not important in this test case",
+                actions = setOf(
+                    createFakeNotificationAction(title = "fake action 1"),
+                    createFakeNotificationAction(title = "fake action 2"),
+                    createFakeNotificationAction(title = "fake action 3"),
+                ),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification should show snackbar when InAppNotification has SnackbarNotification style and SnackbarNotifications is enabled`() =
+        runTest {
+            // Arrange
+            val expectedContentText = "expected text"
+            val expectedAction = createFakeNotificationAction()
+            val expectedSeverity = NotificationSeverity.Warning
+            val expectedDuration = 1.hours
+            val notification = FakeInAppOnlyNotification(
+                contentText = expectedContentText,
+                inAppNotificationStyles = inAppNotificationStyles { snackbar(expectedDuration) },
+                actions = setOf(expectedAction),
+                severity = expectedSeverity,
+            )
+            val flags = persistentSetOf(DisplayInAppNotificationFlag.SnackbarNotifications)
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            testSubject.showInAppNotification(notification)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::snackbarVisual)
+                    .isNotNull()
+                    .all {
+                        prop(SnackbarVisual::message)
+                            .isEqualTo(expectedContentText)
+                        prop(SnackbarVisual::action)
+                            .isEqualTo(expectedAction)
+                        prop(SnackbarVisual::duration)
+                            .isEqualTo(expectedDuration)
+                    }
+            }
+        }
+
+    @Test
+    fun `showInAppNotification should show snackbar when InAppNotification has SnackbarNotification style and AllNotifications is enabled`() =
+        runTest {
+            // Arrange
+            val expectedContentText = "expected text"
+            val expectedAction = createFakeNotificationAction()
+            val expectedSeverity = NotificationSeverity.Warning
+            val expectedDuration = 1.hours
+            val notification = FakeInAppOnlyNotification(
+                contentText = expectedContentText,
+                inAppNotificationStyles = inAppNotificationStyles { snackbar(expectedDuration) },
+                actions = setOf(expectedAction),
+                severity = expectedSeverity,
+            )
+            val flags = DisplayInAppNotificationFlag.AllNotifications
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            testSubject.showInAppNotification(notification)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::snackbarVisual)
+                    .isNotNull()
+                    .all {
+                        prop(SnackbarVisual::message)
+                            .isEqualTo(expectedContentText)
+                        prop(SnackbarVisual::action)
+                            .isEqualTo(expectedAction)
+                        prop(SnackbarVisual::duration)
+                            .isEqualTo(expectedDuration)
+                    }
+            }
+        }
+
+    @Test
+    fun `showInAppNotification should not show snackbar when InAppNotification has SnackbarNotification style but SnackbarNotifications is disabled`() =
+        runTest {
+            // Arrange
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { snackbar() },
+                contentText = "not important in this test case",
+                actions = setOf(createFakeNotificationAction()),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            testSubject.showInAppNotification(notification)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::snackbarVisual)
+                    .isNull()
+            }
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has SnackbarNotification style but no action is configured`() =
+        runTest {
+            // Arrange
+            val expectedMessage = "A notification with a SnackbarNotification style must have exactly one action"
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { snackbar() },
+                contentText = "not important in this test case",
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has SnackbarNotification style but has multiple actions`() =
+        runTest {
+            // Arrange
+            val expectedMessage = "A notification with a SnackbarNotification style must have exactly one action"
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { snackbar() },
+                actions = setOf(
+                    createFakeNotificationAction(title = "fake action 1"),
+                    createFakeNotificationAction(title = "fake action 2"),
+                ),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `showInAppNotification throws IllegalStateException when InAppNotification has SnackbarNotification style but no contentText is configured`() =
+        runTest {
+            // Arrange
+            val expectedMessage = "A notification with a SnackbarNotification style must have a contentText not null"
+            val notification = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { snackbar() },
+                contentText = null,
+                actions = setOf(createFakeNotificationAction()),
+            )
+            val flags = persistentSetOf<DisplayInAppNotificationFlag>()
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+
+            // Act
+            val exception = assertFails {
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Assert
+            assertThat(exception)
+                .isInstanceOf<IllegalStateException>()
+                .hasMessage(expectedMessage)
+        }
+
+    @Test
+    fun `dismiss should remove bannerGlobal notification given a BannerGlobalVisual`() = runTest {
+        // Arrange
+        val notification = FakeInAppOnlyNotification(
+            inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+            actions = setOf(createFakeNotificationAction()),
+        )
+        val visual = requireNotNull(BannerGlobalVisual.from(notification))
+        val flags = persistentSetOf(DisplayInAppNotificationFlag.BannerGlobalNotifications)
+        val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+        testSubject.showInAppNotification(notification)
+
+        // Act
+        testSubject.dismiss(visual)
+
+        // Assert
+        testSubject.currentInAppNotificationHostState.test {
+            val state = awaitItem()
+            assertThat(state)
+                .prop(InAppNotificationHostState::bannerGlobalVisual)
+                .isNull()
+        }
+    }
+
+    @Test
+    fun `dismiss should remove bannerInline notification given a BannerInlineVisual`() = runTest {
+        // Arrange
+        val expectedContentText = "expected text"
+        val expectedAction = createFakeNotificationAction()
+        val expectedSeverity = NotificationSeverity.Warning
+        val notification = FakeInAppOnlyNotification(
+            contentText = expectedContentText,
+            inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+            actions = setOf(expectedAction),
+            severity = expectedSeverity,
+        )
+        val visual = BannerInlineVisual.from(notification).first()
+        val flags = DisplayInAppNotificationFlag.AllNotifications
+        val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+        testSubject.showInAppNotification(notification)
+
+        // Act
+        testSubject.dismiss(visual)
+
+        // Assert
+        testSubject.currentInAppNotificationHostState.test {
+            val state = awaitItem()
+            assertThat(state)
+                .prop(InAppNotificationHostState::bannerInlineVisuals)
+                .isEmpty()
+        }
+    }
+
+    @Test
+    fun `dismiss should remove only one bannerInline notification when multiple bannerInline notifications are visible`() =
+        runTest {
+            // Arrange
+            fun getSeverity(index: Int): NotificationSeverity = when (index) {
+                in 0..<25 -> NotificationSeverity.Critical
+                in 25..<50 -> NotificationSeverity.Information
+                in 50..<75 -> NotificationSeverity.Temporary
+                else -> NotificationSeverity.Fatal
+            }
+
+            fun getAction(index: Int): NotificationAction = when (index) {
+                in 0..<25 -> createFakeNotificationAction(title = "fake action 1")
+                in 25..<50 -> createFakeNotificationAction(title = "fake action 2")
+                in 50..<75 -> createFakeNotificationAction(title = "fake action 3")
+                else -> createFakeNotificationAction(title = "fake action 4")
+            }
+
+            val expectedSize = 99
+            val notificationToDismiss = FakeInAppOnlyNotification(
+                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                actions = setOf(createFakeNotificationAction()),
+            )
+            val visualToDismiss = BannerInlineVisual.from(notificationToDismiss).first()
+            val notifications = List(size = expectedSize) { index ->
+                FakeInAppOnlyNotification(
+                    title = "fake title $index",
+                    contentText = "fake notification $index",
+                    inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                    actions = setOf(getAction(index)),
+                    severity = getSeverity(index),
+                )
+            } + notificationToDismiss
+            val flags = DisplayInAppNotificationFlag.AllNotifications
+            val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+            notifications.forEach { notification ->
+                testSubject.showInAppNotification(notification)
+            }
+
+            // Act
+            testSubject.dismiss(visualToDismiss)
+
+            // Assert
+            testSubject.currentInAppNotificationHostState.test {
+                val state = awaitItem()
+                assertThat(state)
+                    .prop(InAppNotificationHostState::bannerInlineVisuals)
+                    .all {
+                        isNotEmpty()
+                        hasSize(expectedSize)
+                        given { visuals ->
+                            assertThat(visuals.none { it == visualToDismiss }).isTrue()
+                            visuals.forEachIndexed { index, visual ->
+                                assertThat(visual).all {
+                                    prop(BannerInlineVisual::title)
+                                        .isEqualTo("fake title $index")
+                                    prop(BannerInlineVisual::supportingText)
+                                        .isEqualTo("fake notification $index")
+                                    prop(BannerInlineVisual::severity)
+                                        .isEqualTo(getSeverity(index))
+                                    prop(BannerInlineVisual::actions).all {
+                                        hasSize(1)
+                                        containsExactly(getAction(index))
+                                    }
+                                }
+                            }
+                        }
+                    }
+            }
+        }
+
+    @Test
+    fun `dismiss should remove snackbar notification given a SnackbarVisual`() = runTest {
+        // Arrange
+        val notification = FakeInAppOnlyNotification(
+            inAppNotificationStyles = inAppNotificationStyles { snackbar(10.seconds) },
+            actions = setOf(createFakeNotificationAction()),
+        )
+        val visual = requireNotNull(SnackbarVisual.from(notification))
+        val flags = persistentSetOf(DisplayInAppNotificationFlag.SnackbarNotifications)
+        val testSubject = InAppNotificationHostStateHolder(enabled = flags)
+        testSubject.showInAppNotification(notification)
+
+        // Act
+        testSubject.dismiss(visual)
+
+        // Assert
+        testSubject.currentInAppNotificationHostState.test {
+            val state = awaitItem()
+            assertThat(state)
+                .prop(InAppNotificationHostState::snackbarVisual)
+                .isNull()
+        }
+    }
+}

--- a/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyleTest.kt
+++ b/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyleTest.kt
@@ -70,20 +70,6 @@ class InAppNotificationStyleTest {
     }
 
     @Test
-    fun `inAppNotificationStyle dsl should create a bottomSheet in-app notification style`() {
-        // Arrange
-        val expectedStyles = arrayOf<InAppNotificationStyle>(InAppNotificationStyle.BottomSheetNotification)
-
-        // Act
-        val inAppStyles = inAppNotificationStyles {
-            bottomSheet()
-        }
-
-        // Assert
-        assertThat(inAppStyles).containsExactly(elements = expectedStyles)
-    }
-
-    @Test
     fun `inAppNotificationStyle dsl should create a dialog in-app notification style`() {
         // Arrange
         val expectedStyles = arrayOf<InAppNotificationStyle>(InAppNotificationStyle.DialogNotification)
@@ -104,7 +90,6 @@ class InAppNotificationStyleTest {
             InAppNotificationStyle.BannerInlineNotification,
             InAppNotificationStyle.BannerGlobalNotification,
             InAppNotificationStyle.SnackbarNotification(),
-            InAppNotificationStyle.BottomSheetNotification,
             InAppNotificationStyle.DialogNotification,
         )
 
@@ -113,7 +98,6 @@ class InAppNotificationStyleTest {
             bannerInline()
             bannerGlobal()
             snackbar()
-            bottomSheet()
             dialog()
         }
 
@@ -181,52 +165,6 @@ class InAppNotificationStyleTest {
                 snackbar()
                 snackbar(duration = 1.minutes)
                 snackbar(duration = 1.hours)
-            }
-        }
-
-        // Assert
-        assertThat(actual)
-            .isInstanceOf<IllegalStateException>()
-            .hasMessage(expectedErrorMessage)
-    }
-
-    @Test
-    fun `inAppNotificationStyle dsl should throw IllegalStateException when bottomSheet style is added multiple times`() {
-        // Arrange
-        val expectedErrorMessage =
-            "An in-app notification can only have at most one type of ${
-                InAppNotificationStyle.BottomSheetNotification::class.simpleName
-            } style"
-
-        // Act
-        val actual = assertFails {
-            inAppNotificationStyles {
-                bottomSheet()
-                bottomSheet()
-                bottomSheet()
-            }
-        }
-
-        // Assert
-        assertThat(actual)
-            .isInstanceOf<IllegalStateException>()
-            .hasMessage(expectedErrorMessage)
-    }
-
-    @Test
-    fun `inAppNotificationStyle dsl should throw IllegalStateException when dialog style is added multiple times`() {
-        // Arrange
-        val expectedErrorMessage =
-            "An in-app notification can only have at most one type of ${
-                InAppNotificationStyle.DialogNotification::class.simpleName
-            } style"
-
-        // Act
-        val actual = assertFails {
-            inAppNotificationStyles {
-                dialog()
-                dialog()
-                dialog()
             }
         }
 

--- a/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyleTest.kt
+++ b/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyleTest.kt
@@ -29,7 +29,9 @@ class InAppNotificationStyleTest {
     @Test
     fun `inAppNotificationStyle dsl should create a banner global in-app notification style`() {
         // Arrange
-        val expectedStyles = arrayOf<InAppNotificationStyle>(InAppNotificationStyle.BannerGlobalNotification)
+        val expectedStyles = arrayOf<InAppNotificationStyle>(
+            InAppNotificationStyle.BannerGlobalNotification(priority = 0),
+        )
 
         // Act
         val inAppStyles = inAppNotificationStyles {
@@ -88,7 +90,7 @@ class InAppNotificationStyleTest {
         // Arrange
         val expectedStyles = arrayOf(
             InAppNotificationStyle.BannerInlineNotification,
-            InAppNotificationStyle.BannerGlobalNotification,
+            InAppNotificationStyle.BannerGlobalNotification(priority = 0),
             InAppNotificationStyle.SnackbarNotification(),
             InAppNotificationStyle.DialogNotification,
         )

--- a/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/FakeInAppOnlyNotification.kt
+++ b/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/FakeInAppOnlyNotification.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.unit.dp
 import net.thunderbird.feature.notification.api.NotificationSeverity
 import net.thunderbird.feature.notification.api.content.AppNotification
 import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
 import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+import net.thunderbird.feature.notification.api.ui.style.InAppNotificationStyle
 
 data class FakeInAppOnlyNotification(
     override val title: String = "fake title",
@@ -19,4 +21,6 @@ data class FakeInAppOnlyNotification(
             viewportHeight = 0f,
         ).build(),
     ),
+    override val inAppNotificationStyles: List<InAppNotificationStyle> = listOf(),
+    override val actions: Set<NotificationAction> = setOf(),
 ) : AppNotification(), InAppNotification

--- a/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/ui/action/FakeNotificationAction.kt
+++ b/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/ui/action/FakeNotificationAction.kt
@@ -1,0 +1,13 @@
+package net.thunderbird.feature.notification.testing.fake.ui.action
+
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.api.ui.icon.NotificationIcon
+import net.thunderbird.feature.notification.testing.fake.icon.EMPTY_SYSTEM_NOTIFICATION_ICON
+
+fun createFakeNotificationAction(title: String = "fake action"): NotificationAction.CustomAction =
+    NotificationAction.CustomAction(
+        title = title,
+        icon = NotificationIcon(
+            systemNotificationIcon = EMPTY_SYSTEM_NOTIFICATION_ICON,
+        ),
+    )


### PR DESCRIPTION
Part of #9537 and #9312.

- Introduce `InAppNotificationHostStateHolder` and `InAppNotificationHostState` to control the UI state for in-app notifications
- Add `DisplayInAppNotificationFlag`, enabling displaying one or multiple types of in-app notifications. This will be useful when needing to add the InAppNotificationHost within an XML view.
- Remove the bottom sheet in-app notification style as we need more ux work on this type of notification.
- Unit test