### PR TITLE
chore(ci): Ensure exactly 3 milestones exist

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -40,10 +40,16 @@ jobs:
             release) milestone_index=2 ;;
           esac
           echo "$milestone_index"
-          gh api repos/$GITHUB_REPOSITORY/milestones --jq "
+          MILESTONES=$(gh api repos/$GITHUB_REPOSITORY/milestones --jq "
                 map(select(.state == \"open\" and .due_on != null))
-                | sort_by(.due_on) | reverse
-                | .[${milestone_index}] | { number, title }
+                | sort_by(.due_on) | reverse")
+          MILESTONE_COUNT=$(echo "$MILESTONES" | jq "length")
+          if [ "$MILESTONE_COUNT" -ne 3 ]; then
+            echo "Expected exactly 3 open milestones with due dates, but found $MILESTONE_COUNT."
+            exit 1
+          fi
+          echo "$MILESTONES" | jq -r "
+                .[${milestone_index}] | { number, title }
                 | to_entries
                 | map(.key + \"=\" + (.value|tostring)) | join(\"\n\")" | tee -a $GITHUB_OUTPUT
 


### PR DESCRIPTION
Without this check, pull requests could be put in the wrong milestone. For example, if we accidentally have only 2 milestones, one for beta and one for release, pull requests for main would incorrectly be put in the beta milestone.