### PR TITLE
Use Bumped version in GH changelog link if version is bumped

### DIFF
--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -424,7 +424,7 @@ jobs:
           RELEASE_TYPE: ${{ vars.RELEASE_TYPE }}
           APPLICATION_LABEL: ${{ steps.appinfo.outputs.APPLICATION_LABEL }}
           VERSION_CODE: ${{ steps.new_version_code.outputs.new_version_code }}
-          FULL_VERSION_NAME: ${{ steps.appinfo.outputs.VERSION_NAME }}${{ steps.bump_version_suffix.outputs.SUFFIX || steps.appinfo.outputs.VERSION_NAME_SUFFIX }}
+          FULL_VERSION_NAME: ${{ steps.bump_version_name.outputs.VERSION_NAME || steps.appinfo.outputs.VERSION_NAME }}${{ steps.bump_version_suffix.outputs.SUFFIX || steps.appinfo.outputs.VERSION_NAME_SUFFIX }}
           K9MAIL_GITHUB_NOTES: ${{ steps.render_notes.outputs.k9mail_github_notes }}
           THUNDERBIRD_GITHUB_NOTES: ${{ steps.render_notes.outputs.thunderbird_github_notes }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/scripts/ci/contributor_list.py
+++ b/scripts/ci/contributor_list.py
@@ -134,7 +134,7 @@ def generate_contributor_list(
 
     with open(output_file, "w", encoding='utf-8') as f:
         print("\nContributors:", file=f)
-        thanks_to = "Thanks to: " + ', '.join(sorted(contributors, key=str.casefold))
+        thanks_to = "* Thanks to: " + ', '.join(sorted(contributors, key=str.casefold))
         print(thanks_to, file=f)
 
         if first_contributions:


### PR DESCRIPTION
## Contribution Summary

Fixes changelog linked when release version is bumped

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
