### PR TITLE
feat(message-list): adds an indicator to the selected sort type

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/LegacyMessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/LegacyMessageListFragment.kt
@@ -1177,6 +1177,20 @@ class LegacyMessageListFragment :
 
     private fun prepareSortMenu(menu: Menu) {
         menu.findItem(R.id.set_sort).isVisible = true
+        val selectedSortItem = menu.findItem(getSelectedSortId())
+        selectedSortItem.title = "${resources.getString(R.string.sort_by_indicator)} ${selectedSortItem.title}"
+    }
+
+    private fun getSelectedSortId(): Int {
+        return when (this.sortType) {
+            SortType.SORT_DATE -> R.id.set_sort_date
+            SortType.SORT_ARRIVAL -> R.id.set_sort_arrival
+            SortType.SORT_SUBJECT -> R.id.set_sort_subject
+            SortType.SORT_SENDER -> R.id.set_sort_sender
+            SortType.SORT_UNREAD -> R.id.set_sort_unread
+            SortType.SORT_FLAGGED -> R.id.set_sort_flag
+            SortType.SORT_ATTACHMENT -> R.id.set_sort_attach
+        }
     }
 
     private fun prepareDebugMenu(menu: Menu) {

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -651,6 +651,7 @@
     <string name="sort_by_flag">Star</string>
     <string name="sort_by_unread">Read/unread</string>
     <string name="sort_by_attach">Attachments</string>
+    <string name="sort_by_indicator">•</string>
 
     <string name="account_delete_dlg_title">Remove Account</string>
 


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: #11184 

RFC / Technical Design (if applicable): N/A

#### Description

This adds a small text indicator, "•", to the selected sort option. Why? There was some confusion around what item was selected when sorting, and, as it's persistent, users could forget or accidentally change something and not know what sort option was selected. This text-based solution was selected because it was the minimum change we could make to this, mostly because we're planning on replacing this altogether with a new view.

We do already have a custom drop-down sort menu, introduced in [this PR](https://github.com/thunderbird/thunderbird-android/pull/10444), which provides more search options as well as enhanced clarity as to what's selected. However, the UI isn't complete, and completing it isn't currently on the roadmap. We needed something quicker for the existing view, though we do intend to eventually replace this. 


#### Screen Shots

**Before**:

<img width="177" height="325" alt="Screenshot 2026-06-24 at 5 48 08 PM" src="https://github.com/user-attachments/assets/89e7c0b3-a3f5-41fb-a9f8-5e6658863461" />


**After**:

<img width="182" height="326" alt="Screenshot 2026-06-24 at 5 28 48 PM" src="https://github.com/user-attachments/assets/8ddf66b5-1ecf-4989-b459-d2dea8623c10" />
<img width="172" height="324" alt="Screenshot 2026-06-24 at 5 29 27 PM" src="https://github.com/user-attachments/assets/96410e91-b4e8-4071-a8f9-fb69d88f20d2" />


## AI Disclosure

Select **one** of the following (mandatory)

- [X] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [X] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [X] This contribution is in Kotlin where possible
- [X] This contribution does not use merge commits
- [X] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [X] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [X] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [X] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [X] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
