### PR TITLE
fix(message-extractor): always convert text from html for previews

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -15,6 +15,7 @@ internal class PreviewTextExtractor {
 
         // Always converts from html, independently from mimetype
         val plainText = HtmlConverter.htmlToText(text)
+
         return stripTextForPreview(plainText)
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -40,7 +40,7 @@ internal class PreviewTextExtractor {
         intermediateText = intermediateText.replace("\\s*([-=_]{30,}+)\\s*".toRegex(), " ")
 
         // Remove parsed html links: <url>
-        intermediateText = intermediateText.replace("<https?://\\S+".toRegex(), " ")
+        intermediateText = intermediateText.replace("<https?://\\S+>".toRegex(), " ")
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview
         intermediateText = intermediateText.replace("https?://\\S+".toRegex(), "...")

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -39,8 +39,8 @@ internal class PreviewTextExtractor {
 
         // Always parse the text as HTML, independently of the mimetype
         intermediateText = HtmlConverter.htmlToText(intermediateText)
-        // Remove parsed HTML links/images "<url>"
-        intermediateText = intermediateText.replace("<https?://\\S+>".toRegex(), " ")
+        // Remove parsed HTML links/images "<url>", "( url )", "(url)", etc.
+        intermediateText = intermediateText.replace("[(<]\\s?https?://\\S+[^)>]\\s?[>)]".toRegex(), " ")
 
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -37,6 +37,11 @@ internal class PreviewTextExtractor {
         // Remove horizontal rules.
         intermediateText = intermediateText.replace("\\s*([-=_]{30,}+)\\s*".toRegex(), " ")
 
+        // Always parse the text as HTML, independently of the mimetype
+        intermediateText = HtmlConverter.htmlToText(intermediateText)
+        // Remove parsed HTML links/images "<url>", "( url )", "(url)", etc.
+        intermediateText = intermediateText.replace("[(<]\\s?https?://\\S+[^)>]\\s?[>)]".toRegex(), " ")
+
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview
         intermediateText = intermediateText.replace("https?://\\S+".toRegex(), "...")

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -13,7 +13,8 @@ internal class PreviewTextExtractor {
         val text = MessageExtractor.getTextFromPart(textPart, MAX_CHARACTERS_CHECKED_FOR_PREVIEW)
             ?: throw PreviewExtractionException("Couldn't get text from part")
 
-        val plainText = convertFromHtmlIfNecessary(textPart, text)
+        // Always converts from html, independently from mimetype
+        val plainText = HtmlConverter.htmlToText(text)
         return stripTextForPreview(plainText)
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -39,6 +39,8 @@ internal class PreviewTextExtractor {
         // Remove horizontal rules.
         intermediateText = intermediateText.replace("\\s*([-=_]{30,}+)\\s*".toRegex(), " ")
 
+        // Remove parsed html links: <url>
+        intermediateText = intermediateText.replace("<https?://\\S+".toRegex(), " ")
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview
         intermediateText = intermediateText.replace("https?://\\S+".toRegex(), "...")

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -41,6 +41,8 @@ internal class PreviewTextExtractor {
 
         // Remove parsed html links: <url>
         intermediateText = intermediateText.replace("<https?://\\S+>".toRegex(), " ")
+        // Remove ( url ) and (url)
+        intermediateText = intermediateText.replace("(\\s?https?://\\S+\\s?)".toRegex(), " ")
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview
         intermediateText = intermediateText.replace("https?://\\S+".toRegex(), "...")

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -41,8 +41,8 @@ internal class PreviewTextExtractor {
 
         // Remove parsed html links: <url>
         intermediateText = intermediateText.replace("<https?://\\S+>".toRegex(), " ")
-        // Remove ( url ) and (url)
-        intermediateText = intermediateText.replace("(\\s?https?://\\S+\\s?)".toRegex(), " ")
+        // Remove ( url )
+        intermediateText = intermediateText.replace("\\(https?://\\S+\\)".toRegex(), " ")
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview
         intermediateText = intermediateText.replace("https?://\\S+".toRegex(), "...")

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -13,9 +13,7 @@ internal class PreviewTextExtractor {
         val text = MessageExtractor.getTextFromPart(textPart, MAX_CHARACTERS_CHECKED_FOR_PREVIEW)
             ?: throw PreviewExtractionException("Couldn't get text from part")
 
-        // Always converts from html, independently from mimetype
-        val plainText = HtmlConverter.htmlToText(text)
-
+        val plainText = convertFromHtmlIfNecessary(textPart, text)
         return stripTextForPreview(plainText)
     }
 
@@ -39,10 +37,11 @@ internal class PreviewTextExtractor {
         // Remove horizontal rules.
         intermediateText = intermediateText.replace("\\s*([-=_]{30,}+)\\s*".toRegex(), " ")
 
-        // Remove parsed html links: <url>
+        // Always parse the text as HTML, independently of the mimetype
+        intermediateText = HtmlConverter.htmlToText(intermediateText)
+        // Remove parsed HTML links/images "<url>"
         intermediateText = intermediateText.replace("<https?://\\S+>".toRegex(), " ")
-        // Remove ( url )
-        intermediateText = intermediateText.replace("\\( https?://\\S+ \\)".toRegex(), " ")
+
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview
         intermediateText = intermediateText.replace("https?://\\S+".toRegex(), "...")

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -42,7 +42,7 @@ internal class PreviewTextExtractor {
         // Remove parsed html links: <url>
         intermediateText = intermediateText.replace("<https?://\\S+>".toRegex(), " ")
         // Remove ( url )
-        intermediateText = intermediateText.replace("\\(https?://\\S+\\)".toRegex(), " ")
+        intermediateText = intermediateText.replace("\\( https?://\\S+ \\)".toRegex(), " ")
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview
         intermediateText = intermediateText.replace("https?://\\S+".toRegex(), "...")

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -7,6 +7,7 @@ import com.fsck.k9.message.html.EmailSection
 import com.fsck.k9.message.html.EmailSectionExtractor
 import com.fsck.k9.message.html.HtmlConverter
 
+@Suppress("TooManyFunctions")
 internal class PreviewTextExtractor {
     @Throws(PreviewExtractionException::class)
     fun extractPreview(textPart: Part): String {
@@ -32,18 +33,13 @@ internal class PreviewTextExtractor {
         intermediateText = stripSignature(intermediateText)
         intermediateText = extractUnquotedText(intermediateText)
 
-        // try to remove lines of dashes in the preview
-        intermediateText = intermediateText.replace("(?m)^----.*?$".toRegex(), "")
-        // Remove horizontal rules.
-        intermediateText = intermediateText.replace("\\s*([-=_]{30,}+)\\s*".toRegex(), " ")
-
+        // Run line-based cleanup before HTML normalization, so that we don't remove line breaks in HTML
+        intermediateText = stripLineBasedArtifacts(intermediateText)
         // Always parse the text as HTML, independently of the mimetype
         intermediateText = HtmlConverter.htmlToText(intermediateText)
-        // Remove parsed HTML links/images "<url>", "( url )", "(url)", etc.
-        intermediateText = intermediateText.replace("[(<]\\s?https?://\\S+[^)>]\\s?[>)]".toRegex(), " ")
-
-        // Remove invisible formatting characters that can otherwise dominate previews.
-        intermediateText = intermediateText.replace("[\\u034F\\u200B-\\u200D\\uFEFF]".toRegex(), "")
+        intermediateText = stripLineBasedArtifacts(intermediateText)
+        intermediateText = removeParsedHtmlUrls(intermediateText)
+        intermediateText = removeInvisibleFormattingCharacters(intermediateText)
 
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview
@@ -60,6 +56,45 @@ internal class PreviewTextExtractor {
         } else {
             intermediateText
         }
+    }
+
+    private fun stripLineBasedArtifacts(text: String): String {
+        var strippedText = text
+
+        strippedText = stripForwardedMessageMetadata(strippedText)
+        strippedText = stripDashLines(strippedText)
+        strippedText = stripHorizontalRules(strippedText)
+
+        return strippedText
+    }
+
+    private fun stripForwardedMessageMetadata(text: String): String {
+        return REGEX_FORWARDED_MESSAGE_HEADER_BLOCK.replace(text) { matchResult ->
+            val hasContentBefore = text.substring(0, matchResult.range.first).isNotBlank()
+            val hasContentAfter = text.substring(matchResult.range.last + 1).isNotBlank()
+
+            if (hasContentBefore && hasContentAfter) {
+                " $PREVIEW_SECTION_SEPARATOR "
+            } else {
+                " "
+            }
+        }
+    }
+
+    private fun stripDashLines(text: String): String {
+        return text.replace(REGEX_DASH_LINE, "")
+    }
+
+    private fun stripHorizontalRules(text: String): String {
+        return text.replace(REGEX_HORIZONTAL_RULE, " ")
+    }
+
+    private fun removeParsedHtmlUrls(text: String): String {
+        return text.replace(REGEX_PARSED_HTML_URL, " ")
+    }
+
+    private fun removeInvisibleFormattingCharacters(text: String): String {
+        return text.replace(REGEX_INVISIBLE_FORMATTING_CHARACTERS, "")
     }
 
     private fun normalizeLineBreaks(text: String) = text.replace(REGEX_CRLF, "\n")
@@ -129,7 +164,17 @@ internal class PreviewTextExtractor {
     companion object {
         private const val MAX_PREVIEW_LENGTH = 512
         private const val MAX_CHARACTERS_CHECKED_FOR_PREVIEW = 8192L
+        private const val PREVIEW_SECTION_SEPARATOR = "[…]"
 
         private val REGEX_CRLF = "(\\r\\n|\\r)".toRegex()
+        private val REGEX_DASH_LINE = "(?m)^-{4,}\\s*$".toRegex()
+        private val REGEX_HORIZONTAL_RULE = "\\s*([-=_]{30,}+)\\s*".toRegex()
+        private val REGEX_PARSED_HTML_URL = "[(<]\\s?https?://\\S+[^)>]\\s?[>)]".toRegex()
+        private val REGEX_INVISIBLE_FORMATTING_CHARACTERS = "[\\u034F\\u200B-\\u200D\\uFEFF]".toRegex()
+        private val REGEX_FORWARDED_MESSAGE_HEADER_BLOCK = (
+            "(?im)^[\\t -]*Original Message[\\t -]*\\n" +
+                "(?:[\\t ]*[A-Za-z][A-Za-z-]*:.*\\n)+" +
+                "[\\t ]*\\n?"
+            ).toRegex()
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -14,19 +14,19 @@ internal class PreviewTextExtractor {
         val text = MessageExtractor.getTextFromPart(textPart, MAX_CHARACTERS_CHECKED_FOR_PREVIEW)
             ?: throw PreviewExtractionException("Couldn't get text from part")
 
-        val plainText = convertFromHtmlIfNecessary(textPart, text)
-        return stripTextForPreview(plainText)
+        val (plainText, parsePlainTextAsHtml) = convertFromHtmlIfNecessary(textPart, text)
+        return stripTextForPreview(plainText, parsePlainTextAsHtml)
     }
 
-    private fun convertFromHtmlIfNecessary(textPart: Part, text: String): String {
+    private fun convertFromHtmlIfNecessary(textPart: Part, text: String): Pair<String, Boolean> {
         return if (isSameMimeType(textPart.mimeType, "text/html")) {
-            HtmlConverter.htmlToText(text)
+            HtmlConverter.htmlToText(text) to false
         } else {
-            text
+            text to true
         }
     }
 
-    private fun stripTextForPreview(text: String): String {
+    private fun stripTextForPreview(text: String, parsePlainTextAsHtml: Boolean): String {
         var intermediateText = text
 
         intermediateText = normalizeLineBreaks(intermediateText)
@@ -35,9 +35,11 @@ internal class PreviewTextExtractor {
 
         // Run line-based cleanup before HTML normalization, so that we don't remove line breaks in HTML
         intermediateText = stripLineBasedArtifacts(intermediateText)
-        // Always parse the text as HTML, independently of the mimetype
-        intermediateText = HtmlConverter.htmlToText(intermediateText)
-        intermediateText = stripLineBasedArtifacts(intermediateText)
+        // Always parse the text as HTML if it's plaintext, independently of the mimetype
+        if (parsePlainTextAsHtml) {
+            intermediateText = HtmlConverter.htmlToText(intermediateText)
+            intermediateText = stripLineBasedArtifacts(intermediateText)
+        }
         intermediateText = removeParsedHtmlUrls(intermediateText)
         intermediateText = removeInvisibleFormattingCharacters(intermediateText)
 

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -42,6 +42,9 @@ internal class PreviewTextExtractor {
         // Remove parsed HTML links/images "<url>", "( url )", "(url)", etc.
         intermediateText = intermediateText.replace("[(<]\\s?https?://\\S+[^)>]\\s?[>)]".toRegex(), " ")
 
+        // Remove invisible formatting characters that can otherwise dominate previews.
+        intermediateText = intermediateText.replace("[\\u034F\\u200B-\\u200D\\uFEFF]".toRegex(), "")
+
         // URLs in the preview should just be shown as "..." - They're not
         // clickable and they usually overwhelm the preview
         intermediateText = intermediateText.replace("https?://\\S+".toRegex(), "...")

--- a/legacy/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
@@ -223,6 +223,52 @@ class PreviewTextExtractorTest {
     }
 
     @Test
+    fun extractPreview_forwardedMessage() {
+        val text =
+            """
+            |Here is the forwarded message:
+            |
+            |-----Original Message-----
+            |From: alice@example.com
+            |Sent: Monday, January 1, 2024 10:00 AM
+            |To: bob@example.com
+            |Subject: Hello
+            |
+            |This is the original content.
+            """.trimMargin()
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("Here is the forwarded message: […] This is the original content.")
+    }
+
+    @Test
+    fun extractPreview_withHtmlForwardedMessageAsTextPlain() {
+        val text =
+            """
+            |<html>
+            |<body>
+            |Here is the forwarded message:<br>
+            |<br>
+            |-----Original Message-----<br>
+            |From: alice@example.com<br>
+            |Sent: Monday, January 1, 2024 10:00 AM<br>
+            |To: bob@example.com<br>
+            |Subject: Hello<br>
+            |<br>
+            |This is the original content.
+            |</body>
+            |</html>
+            """.trimMargin()
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("Here is the forwarded message: […] This is the original content.")
+    }
+
+    @Test
     fun extractPreview_shouldCollapseAndTrimWhitespace() {
         val text = " whitespace     is\t\tfun  "
         val part = MessageCreationHelper.createTextPart("text/plain", text)

--- a/legacy/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
@@ -183,6 +183,26 @@ class PreviewTextExtractorTest {
     }
 
     @Test
+    fun extractPreview_withZeroWidthCharacters_shouldRemoveThem() {
+        val text = "Actual\u034F\u200C\u200C\u200C preview text"
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("Actual preview text")
+    }
+
+    @Test
+    fun extractPreview_withZeroWidthHtmlEntities_shouldRemoveThem() {
+        val text = "Actual &#847;&#847; preview text"
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("Actual preview text")
+    }
+
+    @Test
     fun extractPreview_withParsedHtmlLink_shouldRemoveUrl() {
         val text = """read <a href="https://thunderbird.net/">Thunderbird</a>"""
         val part = MessageCreationHelper.createTextPart("text/plain", text)

--- a/legacy/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
@@ -144,12 +144,62 @@ class PreviewTextExtractorTest {
 
     @Test
     fun extractPreview_shouldReplaceUrl() {
-        val text = "some url: https://k9mail.org/"
+        val text = "some url: https://thunderbird.net/"
         val part = MessageCreationHelper.createTextPart("text/plain", text)
 
         val preview = previewTextExtractor.extractPreview(part)
 
         assertThat(preview).isEqualTo("some url: ...")
+    }
+
+    @Test
+    fun extractPreview_withTextPlain_shouldParseHtml() {
+        val text = "some <b>HTML</b> text"
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("some HTML text")
+    }
+
+    @Test
+    fun extractPreview_withTextPlainContainingAngleBracketContent_shouldTreatItAsHtml() {
+        val text = "Contact Alice <alice@example.com>"
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("Contact Alice")
+    }
+
+    @Test
+    fun extractPreview_withTextPlain_shouldDecodeHtmlEntities() {
+        val text = "Tom &amp; Jerry&nbsp;are friends"
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("Tom & Jerry are friends")
+    }
+
+    @Test
+    fun extractPreview_withParsedHtmlLink_shouldRemoveUrl() {
+        val text = """read <a href="https://thunderbird.net/">Thunderbird</a>"""
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("read Thunderbird")
+    }
+
+    @Test
+    fun extractPreview_withParenthesizedUrl_shouldRemoveUrl() {
+        val text = "some image: ( https://thunderbird.net/logo.png )"
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("some image:")
     }
 
     @Test

--- a/legacy/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
@@ -69,10 +69,10 @@ class PreviewTextExtractorTest {
     fun extractPreview_shouldStripSignature() {
         val text =
             """
-            Some text
-            -- 
-            Signature
-            """.trimIndent()
+            |Some text
+            |$SIGNATURE_DELIMITER
+            |Signature
+            """.trimMargin()
         val part = MessageCreationHelper.createTextPart("text/plain", text)
 
         val preview = previewTextExtractor.extractPreview(part)
@@ -84,10 +84,10 @@ class PreviewTextExtractorTest {
     fun extractPreview_shouldStripHorizontalLine() {
         val text =
             """
-            line 1
-            ----
-            line 2
-            """.trimIndent()
+            |line 1
+            |----
+            |line 2
+            """.trimMargin()
         val part = MessageCreationHelper.createTextPart("text/plain", text)
 
         val preview = previewTextExtractor.extractPreview(part)
@@ -99,12 +99,12 @@ class PreviewTextExtractorTest {
     fun extractPreview_shouldStripQuoteHeaderAndQuotedText() {
         val text =
             """
-            some text
-            
-            On 01/02/03 someone wrote:
-            > some quoted text
-            > some other quoted text
-            """.trimIndent()
+            |some text
+            |
+            |On 01/02/03 someone wrote:
+            |> some quoted text
+            |> some other quoted text
+            """.trimMargin()
         val part = MessageCreationHelper.createTextPart("text/plain", text)
 
         val preview = previewTextExtractor.extractPreview(part)
@@ -116,11 +116,11 @@ class PreviewTextExtractorTest {
     fun extractPreview_shouldStripGenericQuoteHeader() {
         val text =
             """
-            Am 13.12.2015 um 23:42 schrieb Hans:
-            > hallo
-            hi there
-            
-            """.trimIndent()
+            |Am 13.12.2015 um 23:42 schrieb Hans:
+            |> hallo
+            |hi there
+            |
+            """.trimMargin()
         val part = MessageCreationHelper.createTextPart("text/plain", text)
 
         val preview = previewTextExtractor.extractPreview(part)
@@ -132,9 +132,9 @@ class PreviewTextExtractorTest {
     fun extractPreview_shouldStripHorizontalRules() {
         val text =
             """
-            line 1------------------------------
-            line 2
-            """.trimIndent()
+            |line 1------------------------------
+            |line 2
+            """.trimMargin()
         val part = MessageCreationHelper.createTextPart("text/plain", text)
 
         val preview = previewTextExtractor.extractPreview(part)
@@ -166,10 +166,10 @@ class PreviewTextExtractorTest {
     fun extractPreview_lineEndingWithColon() {
         val text =
             """
-            Here's a list:
-            - item 1
-            - item 2
-            """.trimIndent()
+            |Here's a list:
+            |- item 1
+            |- item 2
+            """.trimMargin()
         val part = MessageCreationHelper.createTextPart("text/plain", text)
 
         val preview = previewTextExtractor.extractPreview(part)
@@ -181,16 +181,16 @@ class PreviewTextExtractorTest {
     fun extractPreview_inlineReplies() {
         val text =
             """
-            On 2020-09-30 at 03:12 Bob wrote:
-            > Hi Alice
-            Hi Bob
-            
-            > How are you?
-            I'm fine. Thanks for asking.
-            
-            > Bye
-            See you tomorrow
-            """.trimIndent()
+            |On 2020-09-30 at 03:12 Bob wrote:
+            |> Hi Alice
+            |Hi Bob
+            |
+            |> How are you?
+            |I'm fine. Thanks for asking.
+            |
+            |> Bye
+            |See you tomorrow
+            """.trimMargin()
         val part = MessageCreationHelper.createTextPart("text/plain", text)
 
         val preview = previewTextExtractor.extractPreview(part)
@@ -202,12 +202,12 @@ class PreviewTextExtractorTest {
     fun extractPreview_quoteHeaderContainingLineBreak() {
         val text =
             """
-            Reply text
-            
-            On 2020-09-30 at 03:12
-            Bob wrote:
-            > Quoted text
-            """.trimIndent()
+            |Reply text
+            |
+            |On 2020-09-30 at 03:12
+            |Bob wrote:
+            |> Quoted text
+            """.trimMargin()
         val part = MessageCreationHelper.createTextPart("text/plain", text)
 
         val preview = previewTextExtractor.extractPreview(part)
@@ -223,5 +223,9 @@ class PreviewTextExtractorTest {
         val preview = previewTextExtractor.extractPreview(part)
 
         assertThat(preview).isEqualTo("")
+    }
+
+    private companion object {
+        const val SIGNATURE_DELIMITER = "-- "
     }
 }


### PR DESCRIPTION
Resolves #10256 
Resolves #8471

This solves html characters or code in notifications (#10256) and message previews (#8471)

Previously it only converted from html after checking the mimetype `convertFromHtmlIfNecessary()` but if the message contained html code or special characters in the plain text part they were rendered in the message previews and in notifications, polluting content.

I kept the function, let me know if there is a cleaner way to accomplish this. I tested it with messages containing special characters and also with html code, they are not shown.
