### PR TITLE
docs: add RFC for rendering inline images in plain-text messages

### DIFF
--- a/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
+++ b/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
@@ -99,12 +99,12 @@ consistently to users.**
 ## Risks & Drawbacks
 
 - **False positives.** Broad inlining may render something a sender or user thought of as an attachment in the body. The
-  default-on preference mitigates this: users who dislike it can turn it off. Scoping to plain-text-only further limits
-  exposure.
+  risk is limited by requiring `Content-Disposition: inline`, supported image types, and scoping the first iteration to
+  plain-text messages without an HTML alternative.
 
-- **Behavioural divergence within Android.** Existing `cid:` inline images are hidden from the attachment list; named
-  positional inline images will be listed. Two inline images could be treated differently in the list depending on how
-  they were authored. This matches Desktop's actual behaviour, but is an internal inconsistency worth noting.
+- **Attachment-list noise.** Named inline images, such as logos or email signatures, may appear in the attachment UI. 
+  This increases clarity for saving user-visible images but can add noise on small screens. **The UI should rely on the
+  existing attachment presentation rather than adding a separate inline-image setting.**
 
 - **Large images.** Inlining a multi-megabyte photo affects body rendering cost. The chosen rendering path loads the
   image lazily (it is not embedded in the HTML document), which keeps this in line with existing `cid:` images.

