### PR TITLE
chore(ci): tweak merge script to have less conflicts and output to be more readable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,11 @@
 
 app-k9mail/build.gradle.kts merge=merge_gradle
 app-thunderbird/build.gradle.kts merge=merge_gradle
+
+app-thunderbird/src/release/res/raw/changelog_master.xml merge=ours
+app-thunderbird/src/beta/res/raw/changelog_master.xml merge=ours
 app-k9mail/src/main/res/raw/changelog_master.xml merge=ours
+
+app-metadata/com.fsck.k9/*/changelogs/** merge=ours
+app-metadata/net.thunderbird.android.beta/*/changelogs/** merge=ours
+app-metadata/net.thunderbird.android/*/changelogs/** merge=ours

--- a/scripts/ci/merges/do_merge.sh
+++ b/scripts/ci/merges/do_merge.sh
@@ -43,8 +43,9 @@ git checkout ${into_branch}
 git pull
 git config merge.ours.driver true
 git config merge.merge_gradle.driver "python3 scripts/ci/merges/merge_gradle.py %A %B"
+git config merge.merge_changelog.driver "scripts/ci/merges/merge_changelog.sh %A %O %B"
 set +e
-git merge "origin/${from_branch}"
+git merge -Xtheirs "origin/${from_branch}" 2>&1 | grep --color=always -E '\bCONFLICT\b|$'
 ret=$?
 set +x
 

--- a/scripts/ci/merges/merge_changelog.sh
+++ b/scripts/ci/merges/merge_changelog.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This merge driver exists to override the -Xtheirs CLI option used when merging
+# two trees together (e.g. main -> beta).
+
+A="$1"  # File A (ours)
+O="$2"  # Common ancestor
+B="$3"  # File B (theirs)
+
+git merge-file -- "$A" "$O" "$B"


### PR DESCRIPTION
This patch does two things:

Tells git to default to a "theirs" strategy when there are merge conflicts (i.e. in a main -> beta merge conflict, take the file from main).

Highlight "CONFLICT" in red, so it can be easily spotted in `git merge` output.
