### PR TITLE
Add interactions subcategory and migrate volume navigation key Setting

### DIFF
--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/GeneralSettings.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/GeneralSettings.kt
@@ -2,6 +2,7 @@ package net.thunderbird.core.preference
 
 import net.thunderbird.core.preference.debugging.DebuggingSettings
 import net.thunderbird.core.preference.display.DisplaySettings
+import net.thunderbird.core.preference.interaction.InteractionSettings
 import net.thunderbird.core.preference.network.NetworkSettings
 import net.thunderbird.core.preference.notification.NotificationPreference
 import net.thunderbird.core.preference.privacy.PrivacySettings
@@ -20,6 +21,7 @@ data class GeneralSettings(
     val display: DisplaySettings = DisplaySettings(),
     val privacy: PrivacySettings = PrivacySettings(),
     val debugging: DebuggingSettings = DebuggingSettings(),
+    val interaction: InteractionSettings = InteractionSettings(),
 )
 
 enum class BackgroundSync {

--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettings.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettings.kt
@@ -1,0 +1,7 @@
+package net.thunderbird.core.preference.interaction
+
+const val INTERACTION_SETTINGS_DEFAULT_USE_VOLUME_KEYS_NAVIGATION = false
+
+data class InteractionSettings(
+    val useVolumeKeysForNavigation: Boolean = INTERACTION_SETTINGS_DEFAULT_USE_VOLUME_KEYS_NAVIGATION,
+)

--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettingsPreferenceManager.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettingsPreferenceManager.kt
@@ -1,0 +1,6 @@
+package net.thunderbird.core.preference.interaction
+
+import net.thunderbird.core.preference.PreferenceManager
+
+const val KEY_USE_VOLUME_KEYS_FOR_NAVIGATION = "useVolumeKeysForNavigation"
+interface InteractionSettingsPreferenceManager : PreferenceManager<InteractionSettings>

--- a/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/DefaultInteractionSettingsPreferenceManager.kt
+++ b/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/DefaultInteractionSettingsPreferenceManager.kt
@@ -1,0 +1,56 @@
+package net.thunderbird.core.preference.interaction
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.core.preference.storage.Storage
+import net.thunderbird.core.preference.storage.StorageEditor
+
+private const val TAG = "DefaultInteractionSettingsPreferenceManager"
+
+class DefaultInteractionSettingsPreferenceManager(
+    private val logger: Logger,
+    private val storage: Storage,
+    private val storageEditor: StorageEditor,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private var scope: CoroutineScope = CoroutineScope(SupervisorJob()),
+) : InteractionSettingsPreferenceManager {
+    private val configState: MutableStateFlow<InteractionSettings> = MutableStateFlow(value = loadConfig())
+    private val mutex = Mutex()
+
+    override fun getConfig(): InteractionSettings = configState.value
+    override fun getConfigFlow(): Flow<InteractionSettings> = configState
+
+    override fun save(config: InteractionSettings) {
+        logger.debug(TAG) { "save() called with: config = $config" }
+        writeConfig(config)
+        configState.update { config }
+    }
+
+    private fun loadConfig(): InteractionSettings = InteractionSettings(
+        useVolumeKeysForNavigation = storage.getBoolean(
+            KEY_USE_VOLUME_KEYS_FOR_NAVIGATION,
+            INTERACTION_SETTINGS_DEFAULT_USE_VOLUME_KEYS_NAVIGATION,
+        ),
+    )
+
+    private fun writeConfig(config: InteractionSettings) {
+        logger.debug(TAG) { "writeConfig() called with: config = $config" }
+        scope.launch(ioDispatcher) {
+            mutex.withLock {
+                storageEditor.putBoolean(KEY_USE_VOLUME_KEYS_FOR_NAVIGATION, config.useVolumeKeysForNavigation)
+                storageEditor.commit().also { commited ->
+                    logger.verbose(TAG) { "writeConfig: storageEditor.commit() resulted in: $commited" }
+                }
+            }
+        }
+    }
+}

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -155,9 +155,6 @@ object K9 : KoinComponent {
         PostMarkAsUnreadNavigation.ReturnToMessageList
 
     @JvmStatic
-    var isUseVolumeKeysForNavigation = false
-
-    @JvmStatic
     var isShowAccountSelector = true
 
     var isNotificationDuringQuietTimeEnabled = true
@@ -239,7 +236,6 @@ object K9 : KoinComponent {
     @JvmStatic
     @Suppress("LongMethod")
     fun loadPrefs(storage: Storage) {
-        isUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false)
         isShowAccountSelector = storage.getBoolean("showAccountSelector", true)
         messageListPreviewLines = storage.getInt("messageListPreviewLines", 2)
 
@@ -304,7 +300,6 @@ object K9 : KoinComponent {
 
     @Suppress("LongMethod")
     internal fun save(editor: StorageEditor) {
-        editor.putBoolean("useVolumeKeysForNavigation", isUseVolumeKeysForNavigation)
         editor.putBoolean("notificationDuringQuietTimeEnabled", isNotificationDuringQuietTimeEnabled)
         editor.putEnum("messageListDensity", messageListDensity)
         editor.putBoolean("showAccountSelector", isShowAccountSelector)

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/DefaultGeneralSettingsManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/DefaultGeneralSettingsManager.kt
@@ -23,6 +23,7 @@ import net.thunderbird.core.preference.display.coreSettings.DisplayCoreSettingsP
 import net.thunderbird.core.preference.display.inboxSettings.DisplayInboxSettingsPreferenceManager
 import net.thunderbird.core.preference.display.miscSettings.DisplayMiscSettingsPreferenceManager
 import net.thunderbird.core.preference.display.visualSettings.DisplayVisualSettingsPreferenceManager
+import net.thunderbird.core.preference.interaction.InteractionSettingsPreferenceManager
 import net.thunderbird.core.preference.network.NetworkSettingsPreferenceManager
 import net.thunderbird.core.preference.notification.NotificationPreferenceManager
 import net.thunderbird.core.preference.privacy.PrivacySettingsPreferenceManager
@@ -51,6 +52,7 @@ internal class DefaultGeneralSettingsManager(
     private val displayMiscSettingsPreferenceManager: DisplayMiscSettingsPreferenceManager,
     private val networkSettingsPreferenceManager: NetworkSettingsPreferenceManager,
     private val debuggingSettingsPreferenceManager: DebuggingSettingsPreferenceManager,
+    private val interactionSettingsPreferenceManager: InteractionSettingsPreferenceManager,
     private val debugLogConfigurator: DebugLogConfigurator,
     private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : GeneralSettingsManager {
@@ -107,6 +109,9 @@ internal class DefaultGeneralSettingsManager(
                 debugLogConfigurator.updateSyncLogging(debuggingSettings.isSyncLoggingEnabled)
             }
         }
+        .combine(interactionSettingsPreferenceManager.getConfigFlow()) { generalSettings, interactionSettings ->
+            generalSettings.copy(interaction = interactionSettings)
+        }
         .stateIn(
             scope = coroutineScope,
             started = SharingStarted.WhileSubscribed(),
@@ -159,6 +164,7 @@ internal class DefaultGeneralSettingsManager(
                 displayMiscSettingsPreferenceManager.save(config.display.miscSettings)
                 networkSettingsPreferenceManager.save(config.network)
                 debuggingSettingsPreferenceManager.save(config.debugging)
+                interactionSettingsPreferenceManager.save(config.interaction)
             }
         }
     }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
@@ -19,6 +19,8 @@ import net.thunderbird.core.preference.display.miscSettings.DefaultDisplayMiscSe
 import net.thunderbird.core.preference.display.miscSettings.DisplayMiscSettingsPreferenceManager
 import net.thunderbird.core.preference.display.visualSettings.DefaultDisplayVisualSettingsPreferenceManager
 import net.thunderbird.core.preference.display.visualSettings.DisplayVisualSettingsPreferenceManager
+import net.thunderbird.core.preference.interaction.DefaultInteractionSettingsPreferenceManager
+import net.thunderbird.core.preference.interaction.InteractionSettingsPreferenceManager
 import net.thunderbird.core.preference.network.DefaultNetworkSettingsPreferenceManager
 import net.thunderbird.core.preference.network.NetworkSettingsPreferenceManager
 import net.thunderbird.core.preference.notification.DefaultNotificationPreferenceManager
@@ -88,6 +90,13 @@ val preferencesModule = module {
             storageEditor = get<Preferences>().createStorageEditor(),
         )
     }
+    single<InteractionSettingsPreferenceManager> {
+        DefaultInteractionSettingsPreferenceManager(
+            logger = get(),
+            storage = get<Preferences>().storage,
+            storageEditor = get<Preferences>().createStorageEditor(),
+        )
+    }
     single<DisplaySettingsPreferenceManager> {
         DefaultDisplaySettingsPreferenceManager(
             logger = get(),
@@ -132,6 +141,7 @@ val preferencesModule = module {
             displayMiscSettingsPreferenceManager = get(),
             networkSettingsPreferenceManager = get(),
             debuggingSettingsPreferenceManager = get(),
+            interactionSettingsPreferenceManager = get(),
             debugLogConfigurator = get(),
         )
     } bind GeneralSettingsManager::class

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -821,7 +821,7 @@ open class MessageList :
             KeyEvent.KEYCODE_VOLUME_UP -> {
                 if (messageViewContainerFragment != null &&
                     displayMode != DisplayMode.MESSAGE_LIST &&
-                    K9.isUseVolumeKeysForNavigation
+                    generalSettingsManager.getConfig().interaction.useVolumeKeysForNavigation
                 ) {
                     showPreviousMessage()
                     return true
@@ -831,7 +831,7 @@ open class MessageList :
             KeyEvent.KEYCODE_VOLUME_DOWN -> {
                 if (messageViewContainerFragment != null &&
                     displayMode != DisplayMode.MESSAGE_LIST &&
-                    K9.isUseVolumeKeysForNavigation
+                    generalSettingsManager.getConfig().interaction.useVolumeKeysForNavigation
                 ) {
                     showNextMessage()
                     return true
@@ -980,7 +980,7 @@ open class MessageList :
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         // Swallow these events too to avoid the audible notification of a volume change
-        if (K9.isUseVolumeKeysForNavigation) {
+        if (generalSettingsManager.getConfig().interaction.useVolumeKeysForNavigation) {
             if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
                 Log.v("Swallowed key up.")
                 return true

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -75,7 +75,7 @@ class GeneralSettingsDataStore(
             "debug_logging" -> generalSettingsManager.getConfig().debugging.isDebugLoggingEnabled
             "sync_debug_logging" -> generalSettingsManager.getConfig().debugging.isSyncLoggingEnabled
             "sensitive_logging" -> generalSettingsManager.getConfig().debugging.isSensitiveLoggingEnabled
-            "volume_navigation" -> K9.isUseVolumeKeysForNavigation
+            "volume_navigation" -> generalSettingsManager.getConfig().interaction.useVolumeKeysForNavigation
             "enable_telemetry" -> K9.isTelemetryEnabled
             else -> defValue
         }
@@ -115,7 +115,7 @@ class GeneralSettingsDataStore(
             "debug_logging" -> setIsDebugLoggingEnabled(isDebugLoggingEnabled = value)
             "sync_debug_logging" -> setIsSyncLoggingEnabled(isSyncLoggingEnabled = value)
             "sensitive_logging" -> setIsSensitiveLoggingEnabled(isSensitiveLoggingEnabled = value)
-            "volume_navigation" -> K9.isUseVolumeKeysForNavigation = value
+            "volume_navigation" -> setUseVolumeKeysForNavigation(value)
             "enable_telemetry" -> setTelemetryEnabled(value)
             else -> return
         }
@@ -625,6 +625,17 @@ class GeneralSettingsDataStore(
             settings.copy(
                 debugging = settings.debugging.copy(
                     isSensitiveLoggingEnabled = isSensitiveLoggingEnabled,
+                ),
+            )
+        }
+    }
+
+    private fun setUseVolumeKeysForNavigation(useVolumeKeysForNavigation: Boolean) {
+        skipSaveSettings = true
+        generalSettingsManager.update { settings ->
+            settings.copy(
+                interaction = settings.interaction.copy(
+                    useVolumeKeysForNavigation = useVolumeKeysForNavigation,
                 ),
             )
         }


### PR DESCRIPTION
- Fixes #9774 

**Implementation Highlights**: 
-  Created a new `InteractionsSettings` data class under **net.thunderbird.core.preference.interactions**.
-  Created` InteractionSettingsPreferenceManager`  under **net.thunderbird.core.preference.interaction** and provided it's implementation to handle reading and writing interaction settings to Preference DataStore.
- Added interactions: InteractionsSettings field to `GeneralSettings`.
- Updated `GeneralSettingsManager `to read/write the new setting from **DataStore**.
- Migrated existing `K9.isUseVolumeKeysForNavigation` preference to the new DataStore-backed setting.
