### PR TITLE
fix(notifications): Respect isQuietTimeEnabled

### DIFF
--- a/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -85,6 +85,10 @@ class K9NotificationStrategy(
     @OptIn(ExperimentalTime::class)
     private val NotificationPreference.isQuietTime: Boolean
         get() {
+            if (!isQuietTimeEnabled) {
+                return false
+            }
+
             val clock = DI.get<Clock>()
             val quietTimeChecker = QuietTimeChecker(
                 clock = clock,

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationHelper.kt
@@ -143,6 +143,10 @@ internal fun NotificationCompat.Builder.setAppearance(
 @OptIn(ExperimentalTime::class)
 internal val NotificationPreference.isQuietTime: Boolean
     get() {
+        if (!isQuietTimeEnabled) {
+            return false
+        }
+
         val clock = DI.get<Clock>()
         val quietTimeChecker = QuietTimeChecker(
             clock = clock,

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SummaryNotificationDataCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SummaryNotificationDataCreatorTest.kt
@@ -104,6 +104,7 @@ class SummaryNotificationDataCreatorTest {
 
     @Test
     fun `single notification with quiet time disabled`() {
+        setClockTo("23:01")
         setQuietTime(false)
         val notificationData = createNotificationData()
 


### PR DESCRIPTION
This PR restores quiet time behaviour from before #9405/TB12. It resolves problems with tests failing between 23:00 and 00:00 and modifies one of the tests, so that such regression will be caught earlier in the future (not only after 23:00).

Fixes #9629

<!-- Please ensure that your pull request meets the following requirements - thanks!

- Does not contain merge commits. Rebase instead.
- Contains commits with descriptive titles.
- New code is written in Kotlin whenever possible.
- Follows our existing codestyle (`gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- Does not break any unit tests (`gradlew testDebugUnitTest`; will be checked by CI).
- Uses a descriptive title; don't put issue numbers in there.
- Contains a reference to the issue that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_) in the body text.
- For cosmetic changes add one or multiple images, if possible.

Finally, please replace this template text with a description of the change and additional context if necessary.
-->