### PR TITLE
fix: show feedback when a scanned QR code contains unsupported data

### DIFF
--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerContract.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerContract.kt
@@ -38,6 +38,7 @@ internal interface QrCodeScannerContract {
 
     sealed interface DisplayText {
         data object HelpText : DisplayText
+        data object UnsupportedQrCode : DisplayText
         data class ProgressText(val scannedCount: Int, val totalCount: Int) : DisplayText
     }
 }

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerView.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerView.kt
@@ -47,6 +47,10 @@ private fun buildString(text: DisplayText): String {
             stringResource(R.string.migration_qrcode_scanning_instructions)
         }
 
+        DisplayText.UnsupportedQrCode -> {
+            stringResource(R.string.migration_qrcode_unsupported_code)
+        }
+
         is DisplayText.ProgressText -> {
             stringResource(R.string.migration_qrcode_scanning_progress, text.scannedCount, text.totalCount)
         }

--- a/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerViewModel.kt
+++ b/feature/migration/qrcode/src/main/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerViewModel.kt
@@ -103,6 +103,10 @@ internal class QrCodeScannerViewModel(
                 unsupportedPayloadHashes.removeFirst()
             }
             unsupportedPayloadHashes.add(payloadHash)
+
+            updateState {
+                it.copy(displayText = DisplayText.UnsupportedQrCode)
+            }
         }
     }
 

--- a/feature/migration/qrcode/src/main/res/values/strings.xml
+++ b/feature/migration/qrcode/src/main/res/values/strings.xml
@@ -5,5 +5,6 @@
     <string name="migration_qrcode_go_to_settings_button_text">Go to settings</string>
     <string name="migration_qrcode_scanning_progress">Scanned %1$s of %2$s</string>
     <string name="migration_qrcode_scanning_instructions">Align the QR code provided from Thunderbird Desktop</string>
+    <string name="migration_qrcode_unsupported_code">The QR code was detected, but it contains invalid or unsupported data.</string>
     <string name="migration_qrcode_done_button_text">Done</string>
 </resources>

--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerViewModelTest.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerViewModelTest.kt
@@ -146,6 +146,56 @@ class QrCodeScannerViewModelTest {
             ensureThatAllEventsAreConsumed()
         }
     }
+
+    @Test
+    fun `user scans unsupported QR code`() = runMviTest {
+        with(QrCodeScannerScreenRobot(mviContext = this)) {
+            startScreen()
+            systemGrantsCameraPermission()
+
+            userScansUnsupportedQrCode()
+            assertUnsupportedQrCodeStatus()
+
+            ensureThatAllEventsAreConsumed()
+        }
+    }
+
+    @Test
+    fun `user scans supported QR code after unsupported QR code`() = runMviTest {
+        with(QrCodeScannerScreenRobot(mviContext = this)) {
+            startScreen()
+            systemGrantsCameraPermission()
+
+            userScansUnsupportedQrCode()
+            assertUnsupportedQrCodeStatus()
+
+            userScansQrCode(sequenceNumber = 1, sequenceEnd = 2)
+            assertScannedStatus(expectedScannedCount = 1, expectedScannedTotal = 2)
+
+            ensureThatAllEventsAreConsumed()
+        }
+    }
+
+    @Test
+    fun `user scans same unsupported QR code more than once`() = runMviTest {
+        with(QrCodeScannerScreenRobot(mviContext = this)) {
+            startScreen()
+            systemGrantsCameraPermission()
+
+            userScansUnsupportedQrCode()
+            assertUnsupportedQrCodeStatus()
+
+            userScansUnsupportedQrCode()
+            assertCurrentState(
+                State(
+                    cameraPermissionState = UiPermissionState.Granted,
+                    displayText = DisplayText.UnsupportedQrCode,
+                ),
+            )
+
+            ensureThatAllEventsAreConsumed()
+        }
+    }
 }
 
 private class QrCodeScannerScreenRobot(
@@ -231,6 +281,10 @@ private class QrCodeScannerScreenRobot(
         qrCodeListener.invoke(payload)
     }
 
+    fun userScansUnsupportedQrCode() {
+        qrCodeListener.invoke("Unsupported QR code payload")
+    }
+
     fun userClicksDoneButton() {
         viewModel.event(Event.DoneClicked)
     }
@@ -245,6 +299,19 @@ private class QrCodeScannerScreenRobot(
                 ),
             ),
         )
+    }
+
+    suspend fun assertUnsupportedQrCodeStatus() {
+        assertThat(turbines.awaitStateItem()).isEqualTo(
+            State(
+                cameraPermissionState = UiPermissionState.Granted,
+                displayText = DisplayText.UnsupportedQrCode,
+            ),
+        )
+    }
+
+    fun assertCurrentState(expectedState: State) {
+        assertThat(viewModel.state.value).isEqualTo(expectedState)
     }
 
     suspend fun assertScanResult(expectedNumberOfAccounts: Int) {

--- a/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerViewModelTest.kt
+++ b/feature/migration/qrcode/src/test/kotlin/app/k9mail/feature/migration/qrcode/ui/QrCodeScannerViewModelTest.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import net.thunderbird.components.ui.testing.coroutines.MainDispatcherHelper
+import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.logging.testing.TestLogger
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -43,6 +45,7 @@ class QrCodeScannerViewModelTest {
 
     @BeforeTest
     fun setUp() {
+        Log.logger = TestLogger()
         mainDispatcher.setUp()
     }
 


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Refs #8520
RFC / Technical Design (if applicable): N/A

#### Description

The "Import via QR code" flow silently ignores QR codes whose payload fails validation. `QrCodeScannerViewModel.handleQrCodeScanned` records the payload hash in `unsupportedPayloadHashes` and returns with no state change, so the bottom bar keeps showing the generic help text and the user sees no reaction at all. That is the top-reported symptom in #8520: the camera clearly frames the code (it scans fine in other apps), but nothing happens because desktop exports with invalid payload data (blank authentication type, missing encryption settings) are decoded and rejected without feedback.

This adds a `DisplayText.UnsupportedQrCode` variant to `QrCodeScannerContract`, sets it in the unsupported branch of `handleQrCodeScanned`, and renders it in `QrCodeScannerView.buildString` with a new `migration_qrcode_unsupported_code` string. A subsequent successful scan restores the progress text through the existing `handleSupportedPayload` path. Only the base `values/strings.xml` is edited; translations flow through Weblate.

Scope note: this converts the silent failure into actionable feedback. It deliberately does not touch desktop-side QR generation (different repo) or device-specific camera lens selection, which the issue thread tracks separately, so the body references the issue with Refs rather than Closes.

#### Screen Shots

N/A: the change adds one line of text to the existing scanner bottom bar, shown only when an unsupported code is scanned.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
