### PR TITLE
chore: update "retrieve logs" link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -86,7 +86,7 @@ body:
     attributes:
       label: Logs
       description: |
-        Please take some time to [retrieve logs](https://github.com/thunderbird/thunderbird-android/wiki/LoggingErrors)
+        Please take some time to [retrieve logs](https://thunderbird.github.io/thunderbird-android/docs/latest/user-guide/troubleshooting/collecting-debug-logs.html)
         and attach them here.
 
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.


### PR DESCRIPTION
The current link in bug report issue template points to an old wiki page that has been removed. This has prevented some people from including logs in bug reports e.g. https://github.com/thunderbird/thunderbird-android/issues/10089.
