### PR TITLE
Fix crash in CreateNewArchiveFolderDialogContent when setting new arc…

### DIFF
--- a/feature/mail/message/list/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/dialog/CreateNewArchiveFolderDialogContent.kt
+++ b/feature/mail/message/list/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/dialog/CreateNewArchiveFolderDialogContent.kt
@@ -37,13 +37,13 @@ internal fun CreateNewArchiveFolderDialogContent(
             visible = syncingMessage != null,
             modifier = Modifier.padding(horizontal = MainTheme.spacings.quadruple),
         ) {
-            requireNotNull(syncingMessage)
-
-            Spacer(modifier = Modifier.height(MainTheme.spacings.oneHalf))
-            TextBodySmall(
-                text = syncingMessage,
-                color = MainTheme.colors.onSurfaceVariant,
-            )
+            syncingMessage?.let { message ->
+                Spacer(modifier = Modifier.height(MainTheme.spacings.oneHalf))
+                TextBodySmall(
+                    text = message,
+                    color = MainTheme.colors.onSurfaceVariant,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request fixes a crash in CreateNewArchiveFolderDialogContent that occurs
when attempting to set a new archive folder via swipe while the device has no network connection.

### Problem
When syncingMessage is null (because the IMAP connection failed), the composable
used `requireNotNull(syncingMessage)` inside an AnimatedVisibility block. Due to
Compose’s animation behavior, the block could be recomposed with syncingMessage = null,
leading to a crash.

### Solution
- Replaced `requireNotNull(syncingMessage)` with a safe call using `syncingMessage?.let { ... }`.
- The TextBodySmall composable is now only rendered if syncingMessage is non-null.
- This prevents the crash while keeping the UI behavior consistent.

### Testing
- Reproduced the bug by simulating no network connection.
- Verified that the folder can be created locally without crashing the app.
- Verified that the syncing message appears/disappears correctly when available.

Closes #9809
