### PR TITLE
chore(ci): add gradle dependabot setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This enables dependabot to also manage Gradle dependency updates.

Resolves #9746
