### PR TITLE
chore(ci): change setup gradle to use basic cache provider

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -29,6 +29,7 @@ runs:
     - name: Set up Gradle without cache
       uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
+        cache-provider: basic
         cache-disabled: ${{ inputs.disable-cache }}
         add-job-summary: ${{ inputs.add-job-summary }}
         cache-read-only: ${{ inputs.write-cache == 'false' }}

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -27,7 +27,7 @@ runs:
         java-version: '21'
 
     - name: Set up Gradle without cache
-      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
         cache-provider: basic
         cache-disabled: ${{ inputs.disable-cache }}


### PR DESCRIPTION
## Contribution Summary

Resolves #11232 

#### Description

Switches the cache provider to the MIT-licensed open-source implementation.
