### PR TITLE
feat(core): add shorthand methods to check the current result state

### DIFF
--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/FeatureFlagResult.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/FeatureFlagResult.kt
@@ -44,4 +44,9 @@ sealed interface FeatureFlagResult {
 
         return this
     }
+
+    fun isEnabled(): Boolean = this is Enabled
+    fun isDisabled(): Boolean = this is Disabled
+    fun isUnavailable(): Boolean = this is Unavailable
+    fun isDisabledOrUnavailable(): Boolean = this is Disabled || this is Unavailable
 }


### PR DESCRIPTION
This adds several convenience methods to the `FeatureFlagResult` to make it easier to check the status of feature flags.
