### PR TITLE
fix daily build workflow link in release doc

### DIFF
--- a/docs/release/RELEASE.md
+++ b/docs/release/RELEASE.md
@@ -230,7 +230,7 @@ The app-k9mail/src/main/res/raw/changelog_master.xml should not include any beta
 ## Releases
 
 Releases for both K-9 and Thunderbird for Android are automated with github actions.
-Daily builds are scheduled with the [Daily Builds](https://github.com/thunderbird/thunderbird-android/actions/workflows/daily_builds.yml) action and all builds are performed by the [Shippable Build & Signing](https://github.com/thunderbird/thunderbird-android/actions/workflows/shippable_builds.yml) action.
+Daily builds are scheduled with the [Daily Builds](https://github.com/thunderbird/thunderbird-android/actions/workflows/build-daily.yml) action and all builds are performed by the [Shippable Build & Signing](https://github.com/thunderbird/thunderbird-android/actions/workflows/shippable_builds.yml) action.
 
 For the historical manual release process, see [Releasing](HISTORICAL_RELEASE.md).
 


### PR DESCRIPTION
Quick fix fox the release doc which currently points to a non-existent workflow for daily builds.

Current: https://github.com/thunderbird/thunderbird-android/actions/workflows/daily_builds.yml

New: https://github.com/thunderbird/thunderbird-android/actions/workflows/build-daily.yml