### PR TITLE
test: add unit test for AttachmentController

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/KoinModule.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/KoinModule.kt
@@ -1,5 +1,7 @@
 package com.fsck.k9.activity
 
+import com.fsck.k9.ui.messageview.AttachmentLoadingController
+import com.fsck.k9.ui.messageview.DefaultAttachmentLoadingController
 import org.koin.dsl.module
 
 val activityModule = module {
@@ -9,5 +11,8 @@ val activityModule = module {
             messageReaderHtmlSettingsProvider = get(),
             messageComposerHtmlSettingsProvider = get(),
         )
+    }
+    factory<AttachmentLoadingController> {
+        DefaultAttachmentLoadingController(messagingController = get(), accountManager = get())
     }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.kt
@@ -30,7 +30,7 @@ import org.apache.commons.io.IOUtils
 class AttachmentController internal constructor(
     private val context: Context,
     private val controller: MessagingController,
-    private val messageViewFragment: MessageViewFragment,
+    private val attachmentDisplayController: AttachmentDisplayController,
     private val attachment: AttachmentViewInfo,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val logger: Logger
@@ -42,7 +42,7 @@ class AttachmentController internal constructor(
             if (!attachment.isContentAvailable) {
                 val success = downloadAttachment()
                 if (success) {
-                    messageViewFragment.refreshAttachmentThumbnail(attachment)
+                    attachmentDisplayController.refreshAttachmentThumbnail(attachment)
                     viewLocalAttachment()
                 }
             } else {
@@ -58,7 +58,7 @@ class AttachmentController internal constructor(
             if (!attachment.isContentAvailable) {
                 val success = downloadAttachment()
                 if (success) {
-                    messageViewFragment.refreshAttachmentThumbnail(attachment)
+                    attachmentDisplayController.refreshAttachmentThumbnail(attachment)
                     saveLocalAttachmentTo(documentUri)
                 }
             } else {
@@ -84,13 +84,13 @@ class AttachmentController internal constructor(
         val localPart = attachment.part as LocalPart
         val account = getPreferences().getAccount(localPart.accountUuid)
 
-        messageViewFragment.showAttachmentLoadingDialog()
+        attachmentDisplayController.showAttachmentLoadingDialog()
         controller.loadAttachment(
             account, localPart.message, attachment.part,
             object : SimpleMessagingListener() {
                 override fun loadAttachmentFinished(account: LegacyAccountDto?, message: Message?, part: Part?) {
                     attachment.setContentAvailable()
-                    messageViewFragment.hideAttachmentLoadingDialogOnMainThread()
+                    attachmentDisplayController.hideAttachmentLoadingDialogOnMainThread()
                     if (continuation.isActive) {
                         continuation.resume(true)
                     }
@@ -102,7 +102,7 @@ class AttachmentController internal constructor(
                     part: Part?,
                     reason: String?,
                 ) {
-                    messageViewFragment.hideAttachmentLoadingDialogOnMainThread()
+                    attachmentDisplayController.hideAttachmentLoadingDialogOnMainThread()
                     if (continuation.isActive) {
                         continuation.resume(false)
                     }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.kt
@@ -7,8 +7,6 @@ import android.net.Uri
 import android.widget.Toast
 import androidx.annotation.WorkerThread
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
-import com.fsck.k9.Preferences.Companion.getPreferences
-import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.Part
 import com.fsck.k9.mailstore.AttachmentViewInfo
@@ -24,12 +22,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.android.account.LegacyAccountDtoManager
 import net.thunderbird.core.logging.Logger
 import org.apache.commons.io.IOUtils
 
 class AttachmentController internal constructor(
     private val context: Context,
-    private val controller: MessagingController,
+    private val controller: AttachmentLoadingController,
     private val attachmentDisplayController: AttachmentDisplayController,
     private val attachment: AttachmentViewInfo,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -81,13 +80,10 @@ class AttachmentController internal constructor(
     }
 
     private suspend fun downloadAttachment(): Boolean = suspendCancellableCoroutine { continuation ->
-        val localPart = attachment.part as LocalPart
-        val account = getPreferences().getAccount(localPart.accountUuid)
-
         attachmentDisplayController.showAttachmentLoadingDialog()
         controller.loadAttachment(
-            account, localPart.message, attachment.part,
-            object : SimpleMessagingListener() {
+            part = attachment.part,
+            listener = object : SimpleMessagingListener() {
                 override fun loadAttachmentFinished(account: LegacyAccountDto?, message: Message?, part: Part?) {
                     attachment.setContentAvailable()
                     attachmentDisplayController.hideAttachmentLoadingDialogOnMainThread()

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentDisplayController.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentDisplayController.kt
@@ -1,0 +1,9 @@
+package com.fsck.k9.ui.messageview
+
+import com.fsck.k9.mailstore.AttachmentViewInfo
+
+interface AttachmentDisplayController {
+    fun showAttachmentLoadingDialog()
+    fun hideAttachmentLoadingDialogOnMainThread()
+    fun refreshAttachmentThumbnail(attachment: AttachmentViewInfo)
+}

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentLoadingController.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentLoadingController.kt
@@ -1,0 +1,11 @@
+package com.fsck.k9.ui.messageview
+
+import app.k9mail.legacy.message.controller.MessagingListener
+import com.fsck.k9.mail.Part
+
+interface AttachmentLoadingController {
+    fun loadAttachment(
+        part: Part?,
+        listener: MessagingListener
+    )
+}

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DefaultAttachmentLoadingController.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DefaultAttachmentLoadingController.kt
@@ -1,0 +1,19 @@
+package com.fsck.k9.ui.messageview
+
+import app.k9mail.legacy.message.controller.MessagingListener
+import com.fsck.k9.controller.MessagingController
+import com.fsck.k9.mail.Part
+import com.fsck.k9.mailstore.LocalPart
+import net.thunderbird.core.android.account.LegacyAccountDtoManager
+
+class DefaultAttachmentLoadingController(
+    private val messagingController: MessagingController,
+    private val accountManager: LegacyAccountDtoManager,
+    ): AttachmentLoadingController {
+    override fun loadAttachment(part: Part?, listener: MessagingListener) {
+        val localPart = part as LocalPart
+        val message = localPart.message
+        val account = accountManager.getAccount(localPart.accountUuid)
+        messagingController.loadAttachment(account, message, part, listener)
+    }
+}

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -98,6 +98,7 @@ import net.thunderbird.feature.mail.message.reader.api.R as MessageReaderR
 class MessageViewFragment :
     Fragment(),
     ConfirmationDialogFragmentListener,
+    AttachmentDisplayController,
     AttachmentViewCallback {
 
     private val themeManager: ThemeManager by inject()
@@ -1055,17 +1056,17 @@ class MessageViewFragment :
         requireActivity().runOnUiThread(runnable)
     }
 
-    fun showAttachmentLoadingDialog() {
+    override fun showAttachmentLoadingDialog() {
         showDialog(R.id.dialog_attachment_progress)
     }
 
-    fun hideAttachmentLoadingDialogOnMainThread() {
+    override fun hideAttachmentLoadingDialogOnMainThread() {
         runOnMainThread {
             removeDialog(R.id.dialog_attachment_progress)
         }
     }
 
-    fun refreshAttachmentThumbnail(attachment: AttachmentViewInfo) {
+    override fun refreshAttachmentThumbnail(attachment: AttachmentViewInfo) {
         messageTopView.refreshAttachmentThumbnail(attachment)
     }
 
@@ -1209,7 +1210,7 @@ class MessageViewFragment :
         return AttachmentController(
             context = requireContext(),
             controller = messagingController,
-            messageViewFragment = this,
+            attachmentDisplayController = this,
             attachment = attachment,
             logger = logger
         )

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -94,7 +94,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.openintents.openpgp.util.OpenPgpIntentStarter
 import net.thunderbird.feature.mail.message.reader.api.R as MessageReaderR
 
-@Suppress("LargeClass")
+@Suppress("LargeClass", "TooManyFunctions")
 class MessageViewFragment :
     Fragment(),
     ConfirmationDialogFragmentListener,

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -106,6 +106,7 @@ class MessageViewFragment :
     private val messageLoaderHelperFactory: MessageLoaderHelperFactory by inject()
     private val accountManager: LegacyAccountDtoManager by inject()
     private val messagingController: MessagingController by inject()
+    private val attachmentLoadingController: AttachmentLoadingController by inject()
     private val shareIntentBuilder: ShareIntentBuilder by inject()
     private val generalSettingsManager: GeneralSettingsManager by inject()
     private val outboxFolderManager: OutboxFolderManager by inject()
@@ -1209,7 +1210,7 @@ class MessageViewFragment :
     private fun createAttachmentController(attachment: AttachmentViewInfo): AttachmentController {
         return AttachmentController(
             context = requireContext(),
-            controller = messagingController,
+            controller = attachmentLoadingController,
             attachmentDisplayController = this,
             attachment = attachment,
             logger = logger

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/AttachmentControllerTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/AttachmentControllerTest.kt
@@ -1,0 +1,241 @@
+package com.fsck.k9.ui.messageview
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ProviderInfo
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import app.k9mail.legacy.message.controller.MessagingListener
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
+import com.fsck.k9.mail.Part
+import com.fsck.k9.mailstore.AttachmentViewInfo
+import com.fsck.k9.mailstore.LocalBodyPart
+import com.fsck.k9.mailstore.LocalPart
+import com.fsck.k9.provider.AttachmentTempFileProvider
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.OutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.android.testing.RobolectricTest
+import net.thunderbird.core.common.appConfig.PlatformConfigProvider
+import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.core.preference.GeneralSettings
+import net.thunderbird.core.preference.GeneralSettingsManager
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Before
+import org.koin.core.context.GlobalContext.stopKoin
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+
+class AttachmentControllerTest : RobolectricTest() {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val logger = TestLogger()
+
+    private val displayName = "document.pdf"
+    private val mimeType = "application/pdf"
+    private val part = LocalBodyPart("00000000-0000-4000-0000-000000000000",
+        null,
+        1L,
+        42L,
+    )
+
+    @Before
+    fun setUp() {
+        Log.logger = logger
+        startKoin {
+            modules(
+                module {
+                    single<GeneralSettingsManager> { FakeGeneralSettingsManager() }
+                },
+            )
+        }
+        initializeAttachmentTempFileProvider()
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `attachment content is set available if download is success`() = runTest {
+        // Arrange
+        val fakeAttachment = AttachmentViewInfo(
+            mimeType = mimeType,
+            displayName = displayName,
+            size = 42L,
+            internalUri = "content://internal/path".toUri(),
+            inlineAttachment = false,
+            part = part,
+            isContentAvailable = false,
+        )
+
+        val fakeAttachmentController = AttachmentController(
+            context = context,
+            controller = FakeAttachmentLoadingController(),
+            attachmentDisplayController = FakeAttachmentDisplayController(),
+            attachment = fakeAttachment,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            logger = logger,
+        )
+        val fileContent = "This is test data".toByteArray()
+        val inputStream = ByteArrayInputStream(fileContent)
+        val contentResolverShadow = shadowOf(context.contentResolver)
+
+        contentResolverShadow.registerInputStream("content://internal/path".toUri(), inputStream)
+
+        // Act
+        fakeAttachmentController.viewAttachment(this)
+        advanceUntilIdle()
+
+        // Assert
+        assertThat(fakeAttachment.isContentAvailable).isTrue()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `saveAttachmentTo should write internal URI data into document URI`() = runTest {
+        // Arrange
+        val internalUri = "content://internal/path".toUri()
+        val documentUri = "content://document/path".toUri()
+
+        val thisAttachment = AttachmentViewInfo(
+            mimeType = mimeType,
+            displayName = displayName,
+            size = 42L,
+            internalUri = internalUri,
+            inlineAttachment = false,
+            part = part,
+            isContentAvailable = true,
+        )
+
+        val controller = AttachmentController(
+            context = context,
+            controller = FakeAttachmentLoadingController(),
+            attachmentDisplayController = FakeAttachmentDisplayController(),
+            attachment = thisAttachment,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            logger = logger,
+        )
+
+        val fileContent = "This is test data".toByteArray()
+        val inputStream = ByteArrayInputStream(fileContent)
+        val outputStream = ByteArrayOutputStream()
+
+        val contentResolverShadow = shadowOf(context.contentResolver)
+        contentResolverShadow.registerInputStream(internalUri, inputStream)
+        contentResolverShadow.registerOutputStream(documentUri, outputStream)
+
+        // Act
+        controller.saveAttachmentTo(this, documentUri)
+        advanceUntilIdle()
+
+        // Assert
+        val writtenBytes = outputStream.toByteArray()
+        assertArrayEquals(fileContent, writtenBytes)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `viewing attachment should an appropriate activity with ACTION intent`() = runTest {
+        // Arrange
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val shadowApplication = shadowOf(application)
+        val contentResolverShadow = shadowOf(context.contentResolver)
+        val internalUri = "content://internal/path".toUri()
+
+        val thisAttachment = AttachmentViewInfo(
+            mimeType = mimeType,
+            displayName = displayName,
+            size = 42L,
+            internalUri = internalUri,
+            inlineAttachment = false,
+            part = part,
+            isContentAvailable = true,
+        )
+
+        val controller = AttachmentController(
+            context = context,
+            controller = FakeAttachmentLoadingController(),
+            attachmentDisplayController = FakeAttachmentDisplayController(),
+            attachment = thisAttachment,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            logger = logger,
+        )
+
+        val fileContent = "This is test data".toByteArray()
+        val inputStream = ByteArrayInputStream(fileContent)
+        contentResolverShadow.registerInputStream(internalUri, inputStream)
+
+        // Act
+        controller.viewAttachment(this)
+        advanceUntilIdle()
+
+        // Assert
+        val intent = shadowApplication.nextStartedActivity
+        assertThat(intent).isNotNull()
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals("application/octet-stream", intent.type)
+    }
+
+    private fun initializeAttachmentTempFileProvider() {
+        val attachmentTempFileProviderAuthority = "${context.packageName}.tempfileprovider"
+
+        val info = ProviderInfo().apply {
+            authority = attachmentTempFileProviderAuthority
+            grantUriPermissions = true
+        }
+        Robolectric.buildContentProvider(AttachmentTempFileProvider::class.java).create(info)
+    }
+
+    class FakeAttachmentDisplayController : AttachmentDisplayController {
+        override fun showAttachmentLoadingDialog() {}
+
+        override fun hideAttachmentLoadingDialogOnMainThread() {}
+
+        override fun refreshAttachmentThumbnail(attachment: AttachmentViewInfo) {}
+    }
+
+    class FakeAttachmentLoadingController: AttachmentLoadingController {
+        override fun loadAttachment(
+            part: Part?,
+            listener: MessagingListener,
+        ) {
+            val localPart = part as? LocalPart
+            val account = LegacyAccountDto("00000000-0000-4000-0000-000000000000")
+            listener.loadAttachmentFinished(account, localPart?.message, part)
+        }
+    }
+
+    private class FakeGeneralSettingsManager : GeneralSettingsManager {
+        override fun getSettings(): GeneralSettings = getConfig()
+        override fun getSettingsFlow(): Flow<GeneralSettings> = getConfigFlow()
+        override fun getConfig(): GeneralSettings = GeneralSettings(
+            platformConfigProvider = object : PlatformConfigProvider {
+                override val isDebug: Boolean = true
+            }
+        )
+        override fun getConfigFlow(): Flow<GeneralSettings> = flowOf(getConfig())
+        override fun save(config: GeneralSettings) {}
+    }
+}

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/AttachmentControllerTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/AttachmentControllerTest.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ProviderInfo
-import android.net.Uri
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import app.k9mail.legacy.message.controller.MessagingListener
@@ -18,15 +17,11 @@ import com.fsck.k9.mailstore.LocalPart
 import com.fsck.k9.provider.AttachmentTempFileProvider
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.io.IOException
-import java.io.OutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -52,7 +47,8 @@ class AttachmentControllerTest : RobolectricTest() {
 
     private val displayName = "document.pdf"
     private val mimeType = "application/pdf"
-    private val part = LocalBodyPart("00000000-0000-4000-0000-000000000000",
+    private val part = LocalBodyPart(
+        "00000000-0000-4000-0000-000000000000",
         null,
         1L,
         42L,
@@ -209,14 +205,14 @@ class AttachmentControllerTest : RobolectricTest() {
     }
 
     class FakeAttachmentDisplayController : AttachmentDisplayController {
-        override fun showAttachmentLoadingDialog() {}
+        override fun showAttachmentLoadingDialog() = Unit
 
-        override fun hideAttachmentLoadingDialogOnMainThread() {}
+        override fun hideAttachmentLoadingDialogOnMainThread() = Unit
 
-        override fun refreshAttachmentThumbnail(attachment: AttachmentViewInfo) {}
+        override fun refreshAttachmentThumbnail(attachment: AttachmentViewInfo) = Unit
     }
 
-    class FakeAttachmentLoadingController: AttachmentLoadingController {
+    class FakeAttachmentLoadingController : AttachmentLoadingController {
         override fun loadAttachment(
             part: Part?,
             listener: MessagingListener,
@@ -233,9 +229,10 @@ class AttachmentControllerTest : RobolectricTest() {
         override fun getConfig(): GeneralSettings = GeneralSettings(
             platformConfigProvider = object : PlatformConfigProvider {
                 override val isDebug: Boolean = true
-            }
+            },
         )
+
         override fun getConfigFlow(): Flow<GeneralSettings> = flowOf(getConfig())
-        override fun save(config: GeneralSettings) {}
+        override fun save(config: GeneralSettings) = Unit
     }
 }


### PR DESCRIPTION
Part of #11096 

#### Description
- Implement AttachmentDisplayController interface to decouple MessageViewFragment from AttachmentController and avoid mocking.
- Implement AttachmentLoadingController interface to decouple `MessagingController` from AttachmentController and avoid mocking
- Introduce tests for AttachmentController

## AI Disclosure

- [x] This contribution includes changes assisted by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
