### PR TITLE
fix(ui): use selected account for manage folders

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeAccountSelector.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeAccountSelector.kt
@@ -1,0 +1,18 @@
+package com.fsck.k9.activity
+
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.android.account.LegacyAccountDtoManager
+import net.thunderbird.feature.search.legacy.LocalMessageSearch
+
+internal fun LocalMessageSearch.resolveAccount(
+    currentAccount: LegacyAccountDto?,
+    accountManager: LegacyAccountDtoManager,
+): LegacyAccountDto? {
+    return if (searchAllAccounts()) {
+        null
+    } else {
+        accountUuids.singleOrNull()
+            ?.let { accountManager.getAccount(it) }
+            ?: currentAccount
+    }
+}

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeActivity.kt
@@ -1420,20 +1420,8 @@ open class MessageHomeActivity :
         singleFolderMode = false
 
         val folderIds = search.folderIds
-        if (search.searchAllAccounts()) {
-            val accountUuids = search.accountUuids
-            if (accountUuids.size == 1) {
-                account = accountManager.getAccount(accountUuids.elementAt(0))
-                singleFolderMode = folderIds.size == 1
-            } else {
-                account = null
-            }
-        } else {
-            if (account == null && search.accountUuids.size == 1) {
-                account = accountManager.getAccount(search.accountUuids.elementAt(0))
-            }
-            singleFolderMode = folderIds.size == 1
-        }
+        account = search.resolveAccount(currentAccount = account, accountManager = accountManager)
+        singleFolderMode = !search.searchAllAccounts() && folderIds.size == 1
 
         configureDrawer()
     }

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/MessageHomeAccountSelectorTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/MessageHomeAccountSelectorTest.kt
@@ -1,0 +1,57 @@
+package com.fsck.k9.activity
+
+import assertk.assertThat
+import assertk.assertions.isSameInstanceAs
+import kotlinx.coroutines.flow.Flow
+import net.thunderbird.core.android.account.AccountRemovedListener
+import net.thunderbird.core.android.account.AccountsChangeListener
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.android.account.LegacyAccountDtoManager
+import net.thunderbird.feature.search.legacy.LocalMessageSearch
+import org.junit.Test
+
+class MessageHomeAccountSelectorTest {
+    private val firstAccount = LegacyAccountDto("11111111-1111-1111-1111-111111111111")
+    private val secondAccount = LegacyAccountDto("22222222-2222-2222-2222-222222222222")
+    private val accountManager = FakeLegacyAccountDtoManager(firstAccount, secondAccount)
+
+    @Test
+    fun `single-account search should replace current account`() {
+        val search = LocalMessageSearch().apply {
+            addAccountUuid(secondAccount.uuid)
+        }
+
+        val account = search.resolveAccount(
+            currentAccount = firstAccount,
+            accountManager = accountManager,
+        )
+
+        assertThat(account).isSameInstanceAs(secondAccount)
+    }
+
+    private class FakeLegacyAccountDtoManager(
+        vararg accounts: LegacyAccountDto,
+    ) : LegacyAccountDtoManager {
+        private val accounts = accounts.associateBy { it.uuid }
+
+        override fun getAccounts(): List<LegacyAccountDto> = accounts.values.toList()
+
+        override fun getAccountsFlow(): Flow<List<LegacyAccountDto>> = error("Not implemented")
+
+        override fun getAccount(accountUuid: String): LegacyAccountDto? = accounts[accountUuid]
+
+        override fun getAccountFlow(accountUuid: String): Flow<LegacyAccountDto?> = error("Not implemented")
+
+        override fun addAccountRemovedListener(listener: AccountRemovedListener) = error("Not implemented")
+
+        override fun moveAccount(account: LegacyAccountDto, newPosition: Int) = error("Not implemented")
+
+        override fun addOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) =
+            error("Not implemented")
+
+        override fun removeOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) =
+            error("Not implemented")
+
+        override fun saveAccount(account: LegacyAccountDto) = error("Not implemented")
+    }
+}


### PR DESCRIPTION
## Description

Fixes #11128.

When MessageHomeActivity initializes from a single-account search, it now resolves and stores the account from that search even if another account was already selected in the activity. This keeps Manage Folders aligned with the account chosen from the drawer instead of reusing a stale account.

The account-selection logic is extracted into a small helper and covered with a focused unit test.

## Screenshots

Not applicable; this changes account selection logic for navigation and does not alter UI layout.

## Checklist

- [x] The change is covered by a focused unit test.
- [x] I ran the relevant local verification.
- [x] This contribution includes changes created by AI.

## Verification

- `git diff --check`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew --no-daemon --console=plain :legacy:ui:legacy:testDebugUnitTest --tests com.fsck.k9.activity.MessageHomeAccountSelectorTest`