### PR TITLE
refactor(notifications): simplify notification command outcomes

### DIFF
--- a/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/SecretDebugSettingsScreenPreview.kt
+++ b/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/SecretDebugSettingsScreenPreview.kt
@@ -10,12 +10,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.flowOf
 import net.thunderbird.core.common.resources.StringsResourceManager
-import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.debug.settings.notification.DebugNotificationSectionViewModel
 import net.thunderbird.feature.mail.account.api.AccountManager
 import net.thunderbird.feature.mail.account.api.BaseAccount
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationEvent
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationReceiver
@@ -25,6 +23,12 @@ import net.thunderbird.feature.notification.api.sender.NotificationSender
 @Composable
 private fun SecretDebugSettingsScreenPreview() {
     koinPreview {
+        single<InAppNotificationReceiver> {
+            object : InAppNotificationReceiver {
+                override val events: SharedFlow<InAppNotificationEvent>
+                    get() = error("not implemented")
+            }
+        }
         single<DebugNotificationSectionViewModel> {
             DebugNotificationSectionViewModel(
                 stringsResourceManager = object : StringsResourceManager {
@@ -47,13 +51,10 @@ private fun SecretDebugSettingsScreenPreview() {
                 notificationSender = object : NotificationSender {
                     override fun send(
                         notification: Notification,
-                    ): Flow<Outcome<Success<Notification>, Failure<Notification>>> =
+                    ): Flow<NotificationCommandOutcome<Notification>> =
                         error("not implemented")
                 },
-                notificationReceiver = object : InAppNotificationReceiver {
-                    override val events: SharedFlow<InAppNotificationEvent>
-                        get() = error("not implemented")
-                },
+                notificationReceiver = get(),
             )
         }
     } WithContent {

--- a/feature/notification/api/build.gradle.kts
+++ b/feature/notification/api/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(projects.core.common)
+            implementation(projects.core.featureflag)
             implementation(projects.core.outcome)
         }
         commonTest.dependencies {

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/NotificationId.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/NotificationId.kt
@@ -10,4 +10,8 @@ package net.thunderbird.feature.notification.api
  * @property value The integer value of the notification ID.
  */
 @JvmInline
-value class NotificationId(val value: Int) : Comparable<Int> by value
+value class NotificationId(val value: Int) : Comparable<Int> by value {
+    companion object {
+        val Undefined = NotificationId(Int.MIN_VALUE)
+    }
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/NotificationCommand.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/NotificationCommand.kt
@@ -1,8 +1,6 @@
 package net.thunderbird.feature.notification.api.command
 
-import androidx.annotation.Discouraged
-import net.thunderbird.core.outcome.Outcome
-import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 
@@ -24,45 +22,5 @@ abstract class NotificationCommand<TNotification : Notification>(
      * Executes the command.
      * @return The result of the execution.
      */
-    abstract suspend fun execute(): Outcome<Success<TNotification>, Failure<TNotification>>
-
-    /**
-     * Represents the outcome of a command's execution.
-     */
-    sealed interface CommandOutcome
-
-    /**
-     * Represents a successful command execution.
-     *
-     * @param TNotification The type of notification associated with the command.
-     * @property notificationId The ID of the notification that was successfully acted upon.
-     * @property command The command that was executed successfully.
-     */
-    data class Success<out TNotification : Notification>(
-        val notificationId: NotificationId,
-        val command: NotificationCommand<out TNotification>,
-    ) : CommandOutcome {
-        companion object {
-            @Discouraged(
-                message = "This is a utility function to enable usage in Java code. " +
-                    "Use Success(NotificationId, NotificationCommand) instead.",
-            )
-            operator fun invoke(
-                notificationId: Int,
-                command: NotificationCommand<*>,
-            ): Success<Notification> = Success(NotificationId(notificationId), command)
-        }
-    }
-
-    /**
-     * Represents a failed command execution.
-     *
-     * @param TNotification The type of notification associated with the command.
-     * @property command The command that failed.
-     * @property throwable The exception that caused the failure.
-     */
-    data class Failure<out TNotification : Notification>(
-        val command: NotificationCommand<out TNotification>?,
-        val throwable: Throwable,
-    ) : CommandOutcome
+    abstract suspend fun execute(): NotificationCommandOutcome<TNotification>
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/outcome/CommandExecutionFailed.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/outcome/CommandExecutionFailed.kt
@@ -1,0 +1,22 @@
+package net.thunderbird.feature.notification.api.command.outcome
+
+import net.thunderbird.feature.notification.api.command.NotificationCommand
+import net.thunderbird.feature.notification.api.content.Notification
+
+/**
+ * Represents a failure that occurred while attempting to execute a command.
+ *
+ * Use this when a command was recognized and supported, but its execution failed due to an error
+ * (e.g., I/O failure, unexpected state, or an exception thrown by the underlying system).
+ *
+ * @param TNotification The type of notification associated with the command.
+ * @property command The command whose execution failed. May be null if the command couldn't be
+ *                   fully constructed.
+ * @property message A human-readable description of the failure. Defaults to a generic message.
+ * @property throwable An optional exception that provides additional context about the failure.
+ */
+data class CommandExecutionFailed<out TNotification : Notification>(
+    override val command: NotificationCommand<out TNotification>,
+    val message: String = "Command failed to execute.",
+    val throwable: Throwable? = null,
+) : Failure<TNotification>

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/outcome/CommandNotCreated.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/outcome/CommandNotCreated.kt
@@ -1,0 +1,10 @@
+package net.thunderbird.feature.notification.api.command.outcome
+
+import net.thunderbird.feature.notification.api.command.NotificationCommand
+import net.thunderbird.feature.notification.api.content.Notification
+
+data class CommandNotCreated<out TNotification : Notification>(
+    val message: String,
+) : Failure<TNotification> {
+    override val command: NotificationCommand<out TNotification>? = null
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/outcome/NotificationCommandOutcome.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/outcome/NotificationCommandOutcome.kt
@@ -1,0 +1,88 @@
+@file:JvmName("NotificationCommandOutcome")
+
+package net.thunderbird.feature.notification.api.command.outcome
+
+import androidx.annotation.Discouraged
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.notification.api.NotificationId
+import net.thunderbird.feature.notification.api.command.NotificationCommand
+import net.thunderbird.feature.notification.api.content.Notification
+
+/**
+ * Outcome type for executing a NotificationCommand.
+ *
+ * When executing a command, the result will be either a [Success] or a [Failure].
+ */
+typealias NotificationCommandOutcome<TNotification> = Outcome<Success<TNotification>, Failure<TNotification>>
+
+/**
+ * Represents a successful command execution.
+ *
+ * @param TNotification The type of notification associated with the command.
+ * @property notificationId The ID of the notification that was successfully acted upon.
+ * @property command The command that was executed successfully.
+ */
+sealed interface Success<out TNotification : Notification> {
+    val notificationId: NotificationId
+    val command: NotificationCommand<out TNotification>?
+
+    /**
+     * Indicates that the command was executed as requested.
+     *
+     * This is the canonical success case that carries the command instance that was executed.
+     *
+     * @param TNotification The type of notification associated with the command.
+     * @property command The concrete command that was executed.
+     */
+    @ConsistentCopyVisibility
+    data class Executed<out TNotification : Notification> internal constructor(
+        override val notificationId: NotificationId,
+        override val command: NotificationCommand<out TNotification>,
+    ) : Success<TNotification>
+
+    /**
+     * Indicates that executing the command resulted in no operation.
+     *
+     * This can be used when the system is already in the desired state or when there is
+     * intentionally nothing to do. The [command] may be null if there isn't a specific
+     * command instance associated with the no-op result.
+     *
+     * @param TNotification The type of notification associated with the command.
+     * @property command The command related to this no-op outcome, if any.
+     */
+    data class NoOperation<out TNotification : Notification>(
+        override val command: NotificationCommand<out TNotification>? = null,
+    ) : Success<TNotification> {
+        override val notificationId: NotificationId = NotificationId.Undefined
+    }
+}
+
+/**
+ * Convenience factory that wraps the given command in a [Success.Executed] instance.
+ */
+fun <TNotification : Notification> Success(
+    notificationId: NotificationId,
+    command: NotificationCommand<out TNotification>,
+): Success<TNotification> = Success.Executed(notificationId, command)
+
+/**
+ * Convenience factory that wraps the given command in a [Success.Executed] instance.
+ */
+@Discouraged(
+    message = "This is a utility function to enable usage in Java code. " +
+        "Use Success(NotificationId, NotificationCommand) instead.",
+)
+fun <TNotification : Notification> Success(
+    notificationId: Int,
+    command: NotificationCommand<out TNotification>,
+): Success<TNotification> = Success.Executed(NotificationId(notificationId), command)
+
+/**
+ * Represents a failed command execution.
+ *
+ * @param TNotification The type of notification associated with the command.
+ * @property command The command that failed.
+ */
+sealed interface Failure<out TNotification : Notification> {
+    val command: NotificationCommand<out TNotification>?
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/outcome/UnsupportedCommand.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/command/outcome/UnsupportedCommand.kt
@@ -1,0 +1,42 @@
+package net.thunderbird.feature.notification.api.command.outcome
+
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.feature.notification.api.command.NotificationCommand
+import net.thunderbird.feature.notification.api.content.Notification
+
+/**
+ * Represents a command that cannot be executed because it is not supported in the current context.
+ *
+ * Typical reasons include disabled feature flags or an unknown/unsupported command on the
+ * current platform or build variant.
+ *
+ * @param TNotification The type of notification associated with the command.
+ * @property command The command that was deemed unsupported. May be null when the unsupported
+ *                   state is determined before a concrete command instance is created.
+ * @property reason The specific reason why the command is not supported.
+ */
+data class UnsupportedCommand<out TNotification : Notification>(
+    override val command: NotificationCommand<out TNotification>?,
+    val reason: Reason,
+) : Failure<TNotification> {
+
+    /**
+     * Describes why a command is unsupported.
+     */
+    sealed interface Reason {
+        /**
+         * The command is behind a feature flag that is currently disabled.
+         *
+         * @property key The feature flag key that disabled this command.
+         */
+        data class FeatureFlagDisabled(val key: FeatureFlagKey) : Reason
+
+        /**
+         * A generic, unknown reason for an unsupported command.
+         *
+         * @property message A human-readable description of the issue.
+         * @property throwable An optional underlying exception that provides more context.
+         */
+        data class Unknown(val message: String, val throwable: Throwable? = null) : Reason
+    }
+}

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/dismisser/NotificationDismisser.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/dismisser/NotificationDismisser.kt
@@ -3,8 +3,9 @@ package net.thunderbird.feature.notification.api.dismisser
 import kotlinx.coroutines.flow.Flow
 import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.NotificationId
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.command.outcome.Failure
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
+import net.thunderbird.feature.notification.api.command.outcome.Success
 import net.thunderbird.feature.notification.api.content.Notification
 
 /**
@@ -18,7 +19,7 @@ interface NotificationDismisser {
      * @return A [Flow] of [Outcome] that emits either a [Success] with the dismissed [Notification]
      * or a [Failure] with the [Notification] that failed to be dismissed.
      */
-    fun dismiss(id: NotificationId): Flow<Outcome<Success<Notification>, Failure<Notification>>>
+    fun dismiss(id: NotificationId): Flow<NotificationCommandOutcome<Notification>>
 
     /**
      * Dismisses a notification.
@@ -28,5 +29,5 @@ interface NotificationDismisser {
      * The [Outcome] will be a [Success] containing the dismissed [Notification] if the operation was successful,
      * or a [Failure] containing the [Notification] if the operation failed.
      */
-    fun dismiss(notification: Notification): Flow<Outcome<Success<Notification>, Failure<Notification>>>
+    fun dismiss(notification: Notification): Flow<NotificationCommandOutcome<Notification>>
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/dismisser/compat/NotificationDismisserCompat.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/dismisser/compat/NotificationDismisserCompat.kt
@@ -9,9 +9,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import net.thunderbird.core.outcome.Outcome
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.dismisser.NotificationDismisser
 
@@ -45,6 +43,6 @@ class NotificationDismisserCompat @JvmOverloads constructor(
     }
 
     fun interface OnResultListener {
-        fun onResult(outcome: Outcome<Success<Notification>, Failure<Notification>>)
+        fun onResult(outcome: NotificationCommandOutcome<Notification>)
     }
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/sender/NotificationSender.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/sender/NotificationSender.kt
@@ -1,10 +1,8 @@
 package net.thunderbird.feature.notification.api.sender
 
 import kotlinx.coroutines.flow.Flow
-import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.command.NotificationCommand
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
 import net.thunderbird.feature.notification.api.content.Notification
 
 /**
@@ -15,7 +13,7 @@ fun interface NotificationSender {
      * Sends a notification by creating and executing the appropriate commands.
      *
      * @param notification The [Notification] to be sent.
-     * @return A [Flow] that emits the [NotificationCommand.CommandOutcome] for each executed command.
+     * @return A [Flow] that emits the [NotificationCommand] for each executed command.
      */
-    fun send(notification: Notification): Flow<Outcome<Success<Notification>, Failure<Notification>>>
+    fun send(notification: Notification): Flow<NotificationCommandOutcome<Notification>>
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompat.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompat.kt
@@ -9,9 +9,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import net.thunderbird.core.outcome.Outcome
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.sender.NotificationSender
 
@@ -45,6 +43,6 @@ class NotificationSenderCompat @JvmOverloads constructor(
     }
 
     fun interface OnResultListener {
-        fun onResult(outcome: Outcome<Success<Notification>, Failure<Notification>>)
+        fun onResult(outcome: NotificationCommandOutcome<Notification>)
     }
 }

--- a/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompatTest.kt
+++ b/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompatTest.kt
@@ -11,9 +11,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.NotificationId
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
 import net.thunderbird.feature.notification.api.command.NotificationCommandException
+import net.thunderbird.feature.notification.api.command.outcome.CommandExecutionFailed
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
+import net.thunderbird.feature.notification.api.command.outcome.Success
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.testing.fake.FakeNotification
 import net.thunderbird.feature.notification.testing.fake.command.FakeInAppNotificationCommand
@@ -25,18 +26,18 @@ class NotificationSenderCompatTest {
     @Test
     fun `send should call listener callback whenever a result is received`() {
         // Arrange
-        val expectedResults = listOf<Outcome<Success<Notification>, Failure<Notification>>>(
+        val expectedResults = listOf<NotificationCommandOutcome<Notification>>(
             Outcome.success(Success(NotificationId(1), FakeInAppNotificationCommand())),
-            Outcome.success(Success(NotificationId(2), FakeSystemNotificationCommand())),
+            Outcome.success(Success(NotificationId(1), FakeSystemNotificationCommand())),
             Outcome.failure(
-                error = Failure(
+                error = CommandExecutionFailed(
                     command = FakeSystemNotificationCommand(),
                     throwable = NotificationCommandException("What an issue?"),
                 ),
             ),
         )
         val sender = FakeNotificationSender(results = expectedResults)
-        val actualResults = mutableListOf<Outcome<Success<Notification>, Failure<Notification>>>()
+        val actualResults = mutableListOf<NotificationCommandOutcome<Notification>>()
         val listener = spy(
             NotificationSenderCompat.OnResultListener { outcome ->
                 actualResults += outcome

--- a/feature/notification/api/src/jvmTest/java/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompatJavaTest.java
+++ b/feature/notification/api/src/jvmTest/java/net/thunderbird/feature/notification/api/sender/compat/NotificationSenderCompatJavaTest.java
@@ -9,9 +9,11 @@ import kotlinx.coroutines.test.TestCoroutineDispatchersKt;
 import kotlinx.coroutines.test.TestDispatcher;
 import kotlinx.coroutines.test.TestDispatchers;
 import net.thunderbird.core.outcome.Outcome;
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure;
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success;
 import net.thunderbird.feature.notification.api.command.NotificationCommandException;
+import net.thunderbird.feature.notification.api.command.outcome.CommandExecutionFailed;
+import net.thunderbird.feature.notification.api.command.outcome.Failure;
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome;
+import net.thunderbird.feature.notification.api.command.outcome.Success;
 import net.thunderbird.feature.notification.api.content.Notification;
 import net.thunderbird.feature.notification.testing.fake.FakeNotification;
 import net.thunderbird.feature.notification.testing.fake.command.FakeInAppNotificationCommand;
@@ -53,11 +55,12 @@ public class NotificationSenderCompatJavaTest {
                 ? extends @NotNull Failure<? extends @NotNull Notification>
                 >
             > expectedResults = List.of(
-            Outcome.Companion.success(Success.Companion.invoke(1, new FakeInAppNotificationCommand())),
-            Outcome.Companion.success(Success.Companion.invoke(2, new FakeSystemNotificationCommand())),
+            Outcome.Companion.success(NotificationCommandOutcome.Success(1, new FakeInAppNotificationCommand())),
+            Outcome.Companion.success(NotificationCommandOutcome.Success(2, new FakeSystemNotificationCommand())),
             Outcome.Companion.failure(
-                new Failure<>(
+                new CommandExecutionFailed<>(
                     new FakeSystemNotificationCommand(),
+                    "What an issue?",
                     new NotificationCommandException("What an issue?")
                 )
             )

--- a/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/DismissSystemNotificationCommand.kt
+++ b/feature/notification/impl/src/commonMain/kotlin/net/thunderbird/feature/notification/impl/command/DismissSystemNotificationCommand.kt
@@ -10,9 +10,9 @@ import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 private const val TAG = "DismissSystemNotificationCommand"
 
 class DismissSystemNotificationCommand(
-    private val logger: Logger,
-    private val featureFlagProvider: FeatureFlagProvider,
-    private val notificationRegistry: NotificationRegistry,
+    logger: Logger,
+    featureFlagProvider: FeatureFlagProvider,
+    notificationRegistry: NotificationRegistry,
     notification: SystemNotification,
     notifier: NotificationNotifier<SystemNotification>,
 ) : DismissNotificationCommand<SystemNotification>(

--- a/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/DisplayInAppNotificationCommandTest.kt
+++ b/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/DisplayInAppNotificationCommandTest.kt
@@ -2,7 +2,6 @@ package net.thunderbird.feature.notification.impl.command
 
 import assertk.all
 import assertk.assertThat
-import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
@@ -19,9 +18,8 @@ import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.NotificationRegistry
 import net.thunderbird.feature.notification.api.NotificationSeverity
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
-import net.thunderbird.feature.notification.api.command.NotificationCommandException
+import net.thunderbird.feature.notification.api.command.outcome.Success
+import net.thunderbird.feature.notification.api.command.outcome.UnsupportedCommand
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 import net.thunderbird.feature.notification.testing.fake.FakeNotification
@@ -47,18 +45,16 @@ class DisplayInAppNotificationCommandTest {
             val outcome = testSubject.execute()
 
             // Assert
-
             assertThat(outcome)
-                .isInstanceOf<Outcome.Failure<Failure<InAppNotification>>>()
+                .isInstanceOf<Outcome.Failure<UnsupportedCommand<InAppNotification>>>()
                 .prop("error") { it.error }
                 .all {
-                    prop(Failure<InAppNotification>::command)
+                    prop(UnsupportedCommand<InAppNotification>::command)
                         .isEqualTo(testSubject)
-                    prop(Failure<InAppNotification>::throwable)
-                        .isInstanceOf<NotificationCommandException>()
-                        .hasMessage(
-                            "${FeatureFlagKey.DisplayInAppNotifications.key} feature flag is not enabled",
-                        )
+                    prop(UnsupportedCommand<InAppNotification>::reason)
+                        .isInstanceOf<UnsupportedCommand.Reason.FeatureFlagDisabled>()
+                        .prop(UnsupportedCommand.Reason.FeatureFlagDisabled::key)
+                        .isEqualTo(FeatureFlagKey.DisplayInAppNotifications)
                 }
         }
 
@@ -80,16 +76,15 @@ class DisplayInAppNotificationCommandTest {
 
             // Assert
             assertThat(outcome)
-                .isInstanceOf<Outcome.Failure<Failure<InAppNotification>>>()
+                .isInstanceOf<Outcome.Failure<UnsupportedCommand<InAppNotification>>>()
                 .prop("error") { it.error }
                 .all {
-                    prop(Failure<InAppNotification>::command)
+                    prop(UnsupportedCommand<InAppNotification>::command)
                         .isEqualTo(testSubject)
-                    prop(Failure<InAppNotification>::throwable)
-                        .isInstanceOf<NotificationCommandException>()
-                        .hasMessage(
-                            "${FeatureFlagKey.DisplayInAppNotifications.key} feature flag is not enabled",
-                        )
+                    prop(UnsupportedCommand<InAppNotification>::reason)
+                        .isInstanceOf<UnsupportedCommand.Reason.FeatureFlagDisabled>()
+                        .prop(UnsupportedCommand.Reason.FeatureFlagDisabled::key)
+                        .isEqualTo(FeatureFlagKey.DisplayInAppNotifications)
                 }
         }
 

--- a/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/DisplaySystemNotificationCommandTest.kt
+++ b/feature/notification/impl/src/commonTest/kotlin/net/thunderbird/feature/notification/impl/command/DisplaySystemNotificationCommandTest.kt
@@ -2,7 +2,6 @@ package net.thunderbird.feature.notification.impl.command
 
 import assertk.all
 import assertk.assertThat
-import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
@@ -20,9 +19,9 @@ import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.NotificationId
 import net.thunderbird.feature.notification.api.NotificationRegistry
 import net.thunderbird.feature.notification.api.NotificationSeverity
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
-import net.thunderbird.feature.notification.api.command.NotificationCommandException
+import net.thunderbird.feature.notification.api.command.outcome.CommandExecutionFailed
+import net.thunderbird.feature.notification.api.command.outcome.Success
+import net.thunderbird.feature.notification.api.command.outcome.UnsupportedCommand
 import net.thunderbird.feature.notification.api.content.SystemNotification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 import net.thunderbird.feature.notification.testing.fake.FakeNotification
@@ -48,19 +47,16 @@ class DisplaySystemNotificationCommandTest {
             val outcome = testSubject.execute()
 
             // Assert
-
             assertThat(outcome)
-                .isInstanceOf<Outcome.Failure<Failure<SystemNotification>>>()
+                .isInstanceOf<Outcome.Failure<UnsupportedCommand<SystemNotification>>>()
                 .prop("error") { it.error }
                 .all {
-                    prop(Failure<SystemNotification>::command)
+                    prop(UnsupportedCommand<SystemNotification>::command)
                         .isEqualTo(testSubject)
-                    prop(Failure<SystemNotification>::throwable)
-                        .isInstanceOf<NotificationCommandException>()
-                        .hasMessage(
-                            "${FeatureFlagKey.UseNotificationSenderForSystemNotifications.key} feature flag" +
-                                "is not enabled",
-                        )
+                    prop(UnsupportedCommand<SystemNotification>::reason)
+                        .isInstanceOf<UnsupportedCommand.Reason.FeatureFlagDisabled>()
+                        .prop(UnsupportedCommand.Reason.FeatureFlagDisabled::key)
+                        .isEqualTo(FeatureFlagKey.UseNotificationSenderForSystemNotifications)
                 }
         }
 
@@ -82,17 +78,15 @@ class DisplaySystemNotificationCommandTest {
 
             // Assert
             assertThat(outcome)
-                .isInstanceOf<Outcome.Failure<Failure<SystemNotification>>>()
+                .isInstanceOf<Outcome.Failure<UnsupportedCommand<SystemNotification>>>()
                 .prop("error") { it.error }
                 .all {
-                    prop(Failure<SystemNotification>::command)
+                    prop(UnsupportedCommand<SystemNotification>::command)
                         .isEqualTo(testSubject)
-                    prop(Failure<SystemNotification>::throwable)
-                        .isInstanceOf<NotificationCommandException>()
-                        .hasMessage(
-                            "${FeatureFlagKey.UseNotificationSenderForSystemNotifications.key} feature flag" +
-                                "is not enabled",
-                        )
+                    prop(UnsupportedCommand<SystemNotification>::reason)
+                        .isInstanceOf<UnsupportedCommand.Reason.FeatureFlagDisabled>()
+                        .prop(UnsupportedCommand.Reason.FeatureFlagDisabled::key)
+                        .isEqualTo(FeatureFlagKey.UseNotificationSenderForSystemNotifications)
                 }
         }
 
@@ -114,14 +108,11 @@ class DisplaySystemNotificationCommandTest {
 
             // Assert
             assertThat(outcome)
-                .isInstanceOf<Outcome.Failure<Failure<SystemNotification>>>()
+                .isInstanceOf<Outcome.Failure<CommandExecutionFailed<SystemNotification>>>()
                 .prop("error") { it.error }
                 .all {
-                    prop(Failure<SystemNotification>::command)
+                    prop(CommandExecutionFailed<SystemNotification>::command)
                         .isEqualTo(testSubject)
-                    prop(Failure<SystemNotification>::throwable)
-                        .isInstanceOf<NotificationCommandException>()
-                        .hasMessage("Can't execute command.")
                 }
         }
 

--- a/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/FakeNotificationManager.kt
+++ b/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/FakeNotificationManager.kt
@@ -2,30 +2,25 @@ package net.thunderbird.feature.notification.testing.fake
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.NotificationId
 import net.thunderbird.feature.notification.api.NotificationManager
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
 import net.thunderbird.feature.notification.api.content.Notification
 
 open class FakeNotificationManager(
-    private val emitOnSend: (notification: Notification) -> Outcome<Success<Notification>, Failure<Notification>>,
-    private val emitOnDismissNotification: (notification: Notification) -> Outcome<
-        Success<Notification>,
-        Failure<Notification>,
-        >,
-    private val emitOnDismissId: (id: NotificationId) -> Outcome<Success<Notification>, Failure<Notification>>,
+    private val emitOnSend: (notification: Notification) -> NotificationCommandOutcome<Notification>,
+    private val emitOnDismissNotification: (notification: Notification) -> NotificationCommandOutcome<Notification>,
+    private val emitOnDismissId: (id: NotificationId) -> NotificationCommandOutcome<Notification>,
 ) : NotificationManager {
-    override fun send(notification: Notification): Flow<Outcome<Success<Notification>, Failure<Notification>>> = flow {
+    override fun send(notification: Notification): Flow<NotificationCommandOutcome<Notification>> = flow {
         emit(emitOnSend(notification))
     }
 
-    override fun dismiss(id: NotificationId): Flow<Outcome<Success<Notification>, Failure<Notification>>> = flow {
+    override fun dismiss(id: NotificationId): Flow<NotificationCommandOutcome<Notification>> = flow {
         emit(emitOnDismissId(id))
     }
 
-    override fun dismiss(notification: Notification): Flow<Outcome<Success<Notification>, Failure<Notification>>> =
+    override fun dismiss(notification: Notification): Flow<NotificationCommandOutcome<Notification>> =
         flow {
             emit(emitOnDismissNotification(notification))
         }

--- a/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/command/FakeInAppNotificationCommand.kt
+++ b/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/command/FakeInAppNotificationCommand.kt
@@ -1,7 +1,7 @@
 package net.thunderbird.feature.notification.testing.fake.command
 
-import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.command.NotificationCommand
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 import net.thunderbird.feature.notification.testing.fake.FakeInAppOnlyNotification
@@ -11,6 +11,6 @@ class FakeInAppNotificationCommand(
     notification: InAppNotification = FakeInAppOnlyNotification(),
     notifier: NotificationNotifier<InAppNotification> = FakeInAppNotificationNotifier(),
 ) : NotificationCommand<InAppNotification>(notification, notifier) {
-    override suspend fun execute(): Outcome<Success<InAppNotification>, Failure<InAppNotification>> =
+    override suspend fun execute(): NotificationCommandOutcome<InAppNotification> =
         error("not implemented")
 }

--- a/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/command/FakeSystemNotificationCommand.kt
+++ b/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/command/FakeSystemNotificationCommand.kt
@@ -1,7 +1,7 @@
 package net.thunderbird.feature.notification.testing.fake.command
 
-import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.notification.api.command.NotificationCommand
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
 import net.thunderbird.feature.notification.api.content.SystemNotification
 import net.thunderbird.feature.notification.api.receiver.NotificationNotifier
 import net.thunderbird.feature.notification.testing.fake.FakeSystemOnlyNotification
@@ -11,6 +11,6 @@ class FakeSystemNotificationCommand(
     notification: SystemNotification = FakeSystemOnlyNotification(),
     notifier: NotificationNotifier<SystemNotification> = FakeSystemNotificationNotifier(),
 ) : NotificationCommand<SystemNotification>(notification, notifier) {
-    override suspend fun execute(): Outcome<Success<SystemNotification>, Failure<SystemNotification>> =
+    override suspend fun execute(): NotificationCommandOutcome<SystemNotification> =
         error("not implemented")
 }

--- a/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/sender/FakeNotificationSender.kt
+++ b/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/sender/FakeNotificationSender.kt
@@ -2,15 +2,13 @@ package net.thunderbird.feature.notification.testing.fake.sender
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import net.thunderbird.core.outcome.Outcome
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Failure
-import net.thunderbird.feature.notification.api.command.NotificationCommand.Success
+import net.thunderbird.feature.notification.api.command.outcome.NotificationCommandOutcome
 import net.thunderbird.feature.notification.api.content.Notification
 import net.thunderbird.feature.notification.api.sender.NotificationSender
 
 class FakeNotificationSender(
-    private val results: List<Outcome<Success<Notification>, Failure<Notification>>>,
+    private val results: List<NotificationCommandOutcome<Notification>>,
 ) : NotificationSender {
-    override fun send(notification: Notification): Flow<Outcome<Success<Notification>, Failure<Notification>>> =
+    override fun send(notification: Notification): Flow<NotificationCommandOutcome<Notification>> =
         results.asFlow()
 }


### PR DESCRIPTION
Resolve #9626.

This PR simplifies the Notification Command Outcome API