### PR TITLE
Refactor unified folders

### DIFF
--- a/feature/search/impl-legacy/src/commonMain/kotlin/net/thunderbird/feature/search/legacy/SearchAccount.kt
+++ b/feature/search/impl-legacy/src/commonMain/kotlin/net/thunderbird/feature/search/legacy/SearchAccount.kt
@@ -28,24 +28,25 @@ class SearchAccount(
     val relatedSearch: LocalMessageSearch = search
 
     companion object {
-        const val UNIFIED_INBOX = "unified_inbox"
+        const val UNIFIED_FOLDERS = "unified_folders"
         const val NEW_MESSAGES = "new_messages"
 
         @JvmStatic
-        fun createUnifiedInboxAccount(
-            unifiedInboxTitle: String,
-            unifiedInboxDetail: String,
+        fun createUnifiedFoldersSearch(
+            title: String,
+            detail: String,
         ): SearchAccount {
             val tmpSearch = LocalMessageSearch().apply {
-                id = UNIFIED_INBOX
+                id = UNIFIED_FOLDERS
+                // The ingrate field is used to identify the unified folders.
                 and(MessageSearchField.INTEGRATE, "1", SearchAttribute.EQUALS)
             }
 
             return SearchAccount(
-                id = UNIFIED_INBOX,
+                id = UNIFIED_FOLDERS,
                 search = tmpSearch,
-                name = unifiedInboxTitle,
-                email = unifiedInboxDetail,
+                name = title,
+                email = detail,
             )
         }
     }

--- a/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListWidget.kt
+++ b/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListWidget.kt
@@ -68,13 +68,13 @@ internal class MessageListWidget : GlanceAppWidget(), KoinComponent {
     }
 
     private fun openApp(context: Context) {
-        val unifiedInboxAccount = createUnifiedFoldersSearch(
+        val unifiedFoldersSearch = createUnifiedFoldersSearch(
             title = coreResourceProvider.searchUnifiedFoldersTitle(),
             detail = coreResourceProvider.searchUnifiedFoldersDetail(),
         )
         val intent = intentDisplaySearch(
             context = context,
-            search = unifiedInboxAccount.relatedSearch,
+            search = unifiedFoldersSearch.relatedSearch,
             noThreading = true,
             newTask = true,
             clearTop = true,

--- a/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListWidget.kt
+++ b/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListWidget.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.thunderbird.core.android.account.SortType
 import net.thunderbird.core.preference.GeneralSettingsManager
-import net.thunderbird.feature.search.legacy.SearchAccount.Companion.createUnifiedInboxAccount
+import net.thunderbird.feature.search.legacy.SearchAccount.Companion.createUnifiedFoldersSearch
 import net.thunderbird.feature.widget.message.list.ui.MessageListWidgetContent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -42,9 +42,9 @@ internal class MessageListWidget : GlanceAppWidget(), KoinComponent {
 
             LaunchedEffect(Unit) {
                 CoroutineScope(Dispatchers.IO).launch {
-                    val unifiedInboxSearch = createUnifiedInboxAccount(
-                        unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
-                        unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+                    val unifiedInboxSearch = createUnifiedFoldersSearch(
+                        title = coreResourceProvider.searchUnifiedFoldersTitle(),
+                        detail = coreResourceProvider.searchUnifiedFoldersDetail(),
                     ).relatedSearch
                     val messageListConfig = MessageListConfig(
                         search = unifiedInboxSearch,
@@ -68,9 +68,9 @@ internal class MessageListWidget : GlanceAppWidget(), KoinComponent {
     }
 
     private fun openApp(context: Context) {
-        val unifiedInboxAccount = createUnifiedInboxAccount(
-            unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
-            unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+        val unifiedInboxAccount = createUnifiedFoldersSearch(
+            title = coreResourceProvider.searchUnifiedFoldersTitle(),
+            detail = coreResourceProvider.searchUnifiedFoldersDetail(),
         )
         val intent = intentDisplaySearch(
             context = context,

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/BaseMessageListWidgetProvider.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/BaseMessageListWidgetProvider.kt
@@ -47,7 +47,7 @@ abstract class BaseMessageListWidgetProvider : AppWidgetProvider(), KoinComponen
         val composeAction = composeActionPendingIntent(context)
         views.setOnClickPendingIntent(R.id.new_message, composeAction)
 
-        val headerClickAction = viewUnifiedInboxPendingIntent(context)
+        val headerClickAction = viewUnifiedFoldersPendingIntent(context)
         views.setOnClickPendingIntent(R.id.top_controls, headerClickAction)
 
         appWidgetManager.updateAppWidget(appWidgetId, views)
@@ -62,7 +62,7 @@ abstract class BaseMessageListWidgetProvider : AppWidgetProvider(), KoinComponen
         return PendingIntentCompat.getActivity(context, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT, true)!!
     }
 
-    private fun viewUnifiedInboxPendingIntent(context: Context): PendingIntent {
+    private fun viewUnifiedFoldersPendingIntent(context: Context): PendingIntent {
         val unifiedFoldersSearch = createUnifiedFoldersSearch(
             title = coreResourceProvider.searchUnifiedFoldersTitle(),
             detail = coreResourceProvider.searchUnifiedFoldersDetail(),

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/BaseMessageListWidgetProvider.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/BaseMessageListWidgetProvider.kt
@@ -11,7 +11,7 @@ import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.activity.MessageCompose
 import com.fsck.k9.activity.MessageList
 import com.fsck.k9.activity.MessageList.Companion.intentDisplaySearch
-import net.thunderbird.feature.search.legacy.SearchAccount.Companion.createUnifiedInboxAccount
+import net.thunderbird.feature.search.legacy.SearchAccount.Companion.createUnifiedFoldersSearch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -63,13 +63,13 @@ abstract class BaseMessageListWidgetProvider : AppWidgetProvider(), KoinComponen
     }
 
     private fun viewUnifiedInboxPendingIntent(context: Context): PendingIntent {
-        val unifiedInboxAccount = createUnifiedInboxAccount(
-            unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
-            unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+        val unifiedFoldersSearch = createUnifiedFoldersSearch(
+            title = coreResourceProvider.searchUnifiedFoldersTitle(),
+            detail = coreResourceProvider.searchUnifiedFoldersDetail(),
         )
         val intent = intentDisplaySearch(
             context = context,
-            search = unifiedInboxAccount.relatedSearch,
+            search = unifiedFoldersSearch.relatedSearch,
             noThreading = true,
             newTask = true,
             clearTop = true,

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
@@ -31,9 +31,9 @@ internal class MessageListRemoteViewFactory(private val context: Context) : Remo
     private var unreadTextColor = 0
 
     override fun onCreate() {
-        unifiedInboxSearch = SearchAccount.createUnifiedInboxAccount(
-            unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
-            unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+        unifiedInboxSearch = SearchAccount.createUnifiedFoldersSearch(
+            title = coreResourceProvider.searchUnifiedFoldersTitle(),
+            detail = coreResourceProvider.searchUnifiedFoldersDetail(),
         ).relatedSearch
 
         senderAboveSubject = generalSettingsManager.getConfig().display.inboxSettings.isMessageListSenderAboveSubject

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListRemoteViewFactory.kt
@@ -23,7 +23,7 @@ internal class MessageListRemoteViewFactory(private val context: Context) : Remo
     private val coreResourceProvider: CoreResourceProvider by inject()
     private val generalSettingsManager: GeneralSettingsManager by inject()
 
-    private lateinit var unifiedInboxSearch: LocalMessageSearch
+    private lateinit var unifiedInboxFolders: LocalMessageSearch
 
     private var messageListItems = emptyList<MessageListItem>()
     private var senderAboveSubject = false
@@ -31,7 +31,7 @@ internal class MessageListRemoteViewFactory(private val context: Context) : Remo
     private var unreadTextColor = 0
 
     override fun onCreate() {
-        unifiedInboxSearch = SearchAccount.createUnifiedFoldersSearch(
+        unifiedInboxFolders = SearchAccount.createUnifiedFoldersSearch(
             title = coreResourceProvider.searchUnifiedFoldersTitle(),
             detail = coreResourceProvider.searchUnifiedFoldersDetail(),
         ).relatedSearch
@@ -48,7 +48,7 @@ internal class MessageListRemoteViewFactory(private val context: Context) : Remo
     private fun loadMessageList() {
         // TODO: Use same sort order that is used for the Unified Inbox inside the app
         val messageListConfig = MessageListConfig(
-            search = unifiedInboxSearch,
+            search = unifiedInboxFolders,
             showingThreadedList = generalSettingsManager.getConfig()
                 .display
                 .inboxSettings

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetConfigurationFragment.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetConfigurationFragment.kt
@@ -113,13 +113,13 @@ class UnreadWidgetConfigurationFragment : PreferenceFragmentCompat() {
         selectedFolderDisplayName = null
         unreadFolder.summary = getString(R.string.unread_widget_folder_summary)
         if (SearchAccount.UNIFIED_FOLDERS == selectedAccountUuid) {
-            handleSearchAccount()
+            handleUnifiedFoldersSearch()
         } else {
-            handleRegularAccount()
+            handleRegularSearch()
         }
     }
 
-    private fun handleSearchAccount() {
+    private fun handleUnifiedFoldersSearch() {
         if (SearchAccount.UNIFIED_FOLDERS == selectedAccountUuid) {
             unreadAccount.setSummary(R.string.unread_widget_unified_inbox_account_summary)
         }
@@ -130,7 +130,7 @@ class UnreadWidgetConfigurationFragment : PreferenceFragmentCompat() {
         selectedFolderDisplayName = null
     }
 
-    private fun handleRegularAccount() {
+    private fun handleRegularSearch() {
         val selectedAccount = preferences.getAccount(selectedAccountUuid!!)
             ?: error("Account $selectedAccountUuid not found")
 

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetConfigurationFragment.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetConfigurationFragment.kt
@@ -112,7 +112,7 @@ class UnreadWidgetConfigurationFragment : PreferenceFragmentCompat() {
         selectedFolderId = null
         selectedFolderDisplayName = null
         unreadFolder.summary = getString(R.string.unread_widget_folder_summary)
-        if (SearchAccount.UNIFIED_INBOX == selectedAccountUuid) {
+        if (SearchAccount.UNIFIED_FOLDERS == selectedAccountUuid) {
             handleSearchAccount()
         } else {
             handleRegularAccount()
@@ -120,7 +120,7 @@ class UnreadWidgetConfigurationFragment : PreferenceFragmentCompat() {
     }
 
     private fun handleSearchAccount() {
-        if (SearchAccount.UNIFIED_INBOX == selectedAccountUuid) {
+        if (SearchAccount.UNIFIED_FOLDERS == selectedAccountUuid) {
             unreadAccount.setSummary(R.string.unread_widget_unified_inbox_account_summary)
         }
         unreadFolderEnabled.isEnabled = false

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
@@ -25,7 +25,7 @@ class UnreadWidgetDataProvider(
 ) {
     fun loadUnreadWidgetData(configuration: UnreadWidgetConfiguration): UnreadWidgetData? = with(configuration) {
         if (SearchAccount.UNIFIED_FOLDERS == accountUuid) {
-            loadSearchAccountData(configuration)
+            loadUnifiedFoldersData(configuration)
         } else if (folderId != null) {
             loadFolderData(configuration)
         } else {
@@ -33,8 +33,8 @@ class UnreadWidgetDataProvider(
         }
     }
 
-    private fun loadSearchAccountData(configuration: UnreadWidgetConfiguration): UnreadWidgetData {
-        val searchAccount = getSearchAccount(configuration.accountUuid)
+    private fun loadUnifiedFoldersData(configuration: UnreadWidgetConfiguration): UnreadWidgetData {
+        val searchAccount = getUnifiedFoldersSearch(configuration.accountUuid)
         val title = searchAccount.name
         val unreadCount = messageCountsProvider.getMessageCounts(searchAccount).unread
         val clickIntent = MessageList.intentDisplaySearch(context, searchAccount.relatedSearch, false, true, true)
@@ -42,7 +42,7 @@ class UnreadWidgetDataProvider(
         return UnreadWidgetData(configuration, title, unreadCount, clickIntent)
     }
 
-    private fun getSearchAccount(accountUuid: String): SearchAccount = when (accountUuid) {
+    private fun getUnifiedFoldersSearch(accountUuid: String): SearchAccount = when (accountUuid) {
         SearchAccount.UNIFIED_FOLDERS -> SearchAccount.createUnifiedFoldersSearch(
             title = coreResourceProvider.searchUnifiedFoldersTitle(),
             detail = coreResourceProvider.searchUnifiedFoldersDetail(),

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
@@ -24,7 +24,7 @@ class UnreadWidgetDataProvider(
     private val coreResourceProvider: CoreResourceProvider,
 ) {
     fun loadUnreadWidgetData(configuration: UnreadWidgetConfiguration): UnreadWidgetData? = with(configuration) {
-        if (SearchAccount.UNIFIED_INBOX == accountUuid) {
+        if (SearchAccount.UNIFIED_FOLDERS == accountUuid) {
             loadSearchAccountData(configuration)
         } else if (folderId != null) {
             loadFolderData(configuration)
@@ -43,9 +43,9 @@ class UnreadWidgetDataProvider(
     }
 
     private fun getSearchAccount(accountUuid: String): SearchAccount = when (accountUuid) {
-        SearchAccount.UNIFIED_INBOX -> SearchAccount.createUnifiedInboxAccount(
-            unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
-            unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+        SearchAccount.UNIFIED_FOLDERS -> SearchAccount.createUnifiedFoldersSearch(
+            title = coreResourceProvider.searchUnifiedFoldersTitle(),
+            detail = coreResourceProvider.searchUnifiedFoldersDetail(),
         )
         else -> throw AssertionError("SearchAccount expected")
     }

--- a/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/FakeCoreResourceProvider.kt
+++ b/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/FakeCoreResourceProvider.kt
@@ -4,9 +4,9 @@ import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.notification.PushNotificationState
 
 class FakeCoreResourceProvider : CoreResourceProvider {
-    override fun searchUnifiedInboxTitle(): String = "Unified Inbox"
+    override fun searchUnifiedFoldersTitle(): String = "Unified Inbox"
 
-    override fun searchUnifiedInboxDetail(): String = "All messages in unified folders"
+    override fun searchUnifiedFoldersDetail(): String = "All messages in unified folders"
 
     override fun defaultIdentityDescription(): String {
         throw UnsupportedOperationException("not implemented")

--- a/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -60,7 +60,7 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
     }
 
     @Test
-    fun unifiedInbox() {
+    fun unifiedFoldersSearch() {
         val configuration = UnreadWidgetConfiguration(
             appWidgetId = 1,
             accountUuid = SearchAccount.UNIFIED_FOLDERS,
@@ -70,13 +70,13 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
         val widgetData = provider.loadUnreadWidgetData(configuration)
 
         with(widgetData!!) {
-            assertThat(title).isEqualTo("Unified Inbox")
+            assertThat(title).isEqualTo("Unified Folders")
             assertThat(unreadCount).isEqualTo(SEARCH_ACCOUNT_UNREAD_COUNT)
         }
     }
 
     @Test
-    fun regularAccount() {
+    fun regularSearch() {
         val configuration = UnreadWidgetConfiguration(
             appWidgetId = 3,
             accountUuid = ACCOUNT_UUID,
@@ -166,8 +166,8 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
     }
 
     private fun createCoreResourceProvider(): CoreResourceProvider = mock {
-        on { searchUnifiedFoldersTitle() } doReturn UNIFIED_INBOX_NAME
-        on { searchUnifiedFoldersDetail() } doReturn UNIFIED_INBOX_DETAIL
+        on { searchUnifiedFoldersTitle() } doReturn UNIFIED_FOLDERS_NAME
+        on { searchUnifiedFoldersDetail() } doReturn UNIFIED_FOLDERS_DETAIL
     }
 
     companion object {
@@ -178,8 +178,8 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
         const val ACCOUNT_UNREAD_COUNT = 2
         const val FOLDER_UNREAD_COUNT = 3
         const val LOCALIZED_FOLDER_NAME = "Posteingang"
-        const val UNIFIED_INBOX_NAME = "Unified Inbox"
-        const val UNIFIED_INBOX_DETAIL = "All Messages"
+        const val UNIFIED_FOLDERS_NAME = "Unified Folders"
+        const val UNIFIED_FOLDERS_DETAIL = "All Messages"
         val FOLDER = Folder(
             id = FOLDER_ID,
             name = "INBOX",

--- a/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -63,7 +63,7 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
     fun unifiedInbox() {
         val configuration = UnreadWidgetConfiguration(
             appWidgetId = 1,
-            accountUuid = SearchAccount.UNIFIED_INBOX,
+            accountUuid = SearchAccount.UNIFIED_FOLDERS,
             folderId = null,
         )
 
@@ -166,8 +166,8 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
     }
 
     private fun createCoreResourceProvider(): CoreResourceProvider = mock {
-        on { searchUnifiedInboxTitle() } doReturn UNIFIED_INBOX_NAME
-        on { searchUnifiedInboxDetail() } doReturn UNIFIED_INBOX_DETAIL
+        on { searchUnifiedFoldersTitle() } doReturn UNIFIED_INBOX_NAME
+        on { searchUnifiedFoldersDetail() } doReturn UNIFIED_INBOX_DETAIL
     }
 
     companion object {

--- a/legacy/common/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
@@ -32,8 +32,8 @@ class K9CoreResourceProvider(
     override fun replyHeader(sender: String, sentDate: String): String =
         context.getString(R.string.message_compose_reply_header_fmt_with_date, sentDate, sender)
 
-    override fun searchUnifiedInboxTitle(): String = context.getString(R.string.integrated_inbox_title)
-    override fun searchUnifiedInboxDetail(): String = context.getString(R.string.integrated_inbox_detail)
+    override fun searchUnifiedFoldersTitle(): String = context.getString(R.string.integrated_inbox_title)
+    override fun searchUnifiedFoldersDetail(): String = context.getString(R.string.integrated_inbox_detail)
 
     override val iconPushNotification: Int = Icons.Outlined.Notifications
 

--- a/legacy/core/src/main/java/com/fsck/k9/CoreResourceProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/CoreResourceProvider.kt
@@ -22,8 +22,8 @@ interface CoreResourceProvider {
     fun replyHeader(sender: String): String
     fun replyHeader(sender: String, sentDate: String): String
 
-    fun searchUnifiedInboxTitle(): String
-    fun searchUnifiedInboxDetail(): String
+    fun searchUnifiedFoldersTitle(): String
+    fun searchUnifiedFoldersDetail(): String
 
     val iconPushNotification: Int
     fun pushNotificationText(notificationState: PushNotificationState): String

--- a/legacy/core/src/main/java/com/fsck/k9/controller/NotificationOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/NotificationOperations.kt
@@ -4,7 +4,7 @@ import app.k9mail.legacy.mailstore.MessageStoreManager
 import com.fsck.k9.notification.NotificationController
 import com.fsck.k9.search.isNewMessages
 import com.fsck.k9.search.isSingleFolder
-import com.fsck.k9.search.isUnifiedInbox
+import com.fsck.k9.search.isUnifiedFolders
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
@@ -15,8 +15,8 @@ internal class NotificationOperations(
     private val messageStoreManager: MessageStoreManager,
 ) {
     fun clearNotifications(search: LocalMessageSearch) {
-        if (search.isUnifiedInbox) {
-            clearUnifiedInboxNotifications()
+        if (search.isUnifiedFolders) {
+            clearUnifiedFoldersNotifications()
         } else if (search.isNewMessages) {
             clearAllNotifications()
         } else if (search.isSingleFolder) {
@@ -29,7 +29,7 @@ internal class NotificationOperations(
         }
     }
 
-    private fun clearUnifiedInboxNotifications() {
+    private fun clearUnifiedFoldersNotifications() {
         for (account in accountManager.getAccounts()) {
             val messageStore = messageStoreManager.getMessageStore(account)
 

--- a/legacy/core/src/main/java/com/fsck/k9/search/LocalSearchExtensions.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/search/LocalSearchExtensions.kt
@@ -7,7 +7,7 @@ import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.SearchAccount
 
-val LocalMessageSearch.isUnifiedInbox: Boolean
+val LocalMessageSearch.isUnifiedFolders: Boolean
     get() = id == SearchAccount.UNIFIED_FOLDERS
 
 val LocalMessageSearch.isNewMessages: Boolean

--- a/legacy/core/src/main/java/com/fsck/k9/search/LocalSearchExtensions.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/search/LocalSearchExtensions.kt
@@ -8,7 +8,7 @@ import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.SearchAccount
 
 val LocalMessageSearch.isUnifiedInbox: Boolean
-    get() = id == SearchAccount.UNIFIED_INBOX
+    get() = id == SearchAccount.UNIFIED_FOLDERS
 
 val LocalMessageSearch.isNewMessages: Boolean
     get() = id == SearchAccount.NEW_MESSAGES

--- a/legacy/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
@@ -23,8 +23,8 @@ class TestCoreResourceProvider : CoreResourceProvider {
     override fun replyHeader(sender: String) = "$sender wrote:"
     override fun replyHeader(sender: String, sentDate: String) = "On $sentDate, $sender wrote:"
 
-    override fun searchUnifiedInboxTitle() = "Unified Inbox"
-    override fun searchUnifiedInboxDetail() = "All messages in unified folders"
+    override fun searchUnifiedFoldersTitle() = "Unified Folders"
+    override fun searchUnifiedFoldersDetail() = "All messages in unified folders"
 
     override val iconPushNotification: Int
         get() = throw UnsupportedOperationException("not implemented")

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.kt
@@ -77,9 +77,9 @@ abstract class AccountList : K9ListActivity(), OnItemClickListener {
         val accounts: MutableList<BaseAccount> = ArrayList()
 
         if (generalSettingsManager.getConfig().display.inboxSettings.isShowUnifiedInbox) {
-            val unifiedInboxAccount: BaseAccount = SearchAccount.createUnifiedInboxAccount(
-                unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
-                unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+            val unifiedInboxAccount: BaseAccount = SearchAccount.createUnifiedFoldersSearch(
+                title = coreResourceProvider.searchUnifiedFoldersTitle(),
+                detail = coreResourceProvider.searchUnifiedFoldersDetail(),
             )
             accounts.add(unifiedInboxAccount)
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -39,7 +39,7 @@ import com.fsck.k9.Preferences
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.activity.compose.MessageActions
 import com.fsck.k9.controller.MessagingController
-import com.fsck.k9.search.isUnifiedInbox
+import com.fsck.k9.search.isUnifiedFolders
 import com.fsck.k9.ui.BuildConfig
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.K9Activity
@@ -383,8 +383,8 @@ open class MessageList :
         }
 
         val launchData = decodeExtrasToLaunchData(intent)
-        // If Unified Inbox was disabled show default account instead
-        val search = if (launchData.search.isUnifiedInbox &&
+        // If Unified Folders was disabled show default account instead
+        val search = if (launchData.search.isUnifiedFolders &&
             !generalSettingsManager.getConfig().display.inboxSettings.isShowUnifiedInbox
         ) {
             createDefaultLocalSearch()
@@ -392,9 +392,9 @@ open class MessageList :
             launchData.search
         }
 
-        // If no account has been specified, keep the currently active account when opening the Unified Inbox
+        // If no account has been specified, keep the currently active account when opening the Unified Folders
         val account = launchData.account
-            ?: account?.takeIf { launchData.search.isUnifiedInbox }
+            ?: account?.takeIf { launchData.search.isUnifiedFolders }
             ?: search.firstAccount()
 
         if (account == null) {
@@ -632,7 +632,7 @@ open class MessageList :
                     openAccount = { accountId -> openRealAccount(accountId) },
                     openAddAccount = { launchAddAccountScreen() },
                     openFolder = { accountId, folderId -> openFolder(accountId, folderId) },
-                    openUnifiedFolder = { openUnifiedInbox() },
+                    openUnifiedFolder = { openUnifiedFolders() },
                     openManageFolders = { launchManageFoldersScreen() },
                     openSettings = { SettingsActivity.launch(this) },
                     createDrawerListener = { createDrawerListener() },
@@ -643,7 +643,7 @@ open class MessageList :
                     parent = this,
                     openAccount = { accountId -> openRealAccount(accountId) },
                     openFolder = { accountId, folderId -> openFolder(accountId, folderId) },
-                    openUnifiedFolder = { openUnifiedInbox() },
+                    openUnifiedFolder = { openUnifiedFolders() },
                     openManageFolders = { launchManageFoldersScreen() },
                     openSettings = { SettingsActivity.launch(this) },
                     createDrawerListener = { createDrawerListener() },
@@ -698,7 +698,7 @@ open class MessageList :
         onMessageListDisplayed()
     }
 
-    private fun openUnifiedInbox() {
+    private fun openUnifiedFolders() {
         actionDisplaySearch(
             this,
             createSearchAccount().relatedSearch,
@@ -725,7 +725,7 @@ open class MessageList :
 
     fun openRealAccount(accountId: String) {
         if (accountId == UnifiedDisplayAccount.UNIFIED_ACCOUNT_ID) {
-            openUnifiedInbox()
+            openUnifiedFolders()
         } else {
             val account = accountManager.getAccount(accountId) ?: return
             val folderId = defaultFolderProvider.getDefaultFolder(account)
@@ -788,7 +788,7 @@ open class MessageList :
             if (isDrawerEnabled && account != null && supportFragmentManager.backStackEntryCount == 0) {
                 if (generalSettingsManager.getConfig().display.inboxSettings.isShowUnifiedInbox) {
                     if (search!!.id != SearchAccount.UNIFIED_FOLDERS) {
-                        openUnifiedInbox()
+                        openUnifiedFolders()
                     } else {
                         super.onBackPressed()
                     }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -419,7 +419,7 @@ open class MessageList :
         if (action == ACTION_SHORTCUT) {
             // Handle shortcut intents
             val specialFolder = intent.getStringExtra(EXTRA_SPECIAL_FOLDER)
-            if (specialFolder == SearchAccount.UNIFIED_INBOX) {
+            if (specialFolder == SearchAccount.UNIFIED_FOLDERS) {
                 return LaunchData(search = createSearchAccount().relatedSearch)
             }
 
@@ -787,7 +787,7 @@ open class MessageList :
         } else {
             if (isDrawerEnabled && account != null && supportFragmentManager.backStackEntryCount == 0) {
                 if (generalSettingsManager.getConfig().display.inboxSettings.isShowUnifiedInbox) {
-                    if (search!!.id != SearchAccount.UNIFIED_INBOX) {
+                    if (search!!.id != SearchAccount.UNIFIED_FOLDERS) {
                         openUnifiedInbox()
                     } else {
                         super.onBackPressed()
@@ -1485,18 +1485,18 @@ open class MessageList :
 
                 // Don't select any item in the drawer because the Unified Inbox is displayed,
                 // but not listed in the drawer
-                search.id == SearchAccount.UNIFIED_INBOX &&
+                search.id == SearchAccount.UNIFIED_FOLDERS &&
                     !generalSettingsManager.getConfig().display.inboxSettings.isShowUnifiedInbox -> drawer.deselect()
 
-                search.id == SearchAccount.UNIFIED_INBOX -> drawer.selectUnifiedInbox()
+                search.id == SearchAccount.UNIFIED_FOLDERS -> drawer.selectUnifiedInbox()
             }
         } ?: logger.warn(TAG) { "Couldn't select folder for $accountUuid as LocalSearch is null." }
     }
 
     private fun createSearchAccount(): SearchAccount {
-        return SearchAccount.createUnifiedInboxAccount(
-            unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
-            unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+        return SearchAccount.createUnifiedFoldersSearch(
+            title = coreResourceProvider.searchUnifiedFoldersTitle(),
+            detail = coreResourceProvider.searchUnifiedFoldersDetail(),
         )
     }
 
@@ -1580,9 +1580,9 @@ open class MessageList :
             account: LegacyAccount,
         ): Intent {
             return Intent(context, MessageList::class.java).apply {
-                val search = SearchAccount.createUnifiedInboxAccount(
-                    unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
-                    unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+                val search = SearchAccount.createUnifiedFoldersSearch(
+                    title = coreResourceProvider.searchUnifiedFoldersTitle(),
+                    detail = coreResourceProvider.searchUnifiedFoldersDetail(),
                 ).relatedSearch
 
                 putExtra(EXTRA_ACCOUNT, account.uuid)
@@ -1647,9 +1647,9 @@ open class MessageList :
         ): Intent {
             return Intent(context, MessageList::class.java).apply {
                 if (openInUnifiedInbox) {
-                    val search = SearchAccount.createUnifiedInboxAccount(
-                        unifiedInboxTitle = coreResourceProvider.searchUnifiedInboxTitle(),
-                        unifiedInboxDetail = coreResourceProvider.searchUnifiedInboxDetail(),
+                    val search = SearchAccount.createUnifiedFoldersSearch(
+                        title = coreResourceProvider.searchUnifiedFoldersTitle(),
+                        detail = coreResourceProvider.searchUnifiedFoldersDetail(),
                     ).relatedSearch
                     putExtra(EXTRA_SEARCH, LocalMessageSearchSerializer.serialize(search))
                 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -180,7 +180,7 @@ class MessageListFragment :
     private var isRemoteSearch = false
     private var initialMessageListLoad = true
 
-    private val isUnifiedInbox: Boolean
+    private val isUnifiedFolders: Boolean
         get() = localSearch.id == SearchAccount.UNIFIED_FOLDERS
 
     private val isNewMessagesView: Boolean
@@ -210,7 +210,7 @@ class MessageListFragment :
         }
 
     val isShowAccountChip: Boolean
-        get() = isUnifiedInbox || !isSingleAccountMode
+        get() = isUnifiedFolders || !isSingleAccountMode
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -587,7 +587,7 @@ class MessageListFragment :
 
     private fun setWindowTitle() {
         val title = when {
-            isUnifiedInbox -> getString(R.string.integrated_inbox_title)
+            isUnifiedFolders -> getString(R.string.integrated_inbox_title)
             isNewMessagesView -> getString(R.string.new_messages_title)
             isManualSearch -> getString(R.string.search_results)
             isThreadDisplay -> threadTitle ?: ""
@@ -596,7 +596,7 @@ class MessageListFragment :
         }
 
         val subtitle = account.let { account ->
-            if (account == null || isUnifiedInbox || accountManager.getAccounts().size == 1) {
+            if (account == null || isUnifiedFolders || accountManager.getAccounts().size == 1) {
                 null
             } else {
                 account.displayName

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -181,7 +181,7 @@ class MessageListFragment :
     private var initialMessageListLoad = true
 
     private val isUnifiedInbox: Boolean
-        get() = localSearch.id == SearchAccount.UNIFIED_INBOX
+        get() = localSearch.id == SearchAccount.UNIFIED_FOLDERS
 
     private val isNewMessagesView: Boolean
         get() = localSearch.id == SearchAccount.NEW_MESSAGES

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
@@ -23,8 +23,8 @@ class TestCoreResourceProvider : CoreResourceProvider {
     override fun replyHeader(sender: String) = throw UnsupportedOperationException("not implemented")
     override fun replyHeader(sender: String, sentDate: String) = throw UnsupportedOperationException("not implemented")
 
-    override fun searchUnifiedInboxTitle() = throw UnsupportedOperationException("not implemented")
-    override fun searchUnifiedInboxDetail() = throw UnsupportedOperationException("not implemented")
+    override fun searchUnifiedFoldersTitle() = throw UnsupportedOperationException("not implemented")
+    override fun searchUnifiedFoldersDetail() = throw UnsupportedOperationException("not implemented")
 
     override val iconPushNotification: Int
         get() = throw UnsupportedOperationException("not implemented")


### PR DESCRIPTION
Part of https://github.com/thunderbird/thunderbird-android/issues/9370

This changes the unified inbox to unified folder to better reflect it's purpose and avoid collisions with a real unified inbox folder in upcoming changes.