### PR TITLE
refactor: rename legacy account

### DIFF
--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
@@ -21,7 +21,7 @@ import com.fsck.k9.preferences.UnifiedInboxConfigurator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.Protocols
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.feature.account.avatar.AvatarMonogramCreator
@@ -113,7 +113,7 @@ internal class AccountCreator(
      * Since the folder list hasn't been synced yet, we don't have database IDs for the folders. So we use the same
      * mechanism that is used when importing settings. See [com.fsck.k9.mailstore.SpecialFolderUpdater] for details.
      */
-    private fun LegacyAccount.setSpecialFolders(specialFolders: SpecialFolderSettings) {
+    private fun LegacyAccountDto.setSpecialFolders(specialFolders: SpecialFolderSettings) {
         importedArchiveFolder = specialFolders.archiveSpecialFolderOption.toFolderServerId()
         archiveFolderSelection = specialFolders.archiveSpecialFolderOption.toFolderSelection()
 
@@ -153,7 +153,7 @@ internal class AccountCreator(
     }
 }
 
-private fun LegacyAccount.setIncomingServerSettings(serverSettings: ServerSettings) {
+private fun LegacyAccountDto.setIncomingServerSettings(serverSettings: ServerSettings) {
     if (serverSettings.type == Protocols.IMAP) {
         useCompression = serverSettings.isUseCompression
         isSendClientInfoEnabled = serverSettings.isSendClientInfo

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AppCommonAccountModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AppCommonAccountModule.kt
@@ -2,9 +2,9 @@ package net.thunderbird.app.common.account
 
 import app.k9mail.feature.account.setup.AccountSetupExternalContract
 import net.thunderbird.app.common.account.data.DefaultAccountProfileLocalDataSource
-import net.thunderbird.app.common.account.data.DefaultLegacyAccountWrapperManager
+import net.thunderbird.app.common.account.data.DefaultLegacyAccountManager
 import net.thunderbird.core.android.account.AccountDefaultsProvider
-import net.thunderbird.core.android.account.LegacyAccountWrapperManager
+import net.thunderbird.core.android.account.LegacyAccountManager
 import net.thunderbird.feature.account.avatar.AvatarMonogramCreator
 import net.thunderbird.feature.account.avatar.DefaultAvatarMonogramCreator
 import net.thunderbird.feature.account.core.AccountCoreExternalContract.AccountProfileLocalDataSource
@@ -19,8 +19,8 @@ internal val appCommonAccountModule = module {
         featureAccountStorageLegacyModule,
     )
 
-    single<LegacyAccountWrapperManager> {
-        DefaultLegacyAccountWrapperManager(
+    single<LegacyAccountManager> {
+        DefaultLegacyAccountManager(
             accountManager = get(),
             accountDataMapper = get(),
         )

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/DefaultAccountDefaultsProvider.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/DefaultAccountDefaultsProvider.kt
@@ -22,7 +22,7 @@ import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.UN
 import net.thunderbird.core.android.account.Expunge
 import net.thunderbird.core.android.account.FolderMode
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.ShowPictures
 import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.featureflag.toFeatureFlagKey
@@ -38,11 +38,11 @@ internal class DefaultAccountDefaultsProvider(
     private val featureFlagProvider: FeatureFlagProvider,
 ) : AccountDefaultsProvider {
 
-    override fun applyDefaults(account: LegacyAccount) = with(account) {
+    override fun applyDefaults(account: LegacyAccountDto) = with(account) {
         applyLegacyDefaults()
     }
 
-    override fun applyOverwrites(account: LegacyAccount, storage: Storage) = with(account) {
+    override fun applyOverwrites(account: LegacyAccountDto, storage: Storage) = with(account) {
         if (storage.contains("${account.uuid}.notifyNewMail")) {
             isNotifyNewMail = storage.getBoolean("${account.uuid}.notifyNewMail", false)
             isNotifySelfNewMail = storage.getBoolean("${account.uuid}.notifySelfNewMail", true)
@@ -64,7 +64,7 @@ internal class DefaultAccountDefaultsProvider(
     }
 
     @Suppress("LongMethod")
-    private fun LegacyAccount.applyLegacyDefaults() {
+    private fun LegacyAccountDto.applyLegacyDefaults() {
         automaticCheckIntervalMinutes = DEFAULT_SYNC_INTERVAL
         idleRefreshMinutes = 24
         displayCount = DEFAULT_VISIBLE_LIMIT

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/DefaultAccountProfileLocalDataSource.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/DefaultAccountProfileLocalDataSource.kt
@@ -3,14 +3,14 @@ package net.thunderbird.app.common.account.data
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
-import net.thunderbird.core.android.account.LegacyAccountWrapperManager
+import net.thunderbird.core.android.account.LegacyAccountManager
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.core.AccountCoreExternalContract.AccountProfileLocalDataSource
 import net.thunderbird.feature.account.profile.AccountProfile
 import net.thunderbird.feature.account.storage.mapper.AccountProfileDataMapper
 
 internal class DefaultAccountProfileLocalDataSource(
-    private val accountManager: LegacyAccountWrapperManager,
+    private val accountManager: LegacyAccountManager,
     private val dataMapper: AccountProfileDataMapper,
 ) : AccountProfileLocalDataSource {
 

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/DefaultLegacyAccountManager.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/DefaultLegacyAccountManager.kt
@@ -4,14 +4,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.LegacyAccount
-import net.thunderbird.core.android.account.LegacyAccountWrapperManager
+import net.thunderbird.core.android.account.LegacyAccountManager
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.storage.legacy.mapper.DefaultLegacyAccountWrapperDataMapper
 
-internal class DefaultLegacyAccountWrapperManager(
+internal class DefaultLegacyAccountManager(
     private val accountManager: AccountManager,
     private val accountDataMapper: DefaultLegacyAccountWrapperDataMapper,
-) : LegacyAccountWrapperManager {
+) : LegacyAccountManager {
 
     override fun getAll(): Flow<List<LegacyAccount>> {
         return accountManager.getAccountsFlow()

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/DefaultLegacyAccountWrapperManager.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/data/DefaultLegacyAccountWrapperManager.kt
@@ -3,7 +3,7 @@ package net.thunderbird.app.common.account.data
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccountWrapper
+import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountWrapperManager
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.storage.legacy.mapper.DefaultLegacyAccountWrapperDataMapper
@@ -13,7 +13,7 @@ internal class DefaultLegacyAccountWrapperManager(
     private val accountDataMapper: DefaultLegacyAccountWrapperDataMapper,
 ) : LegacyAccountWrapperManager {
 
-    override fun getAll(): Flow<List<LegacyAccountWrapper>> {
+    override fun getAll(): Flow<List<LegacyAccount>> {
         return accountManager.getAccountsFlow()
             .map { list ->
                 list.map { account ->
@@ -22,7 +22,7 @@ internal class DefaultLegacyAccountWrapperManager(
             }
     }
 
-    override fun getById(id: AccountId): Flow<LegacyAccountWrapper?> {
+    override fun getById(id: AccountId): Flow<LegacyAccount?> {
         return accountManager.getAccountFlow(id.asRaw()).map { account ->
             account?.let {
                 accountDataMapper.toDomain(it)
@@ -30,7 +30,7 @@ internal class DefaultLegacyAccountWrapperManager(
         }
     }
 
-    override suspend fun update(account: LegacyAccountWrapper) {
+    override suspend fun update(account: LegacyAccount) {
         accountManager.saveAccount(
             accountDataMapper.toDto(account),
         )

--- a/app-common/src/test/kotlin/net/thunderbird/app/common/account/DefaultAccountDefaultsProviderTest.kt
+++ b/app-common/src/test/kotlin/net/thunderbird/app/common/account/DefaultAccountDefaultsProviderTest.kt
@@ -26,7 +26,7 @@ import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.UN
 import net.thunderbird.core.android.account.Expunge
 import net.thunderbird.core.android.account.FolderMode
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.ShowPictures
 import net.thunderbird.core.featureflag.FeatureFlagResult
 import net.thunderbird.core.preference.storage.Storage
@@ -47,7 +47,7 @@ class DefaultAccountDefaultsProviderTest {
         val resourceProvider = mock<CoreResourceProvider> {
             on { defaultIdentityDescription() } doReturn "Default Identity"
         }
-        val account = LegacyAccount(
+        val account = LegacyAccountDto(
             uuid = "cf728064-077d-4369-a0c7-7c2b21693d9b",
             isSensitiveDebugLoggingEnabled = { false },
         )
@@ -144,7 +144,7 @@ class DefaultAccountDefaultsProviderTest {
         val resourceProvider = mock<CoreResourceProvider> {
             on { defaultIdentityDescription() } doReturn "Default Identity"
         }
-        val account = LegacyAccount(
+        val account = LegacyAccountDto(
             uuid = "cf728064-077d-4369-a0c7-7c2b21693d9b",
             isSensitiveDebugLoggingEnabled = { false },
         )
@@ -174,7 +174,7 @@ class DefaultAccountDefaultsProviderTest {
         val resourceProvider = mock<CoreResourceProvider> {
             on { defaultIdentityDescription() } doReturn "Default Identity"
         }
-        val account = LegacyAccount(
+        val account = LegacyAccountDto(
             uuid = "cf728064-077d-4369-a0c7-7c2b21693d9b",
             isSensitiveDebugLoggingEnabled = { false },
         )
@@ -205,7 +205,7 @@ class DefaultAccountDefaultsProviderTest {
         val resourceProvider = mock<CoreResourceProvider> {
             on { defaultIdentityDescription() } doReturn "Default Identity"
         }
-        val account = LegacyAccount(
+        val account = LegacyAccountDto(
             uuid = "cf728064-077d-4369-a0c7-7c2b21693d9b",
             isSensitiveDebugLoggingEnabled = { false },
         )
@@ -236,7 +236,7 @@ class DefaultAccountDefaultsProviderTest {
         val resourceProvider = mock<CoreResourceProvider> {
             on { defaultIdentityDescription() } doReturn "Default Identity"
         }
-        val account = LegacyAccount(
+        val account = LegacyAccountDto(
             uuid = "cf728064-077d-4369-a0c7-7c2b21693d9b",
             isSensitiveDebugLoggingEnabled = { false },
         )

--- a/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/DefaultAccountProfileLocalDataSourceTest.kt
+++ b/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/DefaultAccountProfileLocalDataSourceTest.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.test.runTest
 import net.thunderbird.account.fake.FakeAccountProfileData.PROFILE_COLOR
 import net.thunderbird.account.fake.FakeAccountProfileData.PROFILE_NAME
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccountWrapper
+import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.AccountIdFactory
 import net.thunderbird.feature.account.profile.AccountAvatar
@@ -77,8 +77,8 @@ class DefaultAccountProfileLocalDataSourceTest {
             id: AccountId,
             displayName: String = PROFILE_NAME,
             color: Int = PROFILE_COLOR,
-        ): LegacyAccountWrapper {
-            return LegacyAccountWrapper(
+        ): LegacyAccount {
+            return LegacyAccount(
                 isSensitiveDebugLoggingEnabled = { true },
                 id = id,
                 name = displayName,
@@ -139,7 +139,7 @@ class DefaultAccountProfileLocalDataSourceTest {
         }
 
         private fun createTestSubject(
-            legacyAccount: LegacyAccountWrapper?,
+            legacyAccount: LegacyAccount?,
         ): DefaultAccountProfileLocalDataSource {
             return DefaultAccountProfileLocalDataSource(
                 accountManager = FakeLegacyAccountWrapperManager(

--- a/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/DefaultAccountProfileLocalDataSourceTest.kt
+++ b/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/DefaultAccountProfileLocalDataSourceTest.kt
@@ -142,7 +142,7 @@ class DefaultAccountProfileLocalDataSourceTest {
             legacyAccount: LegacyAccount?,
         ): DefaultAccountProfileLocalDataSource {
             return DefaultAccountProfileLocalDataSource(
-                accountManager = FakeLegacyAccountWrapperManager(
+                accountManager = FakeLegacyAccountManager(
                     initialAccounts = if (legacyAccount != null) {
                         listOf(legacyAccount)
                     } else {

--- a/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/FakeLegacyAccountManager.kt
+++ b/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/FakeLegacyAccountManager.kt
@@ -6,12 +6,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import net.thunderbird.core.android.account.LegacyAccount
-import net.thunderbird.core.android.account.LegacyAccountWrapperManager
+import net.thunderbird.core.android.account.LegacyAccountManager
 import net.thunderbird.feature.account.AccountId
 
-internal class FakeLegacyAccountWrapperManager(
+internal class FakeLegacyAccountManager(
     initialAccounts: List<LegacyAccount> = emptyList(),
-) : LegacyAccountWrapperManager {
+) : LegacyAccountManager {
 
     private val accountsState = MutableStateFlow(
         initialAccounts,

--- a/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/FakeLegacyAccountWrapperManager.kt
+++ b/app-common/src/test/kotlin/net/thunderbird/app/common/account/data/FakeLegacyAccountWrapperManager.kt
@@ -5,27 +5,27 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
-import net.thunderbird.core.android.account.LegacyAccountWrapper
+import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountWrapperManager
 import net.thunderbird.feature.account.AccountId
 
 internal class FakeLegacyAccountWrapperManager(
-    initialAccounts: List<LegacyAccountWrapper> = emptyList(),
+    initialAccounts: List<LegacyAccount> = emptyList(),
 ) : LegacyAccountWrapperManager {
 
     private val accountsState = MutableStateFlow(
         initialAccounts,
     )
-    private val accounts: StateFlow<List<LegacyAccountWrapper>> = accountsState
+    private val accounts: StateFlow<List<LegacyAccount>> = accountsState
 
-    override fun getAll(): Flow<List<LegacyAccountWrapper>> = accounts
+    override fun getAll(): Flow<List<LegacyAccount>> = accounts
 
-    override fun getById(id: AccountId): Flow<LegacyAccountWrapper?> = accounts
+    override fun getById(id: AccountId): Flow<LegacyAccount?> = accounts
         .map { list ->
             list.find { it.id == id }
         }
 
-    override suspend fun update(account: LegacyAccountWrapper) {
+    override suspend fun update(account: LegacyAccount) {
         accountsState.update { currentList ->
             currentList.toMutableList().apply {
                 removeIf { it.uuid == account.uuid }

--- a/app-k9mail/src/debug/kotlin/app/k9mail/dev/DemoBackendFactory.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/dev/DemoBackendFactory.kt
@@ -4,10 +4,10 @@ import app.k9mail.backend.demo.DemoBackend
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.mailstore.K9BackendStorageFactory
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class DemoBackendFactory(private val backendStorageFactory: K9BackendStorageFactory) : BackendFactory {
-    override fun createBackend(account: LegacyAccount): Backend {
+    override fun createBackend(account: LegacyAccountDto): Backend {
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         return DemoBackend(backendStorage)
     }

--- a/app-thunderbird/src/daily/kotlin/net/thunderbird/android/dev/DemoBackendFactory.kt
+++ b/app-thunderbird/src/daily/kotlin/net/thunderbird/android/dev/DemoBackendFactory.kt
@@ -4,10 +4,10 @@ import app.k9mail.backend.demo.DemoBackend
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.mailstore.K9BackendStorageFactory
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class DemoBackendFactory(private val backendStorageFactory: K9BackendStorageFactory) : BackendFactory {
-    override fun createBackend(account: LegacyAccount): Backend {
+    override fun createBackend(account: LegacyAccountDto): Backend {
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         return DemoBackend(backendStorage)
     }

--- a/app-thunderbird/src/debug/kotlin/net/thunderbird/android/dev/DemoBackendFactory.kt
+++ b/app-thunderbird/src/debug/kotlin/net/thunderbird/android/dev/DemoBackendFactory.kt
@@ -4,10 +4,10 @@ import app.k9mail.backend.demo.DemoBackend
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.mailstore.K9BackendStorageFactory
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class DemoBackendFactory(private val backendStorageFactory: K9BackendStorageFactory) : BackendFactory {
-    override fun createBackend(account: LegacyAccount): Backend {
+    override fun createBackend(account: LegacyAccountDto): Backend {
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         return DemoBackend(backendStorage)
     }

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountDefaultsProvider.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountDefaultsProvider.kt
@@ -8,14 +8,14 @@ interface AccountDefaultsProvider {
      *
      * This method should only be called when creating a new account.
      */
-    fun applyDefaults(account: LegacyAccount)
+    fun applyDefaults(account: LegacyAccountDto)
 
     /**
      * Apply any additional default values to the account.
      *
      * This method should be called when updating an existing account.
      */
-    fun applyOverwrites(account: LegacyAccount, storage: Storage)
+    fun applyOverwrites(account: LegacyAccountDto, storage: Storage)
 
     companion object {
         const val DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE = 131072

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountManager.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountManager.kt
@@ -11,14 +11,14 @@ import net.thunderbird.feature.mail.account.api.AccountManager
         "app.k9mail.legacy.account.LegacyAccount",
     ),
 )
-interface AccountManager : AccountManager<LegacyAccount> {
-    override fun getAccounts(): List<LegacyAccount>
-    override fun getAccountsFlow(): Flow<List<LegacyAccount>>
-    override fun getAccount(accountUuid: String): LegacyAccount?
-    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccount?>
+interface AccountManager : AccountManager<LegacyAccountDto> {
+    override fun getAccounts(): List<LegacyAccountDto>
+    override fun getAccountsFlow(): Flow<List<LegacyAccountDto>>
+    override fun getAccount(accountUuid: String): LegacyAccountDto?
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccountDto?>
     fun addAccountRemovedListener(listener: AccountRemovedListener)
-    override fun moveAccount(account: LegacyAccount, newPosition: Int)
+    override fun moveAccount(account: LegacyAccountDto, newPosition: Int)
     fun addOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener)
     fun removeOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener)
-    override fun saveAccount(account: LegacyAccount)
+    override fun saveAccount(account: LegacyAccountDto)
 }

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountRemovedListener.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountRemovedListener.kt
@@ -1,5 +1,5 @@
 package net.thunderbird.core.android.account
 
 fun interface AccountRemovedListener {
-    fun onAccountRemoved(account: LegacyAccount)
+    fun onAccountRemoved(account: LegacyAccountDto)
 }

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccount.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccount.kt
@@ -12,14 +12,9 @@ import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection
 import net.thunderbird.feature.notification.NotificationSettings
 
 /**
- * A immutable wrapper for the [LegacyAccountDto] class.
- *
  * This class is used to store the account data in a way that is safe to pass between threads.
- *
- * Use LegacyAccountWrapper.from(account) to create a wrapper from an account.
- * Use LegacyAccountWrapper.to(wrapper) to create an account from a wrapper.
  */
-data class LegacyAccountWrapper(
+data class LegacyAccount(
     val isSensitiveDebugLoggingEnabled: () -> Boolean = { false },
 
     // [Account]

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountDto.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountDto.kt
@@ -21,9 +21,9 @@ const val DEFAULT_VISIBLE_LIMIT = 25
 /**
  * Account stores all of the settings for a single account defined by the user. Each account is defined by a UUID.
  */
-@Deprecated("Use LegacyAccountWrapper instead")
+@Deprecated("Use LegacyAccount instead")
 @Suppress("TooManyFunctions")
-open class LegacyAccount(
+open class LegacyAccountDto(
     override val uuid: String,
     val isSensitiveDebugLoggingEnabled: () -> Boolean = { false },
 ) : Account, BaseAccount {
@@ -618,7 +618,7 @@ open class LegacyAccount(
     }
 
     override fun equals(other: Any?): Boolean {
-        return if (other is LegacyAccount) {
+        return if (other is LegacyAccountDto) {
             other.uuid == uuid
         } else {
             super.equals(other)
@@ -629,7 +629,7 @@ open class LegacyAccount(
         return uuid.hashCode()
     }
 
-    companion object {
+    companion object Companion {
         /**
          * Fixed name of outbox - not actually displayed.
          */

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountManager.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountManager.kt
@@ -4,9 +4,9 @@ import kotlinx.coroutines.flow.Flow
 import net.thunderbird.feature.account.AccountId
 
 interface LegacyAccountWrapperManager {
-    fun getAll(): Flow<List<LegacyAccountWrapper>>
+    fun getAll(): Flow<List<LegacyAccount>>
 
-    fun getById(id: AccountId): Flow<LegacyAccountWrapper?>
+    fun getById(id: AccountId): Flow<LegacyAccount?>
 
-    suspend fun update(account: LegacyAccountWrapper)
+    suspend fun update(account: LegacyAccount)
 }

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountManager.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountManager.kt
@@ -3,7 +3,7 @@ package net.thunderbird.core.android.account
 import kotlinx.coroutines.flow.Flow
 import net.thunderbird.feature.account.AccountId
 
-interface LegacyAccountWrapperManager {
+interface LegacyAccountManager {
     fun getAll(): Flow<List<LegacyAccount>>
 
     fun getById(id: AccountId): Flow<LegacyAccount?>

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountWrapper.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountWrapper.kt
@@ -12,7 +12,7 @@ import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection
 import net.thunderbird.feature.notification.NotificationSettings
 
 /**
- * A immutable wrapper for the [LegacyAccount] class.
+ * A immutable wrapper for the [LegacyAccountDto] class.
  *
  * This class is used to store the account data in a way that is safe to pass between threads.
  *

--- a/core/android/account/src/test/kotlin/net/thunderbird/core/android/account/LegacyAccountWrapperTest.kt
+++ b/core/android/account/src/test/kotlin/net/thunderbird/core/android/account/LegacyAccountWrapperTest.kt
@@ -24,7 +24,7 @@ class LegacyAccountWrapperTest {
         val expected = createAccountWrapper()
 
         // act
-        val result = LegacyAccountWrapper(
+        val result = LegacyAccount(
             isSensitiveDebugLoggingEnabled = isSensitiveDebugLoggingEnabled,
             id = ACCOUNT_ID,
             name = PROFILE_NAME,
@@ -93,8 +93,8 @@ class LegacyAccountWrapperTest {
         val notificationSettings = NotificationSettings()
 
         @Suppress("LongMethod")
-        fun createAccountWrapper(): LegacyAccountWrapper {
-            return LegacyAccountWrapper(
+        fun createAccountWrapper(): LegacyAccount {
+            return LegacyAccount(
                 isSensitiveDebugLoggingEnabled = isSensitiveDebugLoggingEnabled,
 
                 // [Account]

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAccountStorageHandler.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAccountStorageHandler.kt
@@ -5,7 +5,7 @@ import net.thunderbird.core.android.account.DeletePolicy
 import net.thunderbird.core.android.account.Expunge
 import net.thunderbird.core.android.account.FolderMode
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.MessageFormat
 import net.thunderbird.core.android.account.QuoteStyle
 import net.thunderbird.core.android.account.ShowPictures
@@ -31,7 +31,7 @@ class LegacyAccountStorageHandler(
 
     @Suppress("LongMethod", "MagicNumber")
     @Synchronized
-    override fun load(data: LegacyAccount, storage: Storage) {
+    override fun load(data: LegacyAccountDto, storage: Storage) {
         val keyGen = AccountKeyGenerator(data.id)
 
         profileDtoStorageHandler.load(data, storage)
@@ -309,7 +309,7 @@ class LegacyAccountStorageHandler(
 
     @Suppress("LongMethod")
     @Synchronized
-    override fun save(data: LegacyAccount, storage: Storage, editor: StorageEditor) {
+    override fun save(data: LegacyAccountDto, storage: Storage, editor: StorageEditor) {
         val keyGen = AccountKeyGenerator(data.id)
 
         profileDtoStorageHandler.save(data, storage, editor)
@@ -425,7 +425,7 @@ class LegacyAccountStorageHandler(
 
     @Suppress("LongMethod")
     @Synchronized
-    override fun delete(data: LegacyAccount, storage: Storage, editor: StorageEditor) {
+    override fun delete(data: LegacyAccountDto, storage: Storage, editor: StorageEditor) {
         val keyGen = AccountKeyGenerator(data.id)
         val accountUuid = data.uuid
 
@@ -547,7 +547,7 @@ class LegacyAccountStorageHandler(
     }
 
     @Synchronized
-    private fun saveIdentities(data: LegacyAccount, storage: Storage, editor: StorageEditor) {
+    private fun saveIdentities(data: LegacyAccountDto, storage: Storage, editor: StorageEditor) {
         deleteIdentities(data, storage, editor)
         var ident = 0
         val keyGen = AccountKeyGenerator(data.id)
@@ -566,7 +566,7 @@ class LegacyAccountStorageHandler(
     }
 
     @Synchronized
-    private fun deleteIdentities(data: LegacyAccount, storage: Storage, editor: StorageEditor) {
+    private fun deleteIdentities(data: LegacyAccountDto, storage: Storage, editor: StorageEditor) {
         val keyGen = AccountKeyGenerator(data.id)
 
         var identityIndex = 0

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAvatarDtoStorageHandler.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAvatarDtoStorageHandler.kt
@@ -1,6 +1,6 @@
 package net.thunderbird.feature.account.storage.legacy
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.core.preference.storage.StorageEditor
 import net.thunderbird.core.preference.storage.getEnumOrDefault
@@ -11,7 +11,7 @@ import net.thunderbird.feature.account.storage.profile.AvatarTypeDto
 class LegacyAvatarDtoStorageHandler : AvatarDtoStorageHandler {
 
     override fun load(
-        data: LegacyAccount,
+        data: LegacyAccountDto,
         storage: Storage,
     ) {
         val keyGen = AccountKeyGenerator(data.id)
@@ -27,7 +27,7 @@ class LegacyAvatarDtoStorageHandler : AvatarDtoStorageHandler {
     }
 
     override fun save(
-        data: LegacyAccount,
+        data: LegacyAccountDto,
         storage: Storage,
         editor: StorageEditor,
     ) {
@@ -42,7 +42,7 @@ class LegacyAvatarDtoStorageHandler : AvatarDtoStorageHandler {
     }
 
     override fun delete(
-        data: LegacyAccount,
+        data: LegacyAccountDto,
         storage: Storage,
         editor: StorageEditor,
     ) {

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyProfileDtoStorageHandler.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyProfileDtoStorageHandler.kt
@@ -1,7 +1,7 @@
 package net.thunderbird.feature.account.storage.legacy
 
 import net.thunderbird.core.android.account.AccountDefaultsProvider
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.core.preference.storage.StorageEditor
 
@@ -10,7 +10,7 @@ class LegacyProfileDtoStorageHandler(
 ) : ProfileDtoStorageHandler {
 
     override fun load(
-        data: LegacyAccount,
+        data: LegacyAccountDto,
         storage: Storage,
     ) {
         val keyGen = AccountKeyGenerator(data.id)
@@ -24,7 +24,7 @@ class LegacyProfileDtoStorageHandler(
     }
 
     override fun save(
-        data: LegacyAccount,
+        data: LegacyAccountDto,
         storage: Storage,
         editor: StorageEditor,
     ) {
@@ -39,7 +39,7 @@ class LegacyProfileDtoStorageHandler(
     }
 
     override fun delete(
-        data: LegacyAccount,
+        data: LegacyAccountDto,
         storage: Storage,
         editor: StorageEditor,
     ) {

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/StorageHandler.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/StorageHandler.kt
@@ -1,7 +1,7 @@
 package net.thunderbird.feature.account.storage.legacy
 
 import androidx.annotation.Discouraged
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.core.preference.storage.StorageEditor
 
@@ -42,8 +42,8 @@ interface StorageHandler<T> {
     fun delete(data: T, storage: Storage, editor: StorageEditor)
 }
 
-interface AccountDtoStorageHandler : StorageHandler<LegacyAccount>
+interface AccountDtoStorageHandler : StorageHandler<LegacyAccountDto>
 
-interface ProfileDtoStorageHandler : StorageHandler<LegacyAccount>
+interface ProfileDtoStorageHandler : StorageHandler<LegacyAccountDto>
 
-interface AvatarDtoStorageHandler : StorageHandler<LegacyAccount>
+interface AvatarDtoStorageHandler : StorageHandler<LegacyAccountDto>

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapper.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapper.kt
@@ -1,15 +1,15 @@
 package net.thunderbird.feature.account.storage.legacy.mapper
 
+import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountDto
-import net.thunderbird.core.android.account.LegacyAccountWrapper
 import net.thunderbird.core.architecture.data.DataMapper
 import net.thunderbird.feature.account.storage.profile.ProfileDto
 
-class DefaultLegacyAccountWrapperDataMapper : DataMapper<LegacyAccountWrapper, LegacyAccountDto> {
+class DefaultLegacyAccountWrapperDataMapper : DataMapper<LegacyAccount, LegacyAccountDto> {
 
     @Suppress("LongMethod")
-    override fun toDomain(dto: LegacyAccountDto): LegacyAccountWrapper {
-        return LegacyAccountWrapper(
+    override fun toDomain(dto: LegacyAccountDto): LegacyAccount {
+        return LegacyAccount(
             isSensitiveDebugLoggingEnabled = dto.isSensitiveDebugLoggingEnabled,
 
             // Account
@@ -119,7 +119,7 @@ class DefaultLegacyAccountWrapperDataMapper : DataMapper<LegacyAccountWrapper, L
     }
 
     @Suppress("LongMethod")
-    override fun toDto(domain: LegacyAccountWrapper): LegacyAccountDto {
+    override fun toDto(domain: LegacyAccount): LegacyAccountDto {
         return LegacyAccountDto(
             uuid = domain.uuid,
             isSensitiveDebugLoggingEnabled = domain.isSensitiveDebugLoggingEnabled,

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapper.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapper.kt
@@ -1,14 +1,14 @@
 package net.thunderbird.feature.account.storage.legacy.mapper
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountWrapper
 import net.thunderbird.core.architecture.data.DataMapper
 import net.thunderbird.feature.account.storage.profile.ProfileDto
 
-class DefaultLegacyAccountWrapperDataMapper : DataMapper<LegacyAccountWrapper, LegacyAccount> {
+class DefaultLegacyAccountWrapperDataMapper : DataMapper<LegacyAccountWrapper, LegacyAccountDto> {
 
     @Suppress("LongMethod")
-    override fun toDomain(dto: LegacyAccount): LegacyAccountWrapper {
+    override fun toDomain(dto: LegacyAccountDto): LegacyAccountWrapper {
         return LegacyAccountWrapper(
             isSensitiveDebugLoggingEnabled = dto.isSensitiveDebugLoggingEnabled,
 
@@ -109,7 +109,7 @@ class DefaultLegacyAccountWrapperDataMapper : DataMapper<LegacyAccountWrapper, L
         )
     }
 
-    private fun toProfileDto(dto: LegacyAccount): ProfileDto {
+    private fun toProfileDto(dto: LegacyAccountDto): ProfileDto {
         return ProfileDto(
             id = dto.id,
             name = dto.displayName,
@@ -119,8 +119,8 @@ class DefaultLegacyAccountWrapperDataMapper : DataMapper<LegacyAccountWrapper, L
     }
 
     @Suppress("LongMethod")
-    override fun toDto(domain: LegacyAccountWrapper): LegacyAccount {
-        return LegacyAccount(
+    override fun toDto(domain: LegacyAccountWrapper): LegacyAccountDto {
+        return LegacyAccountDto(
             uuid = domain.uuid,
             isSensitiveDebugLoggingEnabled = domain.isSensitiveDebugLoggingEnabled,
         ).apply {
@@ -216,7 +216,7 @@ class DefaultLegacyAccountWrapperDataMapper : DataMapper<LegacyAccountWrapper, L
         }
     }
 
-    private fun fromProfileDto(dto: ProfileDto, account: LegacyAccount) {
+    private fun fromProfileDto(dto: ProfileDto, account: LegacyAccountDto) {
         account.name = dto.name
         account.chipColor = dto.color
         account.avatar = dto.avatar

--- a/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAvatarDtoStorageHandlerTest.kt
+++ b/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAvatarDtoStorageHandlerTest.kt
@@ -6,7 +6,7 @@ import assertk.assertions.isEqualTo
 import kotlin.test.Test
 import net.thunderbird.account.fake.FakeAccountAvatarData
 import net.thunderbird.account.fake.FakeAccountData
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.storage.legacy.fake.FakeStorage
 import net.thunderbird.feature.account.storage.legacy.fake.FakeStorageEditor
@@ -67,8 +67,8 @@ class LegacyAvatarDtoStorageHandlerTest {
     }
 
     // Arrange methods
-    private fun createAccount(accountId: AccountId): LegacyAccount {
-        return LegacyAccount(accountId.asRaw()).apply {
+    private fun createAccount(accountId: AccountId): LegacyAccountDto {
+        return LegacyAccountDto(accountId.asRaw()).apply {
             name = "Test Account"
             chipColor = 0x0099CC // Default color
             avatar = AvatarDto(

--- a/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyProfileDtoStorageHandlerTest.kt
+++ b/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyProfileDtoStorageHandlerTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 import net.thunderbird.account.fake.FakeAccountAvatarData
 import net.thunderbird.account.fake.FakeAccountData
 import net.thunderbird.account.fake.FakeAccountProfileData
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.storage.legacy.fake.FakeStorage
 import net.thunderbird.feature.account.storage.legacy.fake.FakeStorageEditor
@@ -75,8 +75,8 @@ class LegacyProfileDtoStorageHandlerTest {
     }
 
     // Arrange methods
-    private fun createAccount(accountId: AccountId): LegacyAccount {
-        return LegacyAccount(accountId.asRaw()).apply {
+    private fun createAccount(accountId: AccountId): LegacyAccountDto {
+        return LegacyAccountDto(accountId.asRaw()).apply {
             name = NAME
             chipColor = COLOR
             avatar = AvatarDto(

--- a/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapperTest.kt
+++ b/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapperTest.kt
@@ -11,8 +11,8 @@ import net.thunderbird.core.android.account.DeletePolicy
 import net.thunderbird.core.android.account.Expunge
 import net.thunderbird.core.android.account.FolderMode
 import net.thunderbird.core.android.account.Identity
+import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountDto
-import net.thunderbird.core.android.account.LegacyAccountWrapper
 import net.thunderbird.core.android.account.MessageFormat
 import net.thunderbird.core.android.account.QuoteStyle
 import net.thunderbird.core.android.account.ShowPictures
@@ -293,10 +293,10 @@ class DefaultLegacyAccountWrapperDataMapperTest {
         }
 
         @Suppress("LongMethod")
-        fun createAccountWrapper(): LegacyAccountWrapper {
+        fun createAccountWrapper(): LegacyAccount {
             val id = AccountIdFactory.of(ACCOUNT_ID_RAW)
 
-            return LegacyAccountWrapper(
+            return LegacyAccount(
                 isSensitiveDebugLoggingEnabled = defaultIsSensitiveDebugLoggingEnabled,
 
                 // [Account]

--- a/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapperTest.kt
+++ b/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapperTest.kt
@@ -11,7 +11,7 @@ import net.thunderbird.core.android.account.DeletePolicy
 import net.thunderbird.core.android.account.Expunge
 import net.thunderbird.core.android.account.FolderMode
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountWrapper
 import net.thunderbird.core.android.account.MessageFormat
 import net.thunderbird.core.android.account.QuoteStyle
@@ -184,8 +184,8 @@ class DefaultLegacyAccountWrapperDataMapperTest {
         val defaultNotificationSettings = NotificationSettings()
 
         @Suppress("LongMethod")
-        fun createAccount(): LegacyAccount {
-            return LegacyAccount(
+        fun createAccount(): LegacyAccountDto {
+            return LegacyAccountDto(
                 uuid = ACCOUNT_ID_RAW,
                 isSensitiveDebugLoggingEnabled = defaultIsSensitiveDebugLoggingEnabled,
             ).apply {

--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/FakeData.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/FakeData.kt
@@ -7,7 +7,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
@@ -23,7 +23,7 @@ internal object FakeData {
     const val DISPLAY_NAME = "Account Name"
     const val EMAIL_ADDRESS = "test@example.com"
 
-    val ACCOUNT = LegacyAccount(
+    val ACCOUNT = LegacyAccountDto(
         uuid = ACCOUNT_ID_RAW,
     ).apply {
         identities = ArrayList()

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayAccounts.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayAccounts.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UseCase
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
@@ -66,7 +66,7 @@ internal class GetDisplayAccounts(
         return listOf(unified) + accounts
     }
 
-    private fun getMessageCountsFlow(account: LegacyAccount): Flow<MessageCounts> {
+    private fun getMessageCountsFlow(account: LegacyAccountDto): Flow<MessageCounts> {
         return callbackFlow {
             send(messageCountsProvider.getMessageCounts(account))
 

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/SyncAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/SyncAccount.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UseCase
 
 internal class SyncAccount(
@@ -20,7 +20,7 @@ internal class SyncAccount(
 ) : UseCase.SyncAccount {
     override fun invoke(accountUuid: String): Flow<Result<Unit>> = callbackFlow {
         val listener = object : SimpleMessagingListener() {
-            override fun checkMailFinished(context: Context?, account: LegacyAccount?) {
+            override fun checkMailFinished(context: Context?, account: LegacyAccountDto?) {
                 trySend(Result.success(Unit))
                 close()
             }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/SyncAllAccounts.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/SyncAllAccounts.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.UseCase
 
 class SyncAllAccounts(
@@ -18,7 +18,7 @@ class SyncAllAccounts(
 ) : UseCase.SyncAllAccounts {
     override fun invoke(): Flow<Result<Unit>> = callbackFlow {
         val listener = object : SimpleMessagingListener() {
-            override fun checkMailFinished(context: Context?, account: LegacyAccount?) {
+            override fun checkMailFinished(context: Context?, account: LegacyAccountDto?) {
                 trySend(Result.success(Unit))
                 close()
             }

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/FakeMessageCountsProvider.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/data/FakeMessageCountsProvider.kt
@@ -4,7 +4,7 @@ import app.k9mail.legacy.message.controller.MessageCounts
 import app.k9mail.legacy.message.controller.MessageCountsProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.SearchAccount
 
@@ -14,7 +14,7 @@ internal class FakeMessageCountsProvider(
     var recordedSearch: LocalMessageSearch =
         LocalMessageSearch()
 
-    override fun getMessageCounts(account: LegacyAccount): MessageCounts {
+    override fun getMessageCounts(account: LegacyAccountDto): MessageCounts {
         TODO("Not yet implemented")
     }
 
@@ -31,7 +31,7 @@ internal class FakeMessageCountsProvider(
         return flowOf(messageCounts)
     }
 
-    override fun getUnreadMessageCount(account: LegacyAccount, folderId: Long): Int {
+    override fun getUnreadMessageCount(account: LegacyAccountDto, folderId: Long): Int {
         TODO("Not yet implemented")
     }
 }

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeAccountManager.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeAccountManager.kt
@@ -4,26 +4,26 @@ import kotlinx.coroutines.flow.Flow
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.AccountRemovedListener
 import net.thunderbird.core.android.account.AccountsChangeListener
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class FakeAccountManager(
     val recordedParameters: MutableList<String> = mutableListOf(),
-    private val accounts: List<LegacyAccount> = emptyList(),
+    private val accounts: List<LegacyAccountDto> = emptyList(),
 ) : AccountManager {
-    override fun getAccounts(): List<LegacyAccount> {
+    override fun getAccounts(): List<LegacyAccountDto> {
         TODO("Not yet implemented")
     }
 
-    override fun getAccountsFlow(): Flow<List<LegacyAccount>> {
+    override fun getAccountsFlow(): Flow<List<LegacyAccountDto>> {
         TODO("Not yet implemented")
     }
 
-    override fun getAccount(accountUuid: String): LegacyAccount? {
+    override fun getAccount(accountUuid: String): LegacyAccountDto? {
         recordedParameters.add(accountUuid)
         return accounts.find { it.uuid == accountUuid }
     }
 
-    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccount> {
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccountDto> {
         TODO("Not yet implemented")
     }
 
@@ -31,7 +31,7 @@ internal class FakeAccountManager(
         TODO("Not yet implemented")
     }
 
-    override fun moveAccount(account: LegacyAccount, newPosition: Int) {
+    override fun moveAccount(account: LegacyAccountDto, newPosition: Int) {
         TODO("Not yet implemented")
     }
 
@@ -43,7 +43,7 @@ internal class FakeAccountManager(
         TODO("Not yet implemented")
     }
 
-    override fun saveAccount(account: LegacyAccount) {
+    override fun saveAccount(account: LegacyAccountDto) {
         TODO("Not yet implemented")
     }
 }

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeDisplayFolderRepository.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeDisplayFolderRepository.kt
@@ -3,13 +3,13 @@ package net.thunderbird.feature.navigation.drawer.dropdown.domain.usecase
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.flow.Flow
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class FakeDisplayFolderRepository(
     private val foldersFlow: Flow<List<DisplayFolder>>,
 ) : DisplayFolderRepository {
     override fun getDisplayFoldersFlow(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         includeHiddenFolders: Boolean,
     ): Flow<List<DisplayFolder>> {
         TODO("Not yet implemented")

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeMessagingControllerMailChecker.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/FakeMessagingControllerMailChecker.kt
@@ -2,14 +2,14 @@ package net.thunderbird.feature.navigation.drawer.dropdown.domain.usecase
 
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.MessagingListener
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class FakeMessagingControllerMailChecker(
     val recordedParameters: MutableList<CheckMailParameters> = mutableListOf(),
     private val listenerExecutor: (MessagingListener?) -> Unit = {},
 ) : MessagingControllerMailChecker {
     override fun checkMail(
-        account: LegacyAccount?,
+        account: LegacyAccountDto?,
         ignoreLastCheckedTime: Boolean,
         useManualWakeLock: Boolean,
         notify: Boolean,
@@ -22,7 +22,7 @@ internal class FakeMessagingControllerMailChecker(
 }
 
 internal data class CheckMailParameters(
-    val account: LegacyAccount?,
+    val account: LegacyAccountDto?,
     val ignoreLastCheckedTime: Boolean,
     val useManualWakeLock: Boolean,
     val notify: Boolean,

--- a/feature/navigation/drawer/siderail/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/FakeData.kt
+++ b/feature/navigation/drawer/siderail/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/siderail/ui/FakeData.kt
@@ -7,7 +7,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.navigation.drawer.siderail.domain.entity.DisplayAccount
@@ -21,7 +21,7 @@ internal object FakeData {
     const val DISPLAY_NAME = "Account Name"
     const val EMAIL_ADDRESS = "test@example.com"
 
-    val ACCOUNT = LegacyAccount(
+    val ACCOUNT = LegacyAccountDto(
         uuid = ACCOUNT_ID_RAW,
     ).apply {
         identities = ArrayList()

--- a/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/GetDisplayAccounts.kt
+++ b/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/GetDisplayAccounts.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.navigation.drawer.siderail.domain.DomainContract
 import net.thunderbird.feature.navigation.drawer.siderail.domain.entity.DisplayAccount
 
@@ -49,7 +49,7 @@ internal class GetDisplayAccounts(
             }
     }
 
-    private fun getMessageCountsFlow(account: LegacyAccount): Flow<MessageCounts> {
+    private fun getMessageCountsFlow(account: LegacyAccountDto): Flow<MessageCounts> {
         return callbackFlow {
             send(messageCountsProvider.getMessageCounts(account))
 

--- a/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/SyncAccount.kt
+++ b/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/SyncAccount.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.navigation.drawer.siderail.domain.DomainContract
 
 internal class SyncAccount(
@@ -20,7 +20,7 @@ internal class SyncAccount(
 ) : DomainContract.UseCase.SyncAccount {
     override fun invoke(accountUuid: String): Flow<Result<Unit>> = callbackFlow {
         val listener = object : SimpleMessagingListener() {
-            override fun checkMailFinished(context: Context?, account: LegacyAccount?) {
+            override fun checkMailFinished(context: Context?, account: LegacyAccountDto?) {
                 trySend(Result.success(Unit))
                 close()
             }

--- a/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/SyncAllAccounts.kt
+++ b/feature/navigation/drawer/siderail/src/main/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/SyncAllAccounts.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.navigation.drawer.siderail.domain.DomainContract
 
 class SyncAllAccounts(
@@ -18,7 +18,7 @@ class SyncAllAccounts(
 ) : DomainContract.UseCase.SyncAllAccounts {
     override fun invoke(): Flow<Result<Unit>> = callbackFlow {
         val listener = object : SimpleMessagingListener() {
-            override fun checkMailFinished(context: Context?, account: LegacyAccount?) {
+            override fun checkMailFinished(context: Context?, account: LegacyAccountDto?) {
                 trySend(Result.success(Unit))
                 close()
             }

--- a/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/data/FakeMessageCountsProvider.kt
+++ b/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/data/FakeMessageCountsProvider.kt
@@ -4,7 +4,7 @@ import app.k9mail.legacy.message.controller.MessageCounts
 import app.k9mail.legacy.message.controller.MessageCountsProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.SearchAccount
 
@@ -13,7 +13,7 @@ internal class FakeMessageCountsProvider(
 ) : MessageCountsProvider {
     var recordedSearch: LocalMessageSearch = LocalMessageSearch()
 
-    override fun getMessageCounts(account: LegacyAccount): MessageCounts {
+    override fun getMessageCounts(account: LegacyAccountDto): MessageCounts {
         TODO("Not yet implemented")
     }
 
@@ -30,7 +30,7 @@ internal class FakeMessageCountsProvider(
         return flowOf(messageCounts)
     }
 
-    override fun getUnreadMessageCount(account: LegacyAccount, folderId: Long): Int {
+    override fun getUnreadMessageCount(account: LegacyAccountDto, folderId: Long): Int {
         TODO("Not yet implemented")
     }
 }

--- a/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/FakeAccountManager.kt
+++ b/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/FakeAccountManager.kt
@@ -4,26 +4,26 @@ import kotlinx.coroutines.flow.Flow
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.AccountRemovedListener
 import net.thunderbird.core.android.account.AccountsChangeListener
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class FakeAccountManager(
     val recordedParameters: MutableList<String> = mutableListOf(),
-    private val accounts: List<LegacyAccount> = emptyList(),
+    private val accounts: List<LegacyAccountDto> = emptyList(),
 ) : AccountManager {
-    override fun getAccounts(): List<LegacyAccount> {
+    override fun getAccounts(): List<LegacyAccountDto> {
         TODO("Not yet implemented")
     }
 
-    override fun getAccountsFlow(): Flow<List<LegacyAccount>> {
+    override fun getAccountsFlow(): Flow<List<LegacyAccountDto>> {
         TODO("Not yet implemented")
     }
 
-    override fun getAccount(accountUuid: String): LegacyAccount? {
+    override fun getAccount(accountUuid: String): LegacyAccountDto? {
         recordedParameters.add(accountUuid)
         return accounts.find { it.uuid == accountUuid }
     }
 
-    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccount> {
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccountDto> {
         TODO("Not yet implemented")
     }
 
@@ -31,7 +31,7 @@ internal class FakeAccountManager(
         TODO("Not yet implemented")
     }
 
-    override fun moveAccount(account: LegacyAccount, newPosition: Int) {
+    override fun moveAccount(account: LegacyAccountDto, newPosition: Int) {
         TODO("Not yet implemented")
     }
 
@@ -43,7 +43,7 @@ internal class FakeAccountManager(
         TODO("Not yet implemented")
     }
 
-    override fun saveAccount(account: LegacyAccount) {
+    override fun saveAccount(account: LegacyAccountDto) {
         TODO("Not yet implemented")
     }
 }

--- a/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/FakeDisplayFolderRepository.kt
+++ b/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/FakeDisplayFolderRepository.kt
@@ -3,13 +3,13 @@ package net.thunderbird.feature.navigation.drawer.siderail.domain.usecase
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
 import kotlinx.coroutines.flow.Flow
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class FakeDisplayFolderRepository(
     private val foldersFlow: Flow<List<DisplayFolder>>,
 ) : DisplayFolderRepository {
     override fun getDisplayFoldersFlow(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         includeHiddenFolders: Boolean,
     ): Flow<List<DisplayFolder>> {
         TODO("Not yet implemented")

--- a/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/FakeMessagingControllerMailChecker.kt
+++ b/feature/navigation/drawer/siderail/src/test/kotlin/net/thunderbird/feature/navigation/drawer/siderail/domain/usecase/FakeMessagingControllerMailChecker.kt
@@ -2,14 +2,14 @@ package net.thunderbird.feature.navigation.drawer.siderail.domain.usecase
 
 import app.k9mail.legacy.message.controller.MessagingControllerMailChecker
 import app.k9mail.legacy.message.controller.MessagingListener
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class FakeMessagingControllerMailChecker(
     val recordedParameters: MutableList<CheckMailParameters> = mutableListOf(),
     private val listenerExecutor: (MessagingListener?) -> Unit = {},
 ) : MessagingControllerMailChecker {
     override fun checkMail(
-        account: LegacyAccount?,
+        account: LegacyAccountDto?,
         ignoreLastCheckedTime: Boolean,
         useManualWakeLock: Boolean,
         notify: Boolean,
@@ -22,7 +22,7 @@ internal class FakeMessagingControllerMailChecker(
 }
 
 internal data class CheckMailParameters(
-    val account: LegacyAccount?,
+    val account: LegacyAccountDto?,
     val ignoreLastCheckedTime: Boolean,
     val useManualWakeLock: Boolean,
     val notify: Boolean,

--- a/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/AuthViewModel.kt
+++ b/feature/settings/import/src/main/kotlin/app/k9mail/feature/settings/import/ui/AuthViewModel.kt
@@ -27,7 +27,7 @@ import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 
 private const val KEY_AUTHORIZATION = "app.k9mail_auth"
@@ -41,7 +41,7 @@ internal class AuthViewModel(
     private var authService: AuthorizationService? = null
     private val authState = AuthState()
 
-    private var account: LegacyAccount? = null
+    private var account: LegacyAccountDto? = null
 
     private lateinit var resultObserver: AppAuthResultObserver
 
@@ -53,7 +53,7 @@ internal class AuthViewModel(
         return authService ?: AuthorizationService(getApplication<Application>()).also { authService = it }
     }
 
-    fun init(activityResultRegistry: ActivityResultRegistry, lifecycle: Lifecycle, account: LegacyAccount) {
+    fun init(activityResultRegistry: ActivityResultRegistry, lifecycle: Lifecycle, account: LegacyAccountDto) {
         this.account = account
         resultObserver = AppAuthResultObserver(activityResultRegistry)
         lifecycle.addObserver(resultObserver)
@@ -63,16 +63,16 @@ internal class AuthViewModel(
         _uiState.update { AuthFlowState.Idle }
     }
 
-    fun isAuthorized(account: LegacyAccount): Boolean {
+    fun isAuthorized(account: LegacyAccountDto): Boolean {
         val authState = getOrCreateAuthState(account)
         return authState.isAuthorized
     }
 
-    fun isUsingGoogle(account: LegacyAccount): Boolean {
+    fun isUsingGoogle(account: LegacyAccountDto): Boolean {
         return GoogleOAuthHelper.isGoogle(account.incomingServerSettings.host!!)
     }
 
-    private fun getOrCreateAuthState(account: LegacyAccount): AuthState {
+    private fun getOrCreateAuthState(account: LegacyAccountDto): AuthState {
         return try {
             account.oAuthState?.let { AuthState.jsonDeserialize(it) } ?: AuthState()
         } catch (e: Exception) {
@@ -93,7 +93,7 @@ internal class AuthViewModel(
         }
     }
 
-    private suspend fun startLogin(account: LegacyAccount) {
+    private suspend fun startLogin(account: LegacyAccountDto) {
         val authRequestIntentResult = withContext(Dispatchers.IO) {
             getOAuthRequestIntent.execute(account.incomingServerSettings.host!!, account.email)
         }

--- a/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListItemMapper.kt
+++ b/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListItemMapper.kt
@@ -7,12 +7,12 @@ import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.ui.helper.DisplayAddressHelper
 import java.util.Calendar
 import java.util.Locale
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 internal class MessageListItemMapper(
     private val messageHelper: MessageHelper,
-    private val account: LegacyAccount,
+    private val account: LegacyAccountDto,
     private val generalSettingsManager: GeneralSettingsManager,
 ) : MessageMapper<MessageListItem> {
     private val calendar: Calendar = Calendar.getInstance()
@@ -71,7 +71,7 @@ internal class MessageListItemMapper(
         return String.format("%d %s", dayOfMonth, month)
     }
 
-    private fun createUniqueId(account: LegacyAccount, messageId: Long): Long {
+    private fun createUniqueId(account: LegacyAccountDto, messageId: Long): Long {
         return ((account.accountNumber + 1).toLong() shl ACCOUNT_NUMBER_BIT_SHIFT) + messageId
     }
 

--- a/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListLoader.kt
+++ b/feature/widget/message-list-glance/src/main/kotlin/net/thunderbird/feature/widget/message/list/MessageListLoader.kt
@@ -5,7 +5,7 @@ import com.fsck.k9.Preferences
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mailstore.MessageColumns
 import com.fsck.k9.search.getAccounts
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.SortType
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
@@ -41,7 +41,7 @@ internal class MessageListLoader(
         return messageListItems
     }
 
-    private fun loadMessageListForAccount(account: LegacyAccount, config: MessageListConfig): List<MessageListItem> {
+    private fun loadMessageListForAccount(account: LegacyAccountDto, config: MessageListConfig): List<MessageListItem> {
         val accountUuid = account.uuid
         val sortOrder = buildSortOrder(config)
         val mapper = MessageListItemMapper(messageHelper, account, generalSettingsManager)

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListItemMapper.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListItemMapper.kt
@@ -7,12 +7,12 @@ import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.ui.helper.DisplayAddressHelper
 import java.util.Calendar
 import java.util.Locale
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 internal class MessageListItemMapper(
     private val messageHelper: MessageHelper,
-    private val account: LegacyAccount,
+    private val account: LegacyAccountDto,
     private val generalSettingsManager: GeneralSettingsManager,
 ) : MessageMapper<MessageListItem> {
     private val calendar: Calendar = Calendar.getInstance()
@@ -65,7 +65,7 @@ internal class MessageListItemMapper(
         return String.format("%d %s", dayOfMonth, month)
     }
 
-    private fun createUniqueId(account: LegacyAccount, messageId: Long): Long {
+    private fun createUniqueId(account: LegacyAccountDto, messageId: Long): Long {
         return ((account.accountNumber + 1).toLong() shl ACCOUNT_NUMBER_BIT_SHIFT) + messageId
     }
 

--- a/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListLoader.kt
+++ b/feature/widget/message-list/src/main/kotlin/app/k9mail/feature/widget/message/list/MessageListLoader.kt
@@ -5,7 +5,7 @@ import com.fsck.k9.Preferences
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mailstore.MessageColumns
 import com.fsck.k9.search.getAccounts
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.SortType
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
@@ -41,7 +41,7 @@ internal class MessageListLoader(
         return messageListItems
     }
 
-    private fun loadMessageListForAccount(account: LegacyAccount, config: MessageListConfig): List<MessageListItem> {
+    private fun loadMessageListForAccount(account: LegacyAccountDto, config: MessageListConfig): List<MessageListItem> {
         val accountUuid = account.uuid
         val sortOrder = buildSortOrder(config)
         val mapper = MessageListItemMapper(messageHelper, account, generalSettingsManager)

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProvider.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.Preferences
 import com.fsck.k9.activity.MessageList
 import com.fsck.k9.ui.messagelist.DefaultFolderProvider
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.SearchAccount
@@ -59,7 +59,7 @@ class UnreadWidgetDataProvider(
         return UnreadWidgetData(configuration, title, unreadCount, clickIntent)
     }
 
-    private fun getClickIntentForAccount(account: LegacyAccount): Intent {
+    private fun getClickIntentForAccount(account: LegacyAccountDto): Intent {
         val folderId = defaultFolderProvider.getDefaultFolder(account)
         return getClickIntentForFolder(account, folderId)
     }
@@ -81,7 +81,7 @@ class UnreadWidgetDataProvider(
         return UnreadWidgetData(configuration, title, unreadCount, clickIntent)
     }
 
-    private fun getFolderDisplayName(account: LegacyAccount, folderId: Long): String {
+    private fun getFolderDisplayName(account: LegacyAccountDto, folderId: Long): String {
         val folder = folderRepository.getFolder(account, folderId)
         return if (folder != null) {
             folderNameFormatter.displayName(folder)
@@ -91,7 +91,7 @@ class UnreadWidgetDataProvider(
         }
     }
 
-    private fun getClickIntentForFolder(account: LegacyAccount, folderId: Long): Intent {
+    private fun getClickIntentForFolder(account: LegacyAccountDto, folderId: Long): Intent {
         val search = LocalMessageSearch()
         search.addAllowedFolder(folderId)
         search.addAccountUuid(account.uuid)

--- a/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetUpdateListener.kt
+++ b/feature/widget/unread/src/main/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetUpdateListener.kt
@@ -2,7 +2,7 @@ package app.k9mail.feature.widget.unread
 
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import com.fsck.k9.mail.Message
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 
 class UnreadWidgetUpdateListener(
@@ -19,18 +19,18 @@ class UnreadWidgetUpdateListener(
     }
 
     override fun synchronizeMailboxRemovedMessage(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         folderServerId: String,
         messageServerId: String,
     ) {
         updateUnreadWidget()
     }
 
-    override fun synchronizeMailboxNewMessage(account: LegacyAccount, folderServerId: String, message: Message) {
+    override fun synchronizeMailboxNewMessage(account: LegacyAccountDto, folderServerId: String, message: Message) {
         updateUnreadWidget()
     }
 
-    override fun folderStatusChanged(account: LegacyAccount, folderId: Long) {
+    override fun folderStatusChanged(account: LegacyAccountDto, folderId: Long) {
         updateUnreadWidget()
     }
 }

--- a/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/feature/widget/unread/src/test/kotlin/app/k9mail/feature/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -12,7 +12,7 @@ import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.Preferences
 import com.fsck.k9.ui.messagelist.DefaultFolderProvider
 import kotlinx.coroutines.flow.Flow
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
@@ -120,7 +120,7 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
         assertThat(widgetData).isNull()
     }
 
-    private fun createAccount(): LegacyAccount = mock {
+    private fun createAccount(): LegacyAccountDto = mock {
         on { uuid } doReturn ACCOUNT_UUID
         on { displayName } doReturn ACCOUNT_NAME
     }
@@ -130,7 +130,7 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
     }
 
     private fun createMessageCountsProvider() = object : MessageCountsProvider {
-        override fun getMessageCounts(account: LegacyAccount): MessageCounts {
+        override fun getMessageCounts(account: LegacyAccountDto): MessageCounts {
             return MessageCounts(unread = ACCOUNT_UNREAD_COUNT, starred = 0)
         }
 
@@ -146,7 +146,7 @@ class UnreadWidgetDataProviderTest : AutoCloseKoinTest() {
             throw UnsupportedOperationException()
         }
 
-        override fun getUnreadMessageCount(account: LegacyAccount, folderId: Long): Int {
+        override fun getUnreadMessageCount(account: LegacyAccountDto, folderId: Long): Int {
             return FOLDER_UNREAD_COUNT
         }
     }

--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountActivator.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountActivator.kt
@@ -5,7 +5,7 @@ import app.k9mail.feature.settings.import.SettingsImportExternalContract
 import com.fsck.k9.Core
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Activate account after server password(s) have been provided on settings import.
@@ -28,7 +28,7 @@ class AccountActivator(
         enableAccount(account)
     }
 
-    private fun enableAccount(account: LegacyAccount) {
+    private fun enableAccount(account: LegacyAccountDto) {
         // Start services if necessary
         Core.setServicesEnabled(context)
 
@@ -37,7 +37,7 @@ class AccountActivator(
     }
 
     private fun setAccountPasswords(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         incomingServerPassword: String?,
         outgoingServerPassword: String?,
     ) {

--- a/legacy/common/src/main/java/com/fsck/k9/account/AccountStateLoader.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/account/AccountStateLoader.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.Protocols
 import net.thunderbird.core.logging.legacy.Log
 
@@ -35,7 +35,7 @@ class AccountStateLoader(
         return accountManager.getAccount(accountUuid)?.let { mapToAccountState(it) }
     }
 
-    private fun mapToAccountState(account: LegacyAccount): AccountState {
+    private fun mapToAccountState(account: LegacyAccountDto): AccountState {
         return AccountState(
             uuid = account.uuid,
             emailAddress = account.email,
@@ -46,7 +46,7 @@ class AccountStateLoader(
     }
 }
 
-private val LegacyAccount.incomingServerSettingsExtra: ServerSettings
+private val LegacyAccountDto.incomingServerSettingsExtra: ServerSettings
     get() = when (incomingServerSettings.type) {
         Protocols.IMAP -> toImapServerSettings()
         else -> incomingServerSettings

--- a/legacy/common/src/main/java/com/fsck/k9/backends/AccountAuthStateStorage.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/AccountAuthStateStorage.kt
@@ -2,11 +2,11 @@ package com.fsck.k9.backends
 
 import com.fsck.k9.mail.oauth.AuthStateStorage
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class AccountAuthStateStorage(
     private val accountManager: AccountManager,
-    private val account: LegacyAccount,
+    private val account: LegacyAccountDto,
 ) : AuthStateStorage {
     override fun getAuthorizationState(): String? {
         return account.oAuthState

--- a/legacy/common/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.Expunge
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 @Suppress("LongParameterList")
 class ImapBackendFactory(
@@ -33,7 +33,7 @@ class ImapBackendFactory(
     private val clientInfoAppName: String,
     private val clientInfoAppVersion: String,
 ) : BackendFactory {
-    override fun createBackend(account: LegacyAccount): Backend {
+    override fun createBackend(account: LegacyAccountDto): Backend {
         val accountName = account.displayName
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         val imapStore = createImapStore(account)
@@ -51,7 +51,7 @@ class ImapBackendFactory(
         )
     }
 
-    private fun createImapStore(account: LegacyAccount): ImapStore {
+    private fun createImapStore(account: LegacyAccountDto): ImapStore {
         val serverSettings = account.toImapServerSettings()
 
         val oAuth2TokenProvider = if (serverSettings.authenticationType == AuthType.XOAUTH2) {
@@ -69,7 +69,7 @@ class ImapBackendFactory(
         )
     }
 
-    private fun createImapStoreConfig(account: LegacyAccount): ImapStoreConfig {
+    private fun createImapStoreConfig(account: LegacyAccountDto): ImapStoreConfig {
         return object : ImapStoreConfig {
             override val logLabel
                 get() = account.uuid
@@ -82,7 +82,7 @@ class ImapBackendFactory(
         }
     }
 
-    private fun createSmtpTransport(account: LegacyAccount): SmtpTransport {
+    private fun createSmtpTransport(account: LegacyAccountDto): SmtpTransport {
         val serverSettings = account.outgoingServerSettings
         val oauth2TokenProvider = if (serverSettings.authenticationType == AuthType.XOAUTH2) {
             createOAuth2TokenProvider(account)
@@ -93,12 +93,12 @@ class ImapBackendFactory(
         return SmtpTransport(serverSettings, trustedSocketFactory, oauth2TokenProvider)
     }
 
-    private fun createOAuth2TokenProvider(account: LegacyAccount): RealOAuth2TokenProvider {
+    private fun createOAuth2TokenProvider(account: LegacyAccountDto): RealOAuth2TokenProvider {
         val authStateStorage = AccountAuthStateStorage(accountManager, account)
         return RealOAuth2TokenProvider(context, authStateStorage)
     }
 
-    private fun createPushConfigProvider(account: LegacyAccount) = object : ImapPushConfigProvider {
+    private fun createPushConfigProvider(account: LegacyAccountDto) = object : ImapPushConfigProvider {
         override val maxPushFoldersFlow: Flow<Int>
             get() = accountManager.getAccountFlow(account.uuid)
                 .filterNotNull()

--- a/legacy/common/src/main/java/com/fsck/k9/backends/ImapServerSettingsExtensions.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/ImapServerSettingsExtensions.kt
@@ -4,9 +4,9 @@ import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.autoDetectNamespace
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.pathPrefix
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
-fun LegacyAccount.toImapServerSettings(): ServerSettings {
+fun LegacyAccountDto.toImapServerSettings(): ServerSettings {
     val serverSettings = incomingServerSettings
     return serverSettings.copy(
         extra = ImapStoreSettings.createExtra(

--- a/legacy/common/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
@@ -8,13 +8,13 @@ import com.fsck.k9.mail.ssl.TrustedSocketFactory
 import com.fsck.k9.mail.store.pop3.Pop3Store
 import com.fsck.k9.mail.transport.smtp.SmtpTransport
 import com.fsck.k9.mailstore.K9BackendStorageFactory
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class Pop3BackendFactory(
     private val backendStorageFactory: K9BackendStorageFactory,
     private val trustedSocketFactory: TrustedSocketFactory,
 ) : BackendFactory {
-    override fun createBackend(account: LegacyAccount): Backend {
+    override fun createBackend(account: LegacyAccountDto): Backend {
         val accountName = account.displayName
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         val pop3Store = createPop3Store(account)
@@ -22,12 +22,12 @@ class Pop3BackendFactory(
         return Pop3Backend(accountName, backendStorage, pop3Store, smtpTransport)
     }
 
-    private fun createPop3Store(account: LegacyAccount): Pop3Store {
+    private fun createPop3Store(account: LegacyAccountDto): Pop3Store {
         val serverSettings = account.incomingServerSettings
         return Pop3Store(serverSettings, trustedSocketFactory)
     }
 
-    private fun createSmtpTransport(account: LegacyAccount): SmtpTransport {
+    private fun createSmtpTransport(account: LegacyAccountDto): SmtpTransport {
         val serverSettings = account.outgoingServerSettings
         val oauth2TokenProvider: OAuth2TokenProvider? = null
         return SmtpTransport(serverSettings, trustedSocketFactory, oauth2TokenProvider)

--- a/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.kt
@@ -16,7 +16,7 @@ import com.fsck.k9.activity.MessageList
 import com.fsck.k9.activity.compose.MessageActions
 import com.fsck.k9.ui.messagelist.DefaultFolderProvider
 import com.fsck.k9.ui.notification.DeleteConfirmationActivity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 
@@ -48,13 +48,13 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun createViewFolderPendingIntent(account: LegacyAccount, folderId: Long): PendingIntent {
+    override fun createViewFolderPendingIntent(account: LegacyAccountDto, folderId: Long): PendingIntent {
         val intent = createMessageListIntent(account, folderId)
         return PendingIntentCompat.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
     override fun createViewMessagesPendingIntent(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         val folderIds = extractFolderIds(messageReferences)
@@ -74,12 +74,12 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun createViewFolderListPendingIntent(account: LegacyAccount): PendingIntent {
+    override fun createViewFolderListPendingIntent(account: LegacyAccountDto): PendingIntent {
         val intent = createMessageListIntent(account)
         return PendingIntentCompat.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun createDismissAllMessagesPendingIntent(account: LegacyAccount): PendingIntent {
+    override fun createDismissAllMessagesPendingIntent(account: LegacyAccountDto): PendingIntent {
         val intent = NotificationActionService.createDismissAllMessagesIntent(context, account).apply {
             data = Uri.parse("data:,dismissAll/${account.uuid}/${System.currentTimeMillis()}")
         }
@@ -108,7 +108,7 @@ internal class K9NotificationActionCreator(
     }
 
     override fun createMarkAllAsReadPendingIntent(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         val accountUuid = account.uuid
@@ -119,7 +119,7 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getService(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun getEditIncomingServerSettingsIntent(account: LegacyAccount): PendingIntent {
+    override fun getEditIncomingServerSettingsIntent(account: LegacyAccountDto): PendingIntent {
         val intent = FeatureLauncherActivity.getIntent(
             context = context,
             target = FeatureLauncherTarget.AccountEditIncomingSettings(account.uuid),
@@ -127,7 +127,7 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getActivity(context, account.accountNumber, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    override fun getEditOutgoingServerSettingsIntent(account: LegacyAccount): PendingIntent {
+    override fun getEditOutgoingServerSettingsIntent(account: LegacyAccountDto): PendingIntent {
         val intent = FeatureLauncherActivity.getIntent(
             context = context,
             target = FeatureLauncherTarget.AccountEditOutgoingSettings(account.uuid),
@@ -158,7 +158,7 @@ internal class K9NotificationActionCreator(
     }
 
     override fun createDeleteAllPendingIntent(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         return if (K9.isConfirmDeleteFromNotification) {
@@ -176,7 +176,7 @@ internal class K9NotificationActionCreator(
     }
 
     private fun getDeleteAllServicePendingIntent(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         val accountUuid = account.uuid
@@ -195,7 +195,7 @@ internal class K9NotificationActionCreator(
     }
 
     override fun createArchiveAllPendingIntent(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         messageReferences: List<MessageReference>,
     ): PendingIntent {
         val intent = NotificationActionService.createArchiveAllIntent(context, account, messageReferences).apply {
@@ -211,7 +211,7 @@ internal class K9NotificationActionCreator(
         return PendingIntentCompat.getService(context, 0, intent, FLAG_UPDATE_CURRENT, false)!!
     }
 
-    private fun createMessageListIntent(account: LegacyAccount): Intent {
+    private fun createMessageListIntent(account: LegacyAccountDto): Intent {
         val folderId = defaultFolderProvider.getDefaultFolder(account)
         val search = LocalMessageSearch().apply {
             addAllowedFolder(folderId)
@@ -229,7 +229,7 @@ internal class K9NotificationActionCreator(
         }
     }
 
-    private fun createMessageListIntent(account: LegacyAccount, folderId: Long): Intent {
+    private fun createMessageListIntent(account: LegacyAccountDto, folderId: Long): Intent {
         val search = LocalMessageSearch().apply {
             addAllowedFolder(folderId)
             addAccountUuid(account.uuid)
@@ -252,13 +252,13 @@ internal class K9NotificationActionCreator(
         }
     }
 
-    private fun createUnifiedInboxIntent(account: LegacyAccount): Intent {
+    private fun createUnifiedInboxIntent(account: LegacyAccountDto): Intent {
         return MessageList.createUnifiedInboxIntent(context, account).apply {
             data = Uri.parse("data:,unifiedInbox/${account.uuid}")
         }
     }
 
-    private fun createNewMessagesIntent(account: LegacyAccount): Intent {
+    private fun createNewMessagesIntent(account: LegacyAccountDto): Intent {
         return MessageList.createNewMessagesIntent(context, account).apply {
             data = Uri.parse("data:,newMessages/${account.uuid}")
         }
@@ -268,7 +268,7 @@ internal class K9NotificationActionCreator(
         return messageReferences.asSequence().map { it.folderId }.toSet()
     }
 
-    private fun areAllIncludedInUnifiedInbox(account: LegacyAccount, folderIds: Collection<Long>): Boolean {
+    private fun areAllIncludedInUnifiedInbox(account: LegacyAccountDto, folderIds: Collection<Long>): Boolean {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.areAllIncludedInUnifiedInbox(folderIds)
     }

--- a/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -11,7 +11,7 @@ import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.mailstore.LocalMessage
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.toEmailAddressOrNull
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
@@ -24,7 +24,7 @@ class K9NotificationStrategy(
 
     @Suppress("ReturnCount")
     override fun shouldNotifyForMessage(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         localFolder: LocalFolder,
         message: LocalMessage,
         isOldMessage: Boolean,

--- a/legacy/common/src/test/java/com/fsck/k9/account/AccountServerSettingsUpdaterTest.kt
+++ b/legacy/common/src/test/java/com/fsck/k9/account/AccountServerSettingsUpdaterTest.kt
@@ -18,7 +18,7 @@ import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.logging.testing.TestLogger
 import org.junit.Before
 import org.junit.Test
-import net.thunderbird.core.android.account.LegacyAccount as K9Account
+import net.thunderbird.core.android.account.LegacyAccountDto as K9Account
 
 class AccountServerSettingsUpdaterTest {
 

--- a/legacy/common/src/test/java/com/fsck/k9/account/AccountStateLoaderTest.kt
+++ b/legacy/common/src/test/java/com/fsck/k9/account/AccountStateLoaderTest.kt
@@ -11,7 +11,7 @@ import com.fsck.k9.mail.ServerSettings
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.Test
 
 class AccountStateLoaderTest {
@@ -29,7 +29,7 @@ class AccountStateLoaderTest {
     @Test
     fun `loadAccountState() SHOULD return account when present in accountManager`() = runTest {
         val accounts = mutableMapOf(
-            ACCOUNT_ID_RAW to LegacyAccount(uuid = ACCOUNT_ID_RAW).apply {
+            ACCOUNT_ID_RAW to LegacyAccountDto(uuid = ACCOUNT_ID_RAW).apply {
                 identities = mutableListOf(Identity())
                 email = "emailAddress"
                 incomingServerSettings = INCOMING_SERVER_SETTINGS

--- a/legacy/common/src/test/java/com/fsck/k9/account/FakeAccountManager.kt
+++ b/legacy/common/src/test/java/com/fsck/k9/account/FakeAccountManager.kt
@@ -4,22 +4,22 @@ import kotlinx.coroutines.flow.Flow
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.AccountRemovedListener
 import net.thunderbird.core.android.account.AccountsChangeListener
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class FakeAccountManager(
-    private val accounts: MutableMap<String, LegacyAccount> = mutableMapOf(),
+    private val accounts: MutableMap<String, LegacyAccountDto> = mutableMapOf(),
     private val isFailureOnSave: Boolean = false,
 ) : AccountManager {
 
-    override fun getAccounts(): List<LegacyAccount> = accounts.values.toList()
+    override fun getAccounts(): List<LegacyAccountDto> = accounts.values.toList()
 
-    override fun getAccountsFlow(): Flow<List<LegacyAccount>> {
+    override fun getAccountsFlow(): Flow<List<LegacyAccountDto>> {
         TODO("Not yet implemented")
     }
 
-    override fun getAccount(accountUuid: String): LegacyAccount? = accounts[accountUuid]
+    override fun getAccount(accountUuid: String): LegacyAccountDto? = accounts[accountUuid]
 
-    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccount> {
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccountDto> {
         TODO("Not yet implemented")
     }
 
@@ -27,7 +27,7 @@ class FakeAccountManager(
         TODO("Not yet implemented")
     }
 
-    override fun moveAccount(account: LegacyAccount, newPosition: Int) {
+    override fun moveAccount(account: LegacyAccountDto, newPosition: Int) {
         TODO("Not yet implemented")
     }
 
@@ -40,7 +40,7 @@ class FakeAccountManager(
     }
 
     @Suppress("TooGenericExceptionThrown")
-    override fun saveAccount(account: LegacyAccount) {
+    override fun saveAccount(account: LegacyAccountDto) {
         if (isFailureOnSave) {
             throw Exception("FakeAccountManager.saveAccount() failed")
         }

--- a/legacy/core/src/main/java/com/fsck/k9/LocalKeyStoreManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/LocalKeyStoreManager.kt
@@ -3,7 +3,7 @@ package com.fsck.k9
 import com.fsck.k9.mail.ssl.LocalKeyStore
 import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.mail.mailserver.MailServerDirection
 
 class LocalKeyStoreManager(
@@ -13,7 +13,7 @@ class LocalKeyStoreManager(
      * Add a new certificate for the incoming or outgoing server to the local key store.
      */
     @Throws(CertificateException::class)
-    fun addCertificate(account: LegacyAccount, direction: MailServerDirection, certificate: X509Certificate) {
+    fun addCertificate(account: LegacyAccountDto, direction: MailServerDirection, certificate: X509Certificate) {
         val serverSettings = if (direction === MailServerDirection.INCOMING) {
             account.incomingServerSettings
         } else {
@@ -27,7 +27,7 @@ class LocalKeyStoreManager(
      * new host/port, then try and delete any (possibly non-existent) certificate stored for the
      * old host/port.
      */
-    fun deleteCertificate(account: LegacyAccount, newHost: String, newPort: Int, direction: MailServerDirection) {
+    fun deleteCertificate(account: LegacyAccountDto, newHost: String, newPort: Int, direction: MailServerDirection) {
         val serverSettings = if (direction === MailServerDirection.INCOMING) {
             account.incomingServerSettings
         } else {
@@ -48,7 +48,7 @@ class LocalKeyStoreManager(
      * Examine the settings for the account and attempt to delete (possibly non-existent)
      * certificates for the incoming and outgoing servers.
      */
-    fun deleteCertificates(account: LegacyAccount) {
+    fun deleteCertificates(account: LegacyAccountDto) {
         account.incomingServerSettings.let { serverSettings ->
             localKeyStore.deleteCertificate(serverSettings.host!!, serverSettings.port)
         }

--- a/legacy/core/src/main/java/com/fsck/k9/Preferences.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/Preferences.kt
@@ -22,7 +22,7 @@ import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.UN
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.AccountRemovedListener
 import net.thunderbird.core.android.account.AccountsChangeListener
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
@@ -46,13 +46,13 @@ class Preferences internal constructor(
     private val storageLock = Any()
 
     @GuardedBy("accountLock")
-    private var accountsMap: MutableMap<String, LegacyAccount>? = null
+    private var accountsMap: MutableMap<String, LegacyAccountDto>? = null
 
     @GuardedBy("accountLock")
-    private var accountsInOrder = mutableListOf<LegacyAccount>()
+    private var accountsInOrder = mutableListOf<LegacyAccountDto>()
 
     @GuardedBy("accountLock")
-    private var newAccount: LegacyAccount? = null
+    private var newAccount: LegacyAccountDto? = null
     private val accountsChangeListeners = CopyOnWriteArraySet<AccountsChangeListener>()
     private val accountRemovedListeners = CopyOnWriteArraySet<AccountRemovedListener>()
 
@@ -84,14 +84,14 @@ class Preferences internal constructor(
 
     fun loadAccounts() {
         synchronized(accountLock) {
-            val accounts = mutableMapOf<String, LegacyAccount>()
-            val accountsInOrder = mutableListOf<LegacyAccount>()
+            val accounts = mutableMapOf<String, LegacyAccountDto>()
+            val accountsInOrder = mutableListOf<LegacyAccountDto>()
 
             val accountUuids = storage.getStringOrNull("accountUuids")
             if (!accountUuids.isNullOrEmpty()) {
                 accountUuids.split(",").forEach { uuid ->
                     val existingAccount = accountsMap?.get(uuid)
-                    val account = existingAccount ?: LegacyAccount(
+                    val account = existingAccount ?: LegacyAccountDto(
                         uuid,
                         { generalSettingsManager.getConfig().debugging.isSensitiveLoggingEnabled },
                     )
@@ -116,7 +116,7 @@ class Preferences internal constructor(
         }
     }
 
-    override fun getAccounts(): List<LegacyAccount> {
+    override fun getAccounts(): List<LegacyAccountDto> {
         synchronized(accountLock) {
             if (accountsMap == null) {
                 loadAccounts()
@@ -126,10 +126,10 @@ class Preferences internal constructor(
         }
     }
 
-    private val completeAccounts: List<LegacyAccount>
+    private val completeAccounts: List<LegacyAccountDto>
         get() = getAccounts().filter { it.isFinishedSetup }
 
-    override fun getAccount(accountUuid: String): LegacyAccount? {
+    override fun getAccount(accountUuid: String): LegacyAccountDto? {
         synchronized(accountLock) {
             if (accountsMap == null) {
                 loadAccounts()
@@ -139,7 +139,7 @@ class Preferences internal constructor(
         }
     }
 
-    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccount> {
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccountDto> {
         return callbackFlow {
             val initialAccount = getAccount(accountUuid)
             if (initialAccount == null) {
@@ -167,7 +167,7 @@ class Preferences internal constructor(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun getAccountsFlow(): Flow<List<LegacyAccount>> {
+    override fun getAccountsFlow(): Flow<List<LegacyAccountDto>> {
         return callbackFlow {
             send(completeAccounts)
 
@@ -183,14 +183,14 @@ class Preferences internal constructor(
             .flowOn(backgroundDispatcher)
     }
 
-    fun newAccount(): LegacyAccount {
+    fun newAccount(): LegacyAccountDto {
         val accountUuid = UUID.randomUUID().toString()
         return newAccount(accountUuid)
     }
 
-    fun newAccount(accountUuid: String): LegacyAccount {
+    fun newAccount(accountUuid: String): LegacyAccountDto {
         val account =
-            LegacyAccount(accountUuid, { generalSettingsManager.getConfig().debugging.isSensitiveLoggingEnabled })
+            LegacyAccountDto(accountUuid, { generalSettingsManager.getConfig().debugging.isSensitiveLoggingEnabled })
         accountDefaultsProvider.applyDefaults(account)
 
         synchronized(accountLock) {
@@ -202,7 +202,7 @@ class Preferences internal constructor(
         return account
     }
 
-    fun deleteAccount(account: LegacyAccount) {
+    fun deleteAccount(account: LegacyAccountDto) {
         synchronized(accountLock) {
             accountsMap?.remove(account.uuid)
             accountsInOrder.remove(account)
@@ -220,10 +220,10 @@ class Preferences internal constructor(
         notifyAccountsChangeListeners()
     }
 
-    val defaultAccount: LegacyAccount?
+    val defaultAccount: LegacyAccountDto?
         get() = getAccounts().firstOrNull()
 
-    override fun saveAccount(account: LegacyAccount) {
+    override fun saveAccount(account: LegacyAccountDto) {
         ensureAssignedAccountNumber(account)
         processChangedValues(account)
 
@@ -238,13 +238,13 @@ class Preferences internal constructor(
         notifyAccountsChangeListeners()
     }
 
-    private fun ensureAssignedAccountNumber(account: LegacyAccount) {
+    private fun ensureAssignedAccountNumber(account: LegacyAccountDto) {
         if (account.accountNumber != UNASSIGNED_ACCOUNT_NUMBER) return
 
         account.accountNumber = generateAccountNumber()
     }
 
-    private fun processChangedValues(account: LegacyAccount) {
+    private fun processChangedValues(account: LegacyAccountDto) {
         if (account.isChangedVisibleLimits) {
             try {
                 localStoreProvider.getInstance(account).resetVisibleLimits(account.displayCount)
@@ -273,7 +273,7 @@ class Preferences internal constructor(
         return newAccountNumber
     }
 
-    override fun moveAccount(account: LegacyAccount, newPosition: Int) {
+    override fun moveAccount(account: LegacyAccountDto, newPosition: Int) {
         synchronized(accountLock) {
             val storageEditor = createStorageEditor()
             moveToPosition(account, storage, storageEditor, newPosition)
@@ -285,7 +285,7 @@ class Preferences internal constructor(
         notifyAccountsChangeListeners()
     }
 
-    private fun moveToPosition(account: LegacyAccount, storage: Storage, editor: StorageEditor, newPosition: Int) {
+    private fun moveToPosition(account: LegacyAccountDto, storage: Storage, editor: StorageEditor, newPosition: Int) {
         val accountUuids = storage.getStringOrDefault("accountUuids", "").split(",").filter { it.isNotEmpty() }
         val oldPosition = accountUuids.indexOf(account.uuid)
         if (oldPosition == -1 || oldPosition == newPosition) return
@@ -314,7 +314,7 @@ class Preferences internal constructor(
         accountsChangeListeners.remove(accountsChangeListener)
     }
 
-    private fun notifyAccountRemovedListeners(account: LegacyAccount) {
+    private fun notifyAccountRemovedListeners(account: LegacyAccountDto) {
         for (listener in accountRemovedListeners) {
             listener.onAccountRemoved(account)
         }

--- a/legacy/core/src/main/java/com/fsck/k9/backend/BackendFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/backend/BackendFactory.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.backend
 
 import com.fsck.k9.backend.api.Backend
 import net.thunderbird.backend.api.BackendFactory
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 @Deprecated(
     message = "Use net.thunderbird.backend.api.BackendFactory<TAccount : BaseAccount> instead",
@@ -12,6 +12,6 @@ import net.thunderbird.core.android.account.LegacyAccount
         "net.thunderbird.core.android.account.LegacyAccount",
     ),
 )
-interface BackendFactory : BackendFactory<LegacyAccount> {
-    override fun createBackend(account: LegacyAccount): Backend
+interface BackendFactory : BackendFactory<LegacyAccountDto> {
+    override fun createBackend(account: LegacyAccountDto): Backend
 }

--- a/legacy/core/src/main/java/com/fsck/k9/backend/BackendManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/backend/BackendManager.kt
@@ -3,13 +3,13 @@ package com.fsck.k9.backend
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.mail.ServerSettings
 import java.util.concurrent.CopyOnWriteArraySet
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class BackendManager(private val backendFactories: Map<String, BackendFactory>) {
     private val backendCache = mutableMapOf<String, BackendContainer>()
     private val listeners = CopyOnWriteArraySet<BackendChangedListener>()
 
-    fun getBackend(account: LegacyAccount): Backend {
+    fun getBackend(account: LegacyAccountDto): Backend {
         val newBackend = synchronized(backendCache) {
             val container = backendCache[account.uuid]
             if (container != null && isBackendStillValid(container, account)) {
@@ -30,12 +30,12 @@ class BackendManager(private val backendFactories: Map<String, BackendFactory>) 
         return newBackend
     }
 
-    private fun isBackendStillValid(container: BackendContainer, account: LegacyAccount): Boolean {
+    private fun isBackendStillValid(container: BackendContainer, account: LegacyAccountDto): Boolean {
         return container.incomingServerSettings == account.incomingServerSettings &&
             container.outgoingServerSettings == account.outgoingServerSettings
     }
 
-    fun removeBackend(account: LegacyAccount) {
+    fun removeBackend(account: LegacyAccountDto) {
         synchronized(backendCache) {
             backendCache.remove(account.uuid)
         }
@@ -43,7 +43,7 @@ class BackendManager(private val backendFactories: Map<String, BackendFactory>) 
         notifyListeners(account)
     }
 
-    private fun createBackend(account: LegacyAccount): Backend {
+    private fun createBackend(account: LegacyAccountDto): Backend {
         val serverType = account.incomingServerSettings.type
         val backendFactory = backendFactories[serverType] ?: error("Unsupported account type")
         return backendFactory.createBackend(account)
@@ -57,7 +57,7 @@ class BackendManager(private val backendFactories: Map<String, BackendFactory>) 
         listeners.remove(listener)
     }
 
-    private fun notifyListeners(account: LegacyAccount) {
+    private fun notifyListeners(account: LegacyAccountDto) {
         for (listener in listeners) {
             listener.onBackendChanged(account)
         }
@@ -71,5 +71,5 @@ private data class BackendContainer(
 )
 
 fun interface BackendChangedListener {
-    fun onBackendChanged(account: LegacyAccount)
+    fun onBackendChanged(account: LegacyAccountDto)
 }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/ArchiveOperations.kt
@@ -5,7 +5,7 @@ import com.fsck.k9.controller.MessagingController.MessageActor
 import com.fsck.k9.controller.MessagingController.MoveOrCopyFlavor
 import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.mailstore.LocalMessage
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.featureflag.toFeatureFlagKey
 import net.thunderbird.core.logging.legacy.Log
@@ -34,7 +34,7 @@ internal class ArchiveOperations(
         description: String,
         messages: List<MessageReference>,
         action: (
-            account: LegacyAccount,
+            account: LegacyAccountDto,
             folderId: Long,
             messagesInFolder: List<LocalMessage>,
             archiveFolderId: Long,
@@ -62,7 +62,7 @@ internal class ArchiveOperations(
     }
 
     private fun archiveThreads(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         sourceFolderId: Long,
         messages: List<LocalMessage>,
         archiveFolderId: Long,
@@ -72,7 +72,7 @@ internal class ArchiveOperations(
     }
 
     private fun archiveMessages(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         sourceFolderId: Long,
         messages: List<LocalMessage>,
         archiveFolderId: Long,
@@ -93,7 +93,7 @@ internal class ArchiveOperations(
 
     private fun actOnMessagesGroupedByAccountAndFolder(
         messages: List<MessageReference>,
-        block: (account: LegacyAccount, messageFolder: LocalFolder, messages: List<LocalMessage>) -> Unit,
+        block: (account: LegacyAccountDto, messageFolder: LocalFolder, messages: List<LocalMessage>) -> Unit,
     ) {
         val actor = MessageActor { account, messageFolder, messagesInFolder ->
             block(account, messageFolder, messagesInFolder)

--- a/legacy/core/src/main/java/com/fsck/k9/controller/DefaultMessageCountsProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/DefaultMessageCountsProvider.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.SearchAccount
@@ -31,7 +31,7 @@ internal class DefaultMessageCountsProvider(
     private val messagingControllerRegistry: MessagingControllerRegistry,
     private val coroutineContext: CoroutineContext = Dispatchers.IO,
 ) : MessageCountsProvider {
-    override fun getMessageCounts(account: LegacyAccount): MessageCounts {
+    override fun getMessageCounts(account: LegacyAccountDto): MessageCounts {
         val search = LocalMessageSearch().apply {
             excludeSpecialFolders(account)
             limitToDisplayableFolders()
@@ -59,7 +59,7 @@ internal class DefaultMessageCountsProvider(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    override fun getUnreadMessageCount(account: LegacyAccount, folderId: Long): Int {
+    override fun getUnreadMessageCount(account: LegacyAccountDto, folderId: Long): Int {
         return try {
             val messageStore = messageStoreManager.getMessageStore(account)
             return if (folderId == account.outboxFolderId) {
@@ -78,7 +78,7 @@ internal class DefaultMessageCountsProvider(
             send(getMessageCounts(search))
 
             val folderStatusChangedListener = object : SimpleMessagingListener() {
-                override fun folderStatusChanged(account: LegacyAccount, folderId: Long) {
+                override fun folderStatusChanged(account: LegacyAccountDto, folderId: Long) {
                     trySendBlocking(getMessageCounts(search))
                 }
             }
@@ -93,7 +93,7 @@ internal class DefaultMessageCountsProvider(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun getMessageCounts(account: LegacyAccount, conditions: SearchConditionTreeNode?): MessageCounts {
+    private fun getMessageCounts(account: LegacyAccountDto, conditions: SearchConditionTreeNode?): MessageCounts {
         return try {
             val messageStore = messageStoreManager.getMessageStore(account)
             return MessageCounts(

--- a/legacy/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -12,7 +12,7 @@ import com.fsck.k9.mail.MessageDownloadState
 import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.mailstore.LocalMessage
 import com.fsck.k9.mailstore.SaveMessageDataCreator
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.core.logging.legacy.Log
 import org.jetbrains.annotations.NotNull
@@ -24,7 +24,7 @@ internal class DraftOperations(
 ) {
 
     fun saveDraft(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         message: Message,
         existingDraftId: Long?,
         plaintextSubject: String?,
@@ -46,7 +46,7 @@ internal class DraftOperations(
     }
 
     private fun saveAndUploadDraft(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         message: Message,
         folderId: Long,
         existingDraftId: Long?,
@@ -84,7 +84,7 @@ internal class DraftOperations(
     }
 
     private fun saveDraftLocally(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         message: Message,
         folderId: Long,
         existingDraftId: Long?,
@@ -96,7 +96,7 @@ internal class DraftOperations(
         return messageStore.saveLocalMessage(folderId, messageData, existingDraftId)
     }
 
-    fun processPendingReplace(command: PendingReplace, account: LegacyAccount) {
+    fun processPendingReplace(command: PendingReplace, account: LegacyAccountDto) {
         val localStore = messagingController.getLocalStoreOrThrow(account)
         val localFolder = localStore.getFolder(command.folderId)
         localFolder.open()
@@ -119,7 +119,7 @@ internal class DraftOperations(
 
     private fun uploadMessage(
         backend: Backend,
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         localFolder: LocalFolder,
         localMessage: LocalMessage,
     ) {

--- a/legacy/core/src/main/java/com/fsck/k9/controller/LocalDeleteOperationDecider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/LocalDeleteOperationDecider.kt
@@ -1,15 +1,15 @@
 package com.fsck.k9.controller
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Decides whether deleting a message in the app moves it to the trash folder or deletes it immediately.
  *
  * Note: This only applies to local messages. What remote operation is performed when deleting a message is controlled
- * by [LegacyAccount.deletePolicy].
+ * by [LegacyAccountDto.deletePolicy].
  */
 internal class LocalDeleteOperationDecider {
-    fun isDeleteImmediately(account: LegacyAccount, folderId: Long): Boolean {
+    fun isDeleteImmediately(account: LegacyAccountDto, folderId: Long): Boolean {
         // If there's no trash folder configured, all messages are deleted immediately.
         if (!account.hasTrashFolder()) {
             return true

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
@@ -7,13 +7,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import app.k9mail.legacy.message.controller.MessagingListener;
 import app.k9mail.legacy.message.controller.SimpleMessagingListener;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 
 
 class MemorizingMessagingListener extends SimpleMessagingListener {
     Map<String, Memory> memories = new HashMap<>(31);
 
-    synchronized void removeAccount(LegacyAccount account) {
+    synchronized void removeAccount(LegacyAccountDto account) {
         Iterator<Entry<String, Memory>> memIt = memories.entrySet().iterator();
 
         while (memIt.hasNext()) {
@@ -63,7 +63,7 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     }
 
     @Override
-    public synchronized void synchronizeMailboxStarted(LegacyAccount account, long folderId) {
+    public synchronized void synchronizeMailboxStarted(LegacyAccountDto account, long folderId) {
         Memory memory = getMemory(account, folderId);
         memory.syncingState = MemorizingState.STARTED;
         memory.folderCompleted = 0;
@@ -71,13 +71,13 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     }
 
     @Override
-    public synchronized void synchronizeMailboxFinished(LegacyAccount account, long folderId) {
+    public synchronized void synchronizeMailboxFinished(LegacyAccountDto account, long folderId) {
         Memory memory = getMemory(account, folderId);
         memory.syncingState = MemorizingState.FINISHED;
     }
 
     @Override
-    public synchronized void synchronizeMailboxFailed(LegacyAccount account, long folderId,
+    public synchronized void synchronizeMailboxFailed(LegacyAccountDto account, long folderId,
             String message) {
 
         Memory memory = getMemory(account, folderId);
@@ -86,14 +86,14 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     }
 
     @Override
-    public synchronized void synchronizeMailboxProgress(LegacyAccount account, long folderId, int completed,
+    public synchronized void synchronizeMailboxProgress(LegacyAccountDto account, long folderId, int completed,
             int total) {
         Memory memory = getMemory(account, folderId);
         memory.folderCompleted = completed;
         memory.folderTotal = total;
     }
 
-    private Memory getMemory(LegacyAccount account, long folderId) {
+    private Memory getMemory(LegacyAccountDto account, long folderId) {
         Memory memory = memories.get(getMemoryKey(account, folderId));
         if (memory == null) {
             memory = new Memory(account, folderId);
@@ -102,14 +102,14 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
         return memory;
     }
 
-    private static String getMemoryKey(LegacyAccount account, long folderId) {
+    private static String getMemoryKey(LegacyAccountDto account, long folderId) {
         return account.getUuid() + ":" + folderId;
     }
 
     private enum MemorizingState { STARTED, FINISHED, FAILED }
 
     private static class Memory {
-        LegacyAccount account;
+        LegacyAccountDto account;
         long folderId;
         MemorizingState syncingState = null;
         String failureMessage = null;
@@ -117,7 +117,7 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
         int folderCompleted = 0;
         int folderTotal = 0;
 
-        Memory(LegacyAccount account, long folderId) {
+        Memory(LegacyAccountDto account, long folderId) {
             this.account = account;
             this.folderId = folderId;
         }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -83,7 +83,7 @@ import com.fsck.k9.mailstore.SpecialLocalFoldersCreator;
 import com.fsck.k9.notification.NotificationController;
 import com.fsck.k9.notification.NotificationStrategy;
 import net.thunderbird.core.android.account.DeletePolicy;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.featureflag.FeatureFlagProvider;
 import net.thunderbird.core.logging.Logger;
 import net.thunderbird.core.logging.legacy.Log;
@@ -275,11 +275,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         throw new Error(e);
     }
 
-    Backend getBackend(LegacyAccount account) {
+    Backend getBackend(LegacyAccountDto account) {
         return backendManager.getBackend(account);
     }
 
-    LocalStore getLocalStoreOrThrow(LegacyAccount account) {
+    LocalStore getLocalStoreOrThrow(LegacyAccountDto account) {
         try {
             return localStoreProvider.getInstance(account);
         } catch (MessagingException e) {
@@ -287,7 +287,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private String getFolderServerId(LegacyAccount account, long folderId) {
+    private String getFolderServerId(LegacyAccountDto account, long folderId) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         String folderServerId = messageStore.getFolderServerId(folderId);
         if (folderServerId == null) {
@@ -296,7 +296,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return folderServerId;
     }
 
-    private long getFolderId(LegacyAccount account, String folderServerId) {
+    private long getFolderId(LegacyAccountDto account, String folderServerId) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         Long folderId = messageStore.getFolderId(folderServerId);
         if (folderId == null) {
@@ -337,12 +337,12 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
 
-    void suppressMessages(LegacyAccount account, List<LocalMessage> messages) {
+    void suppressMessages(LegacyAccountDto account, List<LocalMessage> messages) {
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.hideMessages(messages);
     }
 
-    private void unsuppressMessages(LegacyAccount account, List<LocalMessage> messages) {
+    private void unsuppressMessages(LegacyAccountDto account, List<LocalMessage> messages) {
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.unhideMessages(messages);
     }
@@ -355,39 +355,39 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return cache.isMessageHidden(messageId, folderId);
     }
 
-    private void setFlagInCache(final LegacyAccount account, final List<Long> messageIds,
+    private void setFlagInCache(final LegacyAccountDto account, final List<Long> messageIds,
             final Flag flag, final boolean newState) {
 
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.setFlagForMessages(messageIds, flag, newState);
     }
 
-    private void removeFlagFromCache(final LegacyAccount account, final List<Long> messageIds,
+    private void removeFlagFromCache(final LegacyAccountDto account, final List<Long> messageIds,
             final Flag flag) {
 
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.removeFlagForMessages(messageIds, flag);
     }
 
-    private void setFlagForThreadsInCache(final LegacyAccount account, final List<Long> threadRootIds,
+    private void setFlagForThreadsInCache(final LegacyAccountDto account, final List<Long> threadRootIds,
             final Flag flag, final boolean newState) {
 
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.setValueForThreads(threadRootIds, flag, newState);
     }
 
-    private void removeFlagForThreadsFromCache(final LegacyAccount account, final List<Long> messageIds,
+    private void removeFlagForThreadsFromCache(final LegacyAccountDto account, final List<Long> messageIds,
             final Flag flag) {
 
         MessageListCache cache = MessageListCache.getCache(account.getUuid());
         cache.removeFlagForThreads(messageIds, flag);
     }
 
-    public void refreshFolderList(final LegacyAccount account) {
+    public void refreshFolderList(final LegacyAccountDto account) {
         put("refreshFolderList", null, () -> refreshFolderListSynchronous(account));
     }
 
-    public void refreshFolderListBlocking(LegacyAccount account) {
+    public void refreshFolderListBlocking(LegacyAccountDto account) {
         final CountDownLatch latch = new CountDownLatch(1);
         putBackground("refreshFolderListBlocking", null, () -> {
             try {
@@ -404,7 +404,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    void refreshFolderListSynchronous(LegacyAccount account) {
+    void refreshFolderListSynchronous(LegacyAccountDto account) {
         try {
             if (isAuthenticationProblem(account, true)) {
                 Log.d("Authentication will fail. Skip refreshing the folder list.");
@@ -444,7 +444,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     void searchRemoteMessagesSynchronous(String acctUuid, long folderId, String query, Set<Flag> requiredFlags,
             Set<Flag> forbiddenFlags, MessagingListener listener) {
 
-        LegacyAccount account = preferences.getAccount(acctUuid);
+        LegacyAccountDto account = preferences.getAccount(acctUuid);
 
         if (listener != null) {
             listener.remoteSearchStarted(folderId);
@@ -503,7 +503,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
 
     }
 
-    public void loadSearchResults(LegacyAccount account, long folderId, List<String> messageServerIds,
+    public void loadSearchResults(LegacyAccountDto account, long folderId, List<String> messageServerIds,
             MessagingListener listener) {
         threadPool.execute(() -> {
             if (listener != null) {
@@ -530,7 +530,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void loadSearchResultsSynchronous(LegacyAccount account, List<String> messageServerIds, LocalFolder localFolder)
+    private void loadSearchResultsSynchronous(LegacyAccountDto account, List<String> messageServerIds, LocalFolder localFolder)
             throws MessagingException {
 
         Backend backend = getBackend(account);
@@ -545,11 +545,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void loadMoreMessages(LegacyAccount account, long folderId) {
+    public void loadMoreMessages(LegacyAccountDto account, long folderId) {
         putBackground("loadMoreMessages", null, () -> loadMoreMessagesSynchronous(account, folderId));
     }
 
-    public void loadMoreMessagesSynchronous(LegacyAccount account, long folderId) {
+    public void loadMoreMessagesSynchronous(LegacyAccountDto account, long folderId) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         Integer visibleLimit = messageStore.getFolder(folderId, FolderDetailsAccessor::getVisibleLimit);
         if (visibleLimit == null) {
@@ -568,13 +568,13 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Start background synchronization of the specified folder.
      */
-    public void synchronizeMailbox(LegacyAccount account, long folderId, boolean notify, MessagingListener listener) {
+    public void synchronizeMailbox(LegacyAccountDto account, long folderId, boolean notify, MessagingListener listener) {
         putBackground("synchronizeMailbox", listener, () ->
                 synchronizeMailboxSynchronous(account, folderId, notify, listener, new NotificationState())
         );
     }
 
-    public void synchronizeMailboxBlocking(LegacyAccount account, String folderServerId) {
+    public void synchronizeMailboxBlocking(LegacyAccountDto account, String folderServerId) {
         long folderId = getFolderId(account, folderServerId);
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -593,7 +593,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void synchronizeMailboxSynchronous(LegacyAccount account, long folderId, boolean notify,
+    private void synchronizeMailboxSynchronous(LegacyAccountDto account, long folderId, boolean notify,
             MessagingListener listener, NotificationState notificationState) {
         refreshFolderListIfStale(account);
 
@@ -601,7 +601,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         syncFolder(account, folderId, notify, listener, backend, notificationState);
     }
 
-    private void refreshFolderListIfStale(LegacyAccount account) {
+    private void refreshFolderListIfStale(LegacyAccountDto account) {
         long lastFolderListRefresh = account.getLastFolderListRefreshTime();
         long now = System.currentTimeMillis();
 
@@ -613,7 +613,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void syncFolder(LegacyAccount account, long folderId, boolean notify, MessagingListener listener, Backend backend,
+    private void syncFolder(LegacyAccountDto account, long folderId, boolean notify, MessagingListener listener, Backend backend,
             NotificationState notificationState) {
         if (isAuthenticationProblem(account, true)) {
             Log.d("Authentication will fail. Skip synchronizing folder %d.", folderId);
@@ -671,7 +671,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private SyncConfig createSyncConfig(LegacyAccount account) {
+    private SyncConfig createSyncConfig(LegacyAccountDto account) {
         return new SyncConfig(
                     account.getExpungePolicy().toBackendExpungePolicy(),
                     account.getEarliestPollDate(),
@@ -681,12 +681,12 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
                     SYNC_FLAGS);
     }
 
-    private void updateFolderStatus(LegacyAccount account, long folderId, String status) {
+    private void updateFolderStatus(LegacyAccountDto account, long folderId, String status) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         messageStore.setStatus(folderId, status);
     }
 
-    public void handleAuthenticationFailure(LegacyAccount account, boolean incoming) {
+    public void handleAuthenticationFailure(LegacyAccountDto account, boolean incoming) {
         if (account.shouldMigrateToOAuth()) {
             migrateAccountToOAuth(account);
         }
@@ -694,7 +694,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         notificationController.showAuthenticationErrorNotification(account, incoming);
     }
 
-    private void migrateAccountToOAuth(LegacyAccount account) {
+    private void migrateAccountToOAuth(LegacyAccountDto account) {
         account.setIncomingServerSettings(account.getIncomingServerSettings().newAuthenticationType(AuthType.XOAUTH2));
         account.setOutgoingServerSettings(account.getOutgoingServerSettings().newAuthenticationType(AuthType.XOAUTH2));
         account.setShouldMigrateToOAuth(false);
@@ -702,7 +702,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         preferences.saveAccount(account);
     }
 
-    public void handleException(LegacyAccount account, Exception exception) {
+    public void handleException(LegacyAccountDto account, Exception exception) {
         if (exception instanceof AuthenticationFailedException) {
             handleAuthenticationFailure(account, true);
         } else {
@@ -710,7 +710,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    void queuePendingCommand(LegacyAccount account, PendingCommand command) {
+    void queuePendingCommand(LegacyAccountDto account, PendingCommand command) {
         try {
             LocalStore localStore = localStoreProvider.getInstance(account);
             localStore.addPendingCommand(command);
@@ -719,7 +719,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    void processPendingCommands(final LegacyAccount account) {
+    void processPendingCommands(final LegacyAccountDto account) {
         putBackground("processPendingCommands", null, new Runnable() {
             @Override
             public void run() {
@@ -737,7 +737,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void processPendingCommandsSynchronous(LegacyAccount account) throws MessagingException {
+    public void processPendingCommandsSynchronous(LegacyAccountDto account) throws MessagingException {
         LocalStore localStore = localStoreProvider.getInstance(account);
         List<PendingCommand> commands = localStore.getPendingCommands();
 
@@ -793,7 +793,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * that the server message will be synchronized down without an additional copy being
      * created.
      */
-    void processPendingAppend(PendingAppend command, LegacyAccount account) throws MessagingException {
+    void processPendingAppend(PendingAppend command, LegacyAccountDto account) throws MessagingException {
         LocalStore localStore = localStoreProvider.getInstance(account);
         long folderId = command.folderId;
         LocalFolder localFolder = localStore.getFolder(folderId);
@@ -864,11 +864,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    void processPendingReplace(PendingReplace pendingReplace, LegacyAccount account) {
+    void processPendingReplace(PendingReplace pendingReplace, LegacyAccountDto account) {
         draftOperations.processPendingReplace(pendingReplace, account);
     }
 
-    private void queueMoveOrCopy(LegacyAccount account, long srcFolderId, long destFolderId, MoveOrCopyFlavor operation,
+    private void queueMoveOrCopy(LegacyAccountDto account, long srcFolderId, long destFolderId, MoveOrCopyFlavor operation,
             Map<String, String> uidMap) {
         PendingCommand command;
         switch (operation) {
@@ -887,7 +887,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         queuePendingCommand(account, command);
     }
 
-    void processPendingMoveOrCopy(PendingMoveOrCopy command, LegacyAccount account) throws MessagingException {
+    void processPendingMoveOrCopy(PendingMoveOrCopy command, LegacyAccountDto account) throws MessagingException {
         long srcFolder = command.srcFolderId;
         long destFolder = command.destFolderId;
         MoveOrCopyFlavor operation = command.isCopy ? MoveOrCopyFlavor.COPY : MoveOrCopyFlavor.MOVE;
@@ -898,7 +898,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         processPendingMoveOrCopy(account, srcFolder, destFolder, uids, operation, newUidMap);
     }
 
-    void processPendingMoveAndRead(PendingMoveAndMarkAsRead command, LegacyAccount account) throws MessagingException {
+    void processPendingMoveAndRead(PendingMoveAndMarkAsRead command, LegacyAccountDto account) throws MessagingException {
         long srcFolder = command.srcFolderId;
         long destFolder = command.destFolderId;
         Map<String, String> newUidMap = command.newUidMap;
@@ -909,7 +909,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
     @VisibleForTesting
-    void processPendingMoveOrCopy(LegacyAccount account, long srcFolderId, long destFolderId, List<String> uids,
+    void processPendingMoveOrCopy(LegacyAccountDto account, long srcFolderId, long destFolderId, List<String> uids,
                                   MoveOrCopyFlavor operation, Map<String, String> newUidMap) throws MessagingException {
         requireNotNull(newUidMap);
 
@@ -994,7 +994,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void queueSetFlag(LegacyAccount account, long folderId, boolean newState, Flag flag, List<String> uids) {
+    private void queueSetFlag(LegacyAccountDto account, long folderId, boolean newState, Flag flag, List<String> uids) {
         PendingCommand command = PendingSetFlag.create(folderId, newState, flag, uids);
         queuePendingCommand(account, command);
     }
@@ -1002,18 +1002,18 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Processes a pending mark read or unread command.
      */
-    void processPendingSetFlag(PendingSetFlag command, LegacyAccount account) throws MessagingException {
+    void processPendingSetFlag(PendingSetFlag command, LegacyAccountDto account) throws MessagingException {
         Backend backend = getBackend(account);
         String folderServerId = getFolderServerId(account, command.folderId);
         backend.setFlag(folderServerId, command.uids, command.flag, command.newState);
     }
 
-    private void queueDelete(LegacyAccount account, long folderId, List<String> uids) {
+    private void queueDelete(LegacyAccountDto account, long folderId, List<String> uids) {
         PendingCommand command = PendingDelete.create(folderId, uids);
         queuePendingCommand(account, command);
     }
 
-    void processPendingDelete(PendingDelete command, LegacyAccount account) throws MessagingException {
+    void processPendingDelete(PendingDelete command, LegacyAccountDto account) throws MessagingException {
         long folderId = command.folderId;
         List<String> uids = command.uids;
 
@@ -1027,18 +1027,18 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         destroyPlaceholderMessages(localFolder, uids);
     }
 
-    private void queueExpunge(LegacyAccount account, long folderId) {
+    private void queueExpunge(LegacyAccountDto account, long folderId) {
         PendingCommand command = PendingExpunge.create(folderId);
         queuePendingCommand(account, command);
     }
 
-    void processPendingExpunge(PendingExpunge command, LegacyAccount account) throws MessagingException {
+    void processPendingExpunge(PendingExpunge command, LegacyAccountDto account) throws MessagingException {
         Backend backend = getBackend(account);
         String folderServerId = getFolderServerId(account, command.folderId);
         backend.expunge(folderServerId);
     }
 
-    void processPendingMarkAllAsRead(PendingMarkAllAsRead command, LegacyAccount account) throws MessagingException {
+    void processPendingMarkAllAsRead(PendingMarkAllAsRead command, LegacyAccountDto account) throws MessagingException {
         long folderId = command.folderId;
         LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);
@@ -1066,13 +1066,13 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void markAllMessagesRead(LegacyAccount account, long folderId) {
+    public void markAllMessagesRead(LegacyAccountDto account, long folderId) {
         PendingCommand command = PendingMarkAllAsRead.create(folderId);
         queuePendingCommand(account, command);
         processPendingCommands(account);
     }
 
-    public void setFlag(final LegacyAccount account, final List<Long> messageIds, final Flag flag,
+    public void setFlag(final LegacyAccountDto account, final List<Long> messageIds, final Flag flag,
             final boolean newState) {
 
         setFlagInCache(account, messageIds, flag, newState);
@@ -1082,7 +1082,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         );
     }
 
-    public void setFlagForThreads(final LegacyAccount account, final List<Long> threadRootIds,
+    public void setFlagForThreads(final LegacyAccountDto account, final List<Long> threadRootIds,
             final Flag flag, final boolean newState) {
 
         setFlagForThreadsInCache(account, threadRootIds, flag, newState);
@@ -1092,7 +1092,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         );
     }
 
-    private void setFlagSynchronous(final LegacyAccount account, final List<Long> ids,
+    private void setFlagSynchronous(final LegacyAccountDto account, final List<Long> ids,
             final Flag flag, final boolean newState, final boolean threadedList) {
 
         LocalStore localStore;
@@ -1158,7 +1158,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void cancelNotificationsForMessages(LegacyAccount account, long folderId, List<String> uids) {
+    private void cancelNotificationsForMessages(LegacyAccountDto account, long folderId, List<String> uids) {
         for (String uid : uids) {
             MessageReference messageReference = new MessageReference(account.getUuid(), folderId, uid);
             notificationController.removeNewMailNotification(account, messageReference);
@@ -1171,7 +1171,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * The {@link Message} objects passed in are updated to reflect the new flag state.
      * </p>
      */
-    public void setFlag(LegacyAccount account, long folderId, List<LocalMessage> messages, Flag flag, boolean newState) {
+    public void setFlag(LegacyAccountDto account, long folderId, List<LocalMessage> messages, Flag flag, boolean newState) {
         // TODO: Put this into the background, but right now some callers depend on the message
         //       objects being modified right after this method returns.
         try {
@@ -1200,7 +1200,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Set or remove a flag for a message referenced by message UID.
      */
-    public void setFlag(LegacyAccount account, long folderId, String uid, Flag flag, boolean newState) {
+    public void setFlag(LegacyAccountDto account, long folderId, String uid, Flag flag, boolean newState) {
         try {
             LocalStore localStore = localStoreProvider.getInstance(account);
             LocalFolder localFolder = localStore.getFolder(folderId);
@@ -1215,20 +1215,20 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void loadMessageRemotePartial(LegacyAccount account, long folderId, String uid, MessagingListener listener) {
+    public void loadMessageRemotePartial(LegacyAccountDto account, long folderId, String uid, MessagingListener listener) {
         put("loadMessageRemotePartial", listener, () ->
             loadMessageRemoteSynchronous(account, folderId, uid, listener, true)
         );
     }
 
     //TODO: Fix the callback mess. See GH-782
-    public void loadMessageRemote(LegacyAccount account, long folderId, String uid, MessagingListener listener) {
+    public void loadMessageRemote(LegacyAccountDto account, long folderId, String uid, MessagingListener listener) {
         put("loadMessageRemote", listener, () ->
             loadMessageRemoteSynchronous(account, folderId, uid, listener, false)
         );
     }
 
-    private void loadMessageRemoteSynchronous(LegacyAccount account, long folderId, String messageServerId,
+    private void loadMessageRemoteSynchronous(LegacyAccountDto account, long folderId, String messageServerId,
             MessagingListener listener, boolean loadPartialFromSearch) {
         try {
             if (messageServerId.startsWith(K9.LOCAL_UID_PREFIX)) {
@@ -1265,7 +1265,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public LocalMessage loadMessage(LegacyAccount account, long folderId, String uid) throws MessagingException {
+    public LocalMessage loadMessage(LegacyAccountDto account, long folderId, String uid) throws MessagingException {
         LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);
         localFolder.open();
@@ -1283,7 +1283,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return message;
     }
 
-    public LocalMessage loadMessageMetadata(LegacyAccount account, long folderId, String uid) throws MessagingException {
+    public LocalMessage loadMessageMetadata(LegacyAccountDto account, long folderId, String uid) throws MessagingException {
         LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);
         localFolder.open();
@@ -1301,7 +1301,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return message;
     }
 
-    public void markMessageAsOpened(LegacyAccount account, LocalMessage message) {
+    public void markMessageAsOpened(LegacyAccountDto account, LocalMessage message) {
         threadPool.execute(() ->
             notificationController.removeNewMailNotification(account, message.makeMessageReference())
         );
@@ -1330,7 +1330,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void markMessageAsOpenedBlocking(LegacyAccount account, LocalMessage message, boolean markMessageAsRead) {
+    private void markMessageAsOpenedBlocking(LegacyAccountDto account, LocalMessage message, boolean markMessageAsRead) {
         if (markMessageAsRead) {
             markMessageAsRead(account, message);
         } else {
@@ -1340,28 +1340,28 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void markMessageAsRead(LegacyAccount account, LocalMessage message) {
+    private void markMessageAsRead(LegacyAccountDto account, LocalMessage message) {
         List<Long> messageIds = Collections.singletonList(message.getDatabaseId());
         setFlagSynchronous(account, messageIds, Flag.SEEN, true, false);
     }
 
-    private void markMessageAsNotNew(LegacyAccount account, LocalMessage message) {
+    private void markMessageAsNotNew(LegacyAccountDto account, LocalMessage message) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         long folderId = message.getFolder().getDatabaseId();
         String messageServerId = message.getUid();
         messageStore.setNewMessageState(folderId, messageServerId, false);
     }
 
-    public void clearNewMessages(LegacyAccount account) {
+    public void clearNewMessages(LegacyAccountDto account) {
         put("clearNewMessages", null, () -> clearNewMessagesBlocking(account));
     }
 
-    private void clearNewMessagesBlocking(LegacyAccount account) {
+    private void clearNewMessagesBlocking(LegacyAccountDto account) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         messageStore.clearNewMessageState();
     }
 
-    public void loadAttachment(final LegacyAccount account, final LocalMessage message, final Part part,
+    public void loadAttachment(final LegacyAccountDto account, final LocalMessage message, final Part part,
             final MessagingListener listener) {
 
         put("loadAttachment", listener, new Runnable() {
@@ -1405,7 +1405,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Stores the given message in the Outbox and starts a sendPendingMessages command to attempt to send the message.
      */
-    public void sendMessage(LegacyAccount account, Message message, String plaintextSubject, MessagingListener listener) {
+    public void sendMessage(LegacyAccountDto account, Message message, String plaintextSubject, MessagingListener listener) {
         try {
             Long outboxFolderId = account.getOutboxFolderId();
             if (outboxFolderId == null) {
@@ -1435,7 +1435,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void sendMessageBlocking(LegacyAccount account, Message message) throws MessagingException {
+    public void sendMessageBlocking(LegacyAccountDto account, Message message) throws MessagingException {
         Backend backend = getBackend(account);
         backend.sendMessage(message);
     }
@@ -1443,7 +1443,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Attempt to send any messages that are sitting in the Outbox.
      */
-    public void sendPendingMessages(final LegacyAccount account,
+    public void sendPendingMessages(final LegacyAccountDto account,
             MessagingListener listener) {
         putBackground("sendPendingMessages", listener, new Runnable() {
             @Override
@@ -1462,19 +1462,19 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void showSendingNotificationIfNecessary(LegacyAccount account) {
+    private void showSendingNotificationIfNecessary(LegacyAccountDto account) {
         if (account.isNotifySync()) {
             notificationController.showSendingNotification(account);
         }
     }
 
-    private void clearSendingNotificationIfNecessary(LegacyAccount account) {
+    private void clearSendingNotificationIfNecessary(LegacyAccountDto account) {
         if (account.isNotifySync()) {
             notificationController.clearSendingNotification(account);
         }
     }
 
-    private boolean messagesPendingSend(final LegacyAccount account) {
+    private boolean messagesPendingSend(final LegacyAccountDto account) {
         Long outboxFolderId = account.getOutboxFolderId();
         if (outboxFolderId == null) {
             Log.w("Could not get Outbox folder ID from Account");
@@ -1489,7 +1489,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * Attempt to send any messages that are sitting in the Outbox.
      */
     @VisibleForTesting
-    protected void sendPendingMessagesSynchronous(final LegacyAccount account) {
+    protected void sendPendingMessagesSynchronous(final LegacyAccountDto account) {
         Exception lastFailure = null;
         try {
             if (isAuthenticationProblem(account, false)) {
@@ -1627,7 +1627,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void moveOrDeleteSentMessage(LegacyAccount account, LocalStore localStore, LocalMessage message)
+    private void moveOrDeleteSentMessage(LegacyAccountDto account, LocalStore localStore, LocalMessage message)
             throws MessagingException {
         if (!account.hasSentFolder() || !account.isUploadSentMessages()) {
             Log.i("Not uploading sent message; deleting local message");
@@ -1659,7 +1659,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void handleSendFailure(LegacyAccount account, LocalFolder localFolder, Message message, Exception exception)
+    private void handleSendFailure(LegacyAccountDto account, LocalFolder localFolder, Message message, Exception exception)
             throws MessagingException {
 
         Log.e(exception, "Failed to send message");
@@ -1668,7 +1668,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         notifySynchronizeMailboxFailed(account, localFolder, exception);
     }
 
-    private void notifySynchronizeMailboxFailed(LegacyAccount account, LocalFolder localFolder, Exception exception) {
+    private void notifySynchronizeMailboxFailed(LegacyAccountDto account, LocalFolder localFolder, Exception exception) {
         long folderId = localFolder.getDatabaseId();
         String errorMessage = getRootCauseMessage(exception);
         for (MessagingListener listener : getListeners()) {
@@ -1684,39 +1684,39 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return isMoveCapable(message);
     }
 
-    public boolean isMoveCapable(final LegacyAccount account) {
+    public boolean isMoveCapable(final LegacyAccountDto account) {
         return getBackend(account).getSupportsMove();
     }
 
-    public boolean isCopyCapable(final LegacyAccount account) {
+    public boolean isCopyCapable(final LegacyAccountDto account) {
         return getBackend(account).getSupportsCopy();
     }
 
-    public boolean isPushCapable(LegacyAccount account) {
+    public boolean isPushCapable(LegacyAccountDto account) {
         return getBackend(account).isPushCapable();
     }
 
-    public boolean supportsFlags(LegacyAccount account) {
+    public boolean supportsFlags(LegacyAccountDto account) {
         return getBackend(account).getSupportsFlags();
     }
 
-    public boolean supportsExpunge(LegacyAccount account) {
+    public boolean supportsExpunge(LegacyAccountDto account) {
         return getBackend(account).getSupportsExpunge();
     }
 
-    public boolean supportsSearchByDate(LegacyAccount account) {
+    public boolean supportsSearchByDate(LegacyAccountDto account) {
         return getBackend(account).getSupportsSearchByDate();
     }
 
-    public boolean supportsUpload(LegacyAccount account) {
+    public boolean supportsUpload(LegacyAccountDto account) {
         return getBackend(account).getSupportsUpload();
     }
 
-    public boolean supportsFolderSubscriptions(LegacyAccount account) {
+    public boolean supportsFolderSubscriptions(LegacyAccountDto account) {
         return getBackend(account).getSupportsFolderSubscriptions();
     }
 
-    public void moveMessages(LegacyAccount srcAccount, long srcFolderId,
+    public void moveMessages(LegacyAccountDto srcAccount, long srcFolderId,
             List<MessageReference> messageReferences, long destFolderId) {
         actOnMessageGroup(srcAccount, srcFolderId, messageReferences, (account, messageFolder, messages) -> {
             suppressMessages(account, messages);
@@ -1727,7 +1727,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void moveMessagesInThread(LegacyAccount srcAccount, long srcFolderId,
+    public void moveMessagesInThread(LegacyAccountDto srcAccount, long srcFolderId,
             List<MessageReference> messageReferences, long destFolderId) {
         actOnMessageGroup(srcAccount, srcFolderId, messageReferences, (account, messageFolder, messages) -> {
             suppressMessages(account, messages);
@@ -1744,11 +1744,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void moveMessage(LegacyAccount account, long srcFolderId, MessageReference message, long destFolderId) {
+    public void moveMessage(LegacyAccountDto account, long srcFolderId, MessageReference message, long destFolderId) {
         moveMessages(account, srcFolderId, Collections.singletonList(message), destFolderId);
     }
 
-    public void copyMessages(LegacyAccount srcAccount, long srcFolderId,
+    public void copyMessages(LegacyAccountDto srcAccount, long srcFolderId,
             List<MessageReference> messageReferences, long destFolderId) {
         actOnMessageGroup(srcAccount, srcFolderId, messageReferences, (account, messageFolder, messages) -> {
             putBackground("copyMessages", null, () ->
@@ -1757,7 +1757,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void copyMessagesInThread(LegacyAccount srcAccount, long srcFolderId,
+    public void copyMessagesInThread(LegacyAccountDto srcAccount, long srcFolderId,
             final List<MessageReference> messageReferences, long destFolderId) {
         actOnMessageGroup(srcAccount, srcFolderId, messageReferences, (account, messageFolder, messages) -> {
             putBackground("copyMessagesInThread", null, () -> {
@@ -1772,11 +1772,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void copyMessage(LegacyAccount account, long srcFolderId, MessageReference message, long destFolderId) {
+    public void copyMessage(LegacyAccountDto account, long srcFolderId, MessageReference message, long destFolderId) {
         copyMessages(account, srcFolderId, Collections.singletonList(message), destFolderId);
     }
 
-    void moveOrCopyMessageSynchronous(LegacyAccount account, long srcFolderId, List<LocalMessage> inMessages,
+    void moveOrCopyMessageSynchronous(LegacyAccountDto account, long srcFolderId, List<LocalMessage> inMessages,
             long destFolderId, MoveOrCopyFlavor operation) {
 
         try {
@@ -1877,11 +1877,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    public void moveToDraftsFolder(LegacyAccount account, long folderId, List<MessageReference> messages){
+    public void moveToDraftsFolder(LegacyAccountDto account, long folderId, List<MessageReference> messages){
         putBackground("moveToDrafts", null, () -> moveToDraftsFolderInBackground(account, folderId, messages));
     }
 
-    private void moveToDraftsFolderInBackground(LegacyAccount account, long folderId, List<MessageReference> messages) {
+    private void moveToDraftsFolderInBackground(LegacyAccountDto account, long folderId, List<MessageReference> messages) {
         for (MessageReference messageReference : messages) {
             try {
                 Message message = loadMessage(account, folderId, messageReference.getUid());
@@ -1913,22 +1913,22 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         archiveOperations.archiveMessage(message);
     }
 
-    public void expunge(LegacyAccount account, long folderId) {
+    public void expunge(LegacyAccountDto account, long folderId) {
         putBackground("expunge", null, () -> {
             queueExpunge(account, folderId);
             processPendingCommands(account);
         });
     }
 
-    public void deleteDraftSkippingTrashFolder(LegacyAccount account, long messageId) {
+    public void deleteDraftSkippingTrashFolder(LegacyAccountDto account, long messageId) {
         deleteDraft(account, messageId, true);
     }
 
-    public void deleteDraft(LegacyAccount account, long messageId) {
+    public void deleteDraft(LegacyAccountDto account, long messageId) {
         deleteDraft(account, messageId, false);
     }
 
-    private void deleteDraft(LegacyAccount account, long messageId, boolean skipTrashFolder) {
+    private void deleteDraft(LegacyAccountDto account, long messageId, boolean skipTrashFolder) {
         Long folderId = account.getDraftsFolderId();
         if (folderId == null) {
             Log.w("No Drafts folder configured. Can't delete draft.");
@@ -1952,7 +1952,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void deleteThreadsSynchronous(LegacyAccount account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
+    private void deleteThreadsSynchronous(LegacyAccountDto account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
         try {
             List<LocalMessage> messagesToDelete = collectMessagesInThreads(account, messages);
             deleteMessagesSynchronous(account, folderId, messagesToDelete, skipTrashFolder);
@@ -1961,7 +1961,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    List<LocalMessage> collectMessagesInThreads(LegacyAccount account, List<LocalMessage> messages)
+    List<LocalMessage> collectMessagesInThreads(LegacyAccountDto account, List<LocalMessage> messages)
             throws MessagingException {
 
         LocalStore localStore = localStoreProvider.getInstance(account);
@@ -1996,7 +1996,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    private void deleteMessagesSynchronous(LegacyAccount account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
+    private void deleteMessagesSynchronous(LegacyAccountDto account, long folderId, List<LocalMessage> messages, boolean skipTrashFolder) {
         try {
             List<LocalMessage> localOnlyMessages = new ArrayList<>();
             List<LocalMessage> syncedMessages = new ArrayList<>();
@@ -2121,7 +2121,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         return uids;
     }
 
-    void processPendingEmptySpam(LegacyAccount account) throws MessagingException {
+    void processPendingEmptySpam(LegacyAccountDto account) throws MessagingException {
         if (!account.hasSpamFolder()) {
             return;
         }
@@ -2141,7 +2141,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         compact(account);
     }
 
-    public void emptySpam(final LegacyAccount account, MessagingListener listener) {
+    public void emptySpam(final LegacyAccountDto account, MessagingListener listener) {
         putBackground("emptySpam", listener, new Runnable() {
             @Override
             public void run() {
@@ -2173,7 +2173,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    void processPendingEmptyTrash(LegacyAccount account) throws MessagingException {
+    void processPendingEmptyTrash(LegacyAccountDto account) throws MessagingException {
         if (!account.hasTrashFolder()) {
             return;
         }
@@ -2193,7 +2193,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         compact(account);
     }
 
-    public void emptyTrash(final LegacyAccount account, MessagingListener listener) {
+    public void emptyTrash(final LegacyAccountDto account, MessagingListener listener) {
         putBackground("emptyTrash", listener, new Runnable() {
             @Override
             public void run() {
@@ -2232,14 +2232,14 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void clearFolder(LegacyAccount account, long folderId) {
+    public void clearFolder(LegacyAccountDto account, long folderId) {
         putBackground("clearFolder", null, () ->
                 clearFolderSynchronous(account, folderId)
         );
     }
 
     @VisibleForTesting
-    protected void clearFolderSynchronous(LegacyAccount account, long folderId) {
+    protected void clearFolderSynchronous(LegacyAccountDto account, long folderId) {
         try {
             LocalFolder localFolder = localStoreProvider.getInstance(account).getFolder(folderId);
             localFolder.open();
@@ -2261,22 +2261,22 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * @return {@code true} if the account only has a local Trash folder that is not synchronized
      * with a folder on the server. {@code false} otherwise.
      */
-    private boolean isTrashLocalOnly(LegacyAccount account) {
+    private boolean isTrashLocalOnly(LegacyAccountDto account) {
         Backend backend = getBackend(account);
         return !backend.getSupportsTrashFolder();
     }
 
-    public boolean performPeriodicMailSync(LegacyAccount account) {
+    public boolean performPeriodicMailSync(LegacyAccountDto account) {
         final CountDownLatch latch = new CountDownLatch(1);
         MutableBoolean syncError = new MutableBoolean(false);
         checkMail(account, false, false, true, new SimpleMessagingListener() {
             @Override
-            public void checkMailFinished(Context context, LegacyAccount account) {
+            public void checkMailFinished(Context context, LegacyAccountDto account) {
                 latch.countDown();
             }
 
             @Override
-            public void synchronizeMailboxFailed(LegacyAccount account, long folderId, String message) {
+            public void synchronizeMailboxFailed(LegacyAccountDto account, long folderId, String message) {
                 syncError.setValue(true);
             }
         });
@@ -2305,7 +2305,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
      * Checks mail for one or multiple accounts. If account is null all accounts
      * are checked.
      */
-    public void checkMail(LegacyAccount account, boolean ignoreLastCheckedTime, boolean useManualWakeLock, boolean notify,
+    public void checkMail(LegacyAccountDto account, boolean ignoreLastCheckedTime, boolean useManualWakeLock, boolean notify,
             MessagingListener listener) {
 
         final WakeLock wakeLock;
@@ -2329,7 +2329,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
                 try {
                     Log.i("Starting mail check");
 
-                    Collection<LegacyAccount> accounts;
+                    Collection<LegacyAccountDto> accounts;
                     if (account != null) {
                         accounts = new ArrayList<>(1);
                         accounts.add(account);
@@ -2337,7 +2337,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
                         accounts = preferences.getAccounts();
                     }
 
-                    for (final LegacyAccount account : accounts) {
+                    for (final LegacyAccountDto account : accounts) {
                         checkMailForAccount(account, ignoreLastCheckedTime, notify, listener);
                     }
 
@@ -2365,7 +2365,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
 
-    private void checkMailForAccount(LegacyAccount account, boolean ignoreLastCheckedTime, boolean notify,
+    private void checkMailForAccount(LegacyAccountDto account, boolean ignoreLastCheckedTime, boolean notify,
             MessagingListener listener) {
         Log.i("Synchronizing account %s", account);
 
@@ -2408,14 +2408,14 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
 
     }
 
-    private void synchronizeFolder(LegacyAccount account, LocalFolder folder, boolean ignoreLastCheckedTime,
+    private void synchronizeFolder(LegacyAccountDto account, LocalFolder folder, boolean ignoreLastCheckedTime,
             boolean notify, MessagingListener listener, NotificationState notificationState) {
         putBackground("sync" + folder.getServerId(), null, () -> {
             synchronizeFolderInBackground(account, folder, ignoreLastCheckedTime, notify, listener, notificationState);
         });
     }
 
-    private void synchronizeFolderInBackground(LegacyAccount account, LocalFolder folder, boolean ignoreLastCheckedTime,
+    private void synchronizeFolderInBackground(LegacyAccountDto account, LocalFolder folder, boolean ignoreLastCheckedTime,
             boolean notify, MessagingListener listener, NotificationState notificationState) {
         Log.v("Folder %s was last synced @ %tc", folder.getServerId(), folder.getLastChecked());
 
@@ -2448,23 +2448,23 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         }
     }
 
-    private void showFetchingMailNotificationIfNecessary(LegacyAccount account, LocalFolder folder) {
+    private void showFetchingMailNotificationIfNecessary(LegacyAccountDto account, LocalFolder folder) {
         if (account.isNotifySync()) {
             notificationController.showFetchingMailNotification(account, folder);
         }
     }
 
-    private void showEmptyFetchingMailNotificationIfNecessary(LegacyAccount account) {
+    private void showEmptyFetchingMailNotificationIfNecessary(LegacyAccountDto account) {
         if (account.isNotifySync()) {
             notificationController.showEmptyFetchingMailNotification(account);
         }
     }
 
-    private void clearFetchingMailNotification(LegacyAccount account) {
+    private void clearFetchingMailNotification(LegacyAccountDto account) {
         notificationController.clearFetchingMailNotification(account);
     }
 
-    public void compact(LegacyAccount account) {
+    public void compact(LegacyAccountDto account) {
         putBackground("compact:" + account, null, () -> {
             try {
                 MessageStore messageStore = messageStoreManager.getMessageStore(account);
@@ -2475,7 +2475,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void deleteAccount(LegacyAccount account) {
+    public void deleteAccount(LegacyAccountDto account) {
         notificationController.clearNewMailNotifications(account, false);
         memorizingMessagingListener.removeAccount(account);
     }
@@ -2483,7 +2483,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     /**
      * Save a draft message.
      */
-    public Long saveDraft(LegacyAccount account, Message message, Long existingDraftId, String plaintextSubject) {
+    public Long saveDraft(LegacyAccountDto account, Message message, Long existingDraftId, String plaintextSubject) {
         return draftOperations.saveDraft(account, message, existingDraftId, plaintextSubject);
     }
 
@@ -2524,26 +2524,26 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         });
     }
 
-    public void cancelNotificationsForAccount(LegacyAccount account) {
+    public void cancelNotificationsForAccount(LegacyAccountDto account) {
         notificationController.clearNewMailNotifications(account, true);
     }
 
-    public void cancelNotificationForMessage(LegacyAccount account, MessageReference messageReference) {
+    public void cancelNotificationForMessage(LegacyAccountDto account, MessageReference messageReference) {
         notificationController.removeNewMailNotification(account, messageReference);
     }
 
     @Deprecated
-    public void clearCertificateErrorNotifications(LegacyAccount account, boolean incoming) {
+    public void clearCertificateErrorNotifications(LegacyAccountDto account, boolean incoming) {
         notificationController.clearCertificateErrorNotifications(account, incoming);
     }
 
-    public void notifyUserIfCertificateProblem(LegacyAccount account, Exception exception, boolean incoming) {
+    public void notifyUserIfCertificateProblem(LegacyAccountDto account, Exception exception, boolean incoming) {
         if (exception instanceof CertificateValidationException) {
             notificationController.showCertificateErrorNotification(account, incoming);
         }
     }
 
-    private boolean isAuthenticationProblem(LegacyAccount account, boolean incoming) {
+    private boolean isAuthenticationProblem(LegacyAccountDto account, boolean incoming) {
         ServerSettings serverSettings = incoming ?
                 account.getIncomingServerSettings() : account.getOutgoingServerSettings();
 
@@ -2556,7 +2556,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
 
         for (Map.Entry<String, Map<Long, List<MessageReference>>> entry : accountMap.entrySet()) {
             String accountUuid = entry.getKey();
-            LegacyAccount account = preferences.getAccount(accountUuid);
+            LegacyAccountDto account = preferences.getAccount(accountUuid);
 
             Map<Long, List<MessageReference>> folderMap = entry.getValue();
             for (Map.Entry<Long, List<MessageReference>> folderEntry : folderMap.entrySet()) {
@@ -2596,7 +2596,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
     private void actOnMessageGroup(
-            LegacyAccount account, long folderId, List<MessageReference> messageReferences, MessageActor actor) {
+            LegacyAccountDto account, long folderId, List<MessageReference> messageReferences, MessageActor actor) {
         try {
             LocalFolder messageFolder = localStoreProvider.getInstance(account).getFolder(folderId);
             List<LocalMessage> localMessages = messageFolder.getMessagesByReference(messageReferences);
@@ -2608,11 +2608,11 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     }
 
     interface MessageActor {
-        void act(LegacyAccount account, LocalFolder messageFolder, List<LocalMessage> messages);
+        void act(LegacyAccountDto account, LocalFolder messageFolder, List<LocalMessage> messages);
     }
 
     class ControllerSyncListener implements SyncListener {
-        private final LegacyAccount account;
+        private final LegacyAccountDto account;
         private final MessagingListener listener;
         private final LocalStore localStore;
         private final boolean suppressNotifications;
@@ -2620,7 +2620,7 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
         boolean syncFailed = false;
 
 
-        ControllerSyncListener(LegacyAccount account, MessagingListener listener, boolean suppressNotifications,
+        ControllerSyncListener(LegacyAccountDto account, MessagingListener listener, boolean suppressNotifications,
                 NotificationState notificationState) {
             this.account = account;
             this.listener = listener;

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import com.fsck.k9.mail.Flag;
 import net.thunderbird.core.common.exception.MessagingException;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 
 import static com.fsck.k9.controller.Preconditions.requireNotNull;
 import static com.fsck.k9.controller.Preconditions.requireValidUids;
@@ -30,7 +30,7 @@ public class MessagingControllerCommands {
         PendingCommand() { }
 
         public abstract String getCommandName();
-        public abstract void execute(MessagingController controller, LegacyAccount account) throws MessagingException;
+        public abstract void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException;
     }
 
     public static class PendingMoveOrCopy extends PendingCommand {
@@ -62,7 +62,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingMoveOrCopy(this, account);
         }
     }
@@ -90,7 +90,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingMoveAndRead(this, account);
         }
     }
@@ -106,7 +106,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingEmptySpam(account);
         }
     }
@@ -122,7 +122,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingEmptyTrash(account);
         }
     }
@@ -153,7 +153,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingSetFlag(this, account);
         }
     }
@@ -179,7 +179,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingAppend(this, account);
         }
     }
@@ -206,7 +206,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingReplace(this, account);
         }
     }
@@ -229,7 +229,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingMarkAllAsRead(this, account);
         }
     }
@@ -255,7 +255,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingDelete(this, account);
         }
     }
@@ -278,7 +278,7 @@ public class MessagingControllerCommands {
         }
 
         @Override
-        public void execute(MessagingController controller, LegacyAccount account) throws MessagingException {
+        public void execute(MessagingController controller, LegacyAccountDto account) throws MessagingException {
             controller.processPendingExpunge(this, account);
         }
     }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/NotificationOperations.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/NotificationOperations.kt
@@ -6,7 +6,7 @@ import com.fsck.k9.search.isNewMessages
 import com.fsck.k9.search.isSingleFolder
 import com.fsck.k9.search.isUnifiedFolders
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 
 internal class NotificationOperations(
@@ -51,13 +51,13 @@ internal class NotificationOperations(
         }
     }
 
-    private fun clearNotifications(account: LegacyAccount, folderId: Long) {
+    private fun clearNotifications(account: LegacyAccountDto, folderId: Long) {
         notificationController.clearNewMailNotifications(account) { messageReferences ->
             messageReferences.filter { messageReference -> messageReference.folderId == folderId }
         }
     }
 
-    private fun LocalMessageSearch.firstAccount(): LegacyAccount? {
+    private fun LocalMessageSearch.firstAccount(): LegacyAccountDto? {
         return accountManager.getAccount(accountUuids.first())
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 
 internal class AccountPushController(
@@ -18,7 +18,7 @@ internal class AccountPushController(
     private val messagingController: MessagingController,
     private val folderRepository: FolderRepository,
     backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val account: LegacyAccount,
+    private val account: LegacyAccountDto,
 ) {
     private val coroutineScope = CoroutineScope(backgroundDispatcher)
 

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushControllerFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushControllerFactory.kt
@@ -3,14 +3,14 @@ package com.fsck.k9.controller.push
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.controller.MessagingController
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class AccountPushControllerFactory(
     private val backendManager: BackendManager,
     private val messagingController: MessagingController,
     private val folderRepository: FolderRepository,
 ) {
-    fun create(account: LegacyAccount): AccountPushController {
+    fun create(account: LegacyAccountDto): AccountPushController {
         return AccountPushController(
             backendManager,
             messagingController,

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.network.ConnectivityChangeListener
 import net.thunderbird.core.android.network.ConnectivityManager
 import net.thunderbird.core.logging.legacy.Log
@@ -138,7 +138,7 @@ class PushController internal constructor(
         launchUpdatePushers()
     }
 
-    private fun onBackendChanged(account: LegacyAccount) {
+    private fun onBackendChanged(account: LegacyAccountDto) {
         coroutineScope.launch(coroutineDispatcher) {
             val accountPushController = synchronized(lock) {
                 pushers.remove(account.uuid)
@@ -241,14 +241,14 @@ class PushController internal constructor(
         }
     }
 
-    private fun getPushCapableAccounts(): Set<LegacyAccount> {
+    private fun getPushCapableAccounts(): Set<LegacyAccountDto> {
         return accountManager.getAccounts()
             .asSequence()
             .filter { account -> backendManager.getBackend(account).isPushCapable }
             .toSet()
     }
 
-    private fun getPushAccounts(): Set<LegacyAccount> {
+    private fun getPushAccounts(): Set<LegacyAccountDto> {
         return getPushCapableAccounts()
             .asSequence()
             .filter { account -> folderRepository.hasPushEnabledFolder(account) }
@@ -299,7 +299,7 @@ class PushController internal constructor(
         }
     }
 
-    private fun updatePushEnabledListeners(accounts: Set<LegacyAccount>) {
+    private fun updatePushEnabledListeners(accounts: Set<LegacyAccountDto>) {
         synchronized(lock) {
             // Stop listening to push enabled changes in accounts we no longer monitor
             val accountUuids = accounts.mapToSet { it.uuid }

--- a/legacy/core/src/main/java/com/fsck/k9/helper/IdentityHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/helper/IdentityHelper.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.helper
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.Message.RecipientType
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 object IdentityHelper {
     private val RECIPIENT_TYPES = listOf(
@@ -25,10 +25,10 @@ object IdentityHelper {
      * @return The identity the message was sent to, or the account's default identity if it
      * couldn't be determined which identity this message was sent to.
      *
-     * @see LegacyAccount.findIdentity
+     * @see LegacyAccountDto.findIdentity
      */
     @JvmStatic
-    fun getRecipientIdentityFromMessage(account: LegacyAccount, message: Message): Identity {
+    fun getRecipientIdentityFromMessage(account: LegacyAccountDto, message: Message): Identity {
         val recipient: Identity? = RECIPIENT_TYPES.asSequence()
             .flatMap { recipientType -> message.getRecipients(recipientType).asSequence() }
             .map { address -> account.findIdentity(address) }

--- a/legacy/core/src/main/java/com/fsck/k9/helper/ReplyToParser.java
+++ b/legacy/core/src/main/java/com/fsck/k9/helper/ReplyToParser.java
@@ -10,12 +10,12 @@ import androidx.annotation.VisibleForTesting;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Message.RecipientType;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 
 
 public class ReplyToParser {
 
-    public ReplyToAddresses getRecipientsToReplyTo(Message message, LegacyAccount account) {
+    public ReplyToAddresses getRecipientsToReplyTo(Message message, LegacyAccountDto account) {
         Address[] candidateAddress;
 
         Address[] replyToAddresses = message.getReplyTo();
@@ -38,7 +38,7 @@ public class ReplyToParser {
         return new ReplyToAddresses(candidateAddress);
     }
 
-    public ReplyToAddresses getRecipientsToReplyAllTo(Message message, LegacyAccount account) {
+    public ReplyToAddresses getRecipientsToReplyAllTo(Message message, LegacyAccountDto account) {
         List<Address> replyToAddresses = Arrays.asList(getRecipientsToReplyTo(message, account).to);
 
         HashSet<Address> alreadyAddedAddresses = new HashSet<>(replyToAddresses);

--- a/legacy/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
@@ -4,7 +4,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import kotlinx.coroutines.flow.Flow
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 
 class K9JobManager(
@@ -26,7 +26,7 @@ class K9JobManager(
         scheduleMailSync()
     }
 
-    fun scheduleMailSync(account: LegacyAccount) {
+    fun scheduleMailSync(account: LegacyAccountDto) {
         mailSyncWorkerManager.cancelMailSync(account)
         mailSyncWorkerManager.scheduleMailSync(account)
     }

--- a/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
@@ -7,7 +7,7 @@ import androidx.work.WorkerParameters
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.mail.AuthType
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.BackgroundOps
 import net.thunderbird.core.preference.GeneralSettingsManager
@@ -66,7 +66,7 @@ class MailSyncWorker(
         }
     }
 
-    private val LegacyAccount.isPeriodicMailSyncDisabled
+    private val LegacyAccountDto.isPeriodicMailSyncDisabled
         get() = automaticCheckIntervalMinutes <= 0
 
     companion object {

--- a/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
@@ -10,7 +10,7 @@ import androidx.work.workDataOf
 import java.util.concurrent.TimeUnit
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.BackgroundOps
@@ -25,13 +25,13 @@ constructor(
     val generalSettingsManager: GeneralSettingsManager,
 ) {
 
-    fun cancelMailSync(account: LegacyAccount) {
+    fun cancelMailSync(account: LegacyAccountDto) {
         Log.v("Canceling mail sync worker for %s", account)
         val uniqueWorkName = createUniqueWorkName(account.uuid)
         workManager.cancelUniqueWork(uniqueWorkName)
     }
 
-    fun scheduleMailSync(account: LegacyAccount) {
+    fun scheduleMailSync(account: LegacyAccountDto) {
         if (isNeverSyncInBackground()) return
 
         getSyncIntervalIfEnabled(account)?.let { syncIntervalMinutes ->
@@ -75,9 +75,9 @@ constructor(
     private fun isNeverSyncInBackground() =
         generalSettingsManager.getConfig().network.backgroundOps == BackgroundOps.NEVER
 
-    private fun getSyncIntervalIfEnabled(account: LegacyAccount): Long? {
+    private fun getSyncIntervalIfEnabled(account: LegacyAccountDto): Long? {
         val intervalMinutes = account.automaticCheckIntervalMinutes
-        if (intervalMinutes <= LegacyAccount.INTERVAL_MINUTES_NEVER) {
+        if (intervalMinutes <= LegacyAccountDto.INTERVAL_MINUTES_NEVER) {
             return null
         }
 

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/AutoExpandFolderBackendFoldersRefreshListener.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/AutoExpandFolderBackendFoldersRefreshListener.kt
@@ -2,14 +2,14 @@ package com.fsck.k9.mailstore
 
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.Preferences
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Update an Account's auto-expand folder after the folder list has been refreshed.
  */
 class AutoExpandFolderBackendFoldersRefreshListener(
     private val preferences: Preferences,
-    private val account: LegacyAccount,
+    private val account: LegacyAccountDto,
     private val folderRepository: FolderRepository,
 ) : BackendFoldersRefreshListener {
     private var isFirstSync = false

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdater.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdater.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.mailstore
 
 import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.Preferences
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.Protocols
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
@@ -10,7 +10,7 @@ import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection
 import net.thunderbird.feature.mail.folder.api.SpecialFolderUpdater
 
 /**
- * Updates special folders in [LegacyAccount] if they are marked as [SpecialFolderSelection.AUTOMATIC] or if they
+ * Updates special folders in [LegacyAccountDto] if they are marked as [SpecialFolderSelection.AUTOMATIC] or if they
  * are marked as [SpecialFolderSelection.MANUAL] but have been deleted from the server.
  */
 // TODO: Find a better way to deal with local-only special folders
@@ -18,7 +18,7 @@ class DefaultSpecialFolderUpdater private constructor(
     private val preferences: Preferences,
     private val folderRepository: FolderRepository,
     private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
-    private val account: LegacyAccount,
+    private val account: LegacyAccountDto,
 ) : SpecialFolderUpdater {
     override fun updateSpecialFolders() {
         val folders = folderRepository.getRemoteFolders(account)
@@ -136,14 +136,14 @@ class DefaultSpecialFolderUpdater private constructor(
         preferences.saveAccount(account)
     }
 
-    private fun LegacyAccount.isPop3() = incomingServerSettings.type == Protocols.POP3
+    private fun LegacyAccountDto.isPop3() = incomingServerSettings.type == Protocols.POP3
 
     class Factory(
         private val preferences: Preferences,
         private val folderRepository: FolderRepository,
         private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
-    ) : SpecialFolderUpdater.Factory<LegacyAccount> {
-        override fun create(account: LegacyAccount): SpecialFolderUpdater = DefaultSpecialFolderUpdater(
+    ) : SpecialFolderUpdater.Factory<LegacyAccountDto> {
+        override fun create(account: LegacyAccountDto): SpecialFolderUpdater = DefaultSpecialFolderUpdater(
             preferences = preferences,
             folderRepository = folderRepository,
             specialFolderSelectionStrategy = specialFolderSelectionStrategy,

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/FolderSettingsProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/FolderSettingsProvider.kt
@@ -2,12 +2,12 @@ package com.fsck.k9.mailstore
 
 import app.k9mail.legacy.mailstore.FolderSettings
 import com.fsck.k9.Preferences
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Provides imported folder settings if available, otherwise default values.
  */
-class FolderSettingsProvider(val preferences: Preferences, val account: LegacyAccount) {
+class FolderSettingsProvider(val preferences: Preferences, val account: LegacyAccountDto) {
     fun getFolderSettings(folderServerId: String): FolderSettings {
         val storage = preferences.storage
         val prefix = "${account.uuid}.$folderServerId"

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
@@ -4,17 +4,17 @@ import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import com.fsck.k9.Preferences
 import net.thunderbird.backend.api.BackendStorageFactory
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.SpecialFolderUpdater
 
 class K9BackendStorageFactory(
     private val preferences: Preferences,
     private val folderRepository: FolderRepository,
     private val messageStoreManager: MessageStoreManager,
-    private val specialFolderUpdaterFactory: SpecialFolderUpdater.Factory<LegacyAccount>,
+    private val specialFolderUpdaterFactory: SpecialFolderUpdater.Factory<LegacyAccountDto>,
     private val saveMessageDataCreator: SaveMessageDataCreator,
-) : BackendStorageFactory<LegacyAccount> {
-    override fun createBackendStorage(account: LegacyAccount): K9BackendStorage {
+) : BackendStorageFactory<LegacyAccountDto> {
+    override fun createBackendStorage(account: LegacyAccountDto): K9BackendStorage {
         val messageStore = messageStoreManager.getMessageStore(account)
         val folderSettingsProvider = FolderSettingsProvider(preferences, account)
         val specialFolderUpdater = specialFolderUpdaterFactory.create(account)

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -32,7 +32,7 @@ import com.fsck.k9.mail.message.MessageHeaderParser;
 import com.fsck.k9.mailstore.LockableDatabase.DbCallback;
 import com.fsck.k9.message.extractors.AttachmentInfoExtractor;
 
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.preference.GeneralSettingsManager;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.util.MimeUtil;
@@ -1193,7 +1193,7 @@ public class LocalFolder {
         });
     }
 
-    private LegacyAccount getAccount() {
+    private LegacyAccountDto getAccount() {
         return localStore.getAccount();
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -10,7 +10,6 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import androidx.annotation.VisibleForTesting;
-import com.fsck.k9.K9;
 import app.k9mail.legacy.message.controller.MessageReference;
 import com.fsck.k9.core.BuildConfig;
 import com.fsck.k9.mail.Address;
@@ -22,7 +21,7 @@ import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.message.MessageHeaderParser;
 import com.fsck.k9.mailstore.LockableDatabase.DbCallback;
 import app.k9mail.legacy.message.extractors.PreviewResult.PreviewType;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.logging.legacy.Log;
 import net.thunderbird.core.preference.GeneralSettingsManager;
 
@@ -369,7 +368,7 @@ public class LocalMessage extends MimeMessage {
         return rootId;
     }
 
-    public LegacyAccount getAccount() {
+    public LegacyAccountDto getAccount() {
         return localStore.getAccount();
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -46,7 +46,7 @@ import com.fsck.k9.mailstore.LockableDatabase.DbCallback;
 import com.fsck.k9.mailstore.LockableDatabase.SchemaDefinition;
 import com.fsck.k9.message.extractors.AttachmentInfoExtractor;
 import kotlin.time.Clock;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.preference.GeneralSettingsManager;
 import net.thunderbird.feature.search.legacy.LocalMessageSearch;
 import net.thunderbird.feature.search.legacy.api.SearchAttribute;
@@ -163,20 +163,20 @@ public class LocalStore {
     private final AttachmentInfoExtractor attachmentInfoExtractor;
     private final StorageFilesProvider storageFilesProvider;
 
-    private final LegacyAccount account;
+    private final LegacyAccountDto account;
     private final LockableDatabase database;
     private final OutboxStateRepository outboxStateRepository;
     private GeneralSettingsManager generalSettingsManager;
 
-    static LocalStore createInstance(LegacyAccount account, Context context, GeneralSettingsManager generalSettingsManager) throws MessagingException {
+    static LocalStore createInstance(LegacyAccountDto account, Context context, GeneralSettingsManager generalSettingsManager) throws MessagingException {
         return new LocalStore(account, context, generalSettingsManager);
     }
 
     /**
      * local://localhost/path/to/database/uuid.db
-     * This constructor is only used by {@link LocalStoreProvider#getInstance(LegacyAccount,GeneralSettingsManager)}
+     * This constructor is only used by {@link LocalStoreProvider#getInstance(LegacyAccountDto,GeneralSettingsManager)}
      */
-    private LocalStore(final LegacyAccount account, final Context context, final GeneralSettingsManager generalSettingsManager) throws MessagingException {
+    private LocalStore(final LegacyAccountDto account, final Context context, final GeneralSettingsManager generalSettingsManager) throws MessagingException {
         pendingCommandSerializer = PendingCommandSerializer.getInstance();
         attachmentInfoExtractor = DI.get(AttachmentInfoExtractor.class);
         StorageFilesProviderFactory storageFilesProviderFactory = DI.get(StorageFilesProviderFactory.class);
@@ -201,7 +201,7 @@ public class LocalStore {
         return schemaDefinitionFactory.getDatabaseVersion();
     }
 
-    LegacyAccount getAccount() {
+    LegacyAccountDto getAccount() {
         return account;
     }
 
@@ -1039,7 +1039,7 @@ public class LocalStore {
 
     class RealMigrationsHelper implements MigrationsHelper {
         @Override
-        public LegacyAccount getAccount() {
+        public LegacyAccountDto getAccount() {
             return LocalStore.this.getAccount();
         }
 

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStoreProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStoreProvider.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.mailstore
 import android.content.Context
 import app.k9mail.legacy.di.DI
 import java.util.concurrent.ConcurrentHashMap
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.core.preference.GeneralSettingsManager
 
@@ -12,7 +12,7 @@ class LocalStoreProvider {
     private val accountLocks = ConcurrentHashMap<String, Any>()
 
     @Throws(MessagingException::class)
-    fun getInstance(account: LegacyAccount): LocalStore {
+    fun getInstance(account: LegacyAccountDto): LocalStore {
         val context = DI.get(Context::class.java)
         val generalSettingsManager = DI.get(GeneralSettingsManager::class.java)
         val accountUuid = account.uuid
@@ -27,7 +27,7 @@ class LocalStoreProvider {
         }
     }
 
-    fun removeInstance(account: LegacyAccount) {
+    fun removeInstance(account: LegacyAccountDto) {
         val accountUuid = account.uuid
         localStores.remove(accountUuid)
     }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/MigrationsHelper.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/MigrationsHelper.java
@@ -1,13 +1,13 @@
 package com.fsck.k9.mailstore;
 
 
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 
 
 /**
  * Helper to allow accessing classes and methods that aren't visible or accessible to the 'migrations' package
  */
 public interface MigrationsHelper {
-    LegacyAccount getAccount();
+    LegacyAccountDto getAccount();
     void saveAccount();
 }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialLocalFoldersCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/SpecialLocalFoldersCreator.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.mailstore
 
 import com.fsck.k9.Preferences
 import com.fsck.k9.mail.FolderType
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.Protocols
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection
@@ -13,7 +13,7 @@ class SpecialLocalFoldersCreator(
 ) {
     // TODO: When rewriting the account setup code make sure this method is only called once. Until then this can be
     //  called multiple times and we have to make sure folders are only created once.
-    fun createSpecialLocalFolders(account: LegacyAccount) {
+    fun createSpecialLocalFolders(account: LegacyAccountDto) {
         Log.d("Creating special local folders")
 
         val localStore = localStoreProvider.getInstance(account)
@@ -50,7 +50,7 @@ class SpecialLocalFoldersCreator(
         preferences.saveAccount(account)
     }
 
-    fun createOutbox(account: LegacyAccount): Long {
+    fun createOutbox(account: LegacyAccountDto): Long {
         Log.d("Creating Outbox folder")
 
         val localStore = localStoreProvider.getInstance(account)
@@ -62,10 +62,10 @@ class SpecialLocalFoldersCreator(
         return outboxFolderId
     }
 
-    private fun LegacyAccount.isPop3() = incomingServerSettings.type == Protocols.POP3
+    private fun LegacyAccountDto.isPop3() = incomingServerSettings.type == Protocols.POP3
 
     companion object {
-        private const val OUTBOX_FOLDER_NAME = LegacyAccount.OUTBOX_NAME
+        private const val OUTBOX_FOLDER_NAME = LegacyAccountDto.OUTBOX_NAME
         private const val DRAFTS_FOLDER_NAME = "Drafts"
         private const val SENT_FOLDER_NAME = "Sent"
         private const val TRASH_FOLDER_NAME = "Trash"

--- a/legacy/core/src/main/java/com/fsck/k9/message/ReplyActionStrategy.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/ReplyActionStrategy.kt
@@ -2,13 +2,13 @@ package com.fsck.k9.message
 
 import com.fsck.k9.helper.ReplyToParser
 import com.fsck.k9.mail.Message
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Figures out which reply actions are available to the user.
  */
 class ReplyActionStrategy(private val replyRoParser: ReplyToParser) {
-    fun getReplyActions(account: LegacyAccount, message: Message): ReplyActions {
+    fun getReplyActions(account: LegacyAccountDto, message: Message): ReplyActions {
         val recipientsToReplyTo = replyRoParser.getRecipientsToReplyTo(message, account)
         val recipientsToReplyAllTo = replyRoParser.getRecipientsToReplyAllTo(message, account)
 

--- a/legacy/core/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotificationController.kt
@@ -4,7 +4,7 @@ import android.app.Notification
 import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 internal open class AuthenticationErrorNotificationController(
@@ -13,7 +13,7 @@ internal open class AuthenticationErrorNotificationController(
     private val resourceProvider: NotificationResourceProvider,
     private val generalSettingsManager: GeneralSettingsManager,
 ) {
-    fun showAuthenticationErrorNotification(account: LegacyAccount, incoming: Boolean) {
+    fun showAuthenticationErrorNotification(account: LegacyAccountDto, incoming: Boolean) {
         val notificationId = NotificationIds.getAuthenticationErrorNotificationId(account, incoming)
         val editServerSettingsPendingIntent = createContentIntent(account, incoming)
         val title = resourceProvider.authenticationErrorTitle()
@@ -37,12 +37,12 @@ internal open class AuthenticationErrorNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearAuthenticationErrorNotification(account: LegacyAccount, incoming: Boolean) {
+    fun clearAuthenticationErrorNotification(account: LegacyAccountDto, incoming: Boolean) {
         val notificationId = NotificationIds.getAuthenticationErrorNotificationId(account, incoming)
         notificationManager.cancel(notificationId)
     }
 
-    protected open fun createContentIntent(account: LegacyAccount, incoming: Boolean): PendingIntent {
+    protected open fun createContentIntent(account: LegacyAccountDto, incoming: Boolean): PendingIntent {
         return if (incoming) {
             actionCreator.getEditIncomingServerSettingsIntent(account)
         } else {
@@ -50,7 +50,7 @@ internal open class AuthenticationErrorNotificationController(
         }
     }
 
-    private fun createLockScreenNotification(account: LegacyAccount): Notification {
+    private fun createLockScreenNotification(account: LegacyAccountDto): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconWarning)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/BaseNotificationDataCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/BaseNotificationDataCreator.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.notification
 
 import com.fsck.k9.K9
 import com.fsck.k9.K9.LockScreenNotificationVisibility
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 private const val MAX_NUMBER_OF_SENDERS_IN_LOCK_SCREEN_NOTIFICATION = 5
 
@@ -39,7 +39,7 @@ internal class BaseNotificationDataCreator {
             .joinToString()
     }
 
-    private fun createNotificationAppearance(account: LegacyAccount): NotificationAppearance {
+    private fun createNotificationAppearance(account: LegacyAccountDto): NotificationAppearance {
         return with(account.notificationSettings) {
             val vibrationPattern = vibration.systemPattern.takeIf { vibration.isEnabled }
             NotificationAppearance(

--- a/legacy/core/src/main/java/com/fsck/k9/notification/CertificateErrorNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/CertificateErrorNotificationController.kt
@@ -4,7 +4,7 @@ import android.app.Notification
 import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 internal open class CertificateErrorNotificationController(
@@ -13,7 +13,7 @@ internal open class CertificateErrorNotificationController(
     private val resourceProvider: NotificationResourceProvider,
     private val generalSettingsManager: GeneralSettingsManager,
 ) {
-    fun showCertificateErrorNotification(account: LegacyAccount, incoming: Boolean) {
+    fun showCertificateErrorNotification(account: LegacyAccountDto, incoming: Boolean) {
         val notificationId = NotificationIds.getCertificateErrorNotificationId(account, incoming)
         val editServerSettingsPendingIntent = createContentIntent(account, incoming)
         val title = resourceProvider.certificateErrorTitle(account.displayName)
@@ -37,12 +37,12 @@ internal open class CertificateErrorNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearCertificateErrorNotifications(account: LegacyAccount, incoming: Boolean) {
+    fun clearCertificateErrorNotifications(account: LegacyAccountDto, incoming: Boolean) {
         val notificationId = NotificationIds.getCertificateErrorNotificationId(account, incoming)
         notificationManager.cancel(notificationId)
     }
 
-    protected open fun createContentIntent(account: LegacyAccount, incoming: Boolean): PendingIntent {
+    protected open fun createContentIntent(account: LegacyAccountDto, incoming: Boolean): PendingIntent {
         return if (incoming) {
             actionCreator.getEditIncomingServerSettingsIntent(account)
         } else {
@@ -50,7 +50,7 @@ internal open class CertificateErrorNotificationController(
         }
     }
 
-    private fun createLockScreenNotification(account: LegacyAccount): Notification {
+    private fun createLockScreenNotification(account: LegacyAccountDto): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconWarning)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationController.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import androidx.core.app.NotificationManagerCompat
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mailstore.LocalMessage
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Handle notifications for new messages.
@@ -15,7 +15,7 @@ internal class NewMailNotificationController(
     private val singleMessageNotificationCreator: SingleMessageNotificationCreator,
 ) {
     @Synchronized
-    fun restoreNewMailNotifications(accounts: List<LegacyAccount>) {
+    fun restoreNewMailNotifications(accounts: List<LegacyAccountDto>) {
         for (account in accounts) {
             val notificationData = newMailNotificationManager.restoreNewMailNotifications(account)
 
@@ -26,7 +26,7 @@ internal class NewMailNotificationController(
     }
 
     @Synchronized
-    fun addNewMailNotification(account: LegacyAccount, message: LocalMessage, silent: Boolean) {
+    fun addNewMailNotification(account: LegacyAccountDto, message: LocalMessage, silent: Boolean) {
         val notificationData = newMailNotificationManager.addNewMailNotification(account, message, silent)
 
         if (notificationData != null) {
@@ -36,7 +36,7 @@ internal class NewMailNotificationController(
 
     @Synchronized
     fun removeNewMailNotifications(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         clearNewMessageState: Boolean,
         selector: (List<MessageReference>) -> List<MessageReference>,
     ) {
@@ -52,7 +52,7 @@ internal class NewMailNotificationController(
     }
 
     @Synchronized
-    fun clearNewMailNotifications(account: LegacyAccount, clearNewMessageState: Boolean) {
+    fun clearNewMailNotifications(account: LegacyAccountDto, clearNewMessageState: Boolean) {
         val cancelNotificationIds = newMailNotificationManager.clearNewMailNotifications(account, clearNewMessageState)
 
         cancelNotifications(cancelNotificationIds)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationData.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationData.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
 import app.k9mail.legacy.message.controller.MessageReference
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal data class NewMailNotificationData(
     val cancelNotificationIds: List<Int>,
@@ -11,7 +11,7 @@ internal data class NewMailNotificationData(
 )
 
 internal data class BaseNotificationData(
-    val account: LegacyAccount,
+    val account: LegacyAccountDto,
     val accountName: String,
     val groupKey: String,
     val color: Int,

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NewMailNotificationManager.kt
@@ -4,7 +4,7 @@ import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mailstore.LocalMessage
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Manages notifications for new messages
@@ -19,7 +19,7 @@ constructor(
     private val summaryNotificationDataCreator: SummaryNotificationDataCreator,
     private val clock: Clock,
 ) {
-    fun restoreNewMailNotifications(account: LegacyAccount): NewMailNotificationData? {
+    fun restoreNewMailNotifications(account: LegacyAccountDto): NewMailNotificationData? {
         val notificationData = notificationRepository.restoreNotifications(account) ?: return null
 
         val addLockScreenNotification = notificationData.isSingleMessageNotification
@@ -42,7 +42,7 @@ constructor(
     }
 
     fun addNewMailNotification(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         message: LocalMessage,
         silent: Boolean,
     ): NewMailNotificationData? {
@@ -71,7 +71,7 @@ constructor(
     }
 
     fun removeNewMailNotifications(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         clearNewMessageState: Boolean,
         selector: (List<MessageReference>) -> List<MessageReference>,
     ): NewMailNotificationData? {
@@ -104,7 +104,7 @@ constructor(
         )
     }
 
-    fun clearNewMailNotifications(account: LegacyAccount, clearNewMessageState: Boolean): List<Int> {
+    fun clearNewMailNotifications(account: LegacyAccountDto, clearNewMessageState: Boolean): List<Int> {
         notificationRepository.clearNotifications(account, clearNewMessageState)
         return NotificationIds.getAllMessageNotificationIds(account)
     }
@@ -114,7 +114,7 @@ constructor(
     }
 
     private fun createSingleNotificationData(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationId: Int,
         content: NotificationContent,
         timestamp: Long,

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionCreator.kt
@@ -2,21 +2,21 @@ package com.fsck.k9.notification
 
 import android.app.PendingIntent
 import app.k9mail.legacy.message.controller.MessageReference
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 interface NotificationActionCreator {
     fun createViewMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createViewFolderPendingIntent(account: LegacyAccount, folderId: Long): PendingIntent
+    fun createViewFolderPendingIntent(account: LegacyAccountDto, folderId: Long): PendingIntent
 
     fun createViewMessagesPendingIntent(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         messageReferences: List<MessageReference>,
     ): PendingIntent
 
-    fun createViewFolderListPendingIntent(account: LegacyAccount): PendingIntent
+    fun createViewFolderListPendingIntent(account: LegacyAccountDto): PendingIntent
 
-    fun createDismissAllMessagesPendingIntent(account: LegacyAccount): PendingIntent
+    fun createDismissAllMessagesPendingIntent(account: LegacyAccountDto): PendingIntent
 
     fun createDismissMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
@@ -25,21 +25,27 @@ interface NotificationActionCreator {
     fun createMarkMessageAsReadPendingIntent(messageReference: MessageReference): PendingIntent
 
     fun createMarkAllAsReadPendingIntent(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         messageReferences: List<MessageReference>,
     ): PendingIntent
 
-    fun getEditIncomingServerSettingsIntent(account: LegacyAccount): PendingIntent
+    fun getEditIncomingServerSettingsIntent(account: LegacyAccountDto): PendingIntent
 
-    fun getEditOutgoingServerSettingsIntent(account: LegacyAccount): PendingIntent
+    fun getEditOutgoingServerSettingsIntent(account: LegacyAccountDto): PendingIntent
 
     fun createDeleteMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createDeleteAllPendingIntent(account: LegacyAccount, messageReferences: List<MessageReference>): PendingIntent
+    fun createDeleteAllPendingIntent(
+        account: LegacyAccountDto,
+        messageReferences: List<MessageReference>,
+    ): PendingIntent
 
     fun createArchiveMessagePendingIntent(messageReference: MessageReference): PendingIntent
 
-    fun createArchiveAllPendingIntent(account: LegacyAccount, messageReferences: List<MessageReference>): PendingIntent
+    fun createArchiveAllPendingIntent(
+        account: LegacyAccountDto,
+        messageReferences: List<MessageReference>,
+    ): PendingIntent
 
     fun createMarkMessageAsSpamPendingIntent(messageReference: MessageReference): PendingIntent
 }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionService.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationActionService.kt
@@ -13,7 +13,7 @@ import com.fsck.k9.mail.Flag
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import org.koin.android.ext.android.inject
 import org.koin.core.qualifier.named
@@ -66,7 +66,7 @@ class NotificationActionService : Service() {
         return null
     }
 
-    private fun markMessagesAsRead(intent: Intent, account: LegacyAccount) {
+    private fun markMessagesAsRead(intent: Intent, account: LegacyAccountDto) {
         Log.i("NotificationActionService marking messages as read")
 
         val messageReferenceStrings = intent.getStringArrayListExtra(EXTRA_MESSAGE_REFERENCES)
@@ -97,7 +97,7 @@ class NotificationActionService : Service() {
         messagingController.archiveMessages(messageReferences)
     }
 
-    private fun markMessageAsSpam(intent: Intent, account: LegacyAccount) {
+    private fun markMessageAsSpam(intent: Intent, account: LegacyAccountDto) {
         Log.i("NotificationActionService moving messages to spam")
 
         val messageReferenceString = intent.getStringExtra(EXTRA_MESSAGE_REFERENCE)
@@ -120,7 +120,7 @@ class NotificationActionService : Service() {
         }
     }
 
-    private fun cancelNotifications(intent: Intent, account: LegacyAccount) {
+    private fun cancelNotifications(intent: Intent, account: LegacyAccountDto) {
         if (intent.hasExtra(EXTRA_MESSAGE_REFERENCE)) {
             val messageReferenceString = intent.getStringExtra(EXTRA_MESSAGE_REFERENCE)
             val messageReference = MessageReference.parse(messageReferenceString)
@@ -183,7 +183,7 @@ class NotificationActionService : Service() {
             }
         }
 
-        fun createDismissAllMessagesIntent(context: Context, account: LegacyAccount): Intent {
+        fun createDismissAllMessagesIntent(context: Context, account: LegacyAccountDto): Intent {
             return Intent(context, NotificationActionService::class.java).apply {
                 action = ACTION_DISMISS
                 putExtra(EXTRA_ACCOUNT_UUID, account.uuid)
@@ -223,7 +223,7 @@ class NotificationActionService : Service() {
 
         fun createArchiveAllIntent(
             context: Context,
-            account: LegacyAccount,
+            account: LegacyAccountDto,
             messageReferences: List<MessageReference>,
         ): Intent {
             return Intent(context, NotificationActionService::class.java).apply {

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
@@ -10,7 +10,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 import java.util.concurrent.Executor
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.feature.notification.NotificationLight
 import net.thunderbird.feature.notification.NotificationSettings
@@ -58,7 +58,7 @@ class NotificationChannelManager(
     @RequiresApi(api = Build.VERSION_CODES.O)
     private fun addChannelsForAccounts(
         notificationManager: NotificationManager,
-        accounts: List<LegacyAccount>,
+        accounts: List<LegacyAccountDto>,
     ) {
         for (account in accounts) {
             val groupId = account.notificationChannelGroupId
@@ -76,7 +76,7 @@ class NotificationChannelManager(
     @RequiresApi(api = Build.VERSION_CODES.O)
     private fun removeChannelsForNonExistingOrChangedAccounts(
         notificationManager: NotificationManager,
-        accounts: List<LegacyAccount>,
+        accounts: List<LegacyAccountDto>,
     ) {
         val accountUuids = accounts.map { it.uuid }.toSet()
 
@@ -120,7 +120,7 @@ class NotificationChannelManager(
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
-    private fun getChannelMessages(account: LegacyAccount): NotificationChannel {
+    private fun getChannelMessages(account: LegacyAccountDto): NotificationChannel {
         val channelName = resourceProvider.messagesChannelName
         val channelId = getChannelIdFor(account, ChannelType.MESSAGES)
         val importance = NotificationManager.IMPORTANCE_DEFAULT
@@ -134,7 +134,7 @@ class NotificationChannelManager(
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
-    private fun getChannelMiscellaneous(account: LegacyAccount): NotificationChannel {
+    private fun getChannelMiscellaneous(account: LegacyAccountDto): NotificationChannel {
         val channelName = resourceProvider.miscellaneousChannelName
         val channelDescription = resourceProvider.miscellaneousChannelDescription
         val channelId = getChannelIdFor(account, ChannelType.MISCELLANEOUS)
@@ -148,7 +148,7 @@ class NotificationChannelManager(
         return miscellaneousChannel
     }
 
-    fun getChannelIdFor(account: LegacyAccount, channelType: ChannelType): String {
+    fun getChannelIdFor(account: LegacyAccountDto, channelType: ChannelType): String {
         return if (channelType == ChannelType.MESSAGES) {
             getMessagesChannelId(account, account.messagesNotificationChannelSuffix)
         } else {
@@ -156,12 +156,12 @@ class NotificationChannelManager(
         }
     }
 
-    private fun getMessagesChannelId(account: LegacyAccount, suffix: String): String {
+    private fun getMessagesChannelId(account: LegacyAccountDto, suffix: String): String {
         return "messages_channel_${account.uuid}$suffix"
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun getNotificationConfiguration(account: LegacyAccount): NotificationConfiguration {
+    fun getNotificationConfiguration(account: LegacyAccountDto): NotificationConfiguration {
         val channelId = getChannelIdFor(account, ChannelType.MESSAGES)
         val notificationChannel = notificationManager.getNotificationChannel(channelId)
 
@@ -174,7 +174,7 @@ class NotificationChannelManager(
         )
     }
 
-    fun recreateMessagesNotificationChannel(account: LegacyAccount) {
+    fun recreateMessagesNotificationChannel(account: LegacyAccountDto) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
 
         val oldChannelId = getChannelIdFor(account, ChannelType.MESSAGES)
@@ -210,7 +210,7 @@ class NotificationChannelManager(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun NotificationChannel.matches(account: LegacyAccount): Boolean {
+    private fun NotificationChannel.matches(account: LegacyAccountDto): Boolean {
         val systemLight = notificationLightDecoder.decode(
             isBlinkLightsEnabled = shouldShowLights(),
             lightColor = lightColor,
@@ -237,7 +237,7 @@ class NotificationChannelManager(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun NotificationChannel.setPropertiesFrom(account: LegacyAccount) {
+    private fun NotificationChannel.setPropertiesFrom(account: LegacyAccountDto) {
         val notificationSettings = account.notificationSettings
 
         if (notificationSettings.isRingEnabled) {
@@ -254,12 +254,12 @@ class NotificationChannelManager(
         enableVibration(notificationSettings.vibration.isEnabled)
     }
 
-    private val LegacyAccount.notificationChannelGroupId: String
+    private val LegacyAccountDto.notificationChannelGroupId: String
         get() = uuid
 
     private fun String.toAccountUuid(): String = this
 
-    private val LegacyAccount.messagesNotificationChannelSuffix: String
+    private val LegacyAccountDto.messagesNotificationChannelSuffix: String
         get() = messagesNotificationChannelVersion.let { version -> if (version == 0) "" else "_$version" }
 
     private val NotificationSettings.ringtoneUri: Uri?

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationConfigurationConverter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationConfigurationConverter.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.notification.NotificationSettings
 
 /**
@@ -11,7 +11,7 @@ class NotificationConfigurationConverter(
     private val notificationVibrationDecoder: NotificationVibrationDecoder,
 ) {
     fun convert(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationConfiguration: NotificationConfiguration,
     ): NotificationSettings {
         val light = notificationLightDecoder.decode(

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationContentCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationContentCreator.kt
@@ -6,7 +6,7 @@ import app.k9mail.legacy.message.extractors.PreviewResult.PreviewType
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mailstore.LocalMessage
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 internal class NotificationContentCreator(
@@ -14,7 +14,7 @@ internal class NotificationContentCreator(
     private val contactRepository: ContactRepository,
     private val generalSettingsManager: GeneralSettingsManager,
 ) {
-    fun createFromMessage(account: LegacyAccount, message: LocalMessage): NotificationContent {
+    fun createFromMessage(account: LegacyAccountDto, message: LocalMessage): NotificationContent {
         val sender = getMessageSender(account, message)
 
         return NotificationContent(
@@ -70,7 +70,7 @@ internal class NotificationContentCreator(
     }
 
     @Suppress("ReturnCount")
-    private fun getMessageSender(account: LegacyAccount, message: Message): String? {
+    private fun getMessageSender(account: LegacyAccountDto, message: Message): String? {
         val localContactRepository =
             if (generalSettingsManager.getConfig().display.visualSettings.isShowContactName) contactRepository else null
         var isSelf = false

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationController.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.mailstore.LocalMessage
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 
 class NotificationController internal constructor(
@@ -13,55 +13,55 @@ class NotificationController internal constructor(
     private val sendFailedNotificationController: SendFailedNotificationController,
     private val newMailNotificationController: NewMailNotificationController,
 ) {
-    fun showCertificateErrorNotification(account: LegacyAccount, incoming: Boolean) {
+    fun showCertificateErrorNotification(account: LegacyAccountDto, incoming: Boolean) {
         certificateErrorNotificationController.showCertificateErrorNotification(account, incoming)
     }
 
-    fun clearCertificateErrorNotifications(account: LegacyAccount, incoming: Boolean) {
+    fun clearCertificateErrorNotifications(account: LegacyAccountDto, incoming: Boolean) {
         certificateErrorNotificationController.clearCertificateErrorNotifications(account, incoming)
     }
 
-    fun showAuthenticationErrorNotification(account: LegacyAccount, incoming: Boolean) {
+    fun showAuthenticationErrorNotification(account: LegacyAccountDto, incoming: Boolean) {
         authenticationErrorNotificationController.showAuthenticationErrorNotification(account, incoming)
     }
 
-    fun clearAuthenticationErrorNotification(account: LegacyAccount, incoming: Boolean) {
+    fun clearAuthenticationErrorNotification(account: LegacyAccountDto, incoming: Boolean) {
         authenticationErrorNotificationController.clearAuthenticationErrorNotification(account, incoming)
     }
 
-    fun showSendingNotification(account: LegacyAccount) {
+    fun showSendingNotification(account: LegacyAccountDto) {
         syncNotificationController.showSendingNotification(account)
     }
 
-    fun clearSendingNotification(account: LegacyAccount) {
+    fun clearSendingNotification(account: LegacyAccountDto) {
         syncNotificationController.clearSendingNotification(account)
     }
 
-    fun showSendFailedNotification(account: LegacyAccount, exception: Exception) {
+    fun showSendFailedNotification(account: LegacyAccountDto, exception: Exception) {
         sendFailedNotificationController.showSendFailedNotification(account, exception)
     }
 
-    fun clearSendFailedNotification(account: LegacyAccount) {
+    fun clearSendFailedNotification(account: LegacyAccountDto) {
         sendFailedNotificationController.clearSendFailedNotification(account)
     }
 
-    fun showFetchingMailNotification(account: LegacyAccount, folder: LocalFolder) {
+    fun showFetchingMailNotification(account: LegacyAccountDto, folder: LocalFolder) {
         syncNotificationController.showFetchingMailNotification(account, folder)
     }
 
-    fun showEmptyFetchingMailNotification(account: LegacyAccount) {
+    fun showEmptyFetchingMailNotification(account: LegacyAccountDto) {
         syncNotificationController.showEmptyFetchingMailNotification(account)
     }
 
-    fun clearFetchingMailNotification(account: LegacyAccount) {
+    fun clearFetchingMailNotification(account: LegacyAccountDto) {
         syncNotificationController.clearFetchingMailNotification(account)
     }
 
-    fun restoreNewMailNotifications(accounts: List<LegacyAccount>) {
+    fun restoreNewMailNotifications(accounts: List<LegacyAccountDto>) {
         newMailNotificationController.restoreNewMailNotifications(accounts)
     }
 
-    fun addNewMailNotification(account: LegacyAccount, message: LocalMessage, silent: Boolean) {
+    fun addNewMailNotification(account: LegacyAccountDto, message: LocalMessage, silent: Boolean) {
         Log.v(
             "Creating notification for message %s:%s:%s",
             message.account.uuid,
@@ -72,7 +72,7 @@ class NotificationController internal constructor(
         newMailNotificationController.addNewMailNotification(account, message, silent)
     }
 
-    fun removeNewMailNotification(account: LegacyAccount, messageReference: MessageReference) {
+    fun removeNewMailNotification(account: LegacyAccountDto, messageReference: MessageReference) {
         Log.v("Removing notification for message %s", messageReference)
 
         newMailNotificationController.removeNewMailNotifications(account, clearNewMessageState = true) {
@@ -81,7 +81,7 @@ class NotificationController internal constructor(
     }
 
     fun clearNewMailNotifications(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         selector: (List<MessageReference>) -> List<MessageReference>,
     ) {
         Log.v("Removing some notifications for account %s", account.uuid)
@@ -89,7 +89,7 @@ class NotificationController internal constructor(
         newMailNotificationController.removeNewMailNotifications(account, clearNewMessageState = false, selector)
     }
 
-    fun clearNewMailNotifications(account: LegacyAccount, clearNewMessageState: Boolean) {
+    fun clearNewMailNotifications(account: LegacyAccountDto, clearNewMessageState: Boolean) {
         Log.v("Removing all notifications for account %s", account.uuid)
 
         newMailNotificationController.clearNewMailNotifications(account, clearNewMessageState)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationData.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationData.kt
@@ -1,13 +1,13 @@
 package com.fsck.k9.notification
 
 import app.k9mail.legacy.message.controller.MessageReference
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Holds information about active and inactive new message notifications of an account.
  */
 internal data class NotificationData(
-    val account: LegacyAccount,
+    val account: LegacyAccountDto,
     val activeNotifications: List<NotificationHolder>,
     val inactiveNotifications: List<InactiveNotificationHolder>,
 ) {
@@ -35,7 +35,7 @@ internal data class NotificationData(
     fun isEmpty() = activeNotifications.isEmpty()
 
     companion object {
-        fun create(account: LegacyAccount): NotificationData {
+        fun create(account: LegacyAccountDto): NotificationData {
             return NotificationData(account, activeNotifications = emptyList(), inactiveNotifications = emptyList())
         }
     }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationDataStore.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationDataStore.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
 import app.k9mail.legacy.message.controller.MessageReference
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal const val MAX_NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS = 9
 
@@ -16,13 +16,13 @@ internal class NotificationDataStore {
     private val notificationDataMap = mutableMapOf<String, NotificationData>()
 
     @Synchronized
-    fun isAccountInitialized(account: LegacyAccount): Boolean {
+    fun isAccountInitialized(account: LegacyAccountDto): Boolean {
         return notificationDataMap[account.uuid] != null
     }
 
     @Synchronized
     fun initializeAccount(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         activeNotifications: List<NotificationHolder>,
         inactiveNotifications: List<InactiveNotificationHolder>,
     ): NotificationData {
@@ -34,7 +34,11 @@ internal class NotificationDataStore {
     }
 
     @Synchronized
-    fun addNotification(account: LegacyAccount, content: NotificationContent, timestamp: Long): AddNotificationResult? {
+    fun addNotification(
+        account: LegacyAccountDto,
+        content: NotificationContent,
+        timestamp: Long,
+    ): AddNotificationResult? {
         val notificationData = getNotificationData(account)
         val messageReference = content.messageReference
 
@@ -111,7 +115,7 @@ internal class NotificationDataStore {
     @Suppress("LongMethod", "ReturnCount")
     @Synchronized
     fun removeNotifications(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         selector: (List<MessageReference>) -> List<MessageReference>,
     ): RemoveNotificationsResult? {
         var notificationData = getNotificationData(account)
@@ -196,11 +200,11 @@ internal class NotificationDataStore {
     }
 
     @Synchronized
-    fun clearNotifications(account: LegacyAccount) {
+    fun clearNotifications(account: LegacyAccountDto) {
         notificationDataMap.remove(account.uuid)
     }
 
-    private fun getNotificationData(account: LegacyAccount): NotificationData {
+    private fun getNotificationData(account: LegacyAccountDto): NotificationData {
         return notificationDataMap[account.uuid] ?: NotificationData.create(account).also { notificationData ->
             notificationDataMap[account.uuid] = notificationData
         }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationGroupKeys.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationGroupKeys.kt
@@ -1,11 +1,11 @@
 package com.fsck.k9.notification
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 object NotificationGroupKeys {
     private const val NOTIFICATION_GROUP_KEY_PREFIX = "newMailNotifications-"
 
-    fun getGroupKey(account: LegacyAccount): String {
+    fun getGroupKey(account: LegacyAccountDto): String {
         return NOTIFICATION_GROUP_KEY_PREFIX + account.accountNumber
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationHelper.kt
@@ -14,7 +14,7 @@ import com.fsck.k9.QuietTimeChecker
 import com.fsck.k9.notification.NotificationChannelManager.ChannelType
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.core.preference.notification.NotificationPreference
@@ -34,12 +34,12 @@ class NotificationHelper(
         return notificationManager
     }
 
-    fun createNotificationBuilder(account: LegacyAccount, channelType: ChannelType): NotificationCompat.Builder {
+    fun createNotificationBuilder(account: LegacyAccountDto, channelType: ChannelType): NotificationCompat.Builder {
         val notificationChannel = notificationChannelManager.getChannelIdFor(account, channelType)
         return NotificationCompat.Builder(context, notificationChannel)
     }
 
-    fun notify(account: LegacyAccount, notificationId: Int, notification: Notification) {
+    fun notify(account: LegacyAccountDto, notificationId: Int, notification: Notification) {
         try {
             notificationManager.notify(notificationId, notification)
         } catch (e: SecurityException) {
@@ -59,7 +59,7 @@ class NotificationHelper(
         }
     }
 
-    private fun showNotifyErrorNotification(account: LegacyAccount) {
+    private fun showNotifyErrorNotification(account: LegacyAccountDto) {
         val title = resourceProvider.notifyErrorTitle()
         val text = resourceProvider.notifyErrorText()
 

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationIds.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationIds.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.notification
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal object NotificationIds {
     const val PUSH_NOTIFICATION_ID = 1
@@ -20,17 +20,17 @@ internal object NotificationIds {
     private const val NUMBER_OF_NOTIFICATIONS_PER_ACCOUNT =
         NUMBER_OF_MISC_ACCOUNT_NOTIFICATIONS + NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS
 
-    fun getNewMailSummaryNotificationId(account: LegacyAccount): Int {
+    fun getNewMailSummaryNotificationId(account: LegacyAccountDto): Int {
         return getBaseNotificationId(account) + OFFSET_NEW_MAIL_SUMMARY
     }
 
-    fun getSingleMessageNotificationId(account: LegacyAccount, index: Int): Int {
+    fun getSingleMessageNotificationId(account: LegacyAccountDto, index: Int): Int {
         require(index in 0 until NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS) { "Invalid index: $index" }
 
         return getBaseNotificationId(account) + OFFSET_NEW_MAIL_SINGLE + index
     }
 
-    fun getAllMessageNotificationIds(account: LegacyAccount): List<Int> {
+    fun getAllMessageNotificationIds(account: LegacyAccountDto): List<Int> {
         val singleMessageNotificationIdRange = (0 until NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS).map { index ->
             getBaseNotificationId(account) + OFFSET_NEW_MAIL_SINGLE + index
         }
@@ -38,27 +38,27 @@ internal object NotificationIds {
         return singleMessageNotificationIdRange.toList() + getNewMailSummaryNotificationId(account)
     }
 
-    fun getFetchingMailNotificationId(account: LegacyAccount): Int {
+    fun getFetchingMailNotificationId(account: LegacyAccountDto): Int {
         return getBaseNotificationId(account) + OFFSET_FETCHING_MAIL
     }
 
-    fun getSendFailedNotificationId(account: LegacyAccount): Int {
+    fun getSendFailedNotificationId(account: LegacyAccountDto): Int {
         return getBaseNotificationId(account) + OFFSET_SEND_FAILED_NOTIFICATION
     }
 
-    fun getCertificateErrorNotificationId(account: LegacyAccount, incoming: Boolean): Int {
+    fun getCertificateErrorNotificationId(account: LegacyAccountDto, incoming: Boolean): Int {
         val offset = if (incoming) OFFSET_CERTIFICATE_ERROR_INCOMING else OFFSET_CERTIFICATE_ERROR_OUTGOING
 
         return getBaseNotificationId(account) + offset
     }
 
-    fun getAuthenticationErrorNotificationId(account: LegacyAccount, incoming: Boolean): Int {
+    fun getAuthenticationErrorNotificationId(account: LegacyAccountDto, incoming: Boolean): Int {
         val offset = if (incoming) OFFSET_AUTHENTICATION_ERROR_INCOMING else OFFSET_AUTHENTICATION_ERROR_OUTGOING
 
         return getBaseNotificationId(account) + offset
     }
 
-    private fun getBaseNotificationId(account: LegacyAccount): Int {
+    private fun getBaseNotificationId(account: LegacyAccountDto): Int {
         /* skip notification ID 0 */
         return 1 + NUMBER_OF_GENERAL_NOTIFICATIONS +
             account.accountNumber * NUMBER_OF_NOTIFICATIONS_PER_ACCOUNT

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationRepository.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationRepository.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mailstore.LocalStoreProvider
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class NotificationRepository(
     private val notificationStoreProvider: NotificationStoreProvider,
@@ -14,7 +14,7 @@ internal class NotificationRepository(
     private val notificationDataStore = NotificationDataStore()
 
     @Synchronized
-    fun restoreNotifications(account: LegacyAccount): NotificationData? {
+    fun restoreNotifications(account: LegacyAccountDto): NotificationData? {
         if (notificationDataStore.isAccountInitialized(account)) return null
 
         val localStore = localStoreProvider.getInstance(account)
@@ -43,7 +43,11 @@ internal class NotificationRepository(
     }
 
     @Synchronized
-    fun addNotification(account: LegacyAccount, content: NotificationContent, timestamp: Long): AddNotificationResult? {
+    fun addNotification(
+        account: LegacyAccountDto,
+        content: NotificationContent,
+        timestamp: Long,
+    ): AddNotificationResult? {
         restoreNotifications(account)
 
         return notificationDataStore.addNotification(account, content, timestamp)?.also { result ->
@@ -57,7 +61,7 @@ internal class NotificationRepository(
 
     @Synchronized
     fun removeNotifications(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         clearNewMessageState: Boolean = true,
         selector: (List<MessageReference>) -> List<MessageReference>,
     ): RemoveNotificationsResult? {
@@ -73,7 +77,7 @@ internal class NotificationRepository(
     }
 
     @Synchronized
-    fun clearNotifications(account: LegacyAccount, clearNewMessageState: Boolean) {
+    fun clearNotifications(account: LegacyAccountDto, clearNewMessageState: Boolean) {
         notificationDataStore.clearNotifications(account)
         clearNotificationStore(account)
 
@@ -83,7 +87,7 @@ internal class NotificationRepository(
     }
 
     private fun persistNotificationDataStoreChanges(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         operations: List<NotificationStoreOperation>,
         updateNewMessageState: Boolean,
     ) {
@@ -95,7 +99,7 @@ internal class NotificationRepository(
         }
     }
 
-    private fun setNewMessageState(account: LegacyAccount, operations: List<NotificationStoreOperation>) {
+    private fun setNewMessageState(account: LegacyAccountDto, operations: List<NotificationStoreOperation>) {
         val messageStore = messageStoreManager.getMessageStore(account)
 
         for (operation in operations) {
@@ -121,12 +125,12 @@ internal class NotificationRepository(
         }
     }
 
-    private fun clearNewMessageState(account: LegacyAccount) {
+    private fun clearNewMessageState(account: LegacyAccountDto) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.clearNewMessageState()
     }
 
-    private fun clearNotificationStore(account: LegacyAccount) {
+    private fun clearNotificationStore(account: LegacyAccountDto) {
         val notificationStore = notificationStoreProvider.getNotificationStore(account)
         notificationStore.clearNotifications()
     }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationSettingsUpdater.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationSettingsUpdater.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.fsck.k9.Preferences
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Update accounts with notification settings read from their "Messages" `NotificationChannel`.
@@ -25,7 +25,7 @@ class NotificationSettingsUpdater(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun updateNotificationSettings(account: LegacyAccount) {
+    fun updateNotificationSettings(account: LegacyAccountDto) {
         val notificationConfiguration = notificationChannelManager.getNotificationConfiguration(account)
         val notificationSettings = notificationConfigurationConverter.convert(account, notificationConfiguration)
 

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationStoreProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationStoreProvider.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 interface NotificationStoreProvider {
-    fun getNotificationStore(account: LegacyAccount): NotificationStore
+    fun getNotificationStore(account: LegacyAccountDto): NotificationStore
 }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/NotificationStrategy.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/NotificationStrategy.kt
@@ -2,12 +2,12 @@ package com.fsck.k9.notification
 
 import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.mailstore.LocalMessage
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 interface NotificationStrategy {
 
     fun shouldNotifyForMessage(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         localFolder: LocalFolder,
         message: LocalMessage,
         isOldMessage: Boolean,

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
@@ -4,7 +4,7 @@ import android.app.Notification
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.fsck.k9.helper.ExceptionHelper
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 internal class SendFailedNotificationController(
@@ -13,7 +13,7 @@ internal class SendFailedNotificationController(
     private val resourceProvider: NotificationResourceProvider,
     private val generalSettingsManager: GeneralSettingsManager,
 ) {
-    fun showSendFailedNotification(account: LegacyAccount, exception: Exception) {
+    fun showSendFailedNotification(account: LegacyAccountDto, exception: Exception) {
         val title = resourceProvider.sendFailedTitle()
         val text = ExceptionHelper.getRootCauseMessage(exception)
 
@@ -45,12 +45,12 @@ internal class SendFailedNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearSendFailedNotification(account: LegacyAccount) {
+    fun clearSendFailedNotification(account: LegacyAccountDto) {
         val notificationId = NotificationIds.getSendFailedNotificationId(account)
         notificationManager.cancel(notificationId)
     }
 
-    private fun createLockScreenNotification(account: LegacyAccount): Notification {
+    private fun createLockScreenNotification(account: LegacyAccountDto): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconWarning)

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationDataCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationDataCreator.kt
@@ -1,12 +1,12 @@
 package com.fsck.k9.notification
 
 import com.fsck.k9.K9
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class SingleMessageNotificationDataCreator {
 
     fun createSingleNotificationData(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationId: Int,
         content: NotificationContent,
         timestamp: Long,
@@ -52,7 +52,7 @@ internal class SingleMessageNotificationDataCreator {
         }
     }
 
-    private fun createSingleNotificationWearActions(account: LegacyAccount): List<WearNotificationAction> {
+    private fun createSingleNotificationWearActions(account: LegacyAccountDto): List<WearNotificationAction> {
         return buildList {
             add(WearNotificationAction.Reply)
             add(WearNotificationAction.MarkAsRead)
@@ -81,7 +81,7 @@ internal class SingleMessageNotificationDataCreator {
     }
 
     // We don't support confirming actions on Wear devices. So don't show the action when confirmation is enabled.
-    private fun isSpamActionAvailableForWear(account: LegacyAccount): Boolean {
+    private fun isSpamActionAvailableForWear(account: LegacyAccountDto): Boolean {
         return account.hasSpamFolder() && !K9.isConfirmSpam
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
@@ -4,7 +4,7 @@ import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.WearableExtender
 import com.fsck.k9.notification.NotificationChannelManager.ChannelType
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import androidx.core.app.NotificationCompat.Builder as NotificationBuilder
 
@@ -101,14 +101,14 @@ internal class SummaryNotificationCreator(
     }
 
     private fun createViewIntent(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationData: SummaryInboxNotificationData,
     ): PendingIntent {
         return actionCreator.createViewMessagesPendingIntent(account, notificationData.messageReferences)
     }
 
     private fun NotificationBuilder.setDeviceActions(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationData: SummaryInboxNotificationData,
     ) = apply {
         for (action in notificationData.actions) {
@@ -120,7 +120,7 @@ internal class SummaryNotificationCreator(
     }
 
     private fun NotificationBuilder.addMarkAllAsReadAction(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationData: SummaryInboxNotificationData,
     ) {
         val icon = resourceProvider.iconMarkAsRead
@@ -132,7 +132,7 @@ internal class SummaryNotificationCreator(
     }
 
     private fun NotificationBuilder.addDeleteAllAction(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationData: SummaryInboxNotificationData,
     ) {
         val icon = resourceProvider.iconDelete
@@ -145,7 +145,7 @@ internal class SummaryNotificationCreator(
 
     @Suppress("NestedBlockDepth")
     private fun NotificationBuilder.setWearActions(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationData: SummaryInboxNotificationData,
     ) = apply {
         val wearableExtender = WearableExtender().apply {
@@ -162,7 +162,7 @@ internal class SummaryNotificationCreator(
     }
 
     private fun WearableExtender.addMarkAllAsReadAction(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationData: SummaryInboxNotificationData,
     ) {
         val icon = resourceProvider.wearIconMarkAsRead
@@ -175,7 +175,7 @@ internal class SummaryNotificationCreator(
     }
 
     private fun WearableExtender.addDeleteAllAction(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationData: SummaryInboxNotificationData,
     ) {
         val icon = resourceProvider.wearIconDelete
@@ -188,7 +188,7 @@ internal class SummaryNotificationCreator(
     }
 
     private fun WearableExtender.addArchiveAllAction(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         notificationData: SummaryInboxNotificationData,
     ) {
         val icon = resourceProvider.wearIconArchive

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SummaryNotificationDataCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SummaryNotificationDataCreator.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.notification
 
 import com.fsck.k9.K9
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 private const val MAX_NUMBER_OF_MESSAGES_FOR_SUMMARY_NOTIFICATION = 5
@@ -55,7 +55,7 @@ internal class SummaryNotificationDataCreator(
         }
     }
 
-    private fun createSummaryWearNotificationActions(account: LegacyAccount): List<SummaryWearNotificationAction> {
+    private fun createSummaryWearNotificationActions(account: LegacyAccountDto): List<SummaryWearNotificationAction> {
         return buildList {
             add(SummaryWearNotificationAction.MarkAsRead)
 

--- a/legacy/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
@@ -4,14 +4,14 @@ import android.app.Notification
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.fsck.k9.mailstore.LocalFolder
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class SyncNotificationController(
     private val notificationHelper: NotificationHelper,
     private val actionBuilder: NotificationActionCreator,
     private val resourceProvider: NotificationResourceProvider,
 ) {
-    fun showSendingNotification(account: LegacyAccount) {
+    fun showSendingNotification(account: LegacyAccountDto) {
         val accountName = account.displayName
         val title = resourceProvider.sendingMailTitle()
         val tickerText = resourceProvider.sendingMailBody(accountName)
@@ -35,12 +35,12 @@ internal class SyncNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearSendingNotification(account: LegacyAccount) {
+    fun clearSendingNotification(account: LegacyAccountDto) {
         val notificationId = NotificationIds.getFetchingMailNotificationId(account)
         notificationManager.cancel(notificationId)
     }
 
-    fun showFetchingMailNotification(account: LegacyAccount, folder: LocalFolder) {
+    fun showFetchingMailNotification(account: LegacyAccountDto, folder: LocalFolder) {
         val accountName = account.displayName
         val folderId = folder.databaseId
         val folderName = folder.name
@@ -69,7 +69,7 @@ internal class SyncNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun showEmptyFetchingMailNotification(account: LegacyAccount) {
+    fun showEmptyFetchingMailNotification(account: LegacyAccountDto) {
         val title = resourceProvider.checkingMailTitle()
         val text = account.displayName
         val notificationId = NotificationIds.getFetchingMailNotificationId(account)
@@ -88,12 +88,12 @@ internal class SyncNotificationController(
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    fun clearFetchingMailNotification(account: LegacyAccount) {
+    fun clearFetchingMailNotification(account: LegacyAccountDto) {
         val notificationId = NotificationIds.getFetchingMailNotificationId(account)
         notificationManager.cancel(notificationId)
     }
 
-    private fun createSendingLockScreenNotification(account: LegacyAccount): Notification {
+    private fun createSendingLockScreenNotification(account: LegacyAccountDto): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconSendingMail)
@@ -103,7 +103,7 @@ internal class SyncNotificationController(
             .build()
     }
 
-    private fun createFetchingMailLockScreenNotification(account: LegacyAccount): Notification {
+    private fun createFetchingMailLockScreenNotification(account: LegacyAccountDto): Notification {
         return notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
             .setSmallIcon(resourceProvider.iconCheckingMail)

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsWriter.kt
@@ -7,7 +7,7 @@ import com.fsck.k9.mailstore.SpecialLocalFoldersCreator
 import java.util.UUID
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.core.preference.storage.StorageEditor
 import net.thunderbird.feature.account.storage.legacy.LegacyAccountStorageHandler.Companion.ACCOUNT_DESCRIPTION_KEY
@@ -170,7 +170,7 @@ constructor(
         error("Unexpected exit")
     }
 
-    private fun isAccountNameUsed(name: String?, accounts: List<LegacyAccount>): Boolean {
+    private fun isAccountNameUsed(name: String?, accounts: List<LegacyAccountDto>): Boolean {
         return accounts.any { it.displayName == name }
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsProvider.kt
@@ -2,10 +2,10 @@ package com.fsck.k9.preferences
 
 import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.mailstore.RemoteFolderDetails
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class FolderSettingsProvider(private val folderRepository: FolderRepository) {
-    fun getFolderSettings(account: LegacyAccount): List<FolderSettings> {
+    fun getFolderSettings(account: LegacyAccountDto): List<FolderSettings> {
         return folderRepository.getRemoteFolderDetails(account)
             .filterNot { it.containsOnlyDefaultValues() }
             .map { it.toFolderSettings() }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
@@ -13,7 +13,7 @@ import java.io.OutputStream
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.feature.account.storage.legacy.LegacyAccountStorageHandler.Companion.ACCOUNT_DESCRIPTION_KEY
 import net.thunderbird.feature.account.storage.legacy.LegacyAccountStorageHandler.Companion.IDENTITY_DESCRIPTION_KEY
@@ -125,7 +125,7 @@ class SettingsExporter(
     @Suppress("LongMethod", "CyclomaticComplexMethod", "NestedBlockDepth")
     private fun writeAccount(
         serializer: XmlSerializer,
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         prefs: Map<String, Any>,
         includePasswords: Boolean,
     ) {
@@ -273,7 +273,7 @@ class SettingsExporter(
         serializer: XmlSerializer,
         keyPart: String,
         valueString: String,
-        account: LegacyAccount,
+        account: LegacyAccountDto,
     ) {
         val versionedSetting = AccountSettingsDescriptions.SETTINGS[keyPart]
         if (versionedSetting != null) {
@@ -298,7 +298,7 @@ class SettingsExporter(
     }
 
     private fun writeFolderNameSettings(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         folderRepository: FolderRepository,
         serializer: XmlSerializer,
     ) {

--- a/legacy/core/src/main/java/com/fsck/k9/provider/AttachmentProvider.java
+++ b/legacy/core/src/main/java/com/fsck/k9/provider/AttachmentProvider.java
@@ -17,7 +17,7 @@ import androidx.annotation.Nullable;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.helper.MimeTypeUtil;
 import com.fsck.k9.mailstore.LocalStoreProvider;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.logging.legacy.Log;
 import com.fsck.k9.Preferences;
 import net.thunderbird.core.common.exception.MessagingException;
@@ -95,7 +95,7 @@ public class AttachmentProvider extends ContentProvider {
 
         final AttachmentInfo attachmentInfo;
         try {
-            final LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
+            final LegacyAccountDto account = Preferences.getPreferences().getAccount(accountUuid);
             attachmentInfo = DI.get(LocalStoreProvider.class).getInstance(account).getAttachmentInfo(id);
         } catch (MessagingException e) {
             Log.e(e, "Unable to retrieve attachment info from local store for ID: %s", id);
@@ -142,7 +142,7 @@ public class AttachmentProvider extends ContentProvider {
 
     private String getType(String accountUuid, String id, String mimeType) {
         String type;
-        final LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
+        final LegacyAccountDto account = Preferences.getPreferences().getAccount(accountUuid);
 
         try {
             final LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
@@ -181,7 +181,7 @@ public class AttachmentProvider extends ContentProvider {
 
     @Nullable
     private OpenPgpDataSource getAttachmentDataSource(String accountUuid, String attachmentId) throws MessagingException {
-        final LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
+        final LegacyAccountDto account = Preferences.getPreferences().getAccount(accountUuid);
         LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
         return localStore.getAttachmentDataSource(attachmentId);
     }

--- a/legacy/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
+++ b/legacy/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
@@ -26,7 +26,7 @@ import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.mailstore.LocalStoreProvider;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
 import net.thunderbird.core.logging.legacy.Log;
 
@@ -173,7 +173,7 @@ public class RawMessageProvider extends ContentProvider {
         long folderId = messageReference.getFolderId();
         String uid = messageReference.getUid();
 
-        LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
+        LegacyAccountDto account = Preferences.getPreferences().getAccount(accountUuid);
         if (account == null) {
             Log.w("Account not found: %s", accountUuid);
             return null;

--- a/legacy/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
@@ -1,6 +1,6 @@
 package com.fsck.k9.search
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.api.MessageSearchField
 import net.thunderbird.feature.search.legacy.api.SearchAttribute
@@ -29,7 +29,7 @@ fun LocalMessageSearch.limitToDisplayableFolders() {
  *
  * The Inbox will always be included even if one of the special folders is configured to point to the Inbox.
  */
-fun LocalMessageSearch.excludeSpecialFolders(account: LegacyAccount) {
+fun LocalMessageSearch.excludeSpecialFolders(account: LegacyAccountDto) {
     this.excludeSpecialFolder(account.trashFolderId)
     this.excludeSpecialFolder(account.draftsFolderId)
     this.excludeSpecialFolder(account.spamFolderId)

--- a/legacy/core/src/main/java/com/fsck/k9/search/LocalSearchExtensions.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/search/LocalSearchExtensions.kt
@@ -3,7 +3,7 @@
 package com.fsck.k9.search
 
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.SearchAccount
 
@@ -20,7 +20,7 @@ val LocalMessageSearch.isSingleFolder: Boolean
     get() = isSingleAccount && folderIds.size == 1
 
 @JvmName("getAccountsFromLocalSearch")
-fun LocalMessageSearch.getAccounts(accountManager: AccountManager): List<LegacyAccount> {
+fun LocalMessageSearch.getAccounts(accountManager: AccountManager): List<LegacyAccountDto> {
     val accounts = accountManager.getAccounts()
     return if (searchAllAccounts()) {
         accounts

--- a/legacy/core/src/main/java/com/fsck/k9/service/DatabaseUpgradeService.java
+++ b/legacy/core/src/main/java/com/fsck/k9/service/DatabaseUpgradeService.java
@@ -15,7 +15,7 @@ import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.power.PowerManager;
 import com.fsck.k9.mail.power.WakeLock;
 import com.fsck.k9.mailstore.LocalStoreProvider;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.logging.legacy.Log;
 
 /**
@@ -180,11 +180,11 @@ public class DatabaseUpgradeService extends Service {
     private void upgradeDatabases() {
         Preferences preferences = Preferences.getPreferences();
 
-        List<LegacyAccount> accounts = preferences.getAccounts();
+        List<LegacyAccountDto> accounts = preferences.getAccounts();
         mProgressEnd = accounts.size();
         mProgress = 0;
 
-        for (LegacyAccount account : accounts) {
+        for (LegacyAccountDto account : accounts) {
             mAccountUuid = account.getUuid();
 
             sendProgressBroadcast(mAccountUuid, mProgress, mProgressEnd);

--- a/legacy/core/src/test/java/com/fsck/k9/PreferencesTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/PreferencesTest.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.mail.ServerSettings
 import kotlin.test.Test
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_OTHER_RAW
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.preferences.TestStoragePersister
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.logging.testing.TestLogger
@@ -76,8 +76,8 @@ class PreferencesTest {
         assertThat(currentAccountOne.name).isEqualTo("New name")
     }
 
-    private fun createAccount(accountId: String): LegacyAccount {
-        return LegacyAccount(
+    private fun createAccount(accountId: String): LegacyAccountDto {
+        return LegacyAccountDto(
             uuid = accountId,
             isSensitiveDebugLoggingEnabled = { false },
         ).apply {

--- a/legacy/core/src/test/java/com/fsck/k9/controller/DefaultMessageCountsProviderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/controller/DefaultMessageCountsProviderTest.kt
@@ -12,7 +12,7 @@ import assertk.assertions.isEqualTo
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.SearchConditionTreeNode
 import org.junit.Test
@@ -26,7 +26,7 @@ private const val STARRED_COUNT = 3
 
 class DefaultMessageCountsProviderTest {
 
-    private val account = LegacyAccount(ACCOUNT_ID_RAW)
+    private val account = LegacyAccountDto(ACCOUNT_ID_RAW)
     private val accountManager = mock<AccountManager> {
         on { getAccounts() } doReturn listOf(account)
     }

--- a/legacy/core/src/test/java/com/fsck/k9/controller/LocalDeleteOperationDeciderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/controller/LocalDeleteOperationDeciderTest.kt
@@ -5,11 +5,11 @@ import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import java.util.UUID
 import kotlin.test.Test
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class LocalDeleteOperationDeciderTest {
     private val localDeleteOperationDecider = LocalDeleteOperationDecider()
-    private val account = LegacyAccount(UUID.randomUUID().toString()).apply {
+    private val account = LegacyAccountDto(UUID.randomUUID().toString()).apply {
         spamFolderId = SPAM_FOLDER_ID
         trashFolderId = TRASH_FOLDER_ID
     }

--- a/legacy/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/legacy/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import android.content.Context;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.featureflag.FeatureFlagProvider;
 import net.thunderbird.core.featureflag.FeatureFlagResult.Disabled;
 import app.k9mail.legacy.message.controller.SimpleMessagingListener;
@@ -72,7 +72,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
     private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;
 
     private MessagingController controller;
-    private LegacyAccount account;
+    private LegacyAccountDto account;
     @Mock
     private BackendManager backendManager;
     @Mock

--- a/legacy/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.mail.internet.AddressHeaderBuilder
 import com.fsck.k9.mail.internet.MimeMessage
 import java.util.UUID
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.RobolectricTest
 import org.junit.Test
 
@@ -115,7 +115,7 @@ class IdentityHelperTest : RobolectricTest() {
         assertThat(identity.email).isEqualTo(DEFAULT_ADDRESS)
     }
 
-    private fun createDummyAccount() = LegacyAccount(UUID.randomUUID().toString()).apply {
+    private fun createDummyAccount() = LegacyAccountDto(UUID.randomUUID().toString()).apply {
         replaceIdentities(
             listOf(
                 newIdentity("Default", DEFAULT_ADDRESS),

--- a/legacy/core/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
+++ b/legacy/core/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 import net.thunderbird.core.android.testing.RobolectricTest;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import com.fsck.k9.helper.ReplyToParser.ReplyToAddresses;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
@@ -34,13 +34,13 @@ public class ReplyToParserTest extends RobolectricTest {
 
     private ReplyToParser replyToParser;
     private Message message;
-    private LegacyAccount account;
+    private LegacyAccountDto account;
 
 
     @Before
     public void setUp() throws Exception {
         message = mock(Message.class);
-        account = mock(LegacyAccount.class);
+        account = mock(LegacyAccountDto.class);
 
         replyToParser = new ReplyToParser();
     }

--- a/legacy/core/src/test/java/com/fsck/k9/mailstore/K9BackendDefaultStorageTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/mailstore/K9BackendDefaultStorageTest.kt
@@ -10,7 +10,7 @@ import com.fsck.k9.backend.api.BackendStorage
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.mail.ServerSettings
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.After
 import org.junit.Test
 import org.koin.core.component.inject
@@ -23,7 +23,7 @@ class K9BackendDefaultStorageTest : K9RobolectricTest() {
     val messageStoreManager: MessageStoreManager by inject()
     val saveMessageDataCreator: SaveMessageDataCreator by inject()
 
-    val account: LegacyAccount = createAccount()
+    val account: LegacyAccountDto = createAccount()
     val backendStorage = createBackendStorage()
 
     @After
@@ -66,7 +66,7 @@ class K9BackendDefaultStorageTest : K9RobolectricTest() {
     }
 
     @Suppress("ForbiddenComment")
-    fun createAccount(): LegacyAccount {
+    fun createAccount(): LegacyAccountDto {
         // FIXME: This is a hack to get Preferences into a state where it's safe to call newAccount()
         preferences.clearAccounts()
 

--- a/legacy/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
@@ -26,7 +26,7 @@ import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.internet.MimeMessage
 import com.fsck.k9.mail.internet.MimeMessageHelper
 import com.fsck.k9.mail.internet.TextBody
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.After
 import org.junit.Test
 import org.koin.core.component.inject
@@ -37,7 +37,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
     val messageStoreManager: MessageStoreManager by inject()
     val saveMessageDataCreator: SaveMessageDataCreator by inject()
 
-    val account: LegacyAccount = createAccount()
+    val account: LegacyAccountDto = createAccount()
     val backendFolder = createBackendFolder()
     val database: LockableDatabase = localStoreProvider.getInstance(account).database
 
@@ -97,7 +97,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
             .hasMessage("Message requires a server ID to be set")
     }
 
-    fun createAccount(): LegacyAccount {
+    fun createAccount(): LegacyAccountDto {
         // FIXME: This is a hack to get Preferences into a state where it's safe to call newAccount()
         preferences.clearAccounts()
         return preferences.newAccount().apply {

--- a/legacy/core/src/test/java/com/fsck/k9/message/ReplyActionStrategyTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/ReplyActionStrategyTest.kt
@@ -8,7 +8,7 @@ import assertk.assertions.isNull
 import com.fsck.k9.helper.ReplyToParser
 import com.fsck.k9.mail.testing.message.buildMessage
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.Test
 
 private const val IDENTITY_EMAIL_ADDRESS = "myself@domain.example"
@@ -107,8 +107,8 @@ class ReplyActionStrategyTest {
         assertThat(replyActions.additionalActions).isEmpty()
     }
 
-    private fun createAccount(): LegacyAccount {
-        return LegacyAccount("00000000-0000-4000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccountDto {
+        return LegacyAccountDto("00000000-0000-4000-0000-000000000000").apply {
             identities += Identity(name = "Myself", email = IDENTITY_EMAIL_ADDRESS)
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationControllerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationControllerTest.kt
@@ -7,7 +7,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.MockHelper.mockBuilder
 import net.thunderbird.core.android.testing.RobolectricTest
 import net.thunderbird.core.preference.GeneralSettings
@@ -134,7 +134,7 @@ class AuthenticationErrorNotificationControllerTest : RobolectricTest() {
         }
     }
 
-    private fun createFakeAccount(): LegacyAccount {
+    private fun createFakeAccount(): LegacyAccountDto {
         return mock {
             on { accountNumber } doReturn ACCOUNT_NUMBER
             on { displayName } doReturn ACCOUNT_NAME
@@ -156,7 +156,7 @@ class AuthenticationErrorNotificationControllerTest : RobolectricTest() {
             },
         ) {
 
-        override fun createContentIntent(account: LegacyAccount, incoming: Boolean): PendingIntent {
+        override fun createContentIntent(account: LegacyAccountDto, incoming: Boolean): PendingIntent {
             return contentIntent
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/BaseNotificationDataCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/BaseNotificationDataCreatorTest.kt
@@ -8,7 +8,7 @@ import assertk.assertions.isSameInstanceAs
 import com.fsck.k9.K9
 import com.fsck.k9.K9.LockScreenNotificationVisibility
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.notification.NotificationLight
 import net.thunderbird.feature.notification.NotificationVibration
 import net.thunderbird.feature.notification.VibratePattern
@@ -211,8 +211,8 @@ class BaseNotificationDataCreatorTest {
         return NotificationData(account, activeNotifications, inactiveNotifications = emptyList())
     }
 
-    private fun createAccount(): LegacyAccount {
-        return LegacyAccount("00000000-0000-4000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccountDto {
+        return LegacyAccountDto("00000000-0000-4000-0000-000000000000").apply {
             name = "account name"
             replaceIdentities(listOf(Identity()))
         }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationControllerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationControllerTest.kt
@@ -7,7 +7,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.MockHelper.mockBuilder
 import net.thunderbird.core.android.testing.RobolectricTest
 import net.thunderbird.core.preference.GeneralSettings
@@ -134,7 +134,7 @@ class CertificateErrorNotificationControllerTest : RobolectricTest() {
         }
     }
 
-    private fun createFakeAccount(): LegacyAccount {
+    private fun createFakeAccount(): LegacyAccountDto {
         return mock {
             on { accountNumber } doReturn ACCOUNT_NUMBER
             on { displayName } doReturn ACCOUNT_NAME
@@ -155,7 +155,7 @@ class CertificateErrorNotificationControllerTest : RobolectricTest() {
             )
         },
     ) {
-        override fun createContentIntent(account: LegacyAccount, incoming: Boolean): PendingIntent {
+        override fun createContentIntent(account: LegacyAccountDto, incoming: Boolean): PendingIntent {
             return contentIntent
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/LockScreenNotificationCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/LockScreenNotificationCreatorTest.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.notification
 
 import androidx.core.app.NotificationCompat
 import androidx.test.core.app.ApplicationProvider
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.MockHelper.mockBuilder
 import net.thunderbird.core.android.testing.RobolectricTest
 import org.junit.Test
@@ -12,7 +12,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 class LockScreenNotificationCreatorTest : RobolectricTest() {
-    private val account = LegacyAccount("00000000-0000-0000-0000-000000000000")
+    private val account = LegacyAccountDto("00000000-0000-0000-0000-000000000000")
     private val resourceProvider = TestNotificationResourceProvider()
     private val builder = createFakeNotificationBuilder()
     private val publicBuilder = createFakeNotificationBuilder()

--- a/legacy/core/src/test/java/com/fsck/k9/notification/NewMailNotificationManagerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/NewMailNotificationManagerTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertNotNull
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettings
 import net.thunderbird.core.preference.display.DisplaySettings
 import net.thunderbird.core.preference.network.NetworkSettings
@@ -402,8 +402,8 @@ class NewMailNotificationManagerTest {
         }
     }
 
-    private fun createAccount(): LegacyAccount {
-        return LegacyAccount(ACCOUNT_UUID).apply {
+    private fun createAccount(): LegacyAccountDto {
+        return LegacyAccountDto(ACCOUNT_UUID).apply {
             name = ACCOUNT_NAME
             chipColor = ACCOUNT_COLOR
         }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.kt
@@ -8,7 +8,7 @@ import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.Message.RecipientType
 import com.fsck.k9.mailstore.LocalMessage
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.RobolectricTest
 import net.thunderbird.core.preference.GeneralSettings
 import net.thunderbird.core.preference.display.DisplaySettings
@@ -158,7 +158,7 @@ class NotificationContentCreatorTest : RobolectricTest() {
         )
     }
 
-    private fun createFakeAccount(): LegacyAccount = mock()
+    private fun createFakeAccount(): LegacyAccountDto = mock()
 
     private fun createFakeContentRepository(): ContactRepository = mock()
 

--- a/legacy/core/src/test/java/com/fsck/k9/notification/NotificationDataStoreTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/NotificationDataStoreTest.kt
@@ -13,7 +13,7 @@ import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import kotlin.test.assertNotNull
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.RobolectricTest
 import org.junit.Test
 
@@ -229,8 +229,8 @@ class NotificationDataStoreTest : RobolectricTest() {
         assertThat(notificationHolder.content).isSameInstanceAs(content)
     }
 
-    private fun createAccount(): LegacyAccount {
-        return LegacyAccount("00000000-0000-4000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccountDto {
+        return LegacyAccountDto("00000000-0000-4000-0000-000000000000").apply {
             accountNumber = ACCOUNT_NUMBER
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/NotificationIdsTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/NotificationIdsTest.kt
@@ -7,7 +7,7 @@ import assertk.assertions.doesNotContain
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.Test
 
 class NotificationIdsTest {
@@ -100,7 +100,7 @@ class NotificationIdsTest {
         return listOf(NotificationIds.PUSH_NOTIFICATION_ID, NotificationIds.BACKGROUND_WORK_NOTIFICATION_ID)
     }
 
-    private fun getAccountNotificationIds(account: LegacyAccount): List<Int> {
+    private fun getAccountNotificationIds(account: LegacyAccountDto): List<Int> {
         return listOf(
             NotificationIds.getSendFailedNotificationId(account),
             NotificationIds.getCertificateErrorNotificationId(account, true),
@@ -112,14 +112,14 @@ class NotificationIdsTest {
         ) + getNewMessageNotificationIds(account)
     }
 
-    private fun getNewMessageNotificationIds(account: LegacyAccount): Array<Int> {
+    private fun getNewMessageNotificationIds(account: LegacyAccountDto): Array<Int> {
         return (0 until MAX_NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS).map { index ->
             NotificationIds.getSingleMessageNotificationId(account, index)
         }.toTypedArray()
     }
 
-    private fun createAccount(accountNumber: Int): LegacyAccount {
-        return LegacyAccount(ACCOUNT_ID_RAW).apply {
+    private fun createAccount(accountNumber: Int): LegacyAccountDto {
+        return LegacyAccountDto(ACCOUNT_ID_RAW).apply {
             this.accountNumber = accountNumber
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SendFailedNotificationControllerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SendFailedNotificationControllerTest.kt
@@ -7,7 +7,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.MockHelper.mockBuilder
 import net.thunderbird.core.android.testing.RobolectricTest
 import net.thunderbird.core.preference.GeneralSettings
@@ -116,7 +116,7 @@ class SendFailedNotificationControllerTest : RobolectricTest() {
         }
     }
 
-    private fun createFakeAccount(): LegacyAccount {
+    private fun createFakeAccount(): LegacyAccountDto {
         return mock {
             on { accountNumber } doReturn ACCOUNT_NUMBER
             on { name } doReturn ACCOUNT_NAME

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationDataCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationDataCreatorTest.kt
@@ -9,7 +9,7 @@ import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import com.fsck.k9.K9
 import com.fsck.k9.K9.NotificationQuickDelete
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.Test
 
 class SingleMessageNotificationDataCreatorTest {
@@ -257,8 +257,8 @@ class SingleMessageNotificationDataCreatorTest {
         K9.isConfirmSpam = confirm
     }
 
-    private fun createAccount(): LegacyAccount {
-        return LegacyAccount("00000000-0000-0000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccountDto {
+        return LegacyAccountDto("00000000-0000-0000-0000-000000000000").apply {
             accountNumber = 42
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SummaryNotificationDataCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SummaryNotificationDataCreatorTest.kt
@@ -13,7 +13,7 @@ import java.util.Calendar
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettings
 import net.thunderbird.core.preference.display.DisplaySettings
 import net.thunderbird.core.preference.network.NetworkSettings
@@ -289,8 +289,8 @@ class SummaryNotificationDataCreatorTest {
         K9.isConfirmDeleteFromNotification = confirm
     }
 
-    private fun createAccount(): LegacyAccount {
-        return LegacyAccount("00000000-0000-0000-0000-000000000000").apply {
+    private fun createAccount(): LegacyAccountDto {
+        return LegacyAccountDto("00000000-0000-0000-0000-000000000000").apply {
             accountNumber = 42
         }
     }

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SyncNotificationControllerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SyncNotificationControllerTest.kt
@@ -7,7 +7,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.notification.NotificationIds.getFetchingMailNotificationId
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.MockHelper.mockBuilder
 import net.thunderbird.core.android.testing.RobolectricTest
 import org.junit.Test
@@ -128,7 +128,7 @@ class SyncNotificationControllerTest : RobolectricTest() {
         }
     }
 
-    private fun createFakeAccount(): LegacyAccount {
+    private fun createFakeAccount(): LegacyAccountDto {
         return mock {
             on { accountNumber } doReturn ACCOUNT_NUMBER
             on { name } doReturn ACCOUNT_NAME

--- a/legacy/core/src/test/java/net/thunderbird/legacy/core/FakeAccountDefaultsProvider.kt
+++ b/legacy/core/src/test/java/net/thunderbird/legacy/core/FakeAccountDefaultsProvider.kt
@@ -2,11 +2,11 @@ package net.thunderbird.legacy.core
 
 import net.thunderbird.core.android.account.AccountDefaultsProvider
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.storage.Storage
 
 class FakeAccountDefaultsProvider : AccountDefaultsProvider {
-    override fun applyDefaults(account: LegacyAccount) {
+    override fun applyDefaults(account: LegacyAccountDto) {
         with(account) {
             // Just ensure a working account object is created
 
@@ -21,5 +21,5 @@ class FakeAccountDefaultsProvider : AccountDefaultsProvider {
         }
     }
 
-    override fun applyOverwrites(account: LegacyAccount, storage: Storage) = Unit
+    override fun applyOverwrites(account: LegacyAccountDto, storage: Storage) = Unit
 }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderDetails
@@ -23,7 +23,7 @@ class FolderRepository(
     private val messageStoreManager: MessageStoreManager,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
-    fun getFolder(account: LegacyAccount, folderId: Long): Folder? {
+    fun getFolder(account: LegacyAccountDto, folderId: Long): Folder? {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolder(folderId) { folder ->
             Folder(
@@ -35,7 +35,7 @@ class FolderRepository(
         }
     }
 
-    fun getFolderDetails(account: LegacyAccount, folderId: Long): FolderDetails? {
+    fun getFolderDetails(account: LegacyAccountDto, folderId: Long): FolderDetails? {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolder(folderId) { folder ->
             FolderDetails(
@@ -69,10 +69,10 @@ class FolderRepository(
     }
 
     @Throws(MessagingException::class)
-    fun getRemoteFolders(account: LegacyAccount): List<RemoteFolder> =
+    fun getRemoteFolders(account: LegacyAccountDto): List<RemoteFolder> =
         getRemoteFolders(account.uuid)
 
-    fun getRemoteFolderDetails(account: LegacyAccount): List<RemoteFolderDetails> {
+    fun getRemoteFolderDetails(account: LegacyAccountDto): List<RemoteFolderDetails> {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolders(excludeLocalOnly = true) { folder ->
             RemoteFolderDetails(
@@ -92,7 +92,7 @@ class FolderRepository(
         }
     }
 
-    fun getPushFoldersFlow(account: LegacyAccount): Flow<List<RemoteFolder>> {
+    fun getPushFoldersFlow(account: LegacyAccountDto): Flow<List<RemoteFolder>> {
         val messageStore = messageStoreManager.getMessageStore(account)
         return callbackFlow {
             send(getPushFolders(account))
@@ -110,7 +110,7 @@ class FolderRepository(
             .flowOn(ioDispatcher)
     }
 
-    private fun getPushFolders(account: LegacyAccount): List<RemoteFolder> {
+    private fun getPushFolders(account: LegacyAccountDto): List<RemoteFolder> {
         return getRemoteFolderDetails(account)
             .asSequence()
             .filter { folderDetails -> folderDetails.isPushEnabled }
@@ -118,59 +118,59 @@ class FolderRepository(
             .toList()
     }
 
-    fun getFolderServerId(account: LegacyAccount, folderId: Long): String? {
+    fun getFolderServerId(account: LegacyAccountDto, folderId: Long): String? {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolder(folderId) { folder ->
             folder.serverId
         }
     }
 
-    fun getFolderId(account: LegacyAccount, folderServerId: String): Long? {
+    fun getFolderId(account: LegacyAccountDto, folderServerId: String): Long? {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolderId(folderServerId)
     }
 
-    fun isFolderPresent(account: LegacyAccount, folderId: Long): Boolean {
+    fun isFolderPresent(account: LegacyAccountDto, folderId: Long): Boolean {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.getFolder(folderId) { true } ?: false
     }
 
-    fun updateFolderDetails(account: LegacyAccount, folderDetails: FolderDetails) {
+    fun updateFolderDetails(account: LegacyAccountDto, folderDetails: FolderDetails) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.updateFolderSettings(folderDetails)
     }
 
-    fun setIncludeInUnifiedInbox(account: LegacyAccount, folderId: Long, includeInUnifiedInbox: Boolean) {
+    fun setIncludeInUnifiedInbox(account: LegacyAccountDto, folderId: Long, includeInUnifiedInbox: Boolean) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setIncludeInUnifiedInbox(folderId, includeInUnifiedInbox)
     }
 
-    fun setVisible(account: LegacyAccount, folderId: Long, visible: Boolean) {
+    fun setVisible(account: LegacyAccountDto, folderId: Long, visible: Boolean) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setVisible(folderId, visible)
     }
 
-    fun setSyncEnabled(account: LegacyAccount, folderId: Long, enable: Boolean) {
+    fun setSyncEnabled(account: LegacyAccountDto, folderId: Long, enable: Boolean) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setSyncEnabled(folderId, enable)
     }
 
-    fun setNotificationsEnabled(account: LegacyAccount, folderId: Long, enable: Boolean) {
+    fun setNotificationsEnabled(account: LegacyAccountDto, folderId: Long, enable: Boolean) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setNotificationsEnabled(folderId, enable)
     }
 
-    fun setPushDisabled(account: LegacyAccount) {
+    fun setPushDisabled(account: LegacyAccountDto) {
         val messageStore = messageStoreManager.getMessageStore(account)
         messageStore.setPushDisabled()
     }
 
-    fun hasPushEnabledFolder(account: LegacyAccount): Boolean {
+    fun hasPushEnabledFolder(account: LegacyAccountDto): Boolean {
         val messageStore = messageStoreManager.getMessageStore(account)
         return messageStore.hasPushEnabledFolder()
     }
 
-    fun hasPushEnabledFolderFlow(account: LegacyAccount): Flow<Boolean> {
+    fun hasPushEnabledFolderFlow(account: LegacyAccountDto): Flow<Boolean> {
         val messageStore = messageStoreManager.getMessageStore(account)
         return callbackFlow {
             send(hasPushEnabledFolder(account))

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderTypeMapper.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderTypeMapper.kt
@@ -1,11 +1,11 @@
 package app.k9mail.legacy.mailstore
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.FolderType
 
 object FolderTypeMapper {
 
-    fun folderTypeOf(account: LegacyAccount, folderId: Long) = when (folderId) {
+    fun folderTypeOf(account: LegacyAccountDto, folderId: Long) = when (folderId) {
         account.inboxFolderId -> FolderType.INBOX
         account.outboxFolderId -> FolderType.OUTBOX
         account.sentFolderId -> FolderType.SENT

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStoreFactory.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStoreFactory.kt
@@ -1,7 +1,7 @@
 package app.k9mail.legacy.mailstore
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 interface MessageStoreFactory {
-    fun create(account: LegacyAccount): ListenableMessageStore
+    fun create(account: LegacyAccountDto): ListenableMessageStore
 }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStoreManager.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStoreManager.kt
@@ -2,7 +2,7 @@ package app.k9mail.legacy.mailstore
 
 import java.util.concurrent.ConcurrentHashMap
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class MessageStoreManager(
     private val accountManager: AccountManager,
@@ -21,7 +21,7 @@ class MessageStoreManager(
         return getMessageStore(account)
     }
 
-    fun getMessageStore(account: LegacyAccount): ListenableMessageStore {
+    fun getMessageStore(account: LegacyAccountDto): ListenableMessageStore {
         return messageStores.getOrPut(account.uuid) { messageStoreFactory.create(account) }
     }
 

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/MessageStoreManagerTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/MessageStoreManagerTest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isSameInstanceAs
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.AccountRemovedListener
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.Test
 import org.mockito.kotlin.KStubbing
 import org.mockito.kotlin.argumentCaptor
@@ -14,7 +14,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class MessageStoreManagerTest {
-    private val account = LegacyAccount("00000000-0000-4000-0000-000000000000")
+    private val account = LegacyAccountDto("00000000-0000-4000-0000-000000000000")
     private val messageStore1 = mock<ListenableMessageStore>(name = "messageStore1")
     private val messageStore2 = mock<ListenableMessageStore>(name = "messageStore2")
     private val messageStoreFactory = mock<MessageStoreFactory> {

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessageCountsProvider.kt
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessageCountsProvider.kt
@@ -1,16 +1,16 @@
 package app.k9mail.legacy.message.controller
 
 import kotlinx.coroutines.flow.Flow
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.SearchAccount
 
 interface MessageCountsProvider {
-    fun getMessageCounts(account: LegacyAccount): MessageCounts
+    fun getMessageCounts(account: LegacyAccountDto): MessageCounts
     fun getMessageCounts(searchAccount: SearchAccount): MessageCounts
     fun getMessageCounts(search: LocalMessageSearch): MessageCounts
     fun getMessageCountsFlow(search: LocalMessageSearch): Flow<MessageCounts>
-    fun getUnreadMessageCount(account: LegacyAccount, folderId: Long): Int
+    fun getUnreadMessageCount(account: LegacyAccountDto, folderId: Long): Int
 }
 
 data class MessageCounts(val unread: Int, val starred: Int)

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessagingControllerMailChecker.kt
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessagingControllerMailChecker.kt
@@ -1,10 +1,10 @@
 package app.k9mail.legacy.message.controller
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 interface MessagingControllerMailChecker {
     fun checkMail(
-        account: LegacyAccount?,
+        account: LegacyAccountDto?,
         ignoreLastCheckedTime: Boolean,
         useManualWakeLock: Boolean,
         notify: Boolean,

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessagingListener.java
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/MessagingListener.java
@@ -6,33 +6,33 @@ import java.util.List;
 import android.content.Context;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Part;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 
 
 public interface MessagingListener {
-    void synchronizeMailboxStarted(LegacyAccount account, long folderId);
-    void synchronizeMailboxHeadersStarted(LegacyAccount account, String folderServerId);
-    void synchronizeMailboxHeadersProgress(LegacyAccount account, String folderServerId, int completed, int total);
-    void synchronizeMailboxHeadersFinished(LegacyAccount account, String folderServerId, int totalMessagesInMailbox,
+    void synchronizeMailboxStarted(LegacyAccountDto account, long folderId);
+    void synchronizeMailboxHeadersStarted(LegacyAccountDto account, String folderServerId);
+    void synchronizeMailboxHeadersProgress(LegacyAccountDto account, String folderServerId, int completed, int total);
+    void synchronizeMailboxHeadersFinished(LegacyAccountDto account, String folderServerId, int totalMessagesInMailbox,
             int numNewMessages);
-    void synchronizeMailboxProgress(LegacyAccount account, long folderId, int completed, int total);
-    void synchronizeMailboxNewMessage(LegacyAccount account, String folderServerId, Message message);
-    void synchronizeMailboxRemovedMessage(LegacyAccount account, String folderServerId, String messageServerId);
-    void synchronizeMailboxFinished(LegacyAccount account, long folderId);
-    void synchronizeMailboxFailed(LegacyAccount account, long folderId, String message);
+    void synchronizeMailboxProgress(LegacyAccountDto account, long folderId, int completed, int total);
+    void synchronizeMailboxNewMessage(LegacyAccountDto account, String folderServerId, Message message);
+    void synchronizeMailboxRemovedMessage(LegacyAccountDto account, String folderServerId, String messageServerId);
+    void synchronizeMailboxFinished(LegacyAccountDto account, long folderId);
+    void synchronizeMailboxFailed(LegacyAccountDto account, long folderId, String message);
 
-    void loadMessageRemoteFinished(LegacyAccount account, long folderId, String uid);
-    void loadMessageRemoteFailed(LegacyAccount account, long folderId, String uid, Throwable t);
+    void loadMessageRemoteFinished(LegacyAccountDto account, long folderId, String uid);
+    void loadMessageRemoteFailed(LegacyAccountDto account, long folderId, String uid, Throwable t);
 
-    void checkMailStarted(Context context, LegacyAccount account);
-    void checkMailFinished(Context context, LegacyAccount account);
+    void checkMailStarted(Context context, LegacyAccountDto account);
+    void checkMailFinished(Context context, LegacyAccountDto account);
 
-    void folderStatusChanged(LegacyAccount account, long folderId);
+    void folderStatusChanged(LegacyAccountDto account, long folderId);
 
-    void messageUidChanged(LegacyAccount account, long folderId, String oldUid, String newUid);
+    void messageUidChanged(LegacyAccountDto account, long folderId, String oldUid, String newUid);
 
-    void loadAttachmentFinished(LegacyAccount account, Message message, Part part);
-    void loadAttachmentFailed(LegacyAccount account, Message message, Part part, String reason);
+    void loadAttachmentFinished(LegacyAccountDto account, Message message, Part part);
+    void loadAttachmentFailed(LegacyAccountDto account, Message message, Part part, String reason);
 
     void remoteSearchStarted(long folderId);
     void remoteSearchServerQueryComplete(long folderId, int numResults, int maxResults);

--- a/legacy/message/src/main/java/app/k9mail/legacy/message/controller/SimpleMessagingListener.java
+++ b/legacy/message/src/main/java/app/k9mail/legacy/message/controller/SimpleMessagingListener.java
@@ -7,77 +7,77 @@ import java.util.List;
 import android.content.Context;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Part;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 
 
 public abstract class SimpleMessagingListener implements MessagingListener {
     @Override
-    public void synchronizeMailboxStarted(LegacyAccount account, long folderId) {
+    public void synchronizeMailboxStarted(LegacyAccountDto account, long folderId) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersStarted(LegacyAccount account, String folderServerId) {
+    public void synchronizeMailboxHeadersStarted(LegacyAccountDto account, String folderServerId) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersProgress(LegacyAccount account, String folderServerId, int completed, int total) {
+    public void synchronizeMailboxHeadersProgress(LegacyAccountDto account, String folderServerId, int completed, int total) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersFinished(LegacyAccount account, String folderServerId, int totalMessagesInMailbox,
+    public void synchronizeMailboxHeadersFinished(LegacyAccountDto account, String folderServerId, int totalMessagesInMailbox,
             int numNewMessages) {
     }
 
     @Override
-    public void synchronizeMailboxProgress(LegacyAccount account, long folderId, int completed, int total) {
+    public void synchronizeMailboxProgress(LegacyAccountDto account, long folderId, int completed, int total) {
     }
 
     @Override
-    public void synchronizeMailboxNewMessage(LegacyAccount account, String folderServerId, Message message) {
+    public void synchronizeMailboxNewMessage(LegacyAccountDto account, String folderServerId, Message message) {
     }
 
     @Override
-    public void synchronizeMailboxRemovedMessage(LegacyAccount account, String folderServerId, String messageServerId) {
+    public void synchronizeMailboxRemovedMessage(LegacyAccountDto account, String folderServerId, String messageServerId) {
     }
 
     @Override
-    public void synchronizeMailboxFinished(LegacyAccount account, long folderId) {
+    public void synchronizeMailboxFinished(LegacyAccountDto account, long folderId) {
     }
 
     @Override
-    public void synchronizeMailboxFailed(LegacyAccount account, long folderId, String message) {
+    public void synchronizeMailboxFailed(LegacyAccountDto account, long folderId, String message) {
     }
 
     @Override
-    public void loadMessageRemoteFinished(LegacyAccount account, long folderId, String uid) {
+    public void loadMessageRemoteFinished(LegacyAccountDto account, long folderId, String uid) {
     }
 
     @Override
-    public void loadMessageRemoteFailed(LegacyAccount account, long folderId, String uid, Throwable t) {
+    public void loadMessageRemoteFailed(LegacyAccountDto account, long folderId, String uid, Throwable t) {
     }
 
     @Override
-    public void checkMailStarted(Context context, LegacyAccount account) {
+    public void checkMailStarted(Context context, LegacyAccountDto account) {
     }
 
     @Override
-    public void checkMailFinished(Context context, LegacyAccount account) {
+    public void checkMailFinished(Context context, LegacyAccountDto account) {
     }
 
     @Override
-    public void folderStatusChanged(LegacyAccount account, long folderId) {
+    public void folderStatusChanged(LegacyAccountDto account, long folderId) {
     }
 
     @Override
-    public void messageUidChanged(LegacyAccount account, long folderId, String oldUid, String newUid) {
+    public void messageUidChanged(LegacyAccountDto account, long folderId, String oldUid, String newUid) {
     }
 
     @Override
-    public void loadAttachmentFinished(LegacyAccount account, Message message, Part part) {
+    public void loadAttachmentFinished(LegacyAccountDto account, Message message, Part part) {
     }
 
     @Override
-    public void loadAttachmentFailed(LegacyAccount account, Message message, Part part, String reason) {
+    public void loadAttachmentFailed(LegacyAccountDto account, Message message, Part part, String reason) {
     }
 
     @Override

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStoreFactory.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStoreFactory.kt
@@ -6,7 +6,7 @@ import com.fsck.k9.mailstore.LocalStoreProvider
 import com.fsck.k9.mailstore.NotifierMessageStore
 import com.fsck.k9.mailstore.StorageFilesProviderFactory
 import com.fsck.k9.message.extractors.BasicPartInfoExtractor
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 class K9MessageStoreFactory(
@@ -16,7 +16,7 @@ class K9MessageStoreFactory(
     private val generalSettingsManager: GeneralSettingsManager,
 ) : MessageStoreFactory {
 
-    override fun create(account: LegacyAccount): ListenableMessageStore {
+    override fun create(account: LegacyAccountDto): ListenableMessageStore {
         val localStore = localStoreProvider.getInstance(account)
         if (account.incomingServerSettings.host.isGoogle() ||
             account.outgoingServerSettings.host.isGoogle()

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo74.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo74.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.storage.migrations
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import net.thunderbird.core.android.account.DeletePolicy
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Remove all placeholder entries in 'messages' table
@@ -23,7 +23,7 @@ import net.thunderbird.core.android.account.LegacyAccount
  * deleted messages are re-downloaded. And if they are, the next sync after the remote operation has completed will
  * remove them again.
  */
-internal class MigrationTo74(private val db: SQLiteDatabase, private val account: LegacyAccount) {
+internal class MigrationTo74(private val db: SQLiteDatabase, private val account: LegacyAccountDto) {
 
     fun removeDeletedMessages() {
         if (account.deletePolicy != DeletePolicy.ON_DELETE) return

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo76.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo76.kt
@@ -4,7 +4,7 @@ import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import app.k9mail.core.android.common.database.map
 import com.fsck.k9.mailstore.MigrationsHelper
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.Protocols
 import net.thunderbird.core.logging.legacy.Log
 
@@ -121,7 +121,7 @@ internal class MigrationTo76(private val db: SQLiteDatabase, private val migrati
         db.delete("folders", "id = ?", arrayOf(folderId.toString()))
     }
 
-    private fun LegacyAccount.isPop3() = incomingServerSettings.type == Protocols.POP3
+    private fun LegacyAccountDto.isPop3() = incomingServerSettings.type == Protocols.POP3
 
     companion object {
         private const val OUTBOX_FOLDER_TYPE = "outbox"

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo85.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo85.kt
@@ -5,7 +5,7 @@ import android.os.Build
 import androidx.core.content.contentValuesOf
 import com.fsck.k9.mailstore.MigrationsHelper
 import net.thunderbird.core.android.account.FolderMode
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class MigrationTo85(private val db: SQLiteDatabase, private val migrationsHelper: MigrationsHelper) {
     fun addFoldersNotificationsEnabledColumn() {
@@ -93,7 +93,7 @@ internal class MigrationTo85(private val db: SQLiteDatabase, private val migrati
         db.update("folders", contentValuesOf("notifications_enabled" to true), whereClause, ignoreFolders)
     }
 
-    private fun getNotificationIgnoredFolders(account: LegacyAccount): Array<String> {
+    private fun getNotificationIgnoredFolders(account: LegacyAccountDto): Array<String> {
         val inboxFolderId = account.inboxFolderId
 
         // These special folders were ignored via K9NotificationStrategy unless they were pointing to the inbox.

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/notifications/K9NotificationStoreProvider.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/notifications/K9NotificationStoreProvider.kt
@@ -3,10 +3,10 @@ package com.fsck.k9.storage.notifications
 import com.fsck.k9.mailstore.LocalStoreProvider
 import com.fsck.k9.notification.NotificationStore
 import com.fsck.k9.notification.NotificationStoreProvider
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class K9NotificationStoreProvider(private val localStoreProvider: LocalStoreProvider) : NotificationStoreProvider {
-    override fun getNotificationStore(account: LegacyAccount): NotificationStore {
+    override fun getNotificationStore(account: LegacyAccountDto): NotificationStore {
         val localStore = localStoreProvider.getInstance(account)
         return K9NotificationStore(lockableDatabase = localStore.database)
     }

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.kt
@@ -19,7 +19,7 @@ import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mailstore.MigrationsHelper
 import net.thunderbird.core.android.account.FolderMode
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.logging.testing.TestLogger
 import org.junit.Before
@@ -381,7 +381,7 @@ class StoreSchemaDefinitionTest : RobolectricTest() {
     private fun createStoreSchemaDefinition(): StoreSchemaDefinition {
         val account = createAccount()
         val migrationsHelper = object : MigrationsHelper {
-            override fun getAccount(): LegacyAccount {
+            override fun getAccount(): LegacyAccountDto {
                 return account
             }
 
@@ -393,8 +393,8 @@ class StoreSchemaDefinitionTest : RobolectricTest() {
         return StoreSchemaDefinition(migrationsHelper)
     }
 
-    private fun createAccount(): LegacyAccount {
-        return mock<LegacyAccount> {
+    private fun createAccount(): LegacyAccountDto {
+        return mock<LegacyAccountDto> {
             on { legacyInboxFolder } doReturn "Inbox"
             on { importedTrashFolder } doReturn "Trash"
             on { importedDraftsFolder } doReturn "Drafts"

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo85Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo85Test.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.storage.messages.FolderEntry
 import com.fsck.k9.storage.messages.readFolders
 import kotlin.test.Test
 import net.thunderbird.core.android.account.FolderMode
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.After
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doAnswer
@@ -186,15 +186,15 @@ class MigrationTo85Test {
         )
     }
 
-    private fun createAccount(): LegacyAccount {
-        return mock<LegacyAccount> {
+    private fun createAccount(): LegacyAccountDto {
+        return mock<LegacyAccountDto> {
             on { folderNotifyNewMailMode } doAnswer { folderNotifyMode }
         }
     }
 
-    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
+    private fun createMigrationsHelper(account: LegacyAccountDto): MigrationsHelper {
         return object : MigrationsHelper {
-            override fun getAccount(): LegacyAccount {
+            override fun getAccount(): LegacyAccountDto {
                 return account
             }
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo86Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo86Test.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.storage.messages.FolderEntry
 import com.fsck.k9.storage.messages.readFolders
 import kotlin.test.Test
 import net.thunderbird.core.android.account.FolderMode
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.After
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doAnswer
@@ -130,15 +130,15 @@ class MigrationTo86Test {
         )
     }
 
-    private fun createAccount(): LegacyAccount {
-        return mock<LegacyAccount> {
+    private fun createAccount(): LegacyAccountDto {
+        return mock<LegacyAccountDto> {
             on { folderPushMode } doAnswer { folderPushMode }
         }
     }
 
-    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
+    private fun createMigrationsHelper(account: LegacyAccountDto): MigrationsHelper {
         return object : MigrationsHelper {
-            override fun getAccount(): LegacyAccount {
+            override fun getAccount(): LegacyAccountDto {
                 return account
             }
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo87Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo87Test.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.storage.messages.FolderEntry
 import com.fsck.k9.storage.messages.readFolders
 import kotlin.test.Test
 import net.thunderbird.core.android.account.FolderMode
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.After
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doAnswer
@@ -130,15 +130,15 @@ class MigrationTo87Test {
         )
     }
 
-    private fun createAccount(): LegacyAccount {
-        return mock<LegacyAccount> {
+    private fun createAccount(): LegacyAccountDto {
+        return mock<LegacyAccountDto> {
             on { folderSyncMode } doAnswer { folderSyncMode }
         }
     }
 
-    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
+    private fun createMigrationsHelper(account: LegacyAccountDto): MigrationsHelper {
         return object : MigrationsHelper {
-            override fun getAccount(): LegacyAccount {
+            override fun getAccount(): LegacyAccountDto {
                 return account
             }
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo88Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo88Test.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.storage.messages.FolderEntry
 import com.fsck.k9.storage.messages.readFolders
 import kotlin.test.Test
 import net.thunderbird.core.android.account.FolderMode
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.After
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doAnswer
@@ -120,15 +120,15 @@ class MigrationTo88Test {
         )
     }
 
-    private fun createAccount(): LegacyAccount {
-        return mock<LegacyAccount> {
+    private fun createAccount(): LegacyAccountDto {
+        return mock<LegacyAccountDto> {
             on { folderDisplayMode } doAnswer { folderDisplayMode }
         }
     }
 
-    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
+    private fun createMigrationsHelper(account: LegacyAccountDto): MigrationsHelper {
         return object : MigrationsHelper {
-            override fun getAccount(): LegacyAccount {
+            override fun getAccount(): LegacyAccountDto {
                 return account
             }
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo89Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo89Test.kt
@@ -10,7 +10,7 @@ import com.fsck.k9.storage.messages.createMessage
 import com.fsck.k9.storage.messages.readFolders
 import com.fsck.k9.storage.messages.readMessages
 import kotlin.test.Test
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.After
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doReturn
@@ -50,15 +50,15 @@ class MigrationTo89Test {
         assertThat(messages[0].accountId).isEqualTo(ACCOUNT_UUID)
     }
 
-    private fun createAccount(): LegacyAccount {
+    private fun createAccount(): LegacyAccountDto {
         return mock {
             on { uuid } doReturn ACCOUNT_UUID
         }
     }
 
-    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
+    private fun createMigrationsHelper(account: LegacyAccountDto): MigrationsHelper {
         return object : MigrationsHelper {
-            override fun getAccount(): LegacyAccount {
+            override fun getAccount(): LegacyAccountDto {
                 return account
             }
 

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderType
 
@@ -33,7 +33,7 @@ class DefaultDisplayFolderRepository(
             .thenByDescending { it.isInTopGroup }
             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.folder.name }
 
-    private fun getDisplayFolders(account: LegacyAccount, includeHiddenFolders: Boolean): List<DisplayFolder> {
+    private fun getDisplayFolders(account: LegacyAccountDto, includeHiddenFolders: Boolean): List<DisplayFolder> {
         val messageStore = messageStoreManager.getMessageStore(account.uuid)
         return messageStore.getDisplayFolders(
             includeHiddenFolders = includeHiddenFolders,
@@ -55,7 +55,7 @@ class DefaultDisplayFolderRepository(
     }
 
     override fun getDisplayFoldersFlow(
-        account: LegacyAccount,
+        account: LegacyAccountDto,
         includeHiddenFolders: Boolean,
     ): Flow<List<DisplayFolder>> {
         val messageStore = messageStoreManager.getMessageStore(account.uuid)
@@ -64,7 +64,7 @@ class DefaultDisplayFolderRepository(
             send(getDisplayFolders(account, includeHiddenFolders))
 
             val folderStatusChangedListener = object : SimpleMessagingListener() {
-                override fun folderStatusChanged(statusChangedAccount: LegacyAccount, folderId: Long) {
+                override fun folderStatusChanged(statusChangedAccount: LegacyAccountDto, folderId: Long) {
                     if (statusChangedAccount.uuid == account.uuid) {
                         trySendBlocking(getDisplayFolders(account, includeHiddenFolders))
                     }

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DisplayFolderRepository.kt
@@ -1,11 +1,11 @@
 package app.k9mail.legacy.ui.folder
 
 import kotlinx.coroutines.flow.Flow
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 interface DisplayFolderRepository {
 
-    fun getDisplayFoldersFlow(account: LegacyAccount, includeHiddenFolders: Boolean): Flow<List<DisplayFolder>>
+    fun getDisplayFoldersFlow(account: LegacyAccountDto, includeHiddenFolders: Boolean): Flow<List<DisplayFolder>>
 
     fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>>
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/account/AccountRemover.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/account/AccountRemover.kt
@@ -6,7 +6,7 @@ import com.fsck.k9.Preferences
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.mailstore.LocalStoreProvider
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 
 /**
@@ -42,7 +42,7 @@ class AccountRemover(
         Log.v("Finished removing account '%s'.", accountName)
     }
 
-    private fun removeLocalStore(account: LegacyAccount) {
+    private fun removeLocalStore(account: LegacyAccountDto) {
         try {
             val localStore = localStoreProvider.getInstance(account)
             localStore.delete()
@@ -55,7 +55,7 @@ class AccountRemover(
         localStoreProvider.removeInstance(account)
     }
 
-    private fun removeBackend(account: LegacyAccount) {
+    private fun removeBackend(account: LegacyAccountDto) {
         try {
             backendManager.removeBackend(account)
         } catch (e: Exception) {
@@ -63,7 +63,7 @@ class AccountRemover(
         }
     }
 
-    private fun removeCertificates(account: LegacyAccount) {
+    private fun removeCertificates(account: LegacyAccountDto) {
         try {
             localKeyStoreManager.deleteCertificates(account)
         } catch (e: Exception) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.kt
@@ -16,7 +16,7 @@ import com.google.android.material.textview.MaterialTextView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.feature.mail.account.api.BaseAccount
 import net.thunderbird.feature.search.legacy.SearchAccount
@@ -73,7 +73,7 @@ abstract class AccountList : K9ListActivity(), OnItemClickListener {
      * @param realAccounts
      * An array of accounts to display.
      */
-    private fun populateListView(realAccounts: List<LegacyAccount>) {
+    private fun populateListView(realAccounts: List<LegacyAccountDto>) {
         val accounts: MutableList<BaseAccount> = ArrayList()
 
         if (generalSettingsManager.getConfig().display.inboxSettings.isShowUnifiedInbox) {
@@ -123,7 +123,7 @@ abstract class AccountList : K9ListActivity(), OnItemClickListener {
                 holder.email.visibility = View.GONE
             }
 
-            if (account is LegacyAccount) {
+            if (account is LegacyAccountDto) {
                 holder.chip.setBackgroundColor(account.chipColor)
             } else {
                 holder.chip.setBackgroundColor(resources.getColor(R.color.account_list_item_chip_background))

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
@@ -9,7 +9,7 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
 import net.thunderbird.core.android.account.Identity;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.ui.R;
@@ -20,7 +20,7 @@ import java.util.List;
 public class ChooseIdentity extends K9ListActivity {
     private final IdentityFormatter identityFormatter = DI.get(IdentityFormatter.class);
 
-    LegacyAccount mAccount;
+    LegacyAccountDto mAccount;
     ArrayAdapter<String> adapter;
 
     public static final String EXTRA_ACCOUNT = "com.fsck.k9.ChooseIdentity_account";

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
@@ -15,13 +15,13 @@ import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.K9Activity
 import com.google.android.material.checkbox.MaterialCheckBox
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.koin.android.ext.android.inject
 
 class EditIdentity : K9Activity() {
     private val emailAddressValidator: EmailAddressValidator by inject()
 
-    private lateinit var account: LegacyAccount
+    private lateinit var account: LegacyAccountDto
     private lateinit var identity: Identity
 
     private lateinit var description: EditText

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/FolderInfoHolder.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/FolderInfoHolder.kt
@@ -2,14 +2,14 @@ package com.fsck.k9.activity
 
 import app.k9mail.legacy.ui.folder.FolderNameFormatter
 import com.fsck.k9.mailstore.LocalFolder
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderType
 
 class FolderInfoHolder(
     private val folderNameFormatter: FolderNameFormatter,
     localFolder: LocalFolder,
-    account: LegacyAccount,
+    account: LegacyAccountDto,
 ) {
     @JvmField
     val databaseId = localFolder.databaseId
@@ -23,7 +23,7 @@ class FolderInfoHolder(
     @JvmField
     var moreMessages = localFolder.hasMoreMessages()
 
-    private fun getDisplayName(account: LegacyAccount, localFolder: LocalFolder): String {
+    private fun getDisplayName(account: LegacyAccountDto, localFolder: LocalFolder): String {
         val folderId = localFolder.databaseId
         val folder = Folder(
             id = folderId,
@@ -36,7 +36,7 @@ class FolderInfoHolder(
 
     companion object {
         @JvmStatic
-        fun getFolderType(account: LegacyAccount, folderId: Long): FolderType {
+        fun getFolderType(account: LegacyAccountDto, folderId: Long): FolderType {
             return when (folderId) {
                 account.inboxFolderId -> FolderType.INBOX
                 account.outboxFolderId -> FolderType.OUTBOX

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -26,7 +26,6 @@ import android.os.Handler;
 import android.os.Parcelable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.util.AttributeSet;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -53,7 +52,7 @@ import androidx.core.view.WindowInsetsCompat;
 import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import app.k9mail.legacy.di.DI;
 import net.thunderbird.core.android.account.Identity;
 import com.fsck.k9.K9;
@@ -125,7 +124,6 @@ import net.thunderbird.core.android.contact.ContactIntentHelper;
 import net.thunderbird.core.preference.GeneralSettingsManager;
 import net.thunderbird.core.ui.theme.manager.ThemeManager;
 import net.thunderbird.feature.search.legacy.LocalMessageSearch;
-import org.jetbrains.annotations.NotNull;
 import org.openintents.openpgp.OpenPgpApiManager;
 import org.openintents.openpgp.util.OpenPgpIntentStarter;
 import net.thunderbird.core.logging.legacy.Log;
@@ -213,7 +211,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     /**
      * The account used for message composition.
      */
-    private LegacyAccount account;
+    private LegacyAccountDto account;
     private Identity identity;
     private boolean identityChanged = false;
     private boolean signatureChanged = false;
@@ -849,7 +847,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     }
 
 
-    private void onAccountChosen(LegacyAccount account, Identity identity) {
+    private void onAccountChosen(LegacyAccountDto account, Identity identity) {
         if (!this.account.equals(account)) {
             Log.v("Switching account from %s to %s", this.account, account);
 
@@ -861,7 +859,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             // test whether there is something to save
             if (changesMadeSinceLastSave || (draftMessageId != null)) {
                 final Long previousDraftId = draftMessageId;
-                final LegacyAccount previousAccount = this.account;
+                final LegacyAccountDto previousAccount = this.account;
 
                 // make current message appear as new
                 draftMessageId = null;
@@ -1428,7 +1426,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
             if (messageReference != null) {
                 // Check if this is a valid account in our database
-                LegacyAccount account = preferences.getAccount(messageReference.getAccountUuid());
+                LegacyAccountDto account = preferences.getAccount(messageReference.getAccountUuid());
                 if (account != null) {
                     relatedMessageReference = messageReference;
                 }
@@ -1447,7 +1445,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     static class SendMessageTask extends AsyncTask<Void, Void, Void> {
         final MessagingController messagingController;
         final Preferences preferences;
-        final LegacyAccount account;
+        final LegacyAccountDto account;
         final Contacts contacts;
         final Message message;
         final Long draftId;
@@ -1455,7 +1453,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         final MessageReference messageReference;
         final Flag flag;
 
-        SendMessageTask(MessagingController messagingController, Preferences preferences, LegacyAccount account,
+        SendMessageTask(MessagingController messagingController, Preferences preferences, LegacyAccountDto account,
                 Contacts contacts, Message message, Long draftId, String plaintextSubject,
                 MessageReference messageReference, Flag flag) {
             this.messagingController = messagingController;
@@ -1495,7 +1493,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         private void addFlagToReferencedMessage() {
             if (messageReference != null && flag != null) {
                 String accountUuid = messageReference.getAccountUuid();
-                LegacyAccount account = preferences.getAccount(accountUuid);
+                LegacyAccountDto account = preferences.getAccount(accountUuid);
                 long folderId = messageReference.getFolderId();
                 String sourceMessageUid = messageReference.getUid();
 
@@ -1739,7 +1737,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     public MessagingListener messagingListener = new SimpleMessagingListener() {
 
         @Override
-        public void messageUidChanged(LegacyAccount account, long folderId, String oldUid, String newUid) {
+        public void messageUidChanged(LegacyAccountDto account, long folderId, String oldUid, String newUid) {
             if (relatedMessageReference == null) {
                 return;
             }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -56,7 +56,7 @@ import com.fsck.k9.view.ViewSwitcher
 import com.fsck.k9.view.ViewSwitcher.OnSwitchCompleteListener
 import com.google.android.material.textview.MaterialTextView
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.logging.Logger
@@ -115,7 +115,7 @@ open class MessageList :
     private var messageViewPlaceHolder: PlaceholderFragment? = null
     private var messageListFragment: MessageListFragment? = null
     private var messageViewContainerFragment: MessageViewContainerFragment? = null
-    private var account: LegacyAccount? = null
+    private var account: LegacyAccountDto? = null
     private var search: LocalMessageSearch? = null
     private var singleFolderMode = false
 
@@ -250,7 +250,7 @@ open class MessageList :
         displayViews()
     }
 
-    private fun deleteIncompleteAccounts(accounts: List<LegacyAccount>) {
+    private fun deleteIncompleteAccounts(accounts: List<LegacyAccountDto>) {
         accounts.filter { !it.isFinishedSetup }.forEach {
             accountRemover.removeAccountAsync(it.uuid)
         }
@@ -1144,7 +1144,7 @@ open class MessageList :
         MessageActions.actionReply(this, messageReference, true, decryptionResultForReply)
     }
 
-    override fun onCompose(account: LegacyAccount?) {
+    override fun onCompose(account: LegacyAccountDto?) {
         MessageActions.actionCompose(this, account)
     }
 
@@ -1193,7 +1193,7 @@ open class MessageList :
         return true
     }
 
-    override fun startSearch(query: String, account: LegacyAccount?, folderId: Long?): Boolean {
+    override fun startSearch(query: String, account: LegacyAccountDto?, folderId: Long?): Boolean {
         // If this search was started from a MessageList of a single folder, pass along that folder info
         // so that we can enable remote search.
         val appData = if (account != null && folderId != null) {
@@ -1220,7 +1220,7 @@ open class MessageList :
         return super.startSupportActionMode(callback)
     }
 
-    override fun showThread(account: LegacyAccount, threadRootId: Long) {
+    override fun showThread(account: LegacyAccountDto, threadRootId: Long) {
         showMessageViewPlaceHolder()
 
         val tmpSearch = LocalMessageSearch().apply {
@@ -1445,7 +1445,7 @@ open class MessageList :
         configureDrawer()
     }
 
-    private fun LocalMessageSearch.firstAccount(): LegacyAccount? {
+    private fun LocalMessageSearch.firstAccount(): LegacyAccountDto? {
         return if (searchAllAccounts()) {
             preferences.defaultAccount
         } else {
@@ -1508,7 +1508,7 @@ open class MessageList :
 
     private class LaunchData(
         val search: LocalMessageSearch,
-        val account: LegacyAccount? = null,
+        val account: LegacyAccountDto? = null,
         val messageReference: MessageReference? = null,
         val noThreading: Boolean = false,
         val messageViewOnly: Boolean = false,
@@ -1577,7 +1577,7 @@ open class MessageList :
 
         fun createUnifiedInboxIntent(
             context: Context,
-            account: LegacyAccount,
+            account: LegacyAccountDto,
         ): Intent {
             return Intent(context, MessageList::class.java).apply {
                 val search = SearchAccount.createUnifiedFoldersSearch(
@@ -1595,7 +1595,7 @@ open class MessageList :
             }
         }
 
-        fun createNewMessagesIntent(context: Context, account: LegacyAccount): Intent {
+        fun createNewMessagesIntent(context: Context, account: LegacyAccountDto): Intent {
             val search = LocalMessageSearch().apply {
                 id = SearchAccount.NEW_MESSAGES
                 addAccountUuid(account.uuid)
@@ -1680,7 +1680,7 @@ open class MessageList :
         }
 
         @JvmStatic
-        fun launch(context: Context, account: LegacyAccount) {
+        fun launch(context: Context, account: LegacyAccountDto) {
             val folderId = defaultFolderProvider.getDefaultFolder(account)
 
             val search = LocalMessageSearch().apply {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -33,7 +33,7 @@ import com.fsck.k9.ui.crypto.MessageCryptoHelper;
 import com.fsck.k9.ui.crypto.OpenPgpApiFactory;
 import com.fsck.k9.ui.message.LocalMessageExtractorLoader;
 import com.fsck.k9.ui.message.LocalMessageLoader;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import org.openintents.openpgp.OpenPgpDecryptionResult;
 import net.thunderbird.core.logging.legacy.Log;
 
@@ -89,7 +89,7 @@ public class MessageLoaderHelper {
     // transient state
     private boolean onlyLoadMetadata;
     private MessageReference messageReference;
-    private LegacyAccount account;
+    private LegacyAccountDto account;
 
     private LocalMessage localMessage;
     private MessageCryptoAnnotations messageCryptoAnnotations;
@@ -489,7 +489,7 @@ public class MessageLoaderHelper {
 
     MessagingListener downloadMessageListener = new SimpleMessagingListener() {
         @Override
-        public void loadMessageRemoteFinished(final LegacyAccount account, final long folderId, final String uid) {
+        public void loadMessageRemoteFinished(final LegacyAccountDto account, final long folderId, final String uid) {
             handler.post(() -> {
                 if (!messageReference.equals(account.getUuid(), folderId, uid)) {
                     return;
@@ -499,7 +499,7 @@ public class MessageLoaderHelper {
         }
 
         @Override
-        public void loadMessageRemoteFailed(LegacyAccount account, long folderId, String uid, final Throwable t) {
+        public void loadMessageRemoteFailed(LegacyAccountDto account, long folderId, String uid, final Throwable t) {
             handler.post(new Runnable() {
                 @Override
                 public void run() {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
@@ -11,7 +11,7 @@ import android.os.Bundle;
 
 import androidx.core.content.IntentCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessagingController;
@@ -53,7 +53,7 @@ import com.google.android.material.textview.MaterialTextView;
  * Currently we make no attempts to stop the background code (e.g. {@link MessagingController}) from
  * opening the accounts' databases. If this happens the upgrade is performed in one of the
  * background threads and not by {@link DatabaseUpgradeService}. But this is not a problem. Due to
- * the locking in {@link com.fsck.k9.mailstore.LocalStoreProvider#getInstance(LegacyAccount)} the upgrade service will block
+ * the locking in {@link com.fsck.k9.mailstore.LocalStoreProvider#getInstance(LegacyAccountDto)} the upgrade service will block
  * and from the outside (especially for this activity) it will appear as if
  * {@link DatabaseUpgradeService} is performing the upgrade.
  * </p>
@@ -205,7 +205,7 @@ public class UpgradeDatabases extends K9Activity {
                 String accountUuid = intent.getStringExtra(
                         DatabaseUpgradeService.EXTRA_ACCOUNT_UUID);
 
-                LegacyAccount account = mPreferences.getAccount(accountUuid);
+                LegacyAccountDto account = mPreferences.getAccount(accountUuid);
 
                 if (account != null) {
                     String upgradeStatus = getString(R.string.upgrade_database_format, account.getDisplayName());

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/IdentityAdapter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/IdentityAdapter.java
@@ -11,7 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import app.k9mail.legacy.di.DI;
 import net.thunderbird.core.android.account.Identity;
 import com.fsck.k9.Preferences;
@@ -38,8 +38,8 @@ public class IdentityAdapter extends BaseAdapter {
 
         List<Object> items = new ArrayList<>();
         Preferences prefs = Preferences.getPreferences();
-        Collection<LegacyAccount> accounts = prefs.getAccounts();
-        for (LegacyAccount account : accounts) {
+        Collection<LegacyAccountDto> accounts = prefs.getAccounts();
+        for (LegacyAccountDto account : accounts) {
             items.add(account);
             List<Identity> identities = account.getIdentities();
             for (Identity identity : identities) {
@@ -61,7 +61,7 @@ public class IdentityAdapter extends BaseAdapter {
 
     @Override
     public int getItemViewType(int position) {
-        return (mItems.get(position) instanceof LegacyAccount) ? 0 : 1;
+        return (mItems.get(position) instanceof LegacyAccountDto) ? 0 : 1;
     }
 
     @Override
@@ -89,7 +89,7 @@ public class IdentityAdapter extends BaseAdapter {
         Object item = mItems.get(position);
 
         View view = null;
-        if (item instanceof LegacyAccount) {
+        if (item instanceof LegacyAccountDto) {
             if (convertView != null && convertView.getTag() instanceof AccountHolder) {
                 view = convertView;
             } else {
@@ -100,7 +100,7 @@ public class IdentityAdapter extends BaseAdapter {
                 view.setTag(holder);
             }
 
-            LegacyAccount account = (LegacyAccount) item;
+            LegacyAccountDto account = (LegacyAccountDto) item;
             AccountHolder holder = (AccountHolder) view.getTag();
             holder.name.setText(account.getDisplayName());
             holder.chip.setBackgroundColor(account.getChipColor());
@@ -126,15 +126,15 @@ public class IdentityAdapter extends BaseAdapter {
     }
 
     /**
-     * Used to store an {@link Identity} instance together with the {@link LegacyAccount} it belongs to.
+     * Used to store an {@link Identity} instance together with the {@link LegacyAccountDto} it belongs to.
      *
      * @see IdentityAdapter
      */
     public static class IdentityContainer {
         public final Identity identity;
-        public final LegacyAccount account;
+        public final LegacyAccountDto account;
 
-        IdentityContainer(Identity identity, LegacyAccount account) {
+        IdentityContainer(Identity identity, LegacyAccountDto account) {
             this.identity = identity;
             this.account = account;
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/MessageActions.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/MessageActions.kt
@@ -8,7 +8,7 @@ import app.k9mail.feature.launcher.FeatureLauncherTarget.AccountSetup
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.Preferences
 import com.fsck.k9.activity.MessageCompose
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 object MessageActions {
     /**
@@ -17,7 +17,7 @@ object MessageActions {
      * activity.
      */
     @JvmStatic
-    fun actionCompose(context: Context, account: LegacyAccount?) {
+    fun actionCompose(context: Context, account: LegacyAccountDto?) {
         val defaultAccount = Preferences.getPreferences().defaultAccount
         if (account == null && defaultAccount == null) {
             FeatureLauncherActivity.launch(context, AccountSetup)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
@@ -31,7 +31,7 @@ import com.fsck.k9.message.PgpMessageBuilder
 import com.fsck.k9.ui.R
 import com.fsck.k9.view.RecipientSelectView.Recipient
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.contact.ContactIntentHelper
 import net.thunderbird.core.logging.legacy.Log
 import org.openintents.openpgp.OpenPgpApiManager
@@ -59,7 +59,7 @@ class RecipientPresenter(
     loaderManager: LoaderManager,
     private val openPgpApiManager: OpenPgpApiManager,
     private val recipientMvpView: RecipientMvpView,
-    account: LegacyAccount,
+    account: LegacyAccountDto,
     private val composePgpInlineDecider: ComposePgpInlineDecider,
     private val composePgpEnableByDefaultDecider: ComposePgpEnableByDefaultDecider,
     private val autocryptStatusInteractor: AutocryptStatusInteractor,
@@ -67,7 +67,7 @@ class RecipientPresenter(
     private val draftStateHeaderParser: AutocryptDraftStateHeaderParser,
 ) {
     private var isToAddressAdded: Boolean = false
-    private lateinit var account: LegacyAccount
+    private lateinit var account: LegacyAccountDto
     private var alwaysBccAddresses: Array<Address>? = null
     private var hasContactPicker: Boolean? = null
     private var isReplyToEncryptedMessage = false
@@ -329,7 +329,7 @@ class RecipientPresenter(
         menu.findItem(R.id.add_from_contacts).isVisible = hasContactPermission() && hasContactPicker()
     }
 
-    fun onSwitchAccount(account: LegacyAccount) {
+    fun onSwitchAccount(account: LegacyAccountDto) {
         this.account = account
 
         if (account.isAlwaysShowCcBcc) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
@@ -4,20 +4,20 @@ package com.fsck.k9.activity.compose;
 import android.os.AsyncTask;
 import android.os.Handler;
 
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import com.fsck.k9.activity.MessageCompose;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.mail.Message;
 
 public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
     private final MessagingController messagingController;
-    private final LegacyAccount account;
+    private final LegacyAccountDto account;
     private final Handler handler;
     private final Message message;
     private final Long existingDraftId;
     private final String plaintextSubject;
 
-    public SaveMessageTask(MessagingController messagingController, LegacyAccount account, Handler handler, Message message,
+    public SaveMessageTask(MessagingController messagingController, LegacyAccountDto account, Handler handler, Message message,
             Long existingDraftId, String plaintextSubject) {
         this.messagingController = messagingController;
         this.account = account;

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.kt
@@ -15,13 +15,13 @@ import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.K9Activity
 import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.radiobutton.MaterialRadioButton
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.koin.android.ext.android.inject
 
 class AccountSetupComposition : K9Activity() {
     private val emailAddressValidator: EmailAddressValidator by inject()
 
-    private lateinit var account: LegacyAccount
+    private lateinit var account: LegacyAccountDto
 
     private lateinit var accountSignature: EditText
     private lateinit var accountEmail: EditText

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -20,7 +20,7 @@ import com.fsck.k9.ui.base.K9Activity
 import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.adapters.ItemAdapter
 import java.util.Locale
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.FolderType
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -35,7 +35,7 @@ class ChooseFolderActivity : K9Activity() {
 
     private lateinit var recyclerView: RecyclerView
     private lateinit var itemAdapter: ItemAdapter<FolderListItem>
-    private lateinit var account: LegacyAccount
+    private lateinit var account: LegacyAccountDto
     private lateinit var action: Action
     private var currentFolderId: Long? = null
     private var scrollToFolderId: Long? = null

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ChooseFolderViewModel(
@@ -29,7 +29,7 @@ class ChooseFolderViewModel(
         return foldersFlow.asLiveData()
     }
 
-    fun setDisplayMode(account: LegacyAccount, showHiddenFolders: Boolean) {
+    fun setDisplayMode(account: LegacyAccountDto, showHiddenFolders: Boolean) {
         isShowHiddenFolders = showHiddenFolders
         viewModelScope.launch {
             inputFlow.emit(DisplayMode(account, showHiddenFolders))
@@ -37,4 +37,4 @@ class ChooseFolderViewModel(
     }
 }
 
-private data class DisplayMode(val account: LegacyAccount, val showHiddenFolders: Boolean)
+private data class DisplayMode(val account: LegacyAccountDto, val showHiddenFolders: Boolean)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import app.k9mail.core.android.common.compat.BundleCompat;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.android.account.MessageFormat;
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.activity.MessageCompose;
@@ -54,11 +54,11 @@ public class QuotedMessagePresenter {
 
     private SimpleMessageFormat quotedTextFormat;
     private InsertableHtmlContent quotedHtmlContent;
-    private LegacyAccount account;
+    private LegacyAccountDto account;
 
 
     public QuotedMessagePresenter(
-            MessageCompose messageCompose, QuotedMessageMvpView quotedMessageMvpView, LegacyAccount account) {
+            MessageCompose messageCompose, QuotedMessageMvpView quotedMessageMvpView, LegacyAccountDto account) {
         this.messageCompose = messageCompose;
         this.view = quotedMessageMvpView;
         onSwitchAccount(account);
@@ -69,7 +69,7 @@ public class QuotedMessagePresenter {
         quotedMessageMvpView.setOnClickPresenter(this);
     }
 
-    public void onSwitchAccount(LegacyAccount account) {
+    public void onSwitchAccount(LegacyAccountDto account) {
         this.account = account;
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferPresenter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferPresenter.kt
@@ -6,7 +6,7 @@ import com.fsck.k9.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import org.openintents.openpgp.OpenPgpApiManager
 import org.openintents.openpgp.OpenPgpApiManager.OpenPgpApiManagerCallback
@@ -21,7 +21,7 @@ class AutocryptKeyTransferPresenter internal constructor(
     private val presenterScope: CoroutineScope = MainScope(),
 ) {
 
-    private lateinit var account: LegacyAccount
+    private lateinit var account: LegacyAccountDto
     private lateinit var showTransferCodePi: PendingIntent
 
     init {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupMessageLiveEvent.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupMessageLiveEvent.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.openintents.openpgp.util.OpenPgpApi
 
 class AutocryptSetupMessageLiveEvent(
@@ -22,7 +22,7 @@ class AutocryptSetupMessageLiveEvent(
     private val eventScope: CoroutineScope = MainScope(),
 ) : SingleLiveEvent<AutocryptSetupMessage>() {
 
-    fun loadAutocryptSetupMessageAsync(openPgpApi: OpenPgpApi, account: LegacyAccount) {
+    fun loadAutocryptSetupMessageAsync(openPgpApi: OpenPgpApi, account: LegacyAccountDto) {
         eventScope.launch {
             val result = withContext(Dispatchers.IO) {
                 loadAutocryptSetupMessage(openPgpApi, account)
@@ -32,7 +32,7 @@ class AutocryptSetupMessageLiveEvent(
         }
     }
 
-    private fun loadAutocryptSetupMessage(openPgpApi: OpenPgpApi, account: LegacyAccount): AutocryptSetupMessage {
+    private fun loadAutocryptSetupMessage(openPgpApi: OpenPgpApi, account: LegacyAccountDto): AutocryptSetupMessage {
         val keyIds = longArrayOf(account.openPgpKey)
         val address = Address.parse(account.getIdentity(0).email)[0]
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupTransferLiveEvent.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupTransferLiveEvent.kt
@@ -9,14 +9,14 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class AutocryptSetupTransferLiveEvent(
     private val messagingController: MessagingController,
     private val eventScope: CoroutineScope = MainScope(),
 ) : SingleLiveEvent<AutocryptSetupTransferResult>() {
 
-    fun sendMessageAsync(account: LegacyAccount, setupMsg: AutocryptSetupMessage) {
+    fun sendMessageAsync(account: LegacyAccountDto, setupMsg: AutocryptSetupMessage) {
         eventScope.launch {
             val setupMessage = async(Dispatchers.IO) {
                 messagingController.sendMessageBlocking(account, setupMsg.setupMessage)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/helper/DisplayAddressHelper.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/helper/DisplayAddressHelper.kt
@@ -1,9 +1,9 @@
 package com.fsck.k9.ui.helper
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 object DisplayAddressHelper {
-    fun shouldShowRecipients(account: LegacyAccount, folderId: Long): Boolean {
+    fun shouldShowRecipients(account: LegacyAccountDto, folderId: Long): Boolean {
         return when (folderId) {
             account.inboxFolderId -> false
             account.archiveFolderId -> false

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsDataStore.kt
@@ -6,12 +6,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.FolderDetails
 
 class FolderSettingsDataStore(
     private val folderRepository: FolderRepository,
-    private val account: LegacyAccount,
+    private val account: LegacyAccountDto,
     private var folder: FolderDetails,
     private val saveScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) : PreferenceDataStore() {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
@@ -10,7 +10,7 @@ import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.helper.SingleLiveEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderDetails
@@ -25,7 +25,7 @@ class FolderSettingsViewModel(
     private val actionLiveData = SingleLiveEvent<Action>()
     private var folderSettingsLiveData: LiveData<FolderSettingsResult>? = null
 
-    private lateinit var account: LegacyAccount
+    private lateinit var account: LegacyAccountDto
     private var folderId: Long = NO_FOLDER_ID
 
     val showClearFolderInMenu: Boolean
@@ -61,13 +61,13 @@ class FolderSettingsViewModel(
         }
     }
 
-    private suspend fun loadAccount(accountUuid: String): LegacyAccount {
+    private suspend fun loadAccount(accountUuid: String): LegacyAccountDto {
         return withContext(Dispatchers.IO) {
             preferences.getAccount(accountUuid) ?: error("Missing account: $accountUuid")
         }
     }
 
-    private suspend fun FolderRepository.loadFolderDetails(account: LegacyAccount, folderId: Long): FolderDetails? {
+    private suspend fun FolderRepository.loadFolderDetails(account: LegacyAccountDto, folderId: Long): FolderDetails? {
         return withContext(Dispatchers.IO) {
             getFolderDetails(account, folderId)
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
@@ -10,7 +10,7 @@ import androidx.navigation.ui.setupActionBarWithNavController
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.K9Activity
 import com.fsck.k9.ui.base.extensions.findNavController
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class ManageFoldersActivity : K9Activity() {
     private lateinit var navController: NavController
@@ -50,7 +50,7 @@ class ManageFoldersActivity : K9Activity() {
         private const val EXTRA_ACCOUNT = "account"
 
         @JvmStatic
-        fun launch(activity: Activity, account: LegacyAccount) {
+        fun launch(activity: Activity, account: LegacyAccountDto) {
             val intent = Intent(activity, ManageFoldersActivity::class.java).apply {
                 putExtra(EXTRA_ACCOUNT, account.uuid)
             }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
@@ -22,7 +22,7 @@ import com.fsck.k9.ui.base.livedata.observeNotNull
 import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.adapters.ItemAdapter
 import java.util.Locale
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -34,7 +34,7 @@ class ManageFoldersFragment : Fragment() {
     private val preferences: Preferences by inject()
     private val folderIconProvider: FolderIconProvider by inject { parametersOf(requireActivity().theme) }
 
-    private lateinit var account: LegacyAccount
+    private lateinit var account: LegacyAccountDto
     private lateinit var itemAdapter: ItemAdapter<FolderListItem>
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersViewModel.kt
@@ -5,12 +5,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import app.k9mail.legacy.ui.folder.DisplayFolder
 import app.k9mail.legacy.ui.folder.DisplayFolderRepository
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class ManageFoldersViewModel(
     private val folderRepository: DisplayFolderRepository,
 ) : ViewModel() {
-    fun getFolders(account: LegacyAccount): LiveData<List<DisplayFolder>> {
+    fun getFolders(account: LegacyAccountDto): LiveData<List<DisplayFolder>> {
         return folderRepository.getDisplayFoldersFlow(account, includeHiddenFolders = true).asLiveData()
     }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/message/LocalMessageLoader.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/message/LocalMessageLoader.java
@@ -4,7 +4,7 @@ package com.fsck.k9.ui.message;
 import android.content.Context;
 import androidx.loader.content.AsyncTaskLoader;
 
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.logging.legacy.Log;
 import app.k9mail.legacy.message.controller.MessageReference;
 import com.fsck.k9.controller.MessagingController;
@@ -14,12 +14,12 @@ import com.fsck.k9.mailstore.LocalMessage;
 
 public class LocalMessageLoader extends AsyncTaskLoader<LocalMessage> {
     private final MessagingController controller;
-    private final LegacyAccount account;
+    private final LegacyAccountDto account;
     private final MessageReference messageReference;
     private final boolean onlyLoadMetadata;
     private LocalMessage message;
 
-    public LocalMessageLoader(Context context, MessagingController controller, LegacyAccount account,
+    public LocalMessageLoader(Context context, MessagingController controller, LegacyAccountDto account,
             MessageReference messageReference, boolean onlyLoadMetaData) {
         super(context);
         this.controller = controller;

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
@@ -9,14 +9,14 @@ import com.fsck.k9.helper.ContactNameProvider
 import com.fsck.k9.mail.Address
 import com.fsck.k9.ui.R
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 /**
  * Get the display name for a participant to be shown in the message details screen.
  */
 internal interface MessageDetailsParticipantFormatter {
-    fun getDisplayName(address: Address, account: LegacyAccount): CharSequence?
+    fun getDisplayName(address: Address, account: LegacyAccountDto): CharSequence?
 }
 
 internal class RealMessageDetailsParticipantFormatter(
@@ -25,7 +25,7 @@ internal class RealMessageDetailsParticipantFormatter(
     private val contactNameColor: Int?,
     private val meText: String,
 ) : MessageDetailsParticipantFormatter {
-    override fun getDisplayName(address: Address, account: LegacyAccount): CharSequence? {
+    override fun getDisplayName(address: Address, account: LegacyAccountDto): CharSequence? {
         val identity = account.findIdentity(address)
         if (identity != null) {
             return getIdentityName(identity, account)
@@ -38,7 +38,7 @@ internal class RealMessageDetailsParticipantFormatter(
         }
     }
 
-    private fun getIdentityName(identity: Identity, account: LegacyAccount): String {
+    private fun getIdentityName(identity: Identity, account: LegacyAccountDto): String {
         return if (account.identities.size == 1) {
             meText
         } else {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsViewModel.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.toEmailAddressOrNull
 import net.thunderbird.feature.mail.folder.api.Folder
 
@@ -125,7 +125,7 @@ internal class MessageDetailsViewModel(
         )
     }
 
-    private fun List<Address>.toParticipants(account: LegacyAccount): List<Participant> {
+    private fun List<Address>.toParticipants(account: LegacyAccountDto): List<Participant> {
         return this.map { address ->
             val displayName = participantFormatter.getDisplayName(address, account)
             val emailAddress = address.address

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/DefaultFolderProvider.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/DefaultFolderProvider.kt
@@ -1,12 +1,12 @@
 package com.fsck.k9.ui.messagelist
 
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Decides which folder to display when an account is selected.
  */
 class DefaultFolderProvider {
-    fun getDefaultFolder(account: LegacyAccount): Long {
+    fun getDefaultFolder(account: LegacyAccountDto): Long {
         // Until the UI can handle the case where no remote folders have been fetched yet, we fall back to the Outbox
         // which should always exist.
         return account.autoExpandFolderId ?: account.inboxFolderId ?: account.outboxFolderId ?: error("Outbox missing")

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -69,8 +69,8 @@ import kotlinx.coroutines.flow.onEach
 import net.jcip.annotations.GuardedBy
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.Expunge
+import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountDto
-import net.thunderbird.core.android.account.LegacyAccountWrapper
 import net.thunderbird.core.android.account.SortType
 import net.thunderbird.core.android.network.ConnectivityManager
 import net.thunderbird.core.architecture.data.DataMapper
@@ -110,8 +110,8 @@ class MessageListFragment :
     @OptIn(ExperimentalTime::class)
     private val clock: Clock by inject()
     private val setupArchiveFolderDialogFragmentFactory: SetupArchiveFolderDialogFragmentFactory by inject()
-    private val legacyAccountWrapperDataMapper: DataMapper<
-        LegacyAccountWrapper,
+    private val legacyAccountDataMapper: DataMapper<
+        LegacyAccount,
         LegacyAccountDto,
         > by inject<DefaultLegacyAccountWrapperDataMapper>()
     private val preferences: Preferences by inject()
@@ -147,7 +147,7 @@ class MessageListFragment :
     private lateinit var adapter: MessageListAdapter
 
     private lateinit var accountUuids: Array<String>
-    private var accounts: List<LegacyAccountWrapper> = emptyList()
+    private var accounts: List<LegacyAccount> = emptyList()
     private var account: LegacyAccountDto? = null
     private var currentFolder: FolderInfoHolder? = null
     private var remoteSearchFuture: Future<*>? = null
@@ -467,7 +467,7 @@ class MessageListFragment :
                 adapter = adapter,
                 listener = swipeListener,
                 accounts = accounts,
-                legacyAccountWrapperDataMapper = legacyAccountWrapperDataMapper,
+                legacyAccountDataMapper = legacyAccountDataMapper,
             ).also { messageListSwipeCallback = it },
         )
         itemTouchHelper.attachToRecyclerView(recyclerView)
@@ -546,7 +546,7 @@ class MessageListFragment :
     }
 
     private fun updateAccountList(accounts: List<LegacyAccountDto>) {
-        this.accounts = accounts.map(legacyAccountWrapperDataMapper::toDomain)
+        this.accounts = accounts.map(legacyAccountDataMapper::toDomain)
     }
 
     fun folderLoading(folderId: Long, loading: Boolean) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -69,7 +69,7 @@ import kotlinx.coroutines.flow.onEach
 import net.jcip.annotations.GuardedBy
 import net.thunderbird.core.android.account.AccountManager
 import net.thunderbird.core.android.account.Expunge
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountWrapper
 import net.thunderbird.core.android.account.SortType
 import net.thunderbird.core.android.network.ConnectivityManager
@@ -112,10 +112,10 @@ class MessageListFragment :
     private val setupArchiveFolderDialogFragmentFactory: SetupArchiveFolderDialogFragmentFactory by inject()
     private val legacyAccountWrapperDataMapper: DataMapper<
         LegacyAccountWrapper,
-        LegacyAccount,
+        LegacyAccountDto,
         > by inject<DefaultLegacyAccountWrapperDataMapper>()
     private val preferences: Preferences by inject()
-    private val buildSwipeActions: DomainContract.UseCase.BuildSwipeActions<LegacyAccount> by inject {
+    private val buildSwipeActions: DomainContract.UseCase.BuildSwipeActions<LegacyAccountDto> by inject {
         parametersOf(preferences.storage)
     }
 
@@ -148,7 +148,7 @@ class MessageListFragment :
 
     private lateinit var accountUuids: Array<String>
     private var accounts: List<LegacyAccountWrapper> = emptyList()
-    private var account: LegacyAccount? = null
+    private var account: LegacyAccountDto? = null
     private var currentFolder: FolderInfoHolder? = null
     private var remoteSearchFuture: Future<*>? = null
     private var extraSearchResults: List<String>? = null
@@ -545,7 +545,7 @@ class MessageListFragment :
         viewModel.loadMessageList(config, forceUpdate)
     }
 
-    private fun updateAccountList(accounts: List<LegacyAccount>) {
+    private fun updateAccountList(accounts: List<LegacyAccountDto>) {
         this.accounts = accounts.map(legacyAccountWrapperDataMapper::toDomain)
     }
 
@@ -715,7 +715,7 @@ class MessageListFragment :
             density = K9.messageListDensity,
         )
 
-    private fun getFolderInfoHolder(folderId: Long, account: LegacyAccount): FolderInfoHolder {
+    private fun getFolderInfoHolder(folderId: Long, account: LegacyAccountDto): FolderInfoHolder {
         val localFolder = MlfUtils.getOpenFolder(folderId, account)
         return FolderInfoHolder(folderNameFormatter, localFolder, account)
     }
@@ -1142,9 +1142,9 @@ class MessageListFragment :
     private fun setFlagForSelected(flag: Flag, newState: Boolean) {
         if (adapter.selected.isEmpty()) return
 
-        val messageMap = mutableMapOf<LegacyAccount, MutableList<Long>>()
-        val threadMap = mutableMapOf<LegacyAccount, MutableList<Long>>()
-        val accounts = mutableSetOf<LegacyAccount>()
+        val messageMap = mutableMapOf<LegacyAccountDto, MutableList<Long>>()
+        val threadMap = mutableMapOf<LegacyAccountDto, MutableList<Long>>()
+        val accounts = mutableSetOf<LegacyAccountDto>()
 
         for (messageListItem in adapter.selectedMessages) {
             val account = messageListItem.account
@@ -1271,7 +1271,9 @@ class MessageListFragment :
         }
     }
 
-    private fun groupMessagesByAccount(messages: List<MessageReference>): Map<LegacyAccount, List<MessageReference>> {
+    private fun groupMessagesByAccount(
+        messages: List<MessageReference>,
+    ): Map<LegacyAccountDto, List<MessageReference>> {
         return messages.groupBy { accountManager.getAccount(it.accountUuid)!! }
     }
 
@@ -1930,7 +1932,7 @@ class MessageListFragment :
             handler.refreshTitle()
         }
 
-        override fun synchronizeMailboxStarted(account: LegacyAccount, folderId: Long) {
+        override fun synchronizeMailboxStarted(account: LegacyAccountDto, folderId: Long) {
             if (updateForMe(account, folderId)) {
                 handler.progress(true)
                 handler.folderLoading(folderId, true)
@@ -1945,7 +1947,7 @@ class MessageListFragment :
         }
 
         override fun synchronizeMailboxHeadersProgress(
-            account: LegacyAccount,
+            account: LegacyAccountDto,
             folderServerId: String,
             completed: Int,
             total: Int,
@@ -1959,7 +1961,7 @@ class MessageListFragment :
         }
 
         override fun synchronizeMailboxHeadersFinished(
-            account: LegacyAccount,
+            account: LegacyAccountDto,
             folderServerId: String,
             total: Int,
             completed: Int,
@@ -1972,7 +1974,7 @@ class MessageListFragment :
             informUserOfStatus()
         }
 
-        override fun synchronizeMailboxProgress(account: LegacyAccount, folderId: Long, completed: Int, total: Int) {
+        override fun synchronizeMailboxProgress(account: LegacyAccountDto, folderId: Long, completed: Int, total: Int) {
             synchronized(lock) {
                 folderCompleted = completed
                 folderTotal = total
@@ -1981,25 +1983,25 @@ class MessageListFragment :
             informUserOfStatus()
         }
 
-        override fun synchronizeMailboxFinished(account: LegacyAccount, folderId: Long) {
+        override fun synchronizeMailboxFinished(account: LegacyAccountDto, folderId: Long) {
             if (updateForMe(account, folderId)) {
                 handler.progress(false)
                 handler.folderLoading(folderId, false)
             }
         }
 
-        override fun synchronizeMailboxFailed(account: LegacyAccount, folderId: Long, message: String) {
+        override fun synchronizeMailboxFailed(account: LegacyAccountDto, folderId: Long, message: String) {
             if (updateForMe(account, folderId)) {
                 handler.progress(false)
                 handler.folderLoading(folderId, false)
             }
         }
 
-        override fun checkMailFinished(context: Context?, account: LegacyAccount?) {
+        override fun checkMailFinished(context: Context?, account: LegacyAccountDto?) {
             handler.progress(false)
         }
 
-        private fun updateForMe(account: LegacyAccount?, folderId: Long): Boolean {
+        private fun updateForMe(account: LegacyAccountDto?, folderId: Long): Boolean {
             if (account == null || account.uuid !in accountUuids) return false
 
             val folderIds = localSearch.folderIds
@@ -2077,7 +2079,7 @@ class MessageListFragment :
             return true
         }
 
-        private fun setContextCapabilities(account: LegacyAccount?, menu: Menu) {
+        private fun setContextCapabilities(account: LegacyAccountDto?, menu: Menu) {
             if (!isSingleAccountMode || account == null) {
                 // We don't support cross-account copy/move operations right now
                 menu.findItem(R.id.move).isVisible = false
@@ -2231,11 +2233,11 @@ class MessageListFragment :
     interface MessageListFragmentListener {
         fun setMessageListProgressEnabled(enable: Boolean)
         fun setMessageListProgress(level: Int)
-        fun showThread(account: LegacyAccount, threadRootId: Long)
+        fun showThread(account: LegacyAccountDto, threadRootId: Long)
         fun openMessage(messageReference: MessageReference)
         fun setMessageListTitle(title: String, subtitle: String? = null)
-        fun onCompose(account: LegacyAccount?)
-        fun startSearch(query: String, account: LegacyAccount?, folderId: Long?): Boolean
+        fun onCompose(account: LegacyAccountDto?)
+        fun startSearch(query: String, account: LegacyAccountDto?, folderId: Long?): Boolean
         fun startSupportActionMode(callback: ActionMode.Callback): ActionMode?
         fun goBack()
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -2,10 +2,10 @@ package com.fsck.k9.ui.messagelist
 
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mail.Address
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 data class MessageListItem(
-    val account: LegacyAccount,
+    val account: LegacyAccountDto,
     val subject: String?,
     val threadCount: Int,
     val messageDate: Long,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItemMapper.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItemMapper.kt
@@ -5,12 +5,12 @@ import app.k9mail.legacy.mailstore.MessageMapper
 import app.k9mail.legacy.message.extractors.PreviewResult.PreviewType
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.ui.helper.DisplayAddressHelper
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 class MessageListItemMapper(
     private val messageHelper: MessageHelper,
-    private val account: LegacyAccount,
+    private val account: LegacyAccountDto,
     private val generalSettingsManager: GeneralSettingsManager,
 ) : MessageMapper<MessageListItem> {
 
@@ -58,7 +58,7 @@ class MessageListItemMapper(
         )
     }
 
-    private fun createUniqueId(account: LegacyAccount, messageId: Long): Long {
+    private fun createUniqueId(account: LegacyAccountDto, messageId: Long): Long {
         return ((account.accountNumber + 1).toLong() shl 52) + messageId
     }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
@@ -6,7 +6,7 @@ import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mailstore.LocalStoreProvider
 import com.fsck.k9.mailstore.MessageColumns
 import com.fsck.k9.search.getAccounts
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.SortType
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
@@ -46,7 +46,7 @@ class MessageListLoader(
         return MessageListInfo(messageListItems, hasMoreMessages)
     }
 
-    private fun loadMessageListForAccount(account: LegacyAccount, config: MessageListConfig): List<MessageListItem> {
+    private fun loadMessageListForAccount(account: LegacyAccountDto, config: MessageListConfig): List<MessageListItem> {
         val accountUuid = account.uuid
         val threadId = getThreadId(config.search)
         val sortOrder = buildSortOrder(config)
@@ -69,7 +69,7 @@ class MessageListLoader(
         }
     }
 
-    private fun buildSelection(account: LegacyAccount, config: MessageListConfig): Pair<String, Array<String>> {
+    private fun buildSelection(account: LegacyAccountDto, config: MessageListConfig): Pair<String, Array<String>> {
         val query = StringBuilder()
         val queryArgs = mutableListOf<String>()
 
@@ -170,7 +170,7 @@ class MessageListLoader(
         return this.sortedWith(comparator)
     }
 
-    private fun loadHasMoreMessages(accounts: List<LegacyAccount>, folderIds: List<Long>): Boolean {
+    private fun loadHasMoreMessages(accounts: List<LegacyAccountDto>, folderIds: List<Long>): Boolean {
         return if (accounts.size == 1 && folderIds.size == 1) {
             val account = accounts[0]
             val folderId = folderIds[0]

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListSwipeCallback.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListSwipeCallback.kt
@@ -19,8 +19,8 @@ import com.fsck.k9.ui.messagelist.item.MessageViewHolder
 import com.google.android.material.color.ColorRoles
 import com.google.android.material.textview.MaterialTextView
 import kotlin.math.abs
+import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountDto
-import net.thunderbird.core.android.account.LegacyAccountWrapper
 import net.thunderbird.core.architecture.data.DataMapper
 import net.thunderbird.core.common.action.SwipeAction
 import net.thunderbird.core.common.action.SwipeActions
@@ -35,8 +35,8 @@ class MessageListSwipeCallback(
     private val buildSwipeActions: DomainContract.UseCase.BuildSwipeActions<LegacyAccountDto>,
     private val adapter: MessageListAdapter,
     private val listener: MessageListSwipeListener,
-    accounts: List<LegacyAccountWrapper>,
-    private val legacyAccountWrapperDataMapper: DataMapper<LegacyAccountWrapper, LegacyAccountDto>,
+    accounts: List<LegacyAccount>,
+    private val legacyAccountDataMapper: DataMapper<LegacyAccount, LegacyAccountDto>,
 ) : ItemTouchHelper.Callback() {
     private var swipeActions: Map<String, SwipeActions> = emptyMap()
     private val swipePadding = context.resources.getDimension(R.dimen.messageListSwipeIconPadding).toInt()
@@ -326,7 +326,7 @@ class MessageListSwipeCallback(
         return (super.getAnimationDuration(recyclerView, animationType, animateDx, animateDy) * percentage).toLong()
     }
 
-    fun invalidateSwipeActions(accounts: List<LegacyAccountWrapper>) {
+    fun invalidateSwipeActions(accounts: List<LegacyAccount>) {
         swipeActions = buildSwipeActions(accounts)
         swipeLeftConfig.apply {
             clear()
@@ -338,18 +338,18 @@ class MessageListSwipeCallback(
         }
     }
 
-    fun buildSwipeActions(accounts: List<LegacyAccountWrapper>): Map<String, SwipeActions> {
+    fun buildSwipeActions(accounts: List<LegacyAccount>): Map<String, SwipeActions> {
         return buildSwipeActions(
             accountUuids = accounts.map { it.uuid }.toSet(),
             isIncomingServerPop3 = { account ->
-                legacyAccountWrapperDataMapper.toDomain(account).isIncomingServerPop3()
+                legacyAccountDataMapper.toDomain(account).isIncomingServerPop3()
             },
-            hasArchiveFolder = { account -> legacyAccountWrapperDataMapper.toDomain(account).hasArchiveFolder() },
+            hasArchiveFolder = { account -> legacyAccountDataMapper.toDomain(account).hasArchiveFolder() },
         )
     }
 
     private fun setupSwipeActionConfig(
-        accounts: List<LegacyAccountWrapper>,
+        accounts: List<LegacyAccount>,
         resourceProvider: SwipeResourceProvider,
         isLeft: Boolean,
     ): Map<String, SwipeActionConfig> {
@@ -384,8 +384,8 @@ class MessageListSwipeCallback(
     private val ViewHolder.messageListItem: MessageListItem?
         get() = (this as? MessageViewHolder)?.uniqueId?.let { adapter.getItemById(it) }
 
-    private val MessageListItem.accountWrapper: LegacyAccountWrapper
-        get() = legacyAccountWrapperDataMapper.toDomain(account)
+    private val MessageListItem.accountWrapper: LegacyAccount
+        get() = legacyAccountDataMapper.toDomain(account)
 }
 
 fun interface SwipeActionSupportProvider {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListSwipeCallback.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListSwipeCallback.kt
@@ -19,7 +19,7 @@ import com.fsck.k9.ui.messagelist.item.MessageViewHolder
 import com.google.android.material.color.ColorRoles
 import com.google.android.material.textview.MaterialTextView
 import kotlin.math.abs
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountWrapper
 import net.thunderbird.core.architecture.data.DataMapper
 import net.thunderbird.core.common.action.SwipeAction
@@ -32,11 +32,11 @@ class MessageListSwipeCallback(
     context: Context,
     private val resourceProvider: SwipeResourceProvider,
     private val swipeActionSupportProvider: SwipeActionSupportProvider,
-    private val buildSwipeActions: DomainContract.UseCase.BuildSwipeActions<LegacyAccount>,
+    private val buildSwipeActions: DomainContract.UseCase.BuildSwipeActions<LegacyAccountDto>,
     private val adapter: MessageListAdapter,
     private val listener: MessageListSwipeListener,
     accounts: List<LegacyAccountWrapper>,
-    private val legacyAccountWrapperDataMapper: DataMapper<LegacyAccountWrapper, LegacyAccount>,
+    private val legacyAccountWrapperDataMapper: DataMapper<LegacyAccountWrapper, LegacyAccountDto>,
 ) : ItemTouchHelper.Callback() {
     private var swipeActions: Map<String, SwipeActions> = emptyMap()
     private val swipePadding = context.resources.getDimension(R.dimen.messageListSwipeIconPadding).toInt()

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MlfUtils.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MlfUtils.java
@@ -11,12 +11,12 @@ import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.mailstore.LocalStoreProvider;
 import net.thunderbird.core.android.account.AccountManager;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 
 
 public class MlfUtils {
 
-    static LocalFolder getOpenFolder(long folderId, LegacyAccount account) throws MessagingException {
+    static LocalFolder getOpenFolder(long folderId, LegacyAccountDto account) throws MessagingException {
         LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);
         localFolder.open();
@@ -25,7 +25,7 @@ public class MlfUtils {
 
     static void setLastSelectedFolder(AccountManager accountManager, List<MessageReference> messages, long folderId) {
         MessageReference firstMsg = messages.get(0);
-        LegacyAccount account = accountManager.getAccount(firstMsg.getAccountUuid());
+        LegacyAccountDto account = accountManager.getAccount(firstMsg.getAccountUuid());
         account.setLastSelectedFolderId(folderId);
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
@@ -14,7 +14,7 @@ import android.os.AsyncTask;
 import android.widget.Toast;
 
 import androidx.annotation.WorkerThread;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessagingController;
 import app.k9mail.legacy.message.controller.SimpleMessagingListener;
@@ -84,20 +84,20 @@ public class AttachmentController {
 
     private void downloadAttachment(LocalPart localPart, final Runnable attachmentDownloadedCallback) {
         String accountUuid = localPart.getAccountUuid();
-        LegacyAccount account = Preferences.getPreferences().getAccount(accountUuid);
+        LegacyAccountDto account = Preferences.getPreferences().getAccount(accountUuid);
         LocalMessage message = localPart.getMessage();
 
         messageViewFragment.showAttachmentLoadingDialog();
         controller.loadAttachment(account, message, attachment.part, new SimpleMessagingListener() {
             @Override
-            public void loadAttachmentFinished(LegacyAccount account, Message message, Part part) {
+            public void loadAttachmentFinished(LegacyAccountDto account, Message message, Part part) {
                 attachment.setContentAvailable();
                 messageViewFragment.hideAttachmentLoadingDialogOnMainThread();
                 messageViewFragment.runOnMainThread(attachmentDownloadedCallback);
             }
 
             @Override
-            public void loadAttachmentFailed(LegacyAccount account, Message message, Part part, String reason) {
+            public void loadAttachmentFailed(LegacyAccountDto account, Message message, Part part, String reason) {
                 messageViewFragment.hideAttachmentLoadingDialogOnMainThread();
             }
         });

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractor.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractor.kt
@@ -1,7 +1,7 @@
 package com.fsck.k9.ui.messageview
 
 import com.fsck.k9.mail.Message
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 /**
  * Extract recipient names from a message to display them in the message view.
@@ -13,7 +13,7 @@ internal class DisplayRecipientsExtractor(
     private val recipientFormatter: MessageViewRecipientFormatter,
     private val maxNumberOfDisplayRecipients: Int,
 ) {
-    fun extractDisplayRecipients(message: Message, account: LegacyAccount): DisplayRecipients {
+    fun extractDisplayRecipients(message: Message, account: LegacyAccountDto): DisplayRecipients {
         val toRecipients = message.getRecipients(Message.RecipientType.TO)
         val ccRecipients = message.getRecipients(Message.RecipientType.CC)
         val bccRecipients = message.getRecipients(Message.RecipientType.BCC)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -14,7 +14,7 @@ import android.text.TextUtils;
 import com.fsck.k9.mailstore.CryptoResultAnnotation;
 import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.view.MessageCryptoDisplayStatus;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.logging.legacy.Log;
 
 
@@ -48,7 +48,7 @@ public class MessageCryptoPresenter {
         }
     }
 
-    public boolean maybeHandleShowMessage(MessageTopView messageView, LegacyAccount account, MessageViewInfo messageViewInfo) {
+    public boolean maybeHandleShowMessage(MessageTopView messageView, LegacyAccountDto account, MessageViewInfo messageViewInfo) {
         this.cryptoResultAnnotation = messageViewInfo.cryptoResultAnnotation;
 
         MessageCryptoDisplayStatus displayStatus =

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
@@ -26,7 +26,7 @@ import com.fsck.k9.view.ThemeUtils
 import com.fsck.k9.view.ToolableViewAnimator
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textview.MaterialTextView
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.ShowPictures
 import net.thunderbird.core.common.mail.EmailAddress
 import net.thunderbird.core.common.mail.toEmailAddressOrNull
@@ -108,7 +108,7 @@ class MessageTopView(
         setShowDownloadButton(messageViewInfo)
     }
 
-    fun showMessage(account: LegacyAccount, messageViewInfo: MessageViewInfo) {
+    fun showMessage(account: LegacyAccountDto, messageViewInfo: MessageViewInfo) {
         resetAndPrepareMessageView(messageViewInfo)
 
         val showPicturesSetting = account.showPictures
@@ -196,7 +196,7 @@ class MessageTopView(
         }
     }
 
-    fun setHeaders(message: Message?, account: LegacyAccount?, showStar: Boolean) {
+    fun setHeaders(message: Message?, account: LegacyAccountDto?, showStar: Boolean) {
         messageHeaderView.populate(message, account, showStar, showAccountChip)
         messageHeaderView.visibility = VISIBLE
     }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -56,7 +56,7 @@ import com.fsck.k9.ui.settings.account.AccountSettingsActivity
 import com.fsck.k9.ui.share.ShareIntentBuilder
 import java.util.Locale
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.core.ui.theme.api.Theme
@@ -105,7 +105,7 @@ class MessageViewFragment :
     private var destinationFolderId: Long? = null
     private lateinit var fragmentListener: MessageViewFragmentListener
 
-    private lateinit var account: LegacyAccount
+    private lateinit var account: LegacyAccountDto
     lateinit var messageReference: MessageReference
     private var showAccountChip: Boolean = true
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
@@ -9,14 +9,14 @@ import com.fsck.k9.helper.ContactNameProvider
 import com.fsck.k9.mail.Address
 import com.fsck.k9.ui.R
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.preference.GeneralSettingsManager
 
 /**
  * Get the display name for a recipient to be shown in the message view screen.
  */
 internal interface MessageViewRecipientFormatter {
-    fun getDisplayName(address: Address, account: LegacyAccount): CharSequence
+    fun getDisplayName(address: Address, account: LegacyAccountDto): CharSequence
 }
 
 internal class RealMessageViewRecipientFormatter(
@@ -26,7 +26,7 @@ internal class RealMessageViewRecipientFormatter(
     private val contactNameColor: Int?,
     private val meText: String,
 ) : MessageViewRecipientFormatter {
-    override fun getDisplayName(address: Address, account: LegacyAccount): CharSequence {
+    override fun getDisplayName(address: Address, account: LegacyAccountDto): CharSequence {
         val identity = account.findIdentity(address)
         if (identity != null) {
             return getIdentityName(identity, account)
@@ -41,7 +41,7 @@ internal class RealMessageViewRecipientFormatter(
         }
     }
 
-    private fun getIdentityName(identity: Identity, account: LegacyAccount): String {
+    private fun getIdentityName(identity: Identity, account: LegacyAccountDto): String {
         return if (account.identities.size == 1) {
             meText
         } else {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/notification/DeleteConfirmationActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/notification/DeleteConfirmationActivity.kt
@@ -14,14 +14,14 @@ import com.fsck.k9.notification.NotificationActionService
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.K9Activity
 import com.fsck.k9.ui.base.ThemeType
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.koin.android.ext.android.inject
 
 class DeleteConfirmationActivity : K9Activity(ThemeType.DIALOG), ConfirmationDialogFragmentListener {
     private val preferences: Preferences by inject()
     private val messagingController: MessagingController by inject()
 
-    private lateinit var account: LegacyAccount
+    private lateinit var account: LegacyAccountDto
     private lateinit var messagesToDelete: List<MessageReference>
 
     public override fun onCreate(savedInstanceState: Bundle?) {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/AccountItem.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/AccountItem.kt
@@ -12,10 +12,10 @@ import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.drag.IDraggable
 import com.mikepenz.fastadapter.items.AbstractItem
 import com.mikepenz.fastadapter.listeners.TouchEventHook
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class AccountItem(
-    val account: LegacyAccount,
+    val account: LegacyAccountDto,
     override var isDraggable: Boolean,
 ) : AbstractItem<AccountItem.ViewHolder>(), IDraggable {
     override var identifier = 200L + account.accountNumber

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
@@ -30,7 +30,7 @@ import com.mikepenz.fastadapter.adapters.ItemAdapter
 import com.mikepenz.fastadapter.drag.ItemTouchCallback
 import com.mikepenz.fastadapter.drag.SimpleDragCallback
 import com.mikepenz.fastadapter.utils.DragDropUtil
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.provider.BrandNameProvider
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -90,7 +90,7 @@ class SettingsListFragment : Fragment(), ItemTouchCallback {
         }
     }
 
-    private fun populateSettingsList(accounts: List<LegacyAccount>) {
+    private fun populateSettingsList(accounts: List<LegacyAccountDto>) {
         val listItems = buildSettingsList {
             addAction(
                 text = getString(R.string.general_settings_title),
@@ -188,7 +188,7 @@ class SettingsListFragment : Fragment(), ItemTouchCallback {
         }
     }
 
-    private fun launchAccountSettings(account: LegacyAccount) {
+    private fun launchAccountSettings(account: LegacyAccountDto) {
         AccountSettingsActivity.start(requireActivity(), account.uuid)
     }
 
@@ -216,7 +216,7 @@ class SettingsListFragment : Fragment(), ItemTouchCallback {
             settingsList.add(UrlActionItem(itemId, text, url, icon))
         }
 
-        fun addAccount(account: LegacyAccount, isDraggable: Boolean) {
+        fun addAccount(account: LegacyAccountDto, isDraggable: Boolean) {
             settingsList.add(AccountItem(account, isDraggable))
         }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 internal class SettingsViewModel(
     private val accountManager: AccountManager,
@@ -18,7 +18,7 @@ internal class SettingsViewModel(
 ) : ViewModel() {
     val accounts = accountManager.getAccountsFlow().asLiveData()
 
-    fun moveAccount(account: LegacyAccount, newPosition: Int) {
+    fun moveAccount(account: LegacyAccountDto, newPosition: Int) {
         viewModelScope.launch(coroutineDispatcher) {
             // Delay saving the account so the animation is not disturbed
             delay(500)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
@@ -11,11 +11,11 @@ import androidx.appcompat.widget.AppCompatSpinner
 import androidx.core.view.isVisible
 import com.fsck.k9.ui.R
 import com.google.android.material.textview.MaterialTextView
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class AccountSelectionSpinner : AppCompatSpinner {
-    var selection: LegacyAccount
-        get() = selectedItem as LegacyAccount
+    var selection: LegacyAccountDto
+        get() = selectedItem as LegacyAccountDto
         set(account) {
             selectedAccount = account
             val adapter = adapter as AccountsAdapter
@@ -24,7 +24,7 @@ class AccountSelectionSpinner : AppCompatSpinner {
         }
 
     private val cachedBackground: Drawable
-    private var selectedAccount: LegacyAccount? = null
+    private var selectedAccount: LegacyAccountDto? = null
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
@@ -40,7 +40,7 @@ class AccountSelectionSpinner : AppCompatSpinner {
         adapter.notifyDataSetChanged()
     }
 
-    fun setAccounts(accounts: List<LegacyAccount>) {
+    fun setAccounts(accounts: List<LegacyAccountDto>) {
         val adapter = adapter as AccountsAdapter
         adapter.clear()
         adapter.addAll(accounts)
@@ -52,7 +52,7 @@ class AccountSelectionSpinner : AppCompatSpinner {
         background = if (showAccountSwitcher) cachedBackground else null
     }
 
-    internal class AccountsAdapter(context: Context) : ArrayAdapter<LegacyAccount>(context, 0) {
+    internal class AccountsAdapter(context: Context) : ArrayAdapter<LegacyAccountDto>(context, 0) {
         var title: CharSequence = ""
 
         override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.notification.NotificationController
 import java.util.concurrent.ExecutorService
 import net.thunderbird.core.android.account.DeletePolicy
 import net.thunderbird.core.android.account.Expunge
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.MessageFormat
 import net.thunderbird.core.android.account.QuoteStyle
 import net.thunderbird.core.android.account.ShowPictures
@@ -20,7 +20,7 @@ import net.thunderbird.feature.notification.NotificationVibration
 class AccountSettingsDataStore(
     private val preferences: Preferences,
     private val executorService: ExecutorService,
-    private val account: LegacyAccount,
+    private val account: LegacyAccountDto,
     private val jobManager: K9JobManager,
     private val notificationChannelManager: NotificationChannelManager,
     private val notificationController: NotificationController,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreFactory.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreFactory.kt
@@ -6,7 +6,7 @@ import com.fsck.k9.job.K9JobManager
 import com.fsck.k9.notification.NotificationChannelManager
 import com.fsck.k9.notification.NotificationController
 import java.util.concurrent.ExecutorService
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 
 class AccountSettingsDataStoreFactory(
     private val preferences: Preferences,
@@ -16,7 +16,7 @@ class AccountSettingsDataStoreFactory(
     private val notificationController: NotificationController,
     private val messagingController: MessagingController,
 ) {
-    fun create(account: LegacyAccount): AccountSettingsDataStore {
+    fun create(account: LegacyAccountDto): AccountSettingsDataStore {
         return AccountSettingsDataStore(
             preferences,
             executorService,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -34,7 +34,7 @@ import com.fsck.k9.ui.settings.remove
 import com.fsck.k9.ui.settings.removeEntry
 import com.takisoft.preferencex.PreferenceFragmentCompat
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.QuoteStyle
 import net.thunderbird.core.common.provider.AppNameProvider
 import net.thunderbird.core.featureflag.FeatureFlagKey
@@ -177,7 +177,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeUploadSentMessages(account: LegacyAccount) {
+    private fun initializeUploadSentMessages(account: LegacyAccountDto) {
         findPreference<Preference>(PREFERENCE_UPLOAD_SENT_MESSAGES)?.apply {
             if (!messagingController.supportsUpload(account)) {
                 remove()
@@ -204,7 +204,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeDeletePolicy(account: LegacyAccount) {
+    private fun initializeDeletePolicy(account: LegacyAccountDto) {
         (findPreference(PREFERENCE_DELETE_POLICY) as? ListPreference)?.apply {
             if (!messagingController.supportsFlags(account)) {
                 removeEntry(DELETE_POLICY_MARK_AS_READ)
@@ -212,7 +212,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeExpungePolicy(account: LegacyAccount) {
+    private fun initializeExpungePolicy(account: LegacyAccountDto) {
         findPreference<Preference>(PREFERENCE_EXPUNGE_POLICY)?.apply {
             if (!messagingController.supportsExpunge(account)) {
                 remove()
@@ -220,7 +220,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeMessageAge(account: LegacyAccount) {
+    private fun initializeMessageAge(account: LegacyAccountDto) {
         findPreference<Preference>(PREFERENCE_MESSAGE_AGE)?.apply {
             if (!messagingController.supportsSearchByDate(account)) {
                 remove()
@@ -228,13 +228,13 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeAdvancedPushSettings(account: LegacyAccount) {
+    private fun initializeAdvancedPushSettings(account: LegacyAccountDto) {
         if (!messagingController.isPushCapable(account)) {
             findPreference<Preference>(PREFERENCE_ADVANCED_PUSH_SETTINGS)?.remove()
         }
     }
 
-    private fun initializeNotifications(account: LegacyAccount) {
+    private fun initializeNotifications(account: LegacyAccountDto) {
         if (!vibrator.hasVibrator) {
             findPreference<Preference>(PREFERENCE_NOTIFICATION_VIBRATION)?.remove()
         }
@@ -270,7 +270,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun maybeUpdateNotificationPreferences(account: LegacyAccount) {
+    private fun maybeUpdateNotificationPreferences(account: LegacyAccountDto) {
         if (notificationSoundPreference != null ||
             notificationLightPreference != null ||
             notificationVibrationPreference != null
@@ -280,7 +280,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     @SuppressLint("NewApi")
-    private fun updateNotificationPreferences(account: LegacyAccount) {
+    private fun updateNotificationPreferences(account: LegacyAccountDto) {
         notificationSettingsUpdater.updateNotificationSettings(account)
         val notificationSettings = account.notificationSettings
 
@@ -298,13 +298,13 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun initializeCryptoSettings(account: LegacyAccount) {
+    private fun initializeCryptoSettings(account: LegacyAccountDto) {
         findPreference<Preference>(PREFERENCE_OPENPGP)?.let {
             configureCryptoPreferences(account)
         }
     }
 
-    private fun configureCryptoPreferences(account: LegacyAccount) {
+    private fun configureCryptoPreferences(account: LegacyAccountDto) {
         var pgpProviderName: String? = null
         var pgpProvider = account.openPgpProvider
         val isPgpConfigured = pgpProvider != null
@@ -312,7 +312,11 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         if (isPgpConfigured) {
             pgpProviderName = getOpenPgpProviderName(pgpProvider)
             if (pgpProviderName == null) {
-                Toast.makeText(requireContext(), R.string.account_settings_openpgp_missing, Toast.LENGTH_LONG).show()
+                Toast.makeText(
+                    requireContext(),
+                    R.string.account_settings_openpgp_missing,
+                    Toast.LENGTH_LONG,
+                ).show()
 
                 pgpProvider = null
                 removeOpenPgpProvider(account)
@@ -329,7 +333,11 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         return OpenPgpProviderUtil.getOpenPgpProviderName(packageManager, pgpProvider)
     }
 
-    private fun configureEnablePgpSupport(account: LegacyAccount, isPgpConfigured: Boolean, pgpProviderName: String?) {
+    private fun configureEnablePgpSupport(
+        account: LegacyAccountDto,
+        isPgpConfigured: Boolean,
+        pgpProviderName: String?,
+    ) {
         (findPreference<Preference>(PREFERENCE_OPENPGP_ENABLE) as SwitchPreference).apply {
             if (!isPgpConfigured) {
                 isChecked = false
@@ -356,7 +364,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun configurePgpKey(account: LegacyAccount, pgpProvider: String?) {
+    private fun configurePgpKey(account: LegacyAccountDto, pgpProvider: String?) {
         (findPreference<Preference>(PREFERENCE_OPENPGP_KEY) as OpenPgpKeyPreference).apply {
             value = account.openPgpKey
             setOpenPgpProvider(openPgpApiManager, pgpProvider)
@@ -366,14 +374,14 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun configureAutocryptTransfer(account: LegacyAccount) {
+    private fun configureAutocryptTransfer(account: LegacyAccountDto) {
         findPreference<Preference>(PREFERENCE_AUTOCRYPT_TRANSFER)!!.onClick {
             val intent = AutocryptKeyTransferActivity.createIntent(requireContext(), account.uuid)
             startActivity(intent)
         }
     }
 
-    private fun initializeFolderSettings(account: LegacyAccount) {
+    private fun initializeFolderSettings(account: LegacyAccountDto) {
         findPreference<Preference>(PREFERENCE_FOLDERS)?.let {
             if (!messagingController.supportsFolderSubscriptions(account)) {
                 findPreference<Preference>(PREFERENCE_SUBSCRIBED_FOLDERS_ONLY).remove()
@@ -391,7 +399,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         }
     }
 
-    private fun loadFolders(account: LegacyAccount) {
+    private fun loadFolders(account: LegacyAccountDto) {
         viewModel.getFolders(account).observe(this@AccountSettingsFragment) { remoteFolderInfo ->
             if (remoteFolderInfo != null) {
                 setFolders(PREFERENCE_AUTO_EXPAND_FOLDER, remoteFolderInfo.folders)
@@ -424,7 +432,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         super.onActivityResult(requestCode, resultCode, data)
     }
 
-    private fun getAccount(): LegacyAccount {
+    private fun getAccount(): LegacyAccountDto {
         return viewModel.getAccountBlocking(accountUuid)
     }
 
@@ -453,12 +461,12 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         requireActivity().finish()
     }
 
-    private fun setOpenPgpProvider(account: LegacyAccount, openPgpProviderPackage: String) {
+    private fun setOpenPgpProvider(account: LegacyAccountDto, openPgpProviderPackage: String) {
         account.openPgpProvider = openPgpProviderPackage
         dataStore.saveSettingsInBackground()
     }
 
-    private fun removeOpenPgpProvider(account: LegacyAccount) {
+    private fun removeOpenPgpProvider(account: LegacyAccountDto) {
         account.openPgpProvider = null
         account.openPgpKey = NO_OPENPGP_KEY
         dataStore.saveSettingsInBackground()

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.thunderbird.core.android.account.AccountManager
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
 
@@ -24,10 +24,10 @@ class AccountSettingsViewModel(
 ) : ViewModel() {
     val accounts = accountManager.getAccountsFlow().asLiveData()
     private var accountUuid: String? = null
-    private val accountLiveData = MutableLiveData<LegacyAccount?>()
+    private val accountLiveData = MutableLiveData<LegacyAccountDto?>()
     private val foldersLiveData = MutableLiveData<RemoteFolderInfo>()
 
-    fun getAccount(accountUuid: String): LiveData<LegacyAccount?> {
+    fun getAccount(accountUuid: String): LiveData<LegacyAccountDto?> {
         if (this.accountUuid != accountUuid) {
             this.accountUuid = accountUuid
             viewModelScope.launch {
@@ -42,10 +42,10 @@ class AccountSettingsViewModel(
     }
 
     /**
-     * Returns the cached [LegacyAccount] if possible. Otherwise does a blocking load because `PreferenceFragmentCompat`
-     * doesn't support asynchronous preference loading.
+     * Returns the cached [LegacyAccountDto] if possible. Otherwise does a blocking load because
+     * `PreferenceFragmentCompat` doesn't support asynchronous preference loading.
      */
-    fun getAccountBlocking(accountUuid: String): LegacyAccount {
+    fun getAccountBlocking(accountUuid: String): LegacyAccountDto {
         return accountLiveData.value
             ?: loadAccount(accountUuid).also { account ->
                 this.accountUuid = accountUuid
@@ -54,11 +54,11 @@ class AccountSettingsViewModel(
             ?: error("Account $accountUuid not found")
     }
 
-    private fun loadAccount(accountUuid: String): LegacyAccount? {
+    private fun loadAccount(accountUuid: String): LegacyAccountDto? {
         return accountManager.getAccount(accountUuid)
     }
 
-    fun getFolders(account: LegacyAccount): LiveData<RemoteFolderInfo> {
+    fun getFolders(account: LegacyAccountDto): LiveData<RemoteFolderInfo> {
         if (foldersLiveData.value == null) {
             loadFolders(account)
         }
@@ -66,7 +66,7 @@ class AccountSettingsViewModel(
         return foldersLiveData
     }
 
-    private fun loadFolders(account: LegacyAccount) {
+    private fun loadFolders(account: LegacyAccountDto) {
         viewModelScope.launch {
             val remoteFolderInfo = withContext(backgroundDispatcher) {
                 val folders = folderRepository.getRemoteFolders(account)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
@@ -23,7 +23,7 @@ import android.widget.ListAdapter;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.ui.base.K9Activity;
@@ -48,9 +48,9 @@ public class OpenPgpAppSelectDialog extends K9Activity {
             String.format("https://play.google.com/store/apps/details?id=%s", OPENKEYCHAIN_PACKAGE)));
 
 
-    private LegacyAccount account;
+    private LegacyAccountDto account;
 
-    public static void startOpenPgpChooserActivity(Context context, LegacyAccount account) {
+    public static void startOpenPgpChooserActivity(Context context, LegacyAccountDto account) {
         Intent i = new Intent(context, OpenPgpAppSelectDialog.class);
         i.putExtra(EXTRA_ACCOUNT, account.getUuid());
         context.startActivity(i);

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -40,7 +40,7 @@ import com.fsck.k9.ui.messageview.MessageViewRecipientFormatter;
 import com.fsck.k9.ui.messageview.RecipientNamesView;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.textview.MaterialTextView;
-import net.thunderbird.core.android.account.LegacyAccount;
+import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.preference.GeneralSettingsManager;
 
 
@@ -195,7 +195,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         starView.setOnClickListener(listener);
     }
 
-    public void populate(final Message message, final LegacyAccount account, boolean showStar, boolean showAccountChip) {
+    public void populate(final Message message, final LegacyAccountDto account, boolean showStar, boolean showAccountChip) {
         if (showAccountChip) {
             accountNameView.setVisibility(View.VISIBLE);
             accountNameView.setText(account.getDisplayName());
@@ -245,7 +245,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         setVisibility(View.VISIBLE);
     }
 
-    private void setRecipientNames(Message message, LegacyAccount account) {
+    private void setRecipientNames(Message message, LegacyAccountDto account) {
         DisplayRecipientsExtractor displayRecipientsExtractor = new DisplayRecipientsExtractor(recipientFormatter,
                 recipientNamesView.getMaxNumberOfRecipientNames());
 
@@ -255,7 +255,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
                 displayRecipients.getNumberOfRecipients());
     }
 
-    private void setReplyActions(Message message, LegacyAccount account) {
+    private void setReplyActions(Message message, LegacyAccountDto account) {
         ReplyActions replyActions = replyActionStrategy.getReplyActions(account, message);
         this.replyActions = replyActions;
 

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.kt
@@ -23,7 +23,7 @@ import com.fsck.k9.message.ComposePgpEnableByDefaultDecider
 import com.fsck.k9.message.ComposePgpInlineDecider
 import com.fsck.k9.view.RecipientSelectView.Recipient
 import kotlin.test.assertNotNull
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
@@ -57,7 +57,7 @@ class RecipientPresenterTest : K9RobolectricTest() {
         }
     }
     private val recipientMvpView = mock<RecipientMvpView>()
-    private val account = mock<LegacyAccount>()
+    private val account = mock<LegacyAccountDto>()
     private val composePgpInlineDecider = mock<ComposePgpInlineDecider>()
     private val composePgpEnableByDefaultDecider = mock<ComposePgpEnableByDefaultDecider>()
     private val autocryptStatusInteractor = mock<AutocryptStatusInteractor>()

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatterTest.kt
@@ -14,7 +14,7 @@ import com.fsck.k9.helper.ContactNameProvider
 import com.fsck.k9.mail.Address
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.RobolectricTest
 import org.junit.Test
 
@@ -33,7 +33,7 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
         }
     }
 
-    private val account = LegacyAccount(ACCOUNT_ID_RAW).apply {
+    private val account = LegacyAccountDto(ACCOUNT_ID_RAW).apply {
         identities += Identity(name = IDENTITY_NAME, email = IDENTITY_ADDRESS)
     }
 
@@ -48,7 +48,7 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity address with multiple identities`() {
-        val account = LegacyAccount(ACCOUNT_ID_RAW).apply {
+        val account = LegacyAccountDto(ACCOUNT_ID_RAW).apply {
             identities += Identity(name = IDENTITY_NAME, email = IDENTITY_ADDRESS)
             identities += Identity(
                 name = "Another identity",
@@ -63,7 +63,7 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity without a display name`() {
-        val account = LegacyAccount(ACCOUNT_ID_RAW).apply {
+        val account = LegacyAccountDto(ACCOUNT_ID_RAW).apply {
             identities += Identity(name = null, email = IDENTITY_ADDRESS)
         }
 
@@ -74,7 +74,7 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity and address without a display name`() {
-        val account = LegacyAccount(ACCOUNT_ID_RAW).apply {
+        val account = LegacyAccountDto(ACCOUNT_ID_RAW).apply {
             identities += Identity(name = null, email = IDENTITY_ADDRESS)
             identities += Identity(
                 name = "Another identity",

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
@@ -25,7 +25,7 @@ import com.fsck.k9.ui.R
 import com.fsck.k9.ui.helper.RelativeDateTimeFormatter
 import com.google.android.material.textview.MaterialTextView
 import kotlin.time.ExperimentalTime
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.RobolectricTest
 import net.thunderbird.core.testing.TestClock
 import org.junit.Test
@@ -427,7 +427,7 @@ class MessageListAdapterTest : RobolectricTest() {
     }
 
     fun createMessageListItem(
-        account: LegacyAccount = LegacyAccount(
+        account: LegacyAccountDto = LegacyAccountDto(
             SOME_ACCOUNT_UUID,
         ),
         subject: String? = "irrelevant",

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
@@ -6,20 +6,20 @@ import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.testing.message.buildMessage
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import org.junit.Test
 
 private const val IDENTITY_ADDRESS = "me@domain.example"
 
 class DisplayRecipientsExtractorTest {
-    private val account = LegacyAccount(ACCOUNT_ID_RAW).apply {
+    private val account = LegacyAccountDto(ACCOUNT_ID_RAW).apply {
         identities += Identity(
             email = IDENTITY_ADDRESS,
         )
     }
 
     private val recipientFormatter = object : MessageViewRecipientFormatter {
-        override fun getDisplayName(address: Address, account: LegacyAccount): CharSequence {
+        override fun getDisplayName(address: Address, account: LegacyAccountDto): CharSequence {
             return if (account.isAnIdentity(address)) {
                 "me"
             } else {
@@ -173,7 +173,7 @@ class DisplayRecipientsExtractorTest {
         }
         var numberOfTimesCalled = 0
         val recipientFormatter = object : MessageViewRecipientFormatter {
-            override fun getDisplayName(address: Address, account: LegacyAccount): CharSequence {
+            override fun getDisplayName(address: Address, account: LegacyAccountDto): CharSequence {
                 numberOfTimesCalled++
                 return address.address
             }

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatterTest.kt
@@ -12,7 +12,7 @@ import com.fsck.k9.helper.ContactNameProvider
 import com.fsck.k9.mail.Address
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
 import net.thunderbird.core.android.account.Identity
-import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.testing.RobolectricTest
 import org.junit.Test
 
@@ -30,7 +30,7 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
         }
     }
 
-    private val account = LegacyAccount(ACCOUNT_ID_RAW).apply {
+    private val account = LegacyAccountDto(ACCOUNT_ID_RAW).apply {
         identities += Identity(email = IDENTITY_ADDRESS)
     }
 
@@ -45,7 +45,7 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
 
     @Test
     fun `multiple identities`() {
-        val account = LegacyAccount(ACCOUNT_ID_RAW).apply {
+        val account = LegacyAccountDto(ACCOUNT_ID_RAW).apply {
             identities += Identity(
                 description = "My identity",
                 email = IDENTITY_ADDRESS,
@@ -61,7 +61,7 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity without a description`() {
-        val account = LegacyAccount(ACCOUNT_ID_RAW).apply {
+        val account = LegacyAccountDto(ACCOUNT_ID_RAW).apply {
             identities += Identity(name = "My name", email = IDENTITY_ADDRESS)
             identities += Identity(email = "another.one@domain.example")
         }
@@ -74,7 +74,7 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
 
     @Test
     fun `identity without a description and name`() {
-        val account = LegacyAccount(ACCOUNT_ID_RAW).apply {
+        val account = LegacyAccountDto(ACCOUNT_ID_RAW).apply {
             identities += Identity(email = IDENTITY_ADDRESS)
             identities += Identity(email = "another.one@domain.example")
         }


### PR DESCRIPTION
Preparation to for the unified account support #9370

This cleans up naming and renames `LegacyAccountWrapper` to `LegacyAccount`, while the old `LegacyAccount` is now `LegacyAccountDto` which better fits it's real purpose.

