### PR TITLE
chore(ci): Switch app-id to client-id

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/issue-needinfo-answered.yml
+++ b/.github/workflows/issue-needinfo-answered.yml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Remove answered label if both exist

--- a/.github/workflows/issue-needinfo-remove.yml
+++ b/.github/workflows/issue-needinfo-remove.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Remove needinfo label and add answered label

--- a/.github/workflows/issue-needinfo-stale.yml
+++ b/.github/workflows/issue-needinfo-stale.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Close old issues with the needinfo tag

--- a/.github/workflows/pr-auto-assign-reviewer.yml
+++ b/.github/workflows/pr-auto-assign-reviewer.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Assign reviewer to PR

--- a/.github/workflows/pr-dependabot-dependency-guard-update.yml
+++ b/.github/workflows/pr-dependabot-dependency-guard-update.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Checkout the repo

--- a/.github/workflows/pr-label-tb-team.yml
+++ b/.github/workflows/pr-label-tb-team.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Label tb-team for OWNER

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Get active milestone

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Uplift Approval Request

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -210,7 +210,7 @@ jobs:
         if: ${{ vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
@@ -749,7 +749,7 @@ jobs:
         if: ${{ contains(matrix.releaseTarget, 'github') && vars.BOT_CLIENT_ID }}
         id: app-token
         with:
-          app-id: ${{ vars.BOT_CLIENT_ID }}
+          client-id: ${{ vars.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
       - name: Publish to GitHub Releases


### PR DESCRIPTION
actions/create-github-app-token 3.1.1 deprecates app-id
https://github.com/thunderbird/thunderbird-android/pull/10869