### PR TITLE
chore(ci): Add cooldown of 7 days to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       - "type: dependency"
       - "type: github actions"
       - "report: exclude"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: chore
       include: scope
@@ -24,6 +26,8 @@ updates:
     labels:
       - "type: dependency"
       - "type: gradle"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: chore
       include: scope
@@ -36,6 +40,8 @@ updates:
     labels:
       - "type: dependency"
       - "type: pip"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
This helps avoid supply chain attacks by not pulling in changes too quickly.