### PR TITLE
fix: gradle configuration cache issues

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
     alias(libs.plugins.tb.app.versioning)
 }
 
-val testCoverageEnabled = hasProperty("testCoverageEnabled")
+val testCoverageEnabled = providers
+    .gradleProperty("testCoverageEnabled")
+    .isPresent
 
 android {
     namespace = "com.fsck.k9"
@@ -85,12 +87,14 @@ android {
     }
 
     buildTypes {
-        val isCI = project.findProperty("ci") == "true"
+        val isCI = providers.gradleProperty("ci")
+            .map(String::toBoolean)
+            .orElse(false)
         release {
             signingConfig = signingConfigs.getByType(SigningType.K9_RELEASE)
 
-            isMinifyEnabled = !isCI
-            isShrinkResources = !isCI
+            isMinifyEnabled = !isCI.get()
+            isShrinkResources = !isCI.get()
 
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
     alias(libs.plugins.tb.app.versioning)
 }
 
-val testCoverageEnabled = hasProperty("testCoverageEnabled")
+val testCoverageEnabled = providers
+    .gradleProperty("testCoverageEnabled")
+    .isPresent
 
 android {
     namespace = "net.thunderbird.android"
@@ -88,12 +90,14 @@ android {
     }
 
     buildTypes {
-        val isCI = project.findProperty("ci") == "true"
+        val isCI = providers.gradleProperty("ci")
+            .map(String::toBoolean)
+            .orElse(false)
         release {
             signingConfig = signingConfigs.getByType(SigningType.TB_RELEASE)
 
-            isMinifyEnabled = !isCI
-            isShrinkResources = !isCI
+            isMinifyEnabled = !isCI.get()
+            isShrinkResources = !isCI.get()
             isDebuggable = false
 
             proguardFiles(
@@ -112,8 +116,8 @@ android {
             applicationIdSuffix = ".beta"
             versionNameSuffix = "b0"
 
-            isMinifyEnabled = !isCI
-            isShrinkResources = !isCI
+            isMinifyEnabled = isCI.get()
+            isShrinkResources = isCI.get()
             isDebuggable = false
 
             matchingFallbacks += listOf("release")
@@ -134,8 +138,8 @@ android {
             applicationIdSuffix = ".daily"
             versionNameSuffix = "a1"
 
-            isMinifyEnabled = !isCI
-            isShrinkResources = !isCI
+            isMinifyEnabled = isCI.get()
+            isShrinkResources = isCI.get()
             isDebuggable = false
 
             matchingFallbacks += listOf("release")

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -82,7 +82,10 @@ android {
     }
 
     signingConfigs {
-        val useUploadKey = properties.getOrDefault("tb.useUploadKey", "true") == "true"
+        val useUploadKey = providers.gradleProperty("tb.useUploadKey")
+            .map(String::toBoolean)
+            .orElse(true)
+            .get()
 
         createSigningConfig(project, SigningType.TB_RELEASE, isUpload = useUploadKey)
         createSigningConfig(project, SigningType.TB_BETA, isUpload = useUploadKey)

--- a/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/quality/detekt/DetektPlugin.kt
+++ b/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/quality/detekt/DetektPlugin.kt
@@ -38,12 +38,14 @@ class DetektPlugin : Plugin<Project> {
         }
     }
 
+    @Suppress("UnstableApiUsage")
     private fun Project.configureDetekt() {
         extensions.configure<DetektExtension>("detekt") {
-            config.setFrom(project.rootProject.files("config/detekt/detekt.yml"))
+            config.setFrom(isolated.rootProject.projectDirectory.file("config/detekt/detekt.yml").asFile)
 
             val name = project.path.replace(":", "-").replace("/", "-")
-            baseline = project.rootProject.file("config/detekt/detekt-baseline$name.xml")
+            baseline = isolated.rootProject.projectDirectory
+                .file("config/detekt/detekt-baseline$name.xml").asFile
 
             ignoredBuildTypes = listOf("release")
         }

--- a/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/quality/spotless/SpotlessPlugin.kt
+++ b/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/quality/spotless/SpotlessPlugin.kt
@@ -22,6 +22,7 @@ class SpotlessPlugin : Plugin<Project> {
         }
     }
 
+    @Suppress("UnstableApiUsage")
     private fun Project.configureSpotless() {
         extensions.configure<SpotlessExtension> {
             kotlin {
@@ -31,7 +32,7 @@ class SpotlessPlugin : Plugin<Project> {
                 )
 
                 ktlint()
-                    .setEditorConfigPath("${rootProject.projectDir}/.editorconfig")
+                    .setEditorConfigPath("${isolated.rootProject.projectDirectory}/.editorconfig")
                     .editorConfigOverride(kotlinEditorConfigOverride)
             }
 
@@ -41,7 +42,7 @@ class SpotlessPlugin : Plugin<Project> {
                 )
 
                 ktlint()
-                    .setEditorConfigPath("${rootProject.projectDir}/.editorconfig")
+                    .setEditorConfigPath("${isolated.rootProject.projectDirectory}/.editorconfig")
                     .editorConfigOverride(
                         mapOf(
                             "ktlint_code_style" to "intellij_idea",
@@ -65,6 +66,7 @@ class SpotlessPlugin : Plugin<Project> {
         }
     }
 
+    @Suppress("UnstableApiUsage")
     private fun Project.configureSpotlessRoot() {
         extensions.configure<SpotlessExtension> {
             kotlin {
@@ -73,7 +75,7 @@ class SpotlessPlugin : Plugin<Project> {
                     "build-plugin/plugin/src/*/kotlin/**/*.kt",
                 )
                 ktlint()
-                    .setEditorConfigPath("${project.rootProject.projectDir}/.editorconfig")
+                    .setEditorConfigPath("${isolated.rootProject.projectDirectory}/.editorconfig")
                     .editorConfigOverride(kotlinEditorConfigOverride)
             }
 
@@ -85,7 +87,7 @@ class SpotlessPlugin : Plugin<Project> {
                 )
 
                 ktlint()
-                    .setEditorConfigPath("${project.rootProject.projectDir}/.editorconfig")
+                    .setEditorConfigPath("${isolated.rootProject.projectDirectory}/.editorconfig")
                     .editorConfigOverride(
                         mapOf(
                             "ktlint_code_style" to "intellij_idea",

--- a/build-plugin/src/main/kotlin/SigningExtensions.kt
+++ b/build-plugin/src/main/kotlin/SigningExtensions.kt
@@ -57,11 +57,16 @@ fun NamedDomainObjectContainer<out ApkSigningConfig>.getByType(signingType: Sign
     return findByName(signingType.type)
 }
 
+@Suppress("UnstableApiUsage")
 private fun Project.readSigningProperties(signingType: SigningType, isUpload: Boolean) = Properties().apply {
     val signingPropertiesFile = if (isUpload) {
-        rootProject.file("$SIGNING_FOLDER/${signingType.id}$UPLOAD_FILE_ENDING")
+        isolated.rootProject.projectDirectory
+            .file("$SIGNING_FOLDER/${signingType.id}$UPLOAD_FILE_ENDING")
+            .asFile
     } else {
-        rootProject.file("$SIGNING_FOLDER/${signingType.id}$SIGNING_FILE_ENDING")
+        isolated.rootProject.projectDirectory
+            .file("$SIGNING_FOLDER/${signingType.id}$SIGNING_FILE_ENDING")
+            .asFile
     }
 
     if (signingPropertiesFile.exists()) {

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
@@ -35,7 +35,8 @@ android {
         warningsAsErrors = false
         abortOnError = true
         checkDependencies = true
-        lintConfig = project.file("${project.rootProject.projectDir}/config/lint/lint.xml")
+        @Suppress("UnstableApiUsage")
+        lintConfig = isolated.rootProject.projectDirectory.file("config/lint/lint.xml").asFile
         checkReleaseBuilds = System.getenv("CI_CHECK_RELEASE_BUILDS")?.toBoolean() ?: true
     }
 

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
@@ -94,3 +94,11 @@ dependencies {
 
     testImplementation(libs.bundles.shared.android.app.test)
 }
+
+tasks.register("testsOnCi") {
+    dependsOn(
+        tasks.withType<Test>().matching {
+            it.name != "testReleaseUnitTest"
+        }
+    )
+}

--- a/build-plugin/src/main/kotlin/thunderbird.app.jvm.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.jvm.gradle.kts
@@ -20,3 +20,11 @@ dependencies {
     implementation(libs.bundles.shared.jvm)
     testImplementation(libs.bundles.shared.jvm.test)
 }
+
+tasks.register("testsOnCi") {
+    dependsOn(
+        tasks.withType<Test>().matching {
+            it.name != "testReleaseUnitTest"
+        }
+    )
+}

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
@@ -85,3 +85,11 @@ dependencies {
 
     testImplementation(libs.bundles.shared.android.test)
 }
+
+tasks.register("testsOnCi") {
+    dependsOn(
+        tasks.withType<Test>().matching {
+            it.name != "testReleaseUnitTest"
+        }
+    )
+}

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
@@ -28,7 +28,8 @@ android {
         warningsAsErrors = false
         abortOnError = true
         checkDependencies = true
-        lintConfig = project.file("${project.rootProject.projectDir}/config/lint/lint.xml")
+        @Suppress("UnstableApiUsage")
+        lintConfig = isolated.rootProject.projectDirectory.file("config/lint/lint.xml").asFile
         checkReleaseBuilds = System.getenv("CI_CHECK_RELEASE_BUILDS")?.toBoolean() ?: true
     }
 

--- a/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
@@ -36,3 +36,11 @@ dependencies {
     implementation(libs.bundles.shared.jvm)
     testImplementation(libs.bundles.shared.jvm.test)
 }
+
+tasks.register("testsOnCi") {
+    dependsOn(
+        tasks.withType<Test>().matching {
+            it.name.contains("konsist").not()
+        }
+    )
+}

--- a/build-plugin/src/main/kotlin/thunderbird.library.kmp.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.kmp.compose.gradle.kts
@@ -78,3 +78,9 @@ kotlin {
 }
 
 configureKotlinJavaCompatibility()
+
+tasks.register("testsOnCi") {
+    dependsOn(
+        tasks.withType<Test>()
+    )
+}

--- a/build-plugin/src/main/kotlin/thunderbird.library.kmp.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.kmp.gradle.kts
@@ -59,3 +59,9 @@ kotlin {
 }
 
 configureKotlinJavaCompatibility()
+
+tasks.register("testsOnCi") {
+    dependsOn(
+        tasks.withType<Test>()
+    )
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,14 +17,12 @@ plugins {
     id("net.thunderbird.gradle.plugin.quality.spotless")
 }
 
-allprojects {
-    tasks.withType<Test> {
-        testLogging {
-            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-            showCauses = true
-            showExceptions = true
-            showStackTraces = true
-        }
+tasks.withType<Test>().configureEach {
+    testLogging {
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,17 +26,6 @@ tasks.withType<Test>().configureEach {
     }
 }
 
-tasks.register("testsOnCi") {
-    val skipTests = setOf("testReleaseUnitTest")
-
-    dependsOn(
-        subprojects
-            .filterNot { it.path == ":quality:konsist" } // Konsist tests should be run separately
-            .flatMap { it.tasks.withType(Test::class.java) }
-            .filterNot { it.name in skipTests },
-    )
-}
-
 tasks.register("buildCliTools") {
     val cliToolsProjects = subprojects.filter { it.path.startsWith(":cli:") }
     dependsOn(

--- a/feature/mail/message/composer/build.gradle.kts
+++ b/feature/mail/message/composer/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id(ThunderbirdPlugins.Library.androidCompose)
-    alias(libs.plugins.dev.mokkery)
 }
 
 android {

--- a/legacy/common/build.gradle.kts
+++ b/legacy/common/build.gradle.kts
@@ -29,10 +29,6 @@ dependencies {
     implementation(libs.glide)
     annotationProcessor(libs.glide.compiler)
 
-    if (project.hasProperty("k9mail.enableLeakCanary") && project.property("k9mail.enableLeakCanary") == "true") {
-        debugImplementation(libs.leakcanary.android)
-    }
-
     testImplementation(projects.core.logging.testing)
     testImplementation(libs.robolectric)
     testImplementation(projects.feature.account.fake)


### PR DESCRIPTION
## Contribution Summary

Resolves #11133

Linked Issue/Ticket: #10392

#### Description

While exploring [Gradle Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html) as alternative solution for #10392, I found that our project configuration has Gradle Configuration Cache issues: 

- 1133 problems were found storing the configuration cache, 416 of which seem unique.

As Android Studio Quail 1 partially depends on [Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html), I fixed most of the findings. See also: [Known Issues](https://developer.android.com/studio/known-issues#android-studio-quail-1-parallel-sync-execution-issue)

Remaining is our mokkery dependency with 4 findings:

- Plugin 'dev.mokkery': Project ':feature:mail:message:composer' cannot dynamically look up a property in the parent project ':feature:mail:message'
- Plugin 'dev.mokkery': Project ':feature:mail:message:list:internal' cannot dynamically look up a property in the parent project ':feature:mail:message:list'
- Plugin 'dev.mokkery': Project ':feature:notification:api' cannot dynamically look up a property in the parent project ':feature:notification'
- Plugin 'dev.mokkery': Project ':feature:notification:impl' cannot dynamically look up a property in the parent project ':feature:notification'

I won't tackle these for now as the current state is enough to continue investigation.

To test these changes add this to `gradle.properties`:

```
org.gradle.tooling.parallel=true
org.gradle.unsafe.isolated-projects=true
```

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
