### PR TITLE
fix(account-settings): colour picker crashing by 'infinity maximum height constraints'

### DIFF
--- a/core/ui/setting/impl-dialog/src/main/kotlin/net/thunderbird/core/ui/setting/dialog/ui/components/dialog/value/ColorDialogView.kt
+++ b/core/ui/setting/impl-dialog/src/main/kotlin/net/thunderbird/core/ui/setting/dialog/ui/components/dialog/value/ColorDialogView.kt
@@ -1,15 +1,14 @@
 package net.thunderbird.core.ui.setting.dialog.ui.components.dialog.value
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalFlexBoxApi
+import androidx.compose.foundation.layout.FlexBox
+import androidx.compose.foundation.layout.FlexDirection
+import androidx.compose.foundation.layout.FlexWrap
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -21,6 +20,7 @@ import net.thunderbird.core.ui.setting.SettingValue
 import net.thunderbird.core.ui.setting.dialog.ui.components.common.ColorView
 import net.thunderbird.core.ui.setting.dialog.ui.components.dialog.SettingDialogLayout
 
+@OptIn(ExperimentalFlexBoxApi::class)
 @Composable
 internal fun ColorDialogView(
     setting: SettingValue.Color,
@@ -30,7 +30,6 @@ internal fun ColorDialogView(
     modifier: Modifier = Modifier,
 ) {
     val currentColor = rememberSaveable { mutableIntStateOf(setting.value) }
-    val gridState = rememberLazyGridState()
 
     SettingDialogLayout(
         title = setting.title(),
@@ -46,15 +45,17 @@ internal fun ColorDialogView(
             Spacer(modifier = Modifier.height(MainTheme.spacings.double))
         }
 
-        LazyVerticalGrid(
-            state = gridState,
-            columns = GridCells.Adaptive(minSize = MainTheme.sizes.iconAvatar),
-            verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
-            horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.default),
+        val gap = MainTheme.spacings.default
+        FlexBox(
+            config = {
+                direction(FlexDirection.Row)
+                wrap(FlexWrap.Wrap)
+                gap(gap)
+            },
+            modifier = Modifier.height(IntrinsicSize.Min),
         ) {
-            items(setting.colors) { color ->
+            setting.colors.forEach { color ->
                 Box(
-                    modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
                     ColorView(


### PR DESCRIPTION
## Contribution Summary

Fixes #11200.

#### Description

The recent change to `SettingDialogLayout` added a `Modifier.verticalScroll`. This caused the `ColorDialogView`, which was built using a `LazyVerticalGrid` to crash the app, because now the host Composable does not have a fixed height.

This PR fix this issue by:

- Replace `LazyVerticalGrid` with `FlexBox`, so the layout won't have a dynamic height

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.