### PR TITLE
ci(android-pr): change unit-test job to use testsOnCi tasks instead of testDebugUnitTest

### DIFF
--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -144,7 +144,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Running unit tests
-        run: ./gradlew testDebugUnitTest --parallel
+        run: ./gradlew testsOnCi --parallel
 
   dependency-guard:
     name: Quality - Dependency Guard


### PR DESCRIPTION
This PR aims to modify the Pull request checks workflow to utilize the task `testDebugUnitTest`, as it appears to exclude JVM-only projects. 