### PR TITLE
chore(ci): Bump Max Version Code for Beta/Release

### DIFF
--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -274,10 +274,10 @@ jobs:
             NEW_VERSION_CODE=$(($OLD_VERSION_CODE + 1))
             if [[ "$APP_NAME" = "thunderbird" ]]; then
                 # Estimated max version code to get through 2025 is "30"
-                MAX_VERSION_CODE="30"
+                MAX_VERSION_CODE="52"
             else
                 # Estimated max version code to get through 2025 is "39037"
-                MAX_VERSION_CODE="39037"
+                MAX_VERSION_CODE="39059"
             fi
           elif [[ "$RELEASE_TYPE" = "daily" ]]; then
             NEW_VERSION_CODE=$(date_version_code "$RELEASE_DATE")


### PR DESCRIPTION
Bumps MAX_VERSION_CODE for Beta/Release to give us enough room to finish out this year
