### PR TITLE
fix(ui): add spacing between items on the headers screen

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagesource/MessageHeadersFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagesource/MessageHeadersFragment.kt
@@ -50,7 +50,7 @@ class MessageHeadersFragment : Fragment() {
         var first = true
         for ((name, value) in headers) {
             if (!first) {
-                sb.append("\n")
+                sb.append("\n\n")
             } else {
                 first = false
             }


### PR DESCRIPTION
## Summary

The "Show headers" screen previously placed each `name: value` pair on consecutive lines separated by a single newline, which made it hard to tell where one header ended and the next began, particularly with long values such as `X-Spam-Report`. This change inserts a blank line between header entries so each item is visually distinct.

This matches the scope @rafaeltonholo proposed in https://github.com/thunderbird/thunderbird-android/issues/9452 as a good-first-issue workaround for the larger "Show headers" rework that is not on the current roadmap. It does not change how individual values are folded/decoded.

## Before / after

The change in `MessageHeadersFragment#populateHeadersList` is the separator between entries: a single `\n` becomes a double `\n`. Visually the headers screen now reads:

    From: alice@domain.example

    To: bob@domain.example

    Subject: Hi Bob

instead of

    From: alice@domain.example
    To: bob@domain.example
    Subject: Hi Bob

### Prior to submitting a pull request, please familiarize yourself with...

Reviewed the Architecture docs and ADR index, Mozilla's Community Participation Guidelines, and the contribution code quality guides (including the git commit guide for the commit title format used here).

### Please ensure that your pull request meets the following requirements - thanks!

- No merge commits; branch is rebased on `main`.
- Single commit with a descriptive Conventional Commits title.
- New code is Kotlin and matches the existing style of the surrounding file.
- Title is descriptive and contains no issue number.
- Body references the issue with `Closes #9452` below.
- Cosmetic change; the before/after text rendering above stands in for screenshots.
- AI disclosure: authored with Claude as a coding assistant; I reviewed the change before pushing.

Closes #9452
