### PR TITLE
fix: deploy docs failed on non existing file

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Clean docs
         run: |
           rm -rf book/docs/latest/assets/draw.io
-          rm book/docs/latest/.gitignore
-          rm book/docs/latest/install.sh
+          rm -f book/docs/latest/.gitignore
+          rm -f book/docs/latest/install.sh
 
           # Restore mermaid.min.js, it has already been copied over to book/docs/latest
           git restore .


### PR DESCRIPTION
The last deploy docs run failed because of non existing files. This resolves it by enforcing the deletion.
