### PR TITLE
ci: introduce new PR workflow

### DIFF
--- a/.github/actions/gradle_cache/action.yml
+++ b/.github/actions/gradle_cache/action.yml
@@ -1,0 +1,14 @@
+name: Gradle cache
+description: Enable Gradle Wrapper caching (optimization)
+runs:
+  using: 'composite'
+  steps:
+    - name: Enable Gradle Wrapper caching
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # 4.2.4
+      with:
+        path:
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Copy CI gradle.properties
       shell: bash
-      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle-android-pr-workflow.properties ~/.gradle/gradle.properties
 
     - name: Set up JDK
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,20 @@
+name: Set up build environment
+description: Prepares environment for building with JDK and Gradle
+runs:
+  using: 'composite'
+  steps:
+    - name: Copy CI gradle.properties
+      shell: bash
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+    - name: Set up JDK
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
+
+    - name: Restore Gradle cache
+      uses: ./.github/actions/gradle_cache

--- a/.github/ci-gradle-android-pr-workflow.properties
+++ b/.github/ci-gradle-android-pr-workflow.properties
@@ -1,0 +1,10 @@
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+org.gradle.workers.max=4
+org.gradle.jvmargs=-Xmx10g -XX:MaxMetaspaceSize=4g -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError
+
+kotlin.incremental=true
+kotlin.compiler.execution.strategy=in-process

--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -1,0 +1,123 @@
+name: Pull request checks
+on:
+  pull_request:
+    paths-ignore:
+      - '.idea/**'
+      - '.gitattributes'
+      - '.github/**.json'
+      - '.gitignore'
+      - '.gitmodules'
+      - '**.md'
+      - 'LICENSE'
+      - 'NOTICE'
+
+permissions:
+  contents: read
+
+jobs:
+  build-k9:
+    name: Build K9 application
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepares environment
+        uses: ./.github/actions/setup
+
+      - name: Build K9 application
+        run: ./gradlew :app-k9mail:assemble
+
+  build-thunderbird:
+    name: Build Thunderbird application
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepares environment
+        uses: ./.github/actions/setup
+
+      - name: Build Thunderbird application
+        run: ./gradlew :app-thunderbird:assemble
+
+  lint:
+    name: Quality - Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepares environment
+        uses: ./.github/actions/setup
+
+      - name: Running Android lint
+        run: ./gradlew lint
+
+  spotless:
+    name: Quality - Spotless
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepares environment
+        uses: ./.github/actions/setup
+
+      - name: Running spotless check
+        run: ./gradlew spotlessCheck
+
+  detekt:
+    name: Quality - Detekt
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepares environment
+        uses: ./.github/actions/setup
+
+      - name: Running Detekt
+        run: ./gradlew detekt
+
+      - name: Running Detekt including KMP
+        # As we were not verifying detekt in KMP sources before,
+        # this step is likely to fail.
+        continue-on-error: true
+        run: |
+          ./gradlew detektMetadataCommonMain
+          ./gradlew detektMetadataMain
+          ./gradlew detektMetadataCommonJvmMain
+
+  unit-test:
+    name: Quality - Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepares environment
+        uses: ./.github/actions/setup
+
+      - name: Running unit tests
+        run: ./gradlew test --parallel
+
+  dependency-guard:
+    name: Quality - Dependency Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepares environment
+        uses: ./.github/actions/setup
+
+      - name: Running Dependency Guard
+        run: ./gradlew dependencyGuard

--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -106,7 +106,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Running unit tests
-        run: ./gradlew test --parallel
+        run: ./gradlew testDebugUnitTest --parallel
 
   dependency-guard:
     name: Quality - Dependency Guard

--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -121,3 +121,32 @@ jobs:
 
       - name: Running Dependency Guard
         run: ./gradlew dependencyGuard
+
+  check-badging:
+    name: Quality - Badging
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepares environment
+        uses: ./.github/actions/setup
+
+      - name: Running K9 Badging
+        run: |
+          ./gradlew :app-k9mail:checkFossReleaseBadging \
+                    :app-k9mail:checkFullReleaseBadging \
+                    -x assemble \
+                    -x build
+
+      - name: Running Thunderbird Badging
+        run: |
+          ./gradlew :app-thunderbird:checkFossBetaBadging \
+                    :app-thunderbird:checkFossDailyBadging \
+                    :app-thunderbird:checkFossReleaseBadging \
+                    :app-thunderbird:checkFullBetaBadging \
+                    :app-thunderbird:checkFullDailyBadging \
+                    :app-thunderbird:checkFullReleaseBadging \
+                    -x assemble \
+                    -x build


### PR DESCRIPTION
This PR is meant to introduce a new PR workflow (`Pull request checks`), trying to speed up the PR checks.

Key differences between the previous and the new one:

- Split the steps into different jobs. This will allow us to understand easily what is actually falling in the pull request
- Build K-9 and Thunderbird apps separately.
- Run the Badging check in a separate job, allowing a fail-fast.
- Running unit tests only on the debug variant.
- Enabling Gradle caching and Kotlin incremental build.

The idea is to keep both `Android CI` and `Pull request checks` running together, so we can analyse if the new workflow is working correctly as expected.