### PR TITLE
feat(imap): add remaining utf8 bits

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/Address.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Address.java
@@ -74,7 +74,7 @@ public class Address implements Serializable {
                 Log.e("Invalid address: %s", address);
             }
         } else {
-            mAddress = address;
+            mAddress = Rfc822Token.withULabelDomain(address);
             mPersonal = personal;
         }
     }

--- a/mail/common/src/main/java/com/fsck/k9/mail/helper/Rfc822Token.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/helper/Rfc822Token.java
@@ -205,6 +205,7 @@ public class Rfc822Token {
     }
 
     public static String withULabelDomain(final String address) {
+        if (address == null) return null;
         int at = address.lastIndexOf('@');
         if (at < 0 || at == address.length()-1)
             return address;

--- a/mail/common/src/main/java/com/fsck/k9/mail/helper/Rfc822Token.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/helper/Rfc822Token.java
@@ -204,7 +204,8 @@ public class Rfc822Token {
                 stringEquals(mComment, other.mComment));
     }
 
-    public static String withULabelDomain(final String address) {
+    @Nullable
+    public static String withULabelDomain(@Nullable final String address) {
         if (address == null) return null;
         int at = address.lastIndexOf('@');
         if (at < 0 || at == address.length()-1)

--- a/mail/common/src/main/java/com/fsck/k9/mail/helper/Rfc822Token.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/helper/Rfc822Token.java
@@ -17,6 +17,7 @@
 package com.fsck.k9.mail.helper;
 
 
+import java.net.IDN;
 import org.jetbrains.annotations.Nullable;
 
 
@@ -34,7 +35,7 @@ public class Rfc822Token {
      */
     public Rfc822Token(@Nullable String name, @Nullable String address, @Nullable String comment) {
         mName = name;
-        mAddress = address;
+        mAddress = withULabelDomain(address);
         mComment = comment;
     }
 
@@ -73,7 +74,7 @@ public class Rfc822Token {
      * Changes the address to the specified address.
      */
     public void setAddress(@Nullable String address) {
-        mAddress = address;
+        mAddress = withULabelDomain(address);
     }
 
     /**
@@ -201,5 +202,13 @@ public class Rfc822Token {
         return (stringEquals(mName, other.mName) &&
                 stringEquals(mAddress, other.mAddress) &&
                 stringEquals(mComment, other.mComment));
+    }
+
+    public static String withULabelDomain(final String address) {
+        int at = address.lastIndexOf('@');
+        if (at < 0 || at == address.length()-1)
+            return address;
+        return address.substring(0, at+1) +
+            IDN.toUnicode(address.substring(at+1), IDN.ALLOW_UNASSIGNED);
     }
 }

--- a/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
@@ -66,6 +66,7 @@ public class AddressTest {
                 "example@s.solutions",
                 "user@com",
                 "user@localserver",
+                "user@orléans.example",
                 "user@[IPv6:2001:db8::1]"
         };
 

--- a/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
@@ -88,13 +88,30 @@ public class AddressTest {
     }
 
     @Test
+    public void construction_withALabel_shouldDecode() {
+        // Mutt and Exchange do this, and maybe Plesk too. Best fix it
+        // at the earliest opportinity.
+        Address a = new Address("grå@xn--gr-zia.org", "Grå katt");
+
+        assertEquals("Grå katt", a.getPersonal());
+        assertEquals("grå@grå.org", a.getAddress());
+    }
+
+    @Test
     public void parse_withQuotedEncodedPersonal_shouldDecode() {
         Address[] addresses = Address.parse(
                 "\"=?UTF-8?B?WWFob28h44OA44Kk44Os44Kv44OI44Kq44OV44Kh44O8?= \"<directoffer-master@mail.yahoo.co.jp>");
 
         assertEquals("Yahoo!ダイレクトオファー ", addresses[0].getPersonal());
         assertEquals("directoffer-master@mail.yahoo.co.jp", addresses[0].getAddress());
+    }
 
+
+    @Test
+    public void parse_withALabel_shouldDecode() {
+        Address[] addresses = Address.parse("info@xn--gr-zia.org");
+        assertEquals(1, addresses.length);
+        assertEquals("info@grå.org", addresses[0].getAddress());
     }
 
     /**


### PR DESCRIPTION
This contains two changes that build on the earlier EAI work and completes the feature.

- MIME4J needed a parser improvement and new release; without that, Thunderbird would show "unknown sender" for some messages. With 0.8.13 it now shows the correct address. Sorry about the lateness; I overlooked the release of 0.8.13.
- Addresses such as example@zn--gr-zia.example are legal according to the syntax, because the syntax extends rather than narrows RFC5322. However, these addresses are incomprehensible to users, cause questions and even complaints, and are best rewritten to the human-readable form before reaching anyone's screen.