--- a/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
+++ b/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
@@ -1,4 +1,4 @@
-# RFC 0003: Render inline images in plain-text messages (Apple Mail positional images)
+# RFC 0003: Render inline images in plain-text messages
 
 - Issue: [#11179](https://github.com/thunderbird/thunderbird-android/issues/11179)
 - Technical design: TBD
@@ -14,8 +14,9 @@ mirroring Desktop's `mail.inline_attachments`. Additionally, this new behaviour 
 
 ## Motivation
 
-Some senders, most notably Apple Mail composing in plain text, attach images *inline* by position rather than by HTML
-reference. A representative message is a `multipart/mixed` whose children are, in order:
+Some senders attach images *inline* by position rather than by HTML reference. Apple Mail composing in plain text is a
+common producer of this standards-based message shape, but **the behaviour is not Apple-specific**. A representative 
+message is a `multipart/mixed` whose children are, in order:
 
 ```
 multipart/mixed  

--- a/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
+++ b/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
@@ -79,8 +79,8 @@ consistently to users.**
 
 - **Strict, Apple-Mail-only heuristic.** Inline only images that exactly match the Apple Mail shape (explicit
   `Content-Disposition: inline`, sibling of text parts, no HTML). Lowest false-positive risk, but narrower than Desktop
-  and would still render some messages differently from desktop. **Rejected** in favour of Desktop parity, which the
-  preference makes safe to default on.
+  and would still render some standards-based messages differently from desktop. 
+  - **Rejected** in favour of handling the standards-based shape directly.
 
 - **Add a user-visible setting.** This would mirror Desktop's `mail.inline_attachments` preference and provide an 
   opt-out for users who prefer an attachment-only view. 
@@ -89,11 +89,12 @@ consistently to users.**
     correctly by default.
 
 - **Hide all inline images from the attachment list (body-only).** Consistent with how Android treats `cid:` inline
-  images today. **Rejected** because it removes the easy save affordance and diverges from Desktop, which lists named
-  inline images.  ***Note**: TfA supports long-press to save on inline images, but it isn't as explicit as on Desktop.*
+  images today. 
+  - **Rejected** because it removes the explicit save/discovery affordance. Thunderbird for Android supports
+    long-press save on inline images, but that is less visible than the attachment UI.
 
-- **Do nothing.** Leave these images as attachments. **Rejected:** It is a visible cross-product inconsistency on a
-  common message shape.
+- **Do nothing.** Leave these images as attachments. 
+  - **Rejected:** It is a visible cross-product inconsistency on a common message shape.
 
 ## Risks & Drawbacks
 

--- a/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
+++ b/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
@@ -1,0 +1,115 @@
+# RFC 0003: Render inline images in plain-text messages (Apple Mail positional images)
+
+- Issue: [#11179](https://github.com/thunderbird/thunderbird-android/issues/11179)
+- Technical design: TBD
+- Status: **Proposed**
+
+## Summary
+
+Display images in the message body when a message carries them as positionally placed parts rather than `cid:`
+-referenced HTML images. Today these render only as attachments. This brings Thunderbird for Android in line with
+Thunderbird Desktop, which displays such images inline. The behaviour is gated behind a new preference (default on),
+mirroring Desktop's `mail.inline_attachments`. Additionally, this new behaviour must be secured under a feature flag
+(`enable_inline_images_positional_body_message`)
+
+## Motivation
+
+Some senders, most notably Apple Mail composing in plain text, attach images *inline* by position rather than by HTML
+reference. A representative message is a `multipart/mixed` whose children are, in order:
+
+```
+multipart/mixed  
+├── text/plain   "Text before"  
+├── image/jpeg   Content-Disposition: inline; filename=DSC01740.jpeg   (no Content-ID)  
+└── text/plain   "Text after"  
+```
+
+There is no HTML part and no `cid:` reference. The sender intends that the image appear between the two text blocks.
+
+Currently, the app only inlines images that are referenced from an HTML body via `cid:` and have a matching
+`Content-ID`. An image like the one above satisfies neither condition, so it is shown solely as an attachment. The user
+sees an attachment card/entry instead of the picture the sender placed in the message.
+
+Thunderbird Desktop displays this image inline by default. The two products diverging on a common, real-world message
+shape is a usability gap and the same message to look the same.
+
+This is **not** a regression: the `cid:` inline path works correctly. It is a class of message that has never been
+supported on the app.
+
+## Proposal
+
+Render any images which contain the header `Content-Disposition: inline`, that a message places among its body parts
+inline, at its position, even when it has no `Content-ID`, and it is not referenced by any HTML.
+
+Concretely:
+
+1. When a message body contains an image part that is not already handled as a `cid:` attachment, display it inline in
+   the rendered body at the position it occupies in the MIME structure. This applies to supported image types only, and
+   images that contain the header `Content-Disposition: inline`; other media (PDF, video, ...) continue to be shown as a
+   regular attachment because the message body cannot render them.
+
+2. Introduce an Android equivalent of the desktop's `mail.inline_attachments` preference. When enabled (the default),
+   images display inline as described. When disabled, behaviour escape hatch if they prefer a compact, attachment-only
+   view, and matches the control Desktop already exposes.
+
+3. Following Desktop's rule, an inline image that has a filename is shown **both** in the body and as an attachment
+   chip (so it remains easy to find and save). An inline image with no filename is shown in the body only. This differs
+   from how Android currently hides `cid:` inline images from the attachment list; see Risks & Drawbacks.
+
+4. Scope to plain-text messages (no HTML alternative). The unambiguous, high-value case is a `multipart/mixed` (or
+   similar) message with no HTML body. Messages that contain both an HTML alternative and loose inline images are out of
+   scope for the first iteration; they are discussed in Open Questions.
+
+The decision requested from reviewers: **adopt Desktop-parity inline image display for plain-text messages, gated behind
+a default-on preference, with named images also listed as attachments.**
+
+## Alternatives Considered
+
+- **Strict, Apple-Mail-only heuristic.** Inline only images that exactly match the Apple Mail shape (explicit
+  `Content-Disposition: inline`, sibling of text parts, no HTML). Lowest false-positive risk, but narrower than Desktop
+  and would still render some messages differently from desktop. **Rejected** in favour of Desktop parity, which the
+  preference makes safe to default on.
+
+- **Inline broadly with no preference.** Simpler (no settings surface), but removes the user's ability to opt out and is
+  a less faithful match to Desktop, which ships the toggle. **Rejected** because the toggle is cheap insurance against
+  the breadth occasionally inlining something a user considered an attachment.
+
+- **Hide all inline images from the attachment list (body-only).** Consistent with how Android treats `cid:` inline
+  images today. **Rejected** because it removes the easy save affordance and diverges from Desktop, which lists named
+  inline images.  ***Note**: TfA supports long-press to save on inline images, but it isn't as explicit as on Desktop.*
+
+- **Do nothing.** Leave these images as attachments. **Rejected:** It is a visible cross-product inconsistency on a
+  common message shape.
+
+## Risks & Drawbacks
+
+- **False positives.** Broad inlining may render something a sender or user thought of as an attachment in the body. The
+  default-on preference mitigates this: users who dislike it can turn it off. Scoping to plain-text-only further limits
+  exposure.
+
+- **Behavioural divergence within Android.** Existing `cid:` inline images are hidden from the attachment list; named
+  positional inline images will be listed. Two inline images could be treated differently in the list depending on how
+  they were authored. This matches Desktop's actual behaviour, but is an internal inconsistency worth noting.
+
+- **Large images.** Inlining a multi-megabyte photo affects body rendering cost. The chosen rendering path loads the
+  image lazily (it is not embedded in the HTML document), which keeps this in line with existing `cid:` images.
+
+## Open Questions
+
+- **HTML + loose images.** When a message has both an HTML alternative and loose inline images, should the loose images
+  be appended/inlined (as Desktop does), or should we trust the HTML and leave them as attachments? **Proposed:** out of
+  scope for this RFC, follow-up issue.
+
+- **Nested under `multipart/alternative`.** Positional images nested inside an alternative are an unusual shape. Exclude
+  or handle? **Proposed:** exclude.
+
+- **Reply/quote/forward.** Should positional inline images be reproduced when quoting a message (*Desktop has a separate
+  preference for this*)? **Proposed:** out of scope for this RFC.
+
+- **Preference placement and naming.** Where in Settings should the toggle live, and what should it be called?
+  (Implementation detail deferred to the technical design, but the user-facing label needs product/UX input.)
+
+## Outcome
+
+_To be filled in when the RFC is accepted, rejected, or obsoleted. Summarize the final decision and link follow-up
+work._

--- a/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
+++ b/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
@@ -36,6 +36,17 @@ shape is a usability gap and the same message to look the same.
 This is **not** a regression: the `cid:` inline path works correctly. It is a class of message that has never been
 supported on the app.
 
+## Standards References
+
+- [RFC 2183, section 2.1](https://www.rfc-editor.org/rfc/rfc2183.html#section-2.1) defines `inline` as a disposition
+  for body parts intended to be displayed automatically.
+- [RFC 2046, section 5.1.3](https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.3) defines `multipart/mixed` as
+  ordered independent body parts.
+- [RFC 2392](https://www.rfc-editor.org/rfc/rfc2392.html) defines `cid:` URLs used by HTML bodies to reference MIME
+  parts. This is the existing inline-image path and is distinct from this positional plain-text case.
+- [RFC 2387](https://www.rfc-editor.org/rfc/rfc2387.html) defines `multipart/related`, which is relevant for HTML plus
+  related resources but is not the plain-text positional case covered by this RFC.
+
 ## Proposal
 
 Render any images which contain the header `Content-Disposition: inline`, that a message places among its body parts

--- a/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
+++ b/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
@@ -14,7 +14,7 @@ Thunderbird Desktop, which displays such images inline. **This behaviour must be
 ## Motivation
 
 Some senders attach images *inline* by position rather than by HTML reference. Apple Mail composing in plain text is a
-common producer of this standards-based message shape, but **the behaviour is not Apple-specific**. A representative 
+common producer of this standards-based message shape, but **the behaviour is not Apple-specific**. A representative
 message is a `multipart/mixed` whose children are, in order:
 
 ```
@@ -60,7 +60,7 @@ Concretely:
    images that contain the header `Content-Disposition: inline`; other media (PDF, video, ...) continue to be shown as a
    regular attachment because the message body cannot render them.
 
-2. **Keep existing `cid:` inline image rendering unchanged.** This RFC adds support for positional plain-text inline 
+2. **Keep existing `cid:` inline image rendering unchanged.** This RFC adds support for positional plain-text inline
    images; it must not reinterpret HTML `cid:` references or `multipart/related` resources.
 
 3. Treat inline images consistently in the user-facing attachment affordance. If an inline image has a filename, it is
@@ -68,32 +68,29 @@ Concretely:
    placed positionally. **An inline image with no filename is shown in the body only.**
 
 4. **Scope to plain-text messages with no HTML alternative.** The unambiguous, high-value case is a `multipart/mixed`
-   (or similar) message with no HTML body. Messages that contain both an HTML alternative and loose inline images are 
+   (or similar) message with no HTML body. Messages that contain both an HTML alternative and loose inline images are
    out of scope for the first iteration; see Non-goals.
 
-The proposed decision is: **render standards-based positional inline images in plain-text messages, without adding a 
-user-visible setting, while keeping existing `cid:` rendering intact and presenting inline image attachments 
+The proposed decision is: **render standards-based positional inline images in plain-text messages, without adding a
+user-visible setting, while keeping existing `cid:` rendering intact and presenting inline image attachments
 consistently to users.**
 
 ## Alternatives Considered
 
 - **Strict, Apple-Mail-only heuristic.** Inline only images that exactly match the Apple Mail shape (explicit
   `Content-Disposition: inline`, sibling of text parts, no HTML). Lowest false-positive risk, but narrower than Desktop
-  and would still render some standards-based messages differently from desktop. 
+  and would still render some standards-based messages differently from desktop.
   - **Rejected** in favour of handling the standards-based shape directly.
-
-- **Add a user-visible setting.** This would mirror Desktop's `mail.inline_attachments` preference and provide an 
-  opt-out for users who prefer an attachment-only view. 
-  - **Rejected** because the sender explicitly marked these parts as inline, users should not need to reason about 
-    sender implementation details, and the app is moving away from adding settings for behaviour that should work 
+- **Add a user-visible setting.** This would mirror Desktop's `mail.inline_attachments` preference and provide an
+  opt-out for users who prefer an attachment-only view.
+  - **Rejected** because the sender explicitly marked these parts as inline, users should not need to reason about
+    sender implementation details, and the app is moving away from adding settings for behaviour that should work
     correctly by default.
-
 - **Hide all inline images from the attachment list (body-only).** Consistent with how Android treats `cid:` inline
-  images today. 
+  images today.
   - **Rejected** because it removes the explicit save/discovery affordance. Thunderbird for Android supports
     long-press save on inline images, but that is less visible than the attachment UI.
-
-- **Do nothing.** Leave these images as attachments. 
+- **Do nothing.** Leave these images as attachments.
   - **Rejected:** It is a visible cross-product inconsistency on a common message shape.
 
 ## Risks & Drawbacks
@@ -102,7 +99,7 @@ consistently to users.**
   risk is limited by requiring `Content-Disposition: inline`, supported image types, and scoping the first iteration to
   plain-text messages without an HTML alternative.
 
-- **Attachment-list noise.** Named inline images, such as logos or email signatures, may appear in the attachment UI. 
+- **Attachment-list noise.** Named inline images, such as logos or email signatures, may appear in the attachment UI.
   This increases clarity for saving user-visible images but can add noise on small screens. **The UI should rely on the
   existing attachment presentation rather than adding a separate inline-image setting.**
 
@@ -115,13 +112,13 @@ consistently to users.**
   iteration. Appending them may duplicate content or expose tracking assets, so this requires real samples and a
   follow-up proposal.
 
-- **Nested under `multipart/alternative`.** Positional images nested inside an alternative are excluded. Alternatives 
+- **Nested under `multipart/alternative`.** Positional images nested inside an alternative are excluded. Alternatives
   are not content to render together; the renderer should pick the best supported alternative and ignore the others.
 
 - **Reply/quote/forward.** This RFC only changes the message display. Reply, quote, and forward behaviour **should  
   remain unchanged and be handled in a follow-up proposal if needed.**
 
-- **Per-account or per-message overrides.** No user-visible setting is proposed for this feature. Per-message state 
+- **Per-account or per-message overrides.** No user-visible setting is proposed for this feature. Per-message state
   would be device-local and hard to sync or import/export, and per-account behaviour would make the same message render
   differently depending on where it is viewed.
 

--- a/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
+++ b/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
@@ -8,9 +8,8 @@
 
 Display images in the message body when a message carries them as positionally placed parts rather than `cid:`
 -referenced HTML images. Today these render only as attachments. This brings Thunderbird for Android in line with
-Thunderbird Desktop, which displays such images inline. The behaviour is gated behind a new preference (default on),
-mirroring Desktop's `mail.inline_attachments`. Additionally, this new behaviour must be secured under a feature flag
-(`enable_inline_images_positional_body_message`)
+Thunderbird Desktop, which displays such images inline. **This behaviour must be secured under a feature flag
+(`enable_inline_images_positional_body_message`) while it is being implemented and validated.**
 
 ## Motivation
 
@@ -71,9 +70,11 @@ a default-on preference, with named images also listed as attachments.**
   and would still render some messages differently from desktop. **Rejected** in favour of Desktop parity, which the
   preference makes safe to default on.
 
-- **Inline broadly with no preference.** Simpler (no settings surface), but removes the user's ability to opt out and is
-  a less faithful match to Desktop, which ships the toggle. **Rejected** because the toggle is cheap insurance against
-  the breadth occasionally inlining something a user considered an attachment.
+- **Add a user-visible setting.** This would mirror Desktop's `mail.inline_attachments` preference and provide an 
+  opt-out for users who prefer an attachment-only view. 
+  - **Rejected** because the sender explicitly marked these parts as inline, users should not need to reason about 
+    sender implementation details, and the app is moving away from adding settings for behaviour that should work 
+    correctly by default.
 
 - **Hide all inline images from the attachment list (body-only).** Consistent with how Android treats `cid:` inline
   images today. **Rejected** because it removes the easy save affordance and diverges from Desktop, which lists named

--- a/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
+++ b/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
@@ -27,11 +27,12 @@ multipart/mixed
 There is no HTML part and no `cid:` reference. The sender intends that the image appear between the two text blocks.
 
 Currently, the app only inlines images that are referenced from an HTML body via `cid:` and have a matching
-`Content-ID`. An image like the one above satisfies neither condition, so it is shown solely as an attachment. The user
-sees an attachment card/entry instead of the picture the sender placed in the message.
+`Content-ID`. **That existing path should continue to work unchanged.** An image like the one above satisfies neither
+condition, so it is shown solely as an attachment. The user sees an attachment card/entry instead of the picture the
+sender placed in the message.
 
-Thunderbird Desktop displays this image inline by default. The two products diverging on a common, real-world message
-shape is a usability gap and the same message to look the same.
+Thunderbird Desktop displays this image inline by default. This divergence is a usability gap because the same message
+does not look the same across products.
 
 This is **not** a regression: the `cid:` inline path works correctly. It is a class of message that has never been
 supported on the app.
@@ -49,8 +50,8 @@ supported on the app.
 
 ## Proposal
 
-Render any images which contain the header `Content-Disposition: inline`, that a message places among its body parts
-inline, at its position, even when it has no `Content-ID`, and it is not referenced by any HTML.
+Render supported images that have `Content-Disposition: inline` at the position where the message places them among its
+body parts, even when the image has no `Content-ID` and is not referenced by any HTML.
 
 Concretely:
 
@@ -59,20 +60,20 @@ Concretely:
    images that contain the header `Content-Disposition: inline`; other media (PDF, video, ...) continue to be shown as a
    regular attachment because the message body cannot render them.
 
-2. Introduce an Android equivalent of the desktop's `mail.inline_attachments` preference. When enabled (the default),
-   images display inline as described. When disabled, behaviour escape hatch if they prefer a compact, attachment-only
-   view, and matches the control Desktop already exposes.
+2. **Keep existing `cid:` inline image rendering unchanged.** This RFC adds support for positional plain-text inline 
+   images; it must not reinterpret HTML `cid:` references or `multipart/related` resources.
 
-3. Following Desktop's rule, an inline image that has a filename is shown **both** in the body and as an attachment
-   chip (so it remains easy to find and save). An inline image with no filename is shown in the body only. This differs
-   from how Android currently hides `cid:` inline images from the attachment list; see Risks & Drawbacks.
+3. Treat inline images consistently in the user-facing attachment affordance. If an inline image has a filename, it is
+   shown in the body and remains discoverable in the attachment UI, regardless of whether it was referenced by `cid:` or
+   placed positionally. **An inline image with no filename is shown in the body only.**
 
-4. Scope to plain-text messages (no HTML alternative). The unambiguous, high-value case is a `multipart/mixed` (or
-   similar) message with no HTML body. Messages that contain both an HTML alternative and loose inline images are out of
-   scope for the first iteration; they are discussed in Open Questions.
+4. **Scope to plain-text messages with no HTML alternative.** The unambiguous, high-value case is a `multipart/mixed`
+   (or similar) message with no HTML body. Messages that contain both an HTML alternative and loose inline images are 
+   out of scope for the first iteration; see Non-goals.
 
-The decision requested from reviewers: **adopt Desktop-parity inline image display for plain-text messages, gated behind
-a default-on preference, with named images also listed as attachments.**
+The proposed decision is: **render standards-based positional inline images in plain-text messages, without adding a 
+user-visible setting, while keeping existing `cid:` rendering intact and presenting inline image attachments 
+consistently to users.**
 
 ## Alternatives Considered
 

--- a/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
+++ b/docs/engineering/rfcs/0003-render-inline-images-in-plain-text-messages.md
@@ -109,20 +109,21 @@ consistently to users.**
 - **Large images.** Inlining a multi-megabyte photo affects body rendering cost. The chosen rendering path loads the
   image lazily (it is not embedded in the HTML document), which keeps this in line with existing `cid:` images.
 
-## Open Questions
+## Non-goals
 
-- **HTML + loose images.** When a message has both an HTML alternative and loose inline images, should the loose images
-  be appended/inlined (as Desktop does), or should we trust the HTML and leave them as attachments? **Proposed:** out of
-  scope for this RFC, follow-up issue.
+- **HTML + loose images.** Messages with both an HTML alternative and loose inline images are out of scope for the first
+  iteration. Appending them may duplicate content or expose tracking assets, so this requires real samples and a
+  follow-up proposal.
 
-- **Nested under `multipart/alternative`.** Positional images nested inside an alternative are an unusual shape. Exclude
-  or handle? **Proposed:** exclude.
+- **Nested under `multipart/alternative`.** Positional images nested inside an alternative are excluded. Alternatives 
+  are not content to render together; the renderer should pick the best supported alternative and ignore the others.
 
-- **Reply/quote/forward.** Should positional inline images be reproduced when quoting a message (*Desktop has a separate
-  preference for this*)? **Proposed:** out of scope for this RFC.
+- **Reply/quote/forward.** This RFC only changes the message display. Reply, quote, and forward behaviour **should  
+  remain unchanged and be handled in a follow-up proposal if needed.**
 
-- **Preference placement and naming.** Where in Settings should the toggle live, and what should it be called?
-  (Implementation detail deferred to the technical design, but the user-facing label needs product/UX input.)
+- **Per-account or per-message overrides.** No user-visible setting is proposed for this feature. Per-message state 
+  would be device-local and hard to sync or import/export, and per-account behaviour would make the same message render
+  differently depending on where it is viewed.
 
 ## Outcome
 


### PR DESCRIPTION
## Contribution Summary

Closes #11179. 

#### Description

Adds a new RFC for rendering inline images in plain-text messages using positional body placement.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
        **Disclaimer**: Use AI for proofreading.
- [ ] This contribution includes changes created by AI.
