### PR TITLE
Fix: Extract text from HTML part for message preview

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/HTMLPartFinder.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/HTMLPartFinder.kt
@@ -1,0 +1,38 @@
+package com.fsck.k9.message.extractors
+
+import com.fsck.k9.mail.MimeType.Companion.toMimeType
+import com.fsck.k9.mail.MimeType.Companion.toMimeTypeOrNull
+import com.fsck.k9.mail.Multipart
+import com.fsck.k9.mail.Part
+
+private val TEXT_HTML = "text/html".toMimeType()
+
+class HTMLPartFinder {
+    fun findFirstHTMLPart(part: Part): Part? {
+        val mimeType = part.mimeType.toMimeTypeOrNull()
+        val body = part.body
+
+        return if (body is Multipart) {
+            findHTMLPartInMultipart(body)
+        } else if (mimeType == TEXT_HTML) {
+            part
+        } else {
+            null
+        }
+    }
+
+    private fun findHTMLPartInMultipart(multipart: Multipart): Part? {
+        for (bodyPart in multipart.bodyParts) {
+            val mimeType = bodyPart.mimeType.toMimeTypeOrNull()
+            val body = bodyPart.body
+
+            if (body is Multipart) {
+                return findFirstHTMLPart(bodyPart) ?: continue
+            } else if (mimeType == TEXT_HTML) {
+                return bodyPart
+            }
+        }
+
+        return null
+    }
+}

