### PR TITLE
Add Breton to supported languages

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -30,6 +30,7 @@ android {
             "ar",
             "be",
             "bg",
+            "br",
             "ca",
             "co",
             "cs",

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -29,6 +29,7 @@ android {
             "ar",
             "be",
             "bg",
+            "br",
             "ca",
             "co",
             "cs",

--- a/legacy/core/src/main/res/values/arrays_general_settings_values.xml
+++ b/legacy/core/src/main/res/values/arrays_general_settings_values.xml
@@ -6,6 +6,7 @@
         <item>ar</item>
         <item>be</item>
         <item>bg</item>
+        <item>br</item>
         <item>ca</item>
         <item>co</item>
         <item>cs</item>


### PR DESCRIPTION
Since the number of translated channels exceeds 70% (as specified in issue #8496), I propose to re-add support for the Breton language.