### PR TITLE
ci(github): prune stale nightly APKs from FTP latest folder after upload

### DIFF
--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -936,6 +936,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Prune FTP Nightly Latest
+        continue-on-error: true
         if: ${{ !inputs.skipFtp && contains(matrix.releaseTarget, 'ftp') && matrix.packageFormat == 'apk' && needs.dump_config.outputs.releaseType == 'daily' }}
         shell: bash
         env:
@@ -943,6 +944,7 @@ jobs:
           PKG_FILE: ${{ steps.rename.outputs.PKG_FILE }}
           FTP_TAR_FILENAME: ${{ steps.generate_tar.outputs.FTP_TAR_FILENAME }}
         run: |
+          set -x
           gcloud storage ls "gs://${FTP_DESTINATION_NIGHTLY_LATEST}/" \
             | grep -vF "${PKG_FILE}" \
             | grep -vF "${FTP_TAR_FILENAME}" \

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -931,6 +931,23 @@ jobs:
           destination: ${{ steps.prepare_ftp.outputs.FTP_DESTINATION_NIGHTLY_LATEST }}
           gzip: false
 
+      - name: Set up Cloud SDK for pruning
+        if: ${{ !inputs.skipFtp && contains(matrix.releaseTarget, 'ftp') && matrix.packageFormat == 'apk' && needs.dump_config.outputs.releaseType == 'daily' }}
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Prune FTP Nightly Latest
+        if: ${{ !inputs.skipFtp && contains(matrix.releaseTarget, 'ftp') && matrix.packageFormat == 'apk' && needs.dump_config.outputs.releaseType == 'daily' }}
+        shell: bash
+        env:
+          FTP_DESTINATION_NIGHTLY_LATEST: ${{ steps.prepare_ftp.outputs.FTP_DESTINATION_NIGHTLY_LATEST }}
+          PKG_FILE: ${{ steps.rename.outputs.PKG_FILE }}
+          FTP_TAR_FILENAME: ${{ steps.generate_tar.outputs.FTP_TAR_FILENAME }}
+        run: |
+          gcloud storage ls "gs://${FTP_DESTINATION_NIGHTLY_LATEST}/" \
+            | grep -vF "${PKG_FILE}" \
+            | grep -vF "${FTP_TAR_FILENAME}" \
+            | xargs -r gcloud storage rm
+
       - name: Summary
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: summary


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: N/A

#### Description
Currently, the [nightly latest FTP](https://ftp.mozilla.org/pub/thunderbird-mobile/android/nightly/latest-main/) is keeping both latest and previous builds, whereas we want to keep latest only. 

This adds a post-upload cleanup step that removes old files from the nightly latest FTP destination, keeping only the current APK and tar — preventing accumulation of stale builds.

I have tested the proposed `gcloud` command against my own bucket:

- Copied 4 files into the bucket:
```
❯ gcloud storage cp thunderbird-2* gs://test-bucket-ebaginski
Copying file://thunderbird-20-0a1.apk to gs://test-bucket-ebaginski/thunderbird-20-0a1.apk
Copying file://thunderbird-20-0a1.tar.gz to gs://test-bucket-ebaginski/thunderbird-20-0a1.tar.gz
Copying file://thunderbird-21-0a1.apk to gs://test-bucket-ebaginski/thunderbird-21-0a1.apk
Copying file://thunderbird-21-0a1.tar.gz to gs://test-bucket-ebaginski/thunderbird-21-0a1.tar.gz
```

- Prune stale ones:
```
❯ FTP_DESTINATION_NIGHTLY_LATEST=test-bucket-ebaginski
❯ PKG_FILE=thunderbird-21-0a1.apk
❯ FTP_TAR_FILENAME=thunderbird-21-0a1.tar.gz
❯ gcloud storage ls "gs://${FTP_DESTINATION_NIGHTLY_LATEST}/" \
            | grep -vF "${PKG_FILE}" \
            | grep -vF "${FTP_TAR_FILENAME}" \
            | xargs -r gcloud storage rm

Removing objects:

Removing gs://test-bucket-ebaginski/thunderbird-20-0a1.apk...
Removing gs://test-bucket-ebaginski/thunderbird-20-0a1.tar.gz...
```

- Result:
```
❯ gcloud storage ls "gs://${FTP_DESTINATION_NIGHTLY_LATEST}/"
gs://test-bucket-ebaginski/thunderbird-21-0a1.apk
gs://test-bucket-ebaginski/thunderbird-21-0a1.tar.gz
```

## AI Disclosure

Select **one** of the following (mandatory)

- [X] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [X] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [X] This contribution is in Kotlin where possible
- [X] This contribution does not use merge commits
- [X] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [X] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [X] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [X] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
