### PR TITLE
feat(notifications): add banner global notification host composable

### DIFF
--- a/feature/notification/api/build.gradle.kts
+++ b/feature/notification/api/build.gradle.kts
@@ -16,6 +16,11 @@ kotlin {
             implementation(projects.core.ui.compose.designsystem)
             implementation(projects.core.ui.compose.theme2.common)
         }
+        androidUnitTest.dependencies {
+            implementation(projects.core.ui.compose.testing)
+            implementation(libs.bundles.shared.jvm.test.compose)
+            implementation(libs.bundles.shared.jvm.android.compose.debug)
+        }
         jvmTest.dependencies {
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.bundles.shared.jvm.test)
@@ -34,6 +39,11 @@ kotlin {
 
 android {
     namespace = "net.thunderbird.feature.notification.api"
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 java {

--- a/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/BannerGlobalNotificationHost.kt
+++ b/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/BannerGlobalNotificationHost.kt
@@ -1,0 +1,96 @@
+package net.thunderbird.feature.notification.api.ui
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.ErrorBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.InfoBannerGlobalNotificationCard
+import app.k9mail.core.ui.compose.designsystem.organism.banner.global.WarningBannerGlobalNotificationCard
+import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.api.ui.action.ResolvedNotificationActionButton
+import net.thunderbird.feature.notification.api.ui.animation.bannerSlideInSlideOutAnimationSpec
+import net.thunderbird.feature.notification.api.ui.host.InAppNotificationHostStateHolder
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerGlobalVisual
+
+/**
+ * Displays global notifications as banners.
+ *
+ * This Composable observes the [InAppNotificationHostStateHolder] for changes in the
+ * [BannerGlobalVisual] and displays the appropriate banner notification with an animation.
+ *
+ * @param hostStateHolder The [InAppNotificationHostStateHolder] that holds the current notification state.
+ * @param onActionClick A callback that is invoked when a notification action button is clicked.
+ * @param modifier Optional [Modifier] to be applied to the banner host.
+ */
+@Composable
+fun BannerGlobalNotificationHost(
+    hostStateHolder: InAppNotificationHostStateHolder,
+    onActionClick: (NotificationAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by hostStateHolder.currentInAppNotificationHostState.collectAsState()
+    val bannerGlobal = state.bannerGlobalVisual
+    AnimatedContent(
+        targetState = bannerGlobal,
+        modifier = modifier.testTagAsResourceId(BannerGlobalNotificationHostDefaults.TEST_TAG_HOST),
+        transitionSpec = { bannerSlideInSlideOutAnimationSpec() },
+    ) { bannerGlobal ->
+        if (bannerGlobal != null) {
+            BannerGlobalNotificationHostLayout(
+                visual = bannerGlobal,
+                onActionClick = onActionClick,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BannerGlobalNotificationHostLayout(
+    visual: BannerGlobalVisual,
+    onActionClick: (NotificationAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val action = remember(visual.action) {
+        movableContentOf {
+            visual.action?.let { action ->
+                ResolvedNotificationActionButton(
+                    action = action,
+                    onActionClick = onActionClick,
+                )
+            }
+        }
+    }
+
+    when (visual.severity) {
+        NotificationSeverity.Fatal, NotificationSeverity.Critical -> ErrorBannerGlobalNotificationCard(
+            text = visual.message,
+            action = action,
+            modifier = modifier.testTagAsResourceId(BannerGlobalNotificationHostDefaults.TEST_TAG_ERROR_BANNER),
+        )
+
+        NotificationSeverity.Warning -> WarningBannerGlobalNotificationCard(
+            text = visual.message,
+            action = action,
+            modifier = modifier.testTagAsResourceId(BannerGlobalNotificationHostDefaults.TEST_TAG_WARNING_BANNER),
+        )
+
+        NotificationSeverity.Temporary, NotificationSeverity.Information -> InfoBannerGlobalNotificationCard(
+            text = visual.message,
+            action = action,
+            modifier = modifier.testTagAsResourceId(BannerGlobalNotificationHostDefaults.TEST_TAG_INFO_BANNER),
+        )
+    }
+}
+
+object BannerGlobalNotificationHostDefaults {
+    internal const val TEST_TAG_HOST = "banner_global_notification_host"
+    internal const val TEST_TAG_ERROR_BANNER = "error_banner_global_notification"
+    internal const val TEST_TAG_WARNING_BANNER = "warning_banner_global_notification"
+    internal const val TEST_TAG_INFO_BANNER = "info_banner_global_notification"
+}

--- a/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/action/ResolvedNotificationActionButton.kt
+++ b/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/action/ResolvedNotificationActionButton.kt
@@ -1,0 +1,45 @@
+package net.thunderbird.feature.notification.api.ui.action
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.molecule.notification.NotificationActionButton
+import kotlin.let
+
+/**
+ * Displays a [NotificationActionButton] with the title resolved from the [NotificationAction].
+ *
+ * This composable function takes a [NotificationAction] and resolves its title asynchronously.
+ * While the title is being resolved, nothing is displayed. Once the title is available,
+ * it renders a [NotificationActionButton] with the resolved title.
+ *
+ * @param action The [NotificationAction] to display.
+ * @param onActionClick Callback invoked when the action button is clicked.
+ * @param modifier Optional [Modifier] to be applied to the composable.
+ */
+@Composable
+internal fun ResolvedNotificationActionButton(
+    action: NotificationAction,
+    onActionClick: (NotificationAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var text by remember(action) { mutableStateOf<String?>(value = null) }
+
+    LaunchedEffect(action) {
+        text = action.resolveTitle()
+    }
+
+    text?.let { text ->
+        NotificationActionButton(
+            text = text,
+            onClick = {
+                onActionClick(action)
+            },
+            modifier = modifier,
+        )
+    }
+}

--- a/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/animation/BannerSlideInSlideOutAnimationSpec.kt
+++ b/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/animation/BannerSlideInSlideOutAnimationSpec.kt
@@ -1,0 +1,41 @@
+package net.thunderbird.feature.notification.api.ui.animation
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.ui.unit.IntSize
+
+private const val A_QUARTER = 4
+
+/**
+ * Defines a custom animation for a banner that slides in and out vertically.
+ *
+ * The banner fades in and slides in from the top when appearing,
+ * and fades out and slides out towards the top when disappearing.
+ *
+ * The size transformation ensures that the width of the banner changes immediately to the target width,
+ * while the height animates from the initial height to the target height.
+ * The height animation is structured in keyframes:
+ * - For the first quarter of the animation duration, the height remains the initial height.
+ * - After the first quarter, the height transitions to the target height.
+ *
+ * @param T The type of the content being animated.
+ * @return A [ContentTransform] object that specifies the enter and exit transitions,
+ *         as well as the size transformation.
+ */
+fun <T> AnimatedContentTransitionScope<T>.bannerSlideInSlideOutAnimationSpec(): ContentTransform {
+    val enter = fadeIn() + slideInVertically()
+    val exit = fadeOut() + slideOutVertically()
+    return enter togetherWith exit using SizeTransform { initialSize, targetSize ->
+        keyframes {
+            IntSize(width = targetSize.width, height = initialSize.height) at durationMillis / A_QUARTER
+            IntSize(width = targetSize.width, height = targetSize.height)
+        }
+    }
+}

--- a/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerGlobalNotificationHostTest.kt
+++ b/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerGlobalNotificationHostTest.kt
@@ -1,0 +1,395 @@
+package net.thunderbird.feature.notification.api.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasNoClickAction
+import androidx.compose.ui.test.hasTextExactly
+import androidx.compose.ui.test.onChild
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.printToString
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.testing.onNodeWithTag
+import app.k9mail.core.ui.compose.testing.onNodeWithText
+import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import assertk.assertThat
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
+import net.thunderbird.feature.notification.api.NotificationSeverity
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.api.ui.host.rememberInAppNotificationHostState
+import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyles
+import net.thunderbird.feature.notification.testing.fake.FakeInAppOnlyNotification
+import net.thunderbird.feature.notification.testing.fake.ui.action.createFakeNotificationAction
+
+const val BUTTON_NOTIFICATION_TEST_TAG = "button_notification_test_tag"
+
+class BannerGlobalNotificationHostTest : ComposeTest() {
+    @Test
+    fun `should show error banner when severity is fatal`() = runComposeTest {
+        // Arrange
+        val title = "Notification"
+        val contentText = "This is the content text of the notification"
+        val notification = createNotification(
+            title = title,
+            contentText = contentText,
+            severity = NotificationSeverity.Fatal,
+        )
+        mainClock.autoAdvance = false
+
+        setContentWithTheme {
+            TestSubject(notification, onActionClick = {})
+        }
+
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+
+        // Assert
+        printSemanticTree()
+        mainClock.advanceTimeBy(1000L)
+        printSemanticTree()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_HOST)
+            .assertIsDisplayed()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_ERROR_BANNER)
+            .assertIsDisplayed()
+            .onChild()
+            .assertTextEquals(contentText)
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_WARNING_BANNER)
+            .assertDoesNotExist()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_INFO_BANNER)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `should show error banner when severity is critical`() = runComposeTest {
+        // Arrange
+        val title = "Notification"
+        val contentText = "This is the content text of the notification"
+        val notification = createNotification(
+            title = title,
+            contentText = contentText,
+            severity = NotificationSeverity.Critical,
+        )
+        mainClock.autoAdvance = false
+
+        setContentWithTheme {
+            TestSubject(notification, onActionClick = {})
+        }
+
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+        printSemanticTree()
+        mainClock.advanceTimeBy(1000L)
+        printSemanticTree()
+
+        // Assert
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_HOST)
+            .assertIsDisplayed()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_ERROR_BANNER)
+            .assertIsDisplayed()
+            .onChild()
+            .assertTextEquals(contentText)
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_WARNING_BANNER)
+            .assertDoesNotExist()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_INFO_BANNER)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `should show warning banner when severity is warning`() = runComposeTest {
+        // Arrange
+        val title = "Notification"
+        val contentText = "This is the content text of the notification"
+        val notification = createNotification(
+            title = title,
+            contentText = contentText,
+            severity = NotificationSeverity.Warning,
+        )
+        mainClock.autoAdvance = false
+
+        setContentWithTheme {
+            TestSubject(notification, onActionClick = {})
+        }
+
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+        printSemanticTree()
+        mainClock.advanceTimeBy(1000L)
+        printSemanticTree()
+
+        // Assert
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_HOST)
+            .assertIsDisplayed()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_ERROR_BANNER)
+            .assertDoesNotExist()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_WARNING_BANNER)
+            .assertIsDisplayed()
+            .onChild()
+            .assertTextEquals(contentText)
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_INFO_BANNER)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `should show info banner when severity is temporary`() = runComposeTest {
+        // Arrange
+        val title = "Notification"
+        val contentText = "This is the content text of the notification"
+        val notification = createNotification(
+            title = title,
+            contentText = contentText,
+            severity = NotificationSeverity.Temporary,
+        )
+        mainClock.autoAdvance = false
+
+        setContentWithTheme {
+            TestSubject(notification, onActionClick = {})
+        }
+
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+        printSemanticTree()
+        mainClock.advanceTimeBy(1000L)
+        printSemanticTree()
+
+        // Assert
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_HOST)
+            .assertIsDisplayed()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_ERROR_BANNER)
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_WARNING_BANNER)
+            .assertDoesNotExist()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_INFO_BANNER)
+            .assertIsDisplayed()
+            .onChild()
+            .assertTextEquals(contentText)
+    }
+
+    @Test
+    fun `should show info banner when severity is information`() = runComposeTest {
+        // Arrange
+        val title = "Notification"
+        val contentText = "This is the content text of the notification"
+        val notification = createNotification(
+            title = title,
+            contentText = contentText,
+            severity = NotificationSeverity.Information,
+        )
+        mainClock.autoAdvance = false
+
+        setContentWithTheme {
+            TestSubject(notification, onActionClick = {})
+        }
+
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+        printSemanticTree()
+        mainClock.advanceTimeBy(1000L)
+        printSemanticTree()
+
+        // Assert
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_HOST)
+            .assertIsDisplayed()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_ERROR_BANNER)
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_WARNING_BANNER)
+            .assertDoesNotExist()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_INFO_BANNER)
+            .assertIsDisplayed()
+            .onChild()
+            .assertTextEquals(contentText)
+    }
+
+    @Test
+    fun `should show action button when action is not null`() = runComposeTest {
+        // Arrange
+        val title = "Notification"
+        val contentText = "This is the content text of the notification"
+        val actionText = "Fake action"
+        val notification = createNotification(
+            title = title,
+            contentText = contentText,
+            severity = NotificationSeverity.Fatal,
+            action = createFakeNotificationAction(title = actionText),
+        )
+        mainClock.autoAdvance = false
+
+        val actionClicked = mutableStateOf(false)
+
+        setContentWithTheme {
+            TestSubject(notification, onActionClick = { actionClicked.value = true })
+        }
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+        printSemanticTree()
+        mainClock.advanceTimeBy(1000L)
+        printSemanticTree()
+
+        // Assert
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_HOST)
+            .assertIsDisplayed()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_ERROR_BANNER)
+            .assertIsDisplayed()
+            .also { printSemanticTree(it) }
+            .onChildren()
+            .run {
+                filterToOne(hasTextExactly(contentText))
+                    .assertExists()
+                filterToOne(hasTextExactly(actionText))
+                    .assertExists()
+                    .assert(hasClickAction())
+                    .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+            }
+    }
+
+    @Test
+    fun `should not show action button when action is null`() = runComposeTest {
+        // Arrange
+        val title = "Notification"
+        val contentText = "This is the content text of the notification"
+        val notification = createNotification(
+            title = title,
+            contentText = contentText,
+            severity = NotificationSeverity.Fatal,
+            action = null,
+        )
+        mainClock.autoAdvance = false
+
+        val actionClicked = mutableStateOf(false)
+
+        setContentWithTheme {
+            TestSubject(notification, onActionClick = { actionClicked.value = true })
+        }
+
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+        printSemanticTree()
+        mainClock.advanceTimeBy(1000L)
+        printSemanticTree()
+        // Assert
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_HOST)
+            .assertIsDisplayed()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_ERROR_BANNER)
+            .assertIsDisplayed()
+            .also { printSemanticTree(it) }
+            .assert(hasNoClickAction())
+            .onChildren()
+            .assertCountEquals(1)
+            .onFirst()
+            .assertTextEquals(contentText)
+    }
+
+    @Test
+    fun `should call onActionClick when action is clicked`() = runComposeTest {
+        // Arrange
+        val title = "Notification"
+        val contentText = "This is the content text of the notification"
+        val actionText = "Fake action"
+        val notification = createNotification(
+            title = title,
+            contentText = contentText,
+            severity = NotificationSeverity.Fatal,
+            action = createFakeNotificationAction(title = actionText),
+        )
+        mainClock.autoAdvance = false
+
+        val actionClicked = mutableStateOf(false)
+
+        setContentWithTheme {
+            TestSubject(notification, onActionClick = { actionClicked.value = true })
+        }
+
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+        printSemanticTree()
+        mainClock.advanceTimeBy(1000L)
+        printSemanticTree()
+
+        // Assert
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_HOST)
+            .assertIsDisplayed()
+
+        onNodeWithTag(BannerGlobalNotificationHostDefaults.TEST_TAG_ERROR_BANNER)
+            .assertIsDisplayed()
+            .onChildren()
+            .filterToOne(hasTextExactly(contentText))
+
+        printSemanticTree()
+        onNodeWithText(actionText).performClick()
+        assertThat(actionClicked.value)
+            .isTrue()
+    }
+
+    @Composable
+    private fun TestSubject(
+        notification: FakeInAppOnlyNotification,
+        onActionClick: (NotificationAction) -> Unit,
+        modifier: Modifier = Modifier,
+    ) {
+        val state = rememberInAppNotificationHostState()
+        Column(modifier = modifier) {
+            ButtonText(
+                text = "Trigger Notification",
+                onClick = { state.showInAppNotification(notification) },
+                modifier = Modifier.testTagAsResourceId(BUTTON_NOTIFICATION_TEST_TAG),
+            )
+
+            BannerGlobalNotificationHost(
+                hostStateHolder = state,
+                onActionClick = onActionClick,
+            )
+        }
+    }
+
+    private fun createNotification(
+        title: String,
+        contentText: String,
+        severity: NotificationSeverity,
+        action: NotificationAction? = null,
+    ) = FakeInAppOnlyNotification(
+        title = title,
+        contentText = contentText,
+        severity = severity,
+        inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+        actions = action?.let { setOf(it) }.orEmpty(),
+    )
+
+    private fun printSemanticTree(root: SemanticsNodeInteraction = composeTestRule.onRoot(useUnmergedTree = true)) {
+        println()
+        println("Semantic tree:")
+        println(root.printToString())
+        println()
+    }
+}


### PR DESCRIPTION
Part of #9537 and #9312.
Depends on #9575.

- Introduce `BannerGlobalNotificationHost` used to display the banner globals observing the `InAppNotificationHostState`
- Unit test