--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/MessagePreviewCreator.java
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/MessagePreviewCreator.java
@@ -12,24 +12,30 @@ import net.thunderbird.core.logging.legacy.Log;
 
 public class MessagePreviewCreator {
     private final TextPartFinder textPartFinder;
+    private final HTMLPartFinder htmlPartFinder;
     private final PreviewTextExtractor previewTextExtractor;
 
 
-    MessagePreviewCreator(TextPartFinder textPartFinder, PreviewTextExtractor previewTextExtractor) {
+    MessagePreviewCreator(TextPartFinder textPartFinder, HTMLPartFinder htmlPartFinder, PreviewTextExtractor previewTextExtractor) {
         this.textPartFinder = textPartFinder;
+        this.htmlPartFinder = htmlPartFinder;
         this.previewTextExtractor = previewTextExtractor;
     }
 
     public static MessagePreviewCreator newInstance() {
         TextPartFinder textPartFinder = new TextPartFinder();
         PreviewTextExtractor previewTextExtractor = new PreviewTextExtractor();
-        return new MessagePreviewCreator(textPartFinder, previewTextExtractor);
+        HTMLPartFinder htmlPartFinder = new HTMLPartFinder();
+        return new MessagePreviewCreator(textPartFinder, htmlPartFinder, previewTextExtractor);
     }
 
     public PreviewResult createPreview(@NonNull Message message) {
-        Part textPart = textPartFinder.findFirstTextPart(message);
+        Part textPart = htmlPartFinder.findFirstHTMLPart(message);
         if (textPart == null || hasEmptyBody(textPart)) {
-            return PreviewResult.none();
+            textPart = textPartFinder.findFirstTextPart(message);
+            if (textPart == null || hasEmptyBody(textPart)) {
+                return PreviewResult.none();
+            }
         }
 
         try {

--- a/legacy/core/src/test/java/com/fsck/k9/message/extractors/HTMLPartFinderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/extractors/HTMLPartFinderTest.kt
@@ -1,0 +1,256 @@
+package com.fsck.k9.message.extractors
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import com.fsck.k9.message.MessageCreationHelper.createEmptyPart
+import com.fsck.k9.message.MessageCreationHelper.createMultipart
+import com.fsck.k9.message.MessageCreationHelper.createPart
+import com.fsck.k9.message.MessageCreationHelper.createTextPart
+import org.junit.Test
+
+class HTMLPartFinderTest {
+    private val htmlPartFinder = HTMLPartFinder()
+
+    @Test
+    fun `text_plain part`() {
+        val part = createTextPart("text/plain")
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `text_html part`() {
+        val part = createTextPart("text/html")
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(part)
+    }
+
+    @Test
+    fun `without text part`() {
+        val part = createPart("image/jpeg")
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `multipart_alternative text_html and text_plain`() {
+        val expected = createTextPart("text/html")
+        val part = createMultipart(
+            "multipart/alternative",
+            expected,
+            createTextPart("text/plain"),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_alternative containing text_plain and text_html`() {
+        val expected = createTextPart("text/html")
+        val part = createMultipart(
+            "multipart/alternative",
+            createTextPart("text/plain"),
+            expected,
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_alternative containing multiple text_html parts`() {
+        val expected = createTextPart("text/html")
+        val part = createMultipart(
+            "multipart/alternative",
+            createPart("image/gif"),
+            expected,
+            createTextPart("text/html"),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_alternative not containing any text parts`() {
+        val part = createMultipart(
+            "multipart/alternative",
+            createPart("image/gif"),
+            createPart("application/pdf"),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `multipart_alternative containing multipart_related containing text_html`() {
+        val expected = createTextPart("text/html")
+        val part = createMultipart(
+            "multipart/alternative",
+            createMultipart(
+                "multipart/related",
+                expected,
+                createPart("image/jpeg"),
+            ),
+            createTextPart("text/plain"),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_alternative containing multipart_related and text_html`() {
+        val expected = createTextPart("text/html")
+        val part = createMultipart(
+            "multipart/alternative",
+            createMultipart(
+                "multipart/related",
+                createTextPart("text/plain"),
+                createPart("image/jpeg"),
+            ),
+            expected,
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_mixed containing text_html`() {
+        val expected = createTextPart("text/html")
+        val part = createMultipart(
+            "multipart/mixed",
+            createPart("image/jpeg"),
+            expected,
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_mixed containing text_html and text_plain`() {
+        val expected = createTextPart("text/html")
+        val part = createMultipart(
+            "multipart/mixed",
+            expected,
+            createTextPart("text/plain"),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_mixed not containing any text parts`() {
+        val part = createMultipart(
+            "multipart/mixed",
+            createPart("image/jpeg"),
+            createPart("image/gif"),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `multipart_mixed containing multipart_alternative containing text_plain and text_html`() {
+        val expected = createTextPart("text/html")
+        val part = createMultipart(
+            "multipart/mixed",
+            createPart("image/jpeg"),
+            createMultipart(
+                "multipart/alternative",
+                createTextPart("text/plain"),
+                expected,
+            ),
+            createTextPart("text/plain"),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_mixed containing multipart_alternative containing text_html and text_plain`() {
+        val expected = createTextPart("text/html")
+        val part = createMultipart(
+            "multipart/mixed",
+            createMultipart(
+                "multipart/alternative",
+                expected,
+                createTextPart("text/plain"),
+            ),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_alternative containing empty text_plain and text_html`() {
+        val expected = createEmptyPart("text/html")
+        val part = createMultipart(
+            "multipart/alternative",
+            expected,
+            createTextPart("text/plain"),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_mixed containing empty text_html and text_plain`() {
+        val expected = createEmptyPart("text/html")
+        val part = createMultipart(
+            "multipart/mixed",
+            expected,
+            createTextPart("text/plain"),
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_mixed containing multipart_alternative and text_html`() {
+        val expected = createEmptyPart("text/html")
+        val part = createMultipart(
+            "multipart/mixed",
+            createMultipart(
+                "multipart/alternative",
+                createPart("image/jpeg"),
+                createPart("image/png"),
+            ),
+            expected,
+        )
+
+        val result = htmlPartFinder.findFirstHTMLPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+}

--- a/legacy/core/src/test/java/com/fsck/k9/message/extractors/MessagePreviewCreatorTest.java
+++ b/legacy/core/src/test/java/com/fsck/k9/message/extractors/MessagePreviewCreatorTest.java
@@ -21,20 +21,23 @@ import static org.mockito.Mockito.when;
 
 public class MessagePreviewCreatorTest {
     private TextPartFinder textPartFinder;
+    private HTMLPartFinder htmlPartFinder;
     private PreviewTextExtractor previewTextExtractor;
     private MessagePreviewCreator previewCreator;
 
     @Before
     public void setUp() throws Exception {
         textPartFinder = mock(TextPartFinder.class);
+        htmlPartFinder = mock(HTMLPartFinder.class);
         previewTextExtractor = mock(PreviewTextExtractor.class);
 
-        previewCreator = new MessagePreviewCreator(textPartFinder, previewTextExtractor);
+        previewCreator = new MessagePreviewCreator(textPartFinder, htmlPartFinder, previewTextExtractor);
     }
 
     @Test
     public void createPreview_withoutTextPart() {
         Message message = createDummyMessage();
+        when(htmlPartFinder.findFirstHTMLPart(message)).thenReturn(null);
         when(textPartFinder.findFirstTextPart(message)).thenReturn(null);
 
         PreviewResult result = previewCreator.createPreview(message);
@@ -48,6 +51,7 @@ public class MessagePreviewCreatorTest {
     public void createPreview_withEmptyTextPart() throws Exception {
         Message message = createDummyMessage();
         Part textPart = createEmptyPart("text/plain");
+        when(htmlPartFinder.findFirstHTMLPart(message)).thenReturn(null);
         when(textPartFinder.findFirstTextPart(message)).thenReturn(textPart);
 
         PreviewResult result = previewCreator.createPreview(message);
@@ -61,8 +65,23 @@ public class MessagePreviewCreatorTest {
     public void createPreview_withTextPart() throws Exception {
         Message message = createDummyMessage();
         Part textPart = createTextPart("text/plain");
+        when(htmlPartFinder.findFirstHTMLPart(message)).thenReturn(null);
         when(textPartFinder.findFirstTextPart(message)).thenReturn(textPart);
         when(previewTextExtractor.extractPreview(textPart)).thenReturn("expected");
+
+        PreviewResult result = previewCreator.createPreview(message);
+
+        assertTrue(result.isPreviewTextAvailable());
+        assertEquals(PreviewType.TEXT, result.getPreviewType());
+        assertEquals("expected", result.getPreviewText());
+    }
+
+    @Test
+    public void createPreview_withHTMLPart() throws Exception {
+        Message message = createDummyMessage();
+        Part htmlPart = createTextPart("text/html");
+        when(htmlPartFinder.findFirstHTMLPart(message)).thenReturn(htmlPart);
+        when(previewTextExtractor.extractPreview(htmlPart)).thenReturn("expected");
 
         PreviewResult result = previewCreator.createPreview(message);
 
@@ -75,6 +94,7 @@ public class MessagePreviewCreatorTest {
     public void createPreview_withPreviewTextExtractorThrowing() throws Exception {
         Message message = createDummyMessage();
         Part textPart = createTextPart("text/plain");
+        when(htmlPartFinder.findFirstHTMLPart(message)).thenReturn(null);
         when(textPartFinder.findFirstTextPart(message)).thenReturn(textPart);
         when(previewTextExtractor.extractPreview(textPart)).thenThrow(new PreviewExtractionException(""));
 
@@ -88,6 +108,7 @@ public class MessagePreviewCreatorTest {
     public void createPreview_withPreviewTextExtractorThrowingUnexpectedException() throws Exception {
         Message message = createDummyMessage();
         Part textPart = createTextPart("text/plain");
+        when(htmlPartFinder.findFirstHTMLPart(message)).thenReturn(null);
         when(textPartFinder.findFirstTextPart(message)).thenReturn(textPart);
         when(previewTextExtractor.extractPreview(textPart)).thenThrow(new IllegalStateException(""));
 


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes: #5890

#### Description

Now email preview will prioritize HTML over plaintext. Be it notification or any folder.

#### Screen Shots

N/A

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle.
- [x] This contribution does not break existing unit tests.
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [ ] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g Fixes #5890).
