### PR TITLE
fix: db migration to version 90 crashing the app and causing database wipe

### DIFF
--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayTreeFolder.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayTreeFolder.kt
@@ -3,6 +3,7 @@ package net.thunderbird.feature.navigation.drawer.dropdown.domain.usecase
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.mail.folder.api.FOLDER_DEFAULT_PATH_DELIMITER
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderPathDelimiter
 import net.thunderbird.feature.mail.folder.api.FolderType
@@ -28,7 +29,7 @@ internal class GetDisplayTreeFolder(
             )
         }
 
-        val pathDelimiter = folders.first().pathDelimiter
+        val pathDelimiter = folders.firstOrNull()?.pathDelimiter ?: FOLDER_DEFAULT_PATH_DELIMITER
         val accountFolders = folders.filterIsInstance<MailDisplayFolder>().map {
             val path = flattenPath(it.folder.name, pathDelimiter, maxDepth)
             logger.debug { "Flattened path for ${it.folder.name} → $path" }

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo90.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo90.kt
@@ -21,6 +21,7 @@ import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.Protocols
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.logging.legacy.Log
+import okio.IOException
 import org.intellij.lang.annotations.Language
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -55,22 +56,26 @@ internal class MigrationTo90(
         try {
             logger.verbose(TAG) { "fetching IMAP prefix" }
             imapStore.fetchImapPrefix()
+            val imapPrefix = imapStore.combinedPrefix
+
+            if (imapPrefix?.isNotBlank() == true) {
+                logger.verbose(TAG) { "Imap Prefix ($imapPrefix) detected, updating folder's server_id" }
+                val query = buildQuery(imapPrefix)
+                db.execSQL(query)
+            } else {
+                logger.verbose(TAG) { "No Imap Prefix detected, skipping db migration" }
+            }
+
+            logger.verbose(TAG) { "completed db migration to version 90 for account ${account.uuid}" }
         } catch (e: AuthenticationFailedException) {
-            logger.warn(TAG, e) { "failed to fetch IMAP prefix. skipping db migration" }
-            return
+            logger.warn(TAG, e) {
+                "failed to fetch IMAP prefix due to authentication error. skipping db migration"
+            }
+        } catch (e: IOException) {
+            logger.warn(TAG, e) {
+                "failed to fetch IMAP prefix due to network error. skipping db migration"
+            }
         }
-
-        val imapPrefix = imapStore.combinedPrefix
-
-        if (imapPrefix?.isNotBlank() == true) {
-            logger.verbose(TAG) { "Imap Prefix ($imapPrefix) detected, updating folder's server_id" }
-            val query = buildQuery(imapPrefix)
-            db.execSQL(query)
-        } else {
-            logger.verbose(TAG) { "No Imap Prefix detected, skipping db migration" }
-        }
-
-        logger.verbose(TAG) { "completed db migration to version 90 for account ${account.uuid}" }
     }
 
     private fun createImapStore(account: LegacyAccountDto): ImapStore {


### PR DESCRIPTION
Fixes #9825.

## PR Description

This pull request addresses two related app crashes:

1. During the database migration to version 90, the app attempts to fetch the IMAP prefix from the email server. If there is no connection available at that time, the migration throws an exception. This exception leads to the `StoreSchemaDefinition` wiping out all the database data by [setting the db version to 0](https://github.com/thunderbird/thunderbird-android/blob/1877d84d9726aaa16e4bea6387007eb8dca8751f/legacy/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java#L39).

2. When trying to open the app with no available folders, a crash occurs because the code assumes there is [at least one folder in the list when creating the drawer instance](https://github.com/thunderbird/thunderbird-android/blob/1877d84d9726aaa16e4bea6387007eb8dca8751f/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayTreeFolder.kt#L31). Since the database has been wiped, no folders are present, making it impossible to open the app.

This pull request resolves both issues by:

1. Catching any `IOException` that occurs while attempting to fetch the IMAP prefix during the migration. If an exception is encountered, the data migration will be ignored.
2. Allowing for the possibility of an empty list of folders when creating the drawer instance and using the default path delimiter in that case.

## Steps to reproduce
1. Uninstall the app
2. `git checkout dc3a253f6289cf45c737d49aa782a8a5bc69a714` (Revision before db migration 90)
3. Build and install the app
4. Setup an account
5. Once you land in the Message List, turn off the Network and close the app.
6. `git switch main && git pull`
7. Build and install the app. **Make sure the app gets updated.**
8. **With NO network connection**, open the app.

## Expected behaviour

1. The app should open without issues
2. The data migration should be ignored
3. The app's data stays the same as before the update happens.

## Actual behaviour

The app crashes and wipes out the data.