### PR TITLE
chore(ci): fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,22 @@
 version: 2
-commit-message:
-  prefix: chore
-  include: scope
-labels:
-  - "type: dependency"
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "type: dependency"
+      - "type: github actions"
+    commit-message:
+      prefix: chore
+      include: scope
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "type: dependency"
+      - "type: gradle"
+    commit-message:
+      prefix: chore
+      include: scope


### PR DESCRIPTION
The `commit-message` and `labels` are not allowed on root level in version 2, see [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)

I moved them to the corresponding update definitions.