### PR TITLE
fix: thread counted as single message in confirmation dialog

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/LegacyMessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/LegacyMessageListFragment.kt
@@ -1008,11 +1008,11 @@ class LegacyMessageListFragment :
         changeSort(nextSortType)
     }
 
-    private fun onDelete(messages: List<MessageReference>) {
+    private fun onDelete(messages: List<MessageReference>, count: Int) {
         if (interactionSettings.isConfirmDelete) {
             // remember the message selection for #onCreateDialog(int)
             activeMessages = messages
-            showDialog(R.id.dialog_confirm_delete)
+            showDialog(R.id.dialog_confirm_delete, count)
         } else {
             onDeleteConfirmed(messages)
         }
@@ -1056,15 +1056,14 @@ class LegacyMessageListFragment :
             return currentFolder!!.databaseId == account!!.trashFolderId
         }
 
-    private fun showDialog(dialogId: Int) {
+    private fun showDialog(dialogId: Int, selectionCount: Int = 1) {
         val dialogFragment = when (dialogId) {
             R.id.dialog_confirm_spam -> {
                 val title = getString(R.string.dialog_confirm_spam_title)
-                val selectionSize = activeMessages!!.size
                 val message = resources.getQuantityString(
                     R.plurals.dialog_confirm_spam_message,
-                    selectionSize,
-                    selectionSize,
+                    selectionCount,
+                    selectionCount,
                 )
                 val confirmText = getString(R.string.dialog_confirm_spam_confirm_button)
                 val cancelText = getString(R.string.dialog_confirm_spam_cancel_button)
@@ -1073,11 +1072,10 @@ class LegacyMessageListFragment :
 
             R.id.dialog_confirm_delete -> {
                 val title = getString(R.string.dialog_confirm_delete_title)
-                val selectionSize = activeMessages!!.size
                 val message = resources.getQuantityString(
                     R.plurals.dialog_confirm_delete_messages,
-                    selectionSize,
-                    selectionSize,
+                    selectionCount,
+                    selectionCount,
                 )
                 val confirmText = getString(R.string.dialog_confirm_delete_confirm_button)
                 val cancelText = getString(R.string.dialog_confirm_delete_cancel_button)
@@ -1109,7 +1107,7 @@ class LegacyMessageListFragment :
             }
 
             else -> {
-                throw RuntimeException("Called showDialog(int) with unknown dialog id.")
+                throw RuntimeException("Called showDialog(int, int) with unknown dialog id.")
             }
         }
 
@@ -1662,11 +1660,11 @@ class LegacyMessageListFragment :
         return messages.groupBy { accountManager.getAccount(it.accountUuid)!! }
     }
 
-    private fun onSpam(messages: List<MessageReference>) {
+    private fun onSpam(messages: List<MessageReference>, count: Int) {
         if (interactionSettings.isConfirmSpam) {
             // remember the message selection for #onCreateDialog(int)
             activeMessages = messages
-            showDialog(R.id.dialog_confirm_spam)
+            showDialog(R.id.dialog_confirm_spam, count)
         } else {
             onSpamConfirmed(messages)
         }
@@ -1903,9 +1901,12 @@ class LegacyMessageListFragment :
     private val selectedMessages: List<MessageReference>
         get() = adapter.selectedMessages.map { it.messageReference }
 
+    private val selectedMessagesCount
+        get() = adapter.selectedCount
+
     override fun onDelete() {
         selectedMessage?.let { message ->
-            onDelete(listOf(message))
+            onDelete(listOf(message), selectedMessagesCount)
         }
     }
 
@@ -2254,11 +2255,11 @@ class LegacyMessageListFragment :
                 }
 
                 SwipeAction.Delete -> {
-                    onDelete(listOf(item.messageReference))
+                    onDelete(listOf(item.messageReference), item.threadCount)
                 }
 
                 SwipeAction.Spam -> {
-                    onSpam(listOf(item.messageReference))
+                    onSpam(listOf(item.messageReference), item.threadCount)
                 }
 
                 SwipeAction.Move -> {
@@ -2614,7 +2615,7 @@ class LegacyMessageListFragment :
 
             val endSelectionMode = when (item.itemId) {
                 R.id.delete -> {
-                    onDelete(selectedMessages)
+                    onDelete(selectedMessages, selectedMessagesCount)
                     true
                 }
 
@@ -2650,7 +2651,7 @@ class LegacyMessageListFragment :
                 }
 
                 R.id.spam -> {
-                    onSpam(selectedMessages)
+                    onSpam(selectedMessages, selectedMessagesCount)
                     // TODO: Only finish action mode if all messages have been moved.
                     true
                 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -953,7 +953,7 @@ class MessageListFragment :
         val dialogFragment = when (dialogId) {
             R.id.dialog_confirm_spam -> {
                 val title = getString(R.string.dialog_confirm_spam_title)
-                val selectionSize = activeMessages!!.size
+                val selectionSize = selectedMessagesCount
                 val message = resources.getQuantityString(
                     R.plurals.dialog_confirm_spam_message,
                     selectionSize,
@@ -966,7 +966,7 @@ class MessageListFragment :
 
             R.id.dialog_confirm_delete -> {
                 val title = getString(R.string.dialog_confirm_delete_title)
-                val selectionSize = activeMessages!!.size
+                val selectionSize = selectedMessagesCount
                 val message = resources.getQuantityString(
                     R.plurals.dialog_confirm_delete_messages,
                     selectionSize,


### PR DESCRIPTION
Fixes #8223 

#### Description

- Display the correct count of messages in the confirmation dialog when trying to delete/spam a thread by either swiping or selecting it.
- MessageListFragment does not yet have swipe actions, so for now, `selectedMessagesCount` can be used to get the correct count.

#### Updated Behaviour


https://github.com/user-attachments/assets/7cf1b537-3718-4296-a7d4-353e1c50e80b



## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
