### PR TITLE
Fix: Save all option overrides attachment files

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.kt
@@ -4,6 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.provider.DocumentsContract
 import android.widget.Toast
 import androidx.annotation.WorkerThread
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
@@ -66,6 +67,21 @@ class AttachmentController internal constructor(
         }
     }
 
+    fun saveAttachmentToDirectory(scope: CoroutineScope, directoryUri: Uri?) {
+        if (directoryUri == null) return
+        scope.launch {
+            if (!attachment.isContentAvailable) {
+                val success = downloadAttachment()
+                if (success) {
+                    attachmentDisplayController.refreshAttachmentThumbnail(attachment)
+                    saveLocalAttachmentToDirectory(directoryUri)
+                }
+            } else {
+                saveLocalAttachmentToDirectory(directoryUri)
+            }
+        }
+    }
+
     private suspend fun saveLocalAttachmentTo(documentUri: Uri) {
         val success = withContext(ioDispatcher) {
             try {
@@ -73,6 +89,33 @@ class AttachmentController internal constructor(
                 true
             } catch (e: IOException) {
                 logger.error(throwable = e) { "Error saving attachment" }
+                false
+            }
+        }
+        if (!success) displayAttachmentNotSavedMessage()
+    }
+
+    private suspend fun saveLocalAttachmentToDirectory(directoryUri: Uri) {
+        val success = withContext(ioDispatcher) {
+            try {
+                val contentResolver = context.contentResolver
+                val treeId = DocumentsContract.getTreeDocumentId(directoryUri)
+                val rootDocUri = DocumentsContract.buildDocumentUriUsingTree(directoryUri, treeId)
+
+                val documentUri = attachment.mimeType?.let {
+                    attachment.displayName?.let { displayName ->
+                        DocumentsContract.createDocument(
+                            contentResolver,
+                            rootDocUri,
+                            it,
+                            displayName
+                        )
+                    }
+                } ?: return@withContext false
+                writeAttachment(documentUri)
+                true
+            } catch (e: IOException) {
+                logger.error(throwable = e) { "Error saving attachment to directory" }
                 false
             }
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -20,6 +20,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
@@ -118,6 +119,10 @@ class MessageViewFragment :
     private val createDocumentLauncher: ActivityResultLauncher<CreateDocumentResultContract.Input> =
         registerForActivityResult(CreateDocumentResultContract()) { documentUri ->
             onCreateDocumentResult(documentUri)
+        }
+    private val openDocumentTreeLauncher: ActivityResultLauncher<Uri?> =
+        registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { directoryUri ->
+            onOpenDocumentTreeResult(directoryUri)
         }
     private val chooseFolderForCopyLauncher: ActivityResultLauncher<ChooseFolderResultContract.Input> =
         registerForActivityResult(ChooseFolderResultContract(ChooseFolderActivity.Action.COPY)) { result ->
@@ -245,11 +250,7 @@ class MessageViewFragment :
                             onSaveClick = { attachment ->
                                 onSaveAttachment(attachment)
                             },
-                            onSaveAllClick = {
-                                attachments.forEach { item ->
-                                    onSaveAttachment(item.attachment)
-                                }
-                            },
+                            onSaveAllClick = { onSaveAllAttachments() },
                         )
                     }
                 }
@@ -828,6 +829,18 @@ class MessageViewFragment :
         }
     }
 
+    private fun onOpenDocumentTreeResult(directoryUri: Uri?) {
+        if (directoryUri == null) return
+
+        val messageView = mMessageViewInfo ?: return
+        val attachments = messageView.attachments.filter { !it.inlineAttachment }
+        attachments.forEach {
+            currentAttachmentViewInfo = it
+                createAttachmentController(it)
+                    .saveAttachmentToDirectory(lifecycleScope ,directoryUri)
+        }
+    }
+
     private fun onChooseFolderMoveResult(result: ChooseFolderResultContract.Result?) {
         if (result == null) return
 
@@ -1188,6 +1201,14 @@ class MessageViewFragment :
         currentAttachmentViewInfo = attachment
 
         createAttachmentController(attachment).viewAttachment(lifecycleScope)
+    }
+
+    fun onSaveAllAttachments() {
+        try {
+            openDocumentTreeLauncher.launch(null)
+        } catch (_: ActivityNotFoundException) {
+            Toast.makeText(requireContext(), R.string.error_activity_not_found, Toast.LENGTH_LONG).show()
+        }
     }
 
     override fun onSaveAttachment(attachment: AttachmentViewInfo) {


### PR DESCRIPTION
Fixes #10965

#### Description

Makes use of `OpenDocumentTree Contract` for `onSaveAllAttachments` option to let users choose a destination folder for all the attachments. Previously, we were forced to click 'save' for each attachment file.

#### Screen Shots

https://github.com/user-attachments/assets/a643b473-da0b-4b1b-a9dd-653cbe5fd65d




## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).


