### PR TITLE
chore(quality): add DebugLogConfigurator into the exclusion list of Timber logging

### DIFF
--- a/quality/konsist/src/test/kotlin/net/thunderbird/quality/ValidateLogger.kt
+++ b/quality/konsist/src/test/kotlin/net/thunderbird/quality/ValidateLogger.kt
@@ -30,7 +30,7 @@ class ValidateLogger {
             .filterNot { it.hasNameMatching("ConsoleLogSink.android|ConsoleLogSinkTest.android".toRegex()) }
             .filterNot {
                 // Exclude legacy code that still uses Timber
-                it.hasNameMatching("LogFileWriter|FileLoggerTree|K9".toRegex())
+                it.hasNameMatching("LogFileWriter|FileLoggerTree|K9|DebugLogConfigurator".toRegex())
             }
             .assertFalse(
                 additionalMessage = "No class should use timber.log.Timber import, use net.thunderbird.core.logging.Logger instead."


### PR DESCRIPTION
This PR is meant to fix the following test failure:

```
ValidateLogger > no class should use Timber logging FAILED
    com.lemonappdev.konsist.core.exception.KoAssertionFailedException: Assert 'no class should use Timber logging' was violated (1 time).
    No class should use timber.log.Timber import, use net.thunderbird.core.logging.Logger instead.
    Invalid files:
    └── File DebugLogConfigurator.kt file:///home/runner/work/thunderbird-android/thunderbird-android/core/logging/impl-legacy/src/androidMain/kotlin/net/thunderbird/core/logging/legacy/DebugLogConfigurator.kt
        at app//com.lemonappdev.konsist.core.verify.KoDeclarationAndProviderAssertCoreKt.getResult(KoDeclarationAndProviderAssertCore.kt:224)
        at app//com.lemonappdev.konsist.core.verify.KoDeclarationAndProviderAssertCoreKt.assert(KoDeclarationAndProviderAssertCore.kt:56)
        at app//com.lemonappdev.konsist.api.verify.KoDeclarationAndProviderAssertKt.assertFalse(KoDeclarationAndProviderAssert.kt:100)
        at app//com.lemonappdev.konsist.api.verify.KoDeclarationAndProviderAssertKt.assertFalse$default(KoDeclarationAndProviderAssert.kt:94)
        at app//net.thunderbird.quality.ValidateLogger.no class should use Timber logging(ValidateLogger.kt:35)
```

- Added `DebugLogConfigurator` into the exclusion list of Timber logging until #9573 is complete