### PR TITLE
fix: prevent horizontal scrolling in the message viewport

### DIFF
--- a/feature/mail/message/reader/impl/src/androidHostTest/kotlin/net/thunderbird/feature/mail/message/reader/impl/css/DefaultGlobalCssStyleProviderTest.kt
+++ b/feature/mail/message/reader/impl/src/androidHostTest/kotlin/net/thunderbird/feature/mail/message/reader/impl/css/DefaultGlobalCssStyleProviderTest.kt
@@ -1,0 +1,80 @@
+package net.thunderbird.feature.mail.message.reader.impl.css
+
+import assertk.assertThat
+import assertk.assertions.contains
+import kotlin.test.Test
+import net.thunderbird.core.common.mail.html.HtmlSettings
+import net.thunderbird.feature.mail.message.reader.api.css.CssClassNameProvider
+import net.thunderbird.feature.mail.message.reader.api.css.CssVariableNameProvider
+
+class DefaultGlobalCssStyleProviderTest {
+
+    @Test
+    fun `style should set main content box sizing to border box`() {
+        // Arrange
+        val testSubject = createTestSubject()
+
+        // Act
+        val style = testSubject.create(createHtmlSettings()).style
+
+        // Assert
+        assertThat(style).contains("box-sizing: border-box")
+    }
+
+    @Test
+    fun `style should preserve main content width and padding`() {
+        // Arrange
+        val testSubject = createTestSubject()
+
+        // Act
+        val style = testSubject.create(createHtmlSettings()).style
+        val mainContentRule = style.mainContentRule()
+
+        // Assert
+        assertThat(mainContentRule).contains("width: 100%")
+        assertThat(mainContentRule).contains("padding: 0 8px")
+    }
+
+    @Test
+    fun `style should preserve pre wrapping`() {
+        // Arrange
+        val testSubject = createTestSubject()
+
+        // Act
+        val style = testSubject.create(createHtmlSettings()).style
+
+        // Assert
+        assertThat(style).contains("white-space: pre-wrap")
+    }
+
+    private fun createTestSubject(): DefaultGlobalCssStyleProvider.Factory {
+        return DefaultGlobalCssStyleProvider.Factory(
+            cssClassNameProvider = FakeCssClassNameProvider,
+            cssVariableNameProvider = FakeCssVariableNameProvider,
+        )
+    }
+
+    private fun createHtmlSettings(): HtmlSettings {
+        return HtmlSettings(
+            useDarkMode = false,
+            useFixedWidthFont = false,
+        )
+    }
+
+    private fun String.mainContentRule(): String {
+        return substringAfter("  .root.main-content {")
+            .substringBefore("  .root.main-content pre {")
+    }
+
+    private object FakeCssClassNameProvider : CssClassNameProvider {
+        override val defaultNamespaceClassName = "default-namespace"
+        override val rootClassName = "root"
+        override val mainContentClassName = "main-content"
+        override val plainTextMessagePreClassName = "plain-text-message-pre"
+        override val signatureClassName = "signature"
+    }
+
+    private object FakeCssVariableNameProvider : CssVariableNameProvider {
+        override val blockquoteDefaultBorderLeftColor = "--blockquote-default-border-left-color"
+    }
+}

--- a/feature/mail/message/reader/impl/src/commonMain/kotlin/net/thunderbird/feature/mail/message/reader/impl/css/DefaultGlobalCssStyleProvider.kt
+++ b/feature/mail/message/reader/impl/src/commonMain/kotlin/net/thunderbird/feature/mail/message/reader/impl/css/DefaultGlobalCssStyleProvider.kt
@@ -26,6 +26,7 @@ internal class DefaultGlobalCssStyleProvider private constructor(
         |    -webkit-user-select: auto;
         |  }
         |  .${cssClassNameProvider.rootClassName}.${cssClassNameProvider.mainContentClassName} {
+        |    box-sizing: border-box;
         |    width: 100%;
         |    overflow-wrap: break-word;
         |    padding: 0 8px;


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #11038
RFC / Technical Design (if applicable): N/A

#### Description

The message view allows a few pixels of horizontal scrolling: the rendered content ends up slightly wider than the screen and can be dragged left/right. As #11038 notes, ordinary messages were not horizontally scrollable before this regressed.

The cause is in the new message reader stylesheet. The main content rule sets `width: 100%` together with `padding: 0 8px`, but without `box-sizing: border-box`:

```css
.root.main-content {
  width: 100%;
  overflow-wrap: break-word;
  padding: 0 8px;
}
```

Under the default `content-box` model the 8px left/right padding is added on top of the full 100% width, so the body becomes 16px wider than the viewport, which is the small horizontal overflow the issue describes. (This also rules out the font-size theory raised on the thread: the reporter confirmed font size is at 100% and the overflow persists.)

Adding `box-sizing: border-box` to that rule makes the padding count inside the 100% width instead of being added to it, so the content matches the viewport width again. The change is confined to `DefaultGlobalCssStyleProvider` (the current default path); the legacy provider does not emit this rule and is left untouched. The existing `width: 100%`, `overflow-wrap`, and `padding: 0 8px` declarations are preserved, so the 8px gutter is still rendered, now within the viewport.

#### Screen Shots

This is a CSS box-model fix that removes a few pixels of horizontal overscroll; the difference is the absence of left/right drag rather than a visible layout change, so it is not meaningfully captured in a static screenshot. The behavior is covered instead by a unit test in `DefaultGlobalCssStyleProviderTest`.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [ ] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
