### PR TITLE
fix(ci): dependabot workflow update dependency guard task

### DIFF
--- a/.github/workflows/dependabot-dependency-guard-update.yml
+++ b/.github/workflows/dependabot-dependency-guard-update.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Update dependency guard
-        run: ./gradlew :dependencyGuardBaseline
+        run: ./gradlew dependencyGuardBaseline
 
       - name: Commit and push changes if any
         # The email address is composed by {user.id}+{user.login}@users.noreply.github.com


### PR DESCRIPTION
Removed unnecessary leading `:` from gradle task command