### PR TITLE
fix: dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,7 @@ updates:
     labels:
       - "type: dependency"
       - "type: gradle"
+      - "report: exclude"
     cooldown:
       default-days: 7
     commit-message:
@@ -40,6 +41,7 @@ updates:
     labels:
       - "type: dependency"
       - "type: pip"
+      - "report: exclude"
     cooldown:
       default-days: 7
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,8 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      - dependency-name: "gradle"
   - package-ecosystem: pip
     open-pull-requests-limit: 10
     directories:


### PR DESCRIPTION
This improves the dependabot config by adding `report: exclude` by default for Gradle and Pip updates. 

Added rule to exclude Gradle wrapper updates as they always require manual updates.
