### PR TITLE
chore: remove foojay resolver

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,10 +43,6 @@ dependencyResolutionManagement {
     }
 }
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
-}
-
 include(
     ":app-k9mail",
     ":app-thunderbird",


### PR DESCRIPTION
There is no need to use the foojay resolver plugin, hence we could remove it.
