### PR TITLE
Prevent newline in header

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/message/html/TextToHtml.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/html/TextToHtml.kt
@@ -59,11 +59,11 @@ class TextToHtml private constructor(
     }
 
     private fun appendHtmlPrefix() {
-        html.append("""<div dir="auto">""")
+        html.append("""<span dir="auto">""")
     }
 
     private fun appendHtmlSuffix() {
-        html.append("</div>")
+        html.append("</span>")
     }
 
     private fun appendHtmlEncoded(startIndex: Int, endIndex: Int) {


### PR DESCRIPTION
Fix #9236 

Prevent newline that comes from using a div by using an "inline" span-element
