### PR TITLE
Fix crash when camera result arrives after process death (#11296)

### DIFF
--- a/core/android/common/src/main/kotlin/app/k9mail/core/android/common/camera/CameraCaptureHandler.kt
+++ b/core/android/common/src/main/kotlin/app/k9mail/core/android/common/camera/CameraCaptureHandler.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Bundle
 import android.provider.MediaStore
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityCompat.startActivityForResult
@@ -16,18 +17,47 @@ class CameraCaptureHandler(
     private val captureImageFileWriter: CaptureImageFileWriter,
 ) {
 
-    private lateinit var capturedImageUri: Uri
+    private var capturedImageUri: Uri? = null
 
     companion object {
         const val REQUEST_IMAGE_CAPTURE: Int = 6
         const val CAMERA_PERMISSION_REQUEST_CODE: Int = 100
+
+        // Kept public so callers can namespace the key inside their own
+        // saved-state bundles if they prefer; the save/restore helpers
+        // below use it by default.
+        const val STATE_KEY_CAPTURED_IMAGE_URI: String =
+            "app.k9mail.core.android.common.camera.CAPTURED_IMAGE_URI"
     }
 
-    fun getCapturedImageUri(): Uri {
-        if (::capturedImageUri.isInitialized) {
-            return capturedImageUri
-        } else {
-            throw UninitializedPropertyAccessException("Image Uri not initialized")
+    /**
+     * Returns the URI the camera was told to write to for the last
+     * [openCamera] call, or `null` if the handler has no captured URI
+     * on record. Callers must handle the null case (see issue #11296:
+     * when the app process is killed while the camera is in the
+     * foreground, the URI is not restored and the activity result
+     * arrives with data=null).
+     */
+    fun getCapturedImageUri(): Uri? = capturedImageUri
+
+    /**
+     * Persist the captured-image URI into [outState] so it survives
+     * process death alongside the hosting Activity's state. Wire this
+     * up from the Activity's `onSaveInstanceState`.
+     */
+    fun saveInstanceState(outState: Bundle) {
+        capturedImageUri?.let { outState.putParcelable(STATE_KEY_CAPTURED_IMAGE_URI, it) }
+    }
+
+    /**
+     * Restore the captured-image URI from the given saved-state bundle
+     * (or clear it when [savedInstanceState] is null). Wire this up
+     * from the Activity's `onCreate(savedInstanceState)`.
+     */
+    fun restoreInstanceState(savedInstanceState: Bundle?) {
+        capturedImageUri = savedInstanceState?.let {
+            @Suppress("DEPRECATION")
+            it.getParcelable(STATE_KEY_CAPTURED_IMAGE_URI) as? Uri
         }
     }
 
@@ -36,8 +66,9 @@ class CameraCaptureHandler(
 
     fun openCamera(activity: Activity) {
         val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        capturedImageUri = captureImageFileWriter.getFileUri()
-        intent.putExtra(MediaStore.EXTRA_OUTPUT, capturedImageUri)
+        val uri = captureImageFileWriter.getFileUri()
+        capturedImageUri = uri
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
         intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
         startActivityForResult(activity, intent, REQUEST_IMAGE_CAPTURE, null)
     }

--- a/core/android/common/src/test/kotlin/app/k9mail/core/android/common/camera/CameraCaptureHandlerTest.kt
+++ b/core/android/common/src/test/kotlin/app/k9mail/core/android/common/camera/CameraCaptureHandlerTest.kt
@@ -1,0 +1,62 @@
+package app.k9mail.core.android.common.camera
+
+import android.net.Uri
+import android.os.Bundle
+import app.k9mail.core.android.common.camera.CameraCaptureHandler.Companion.STATE_KEY_CAPTURED_IMAGE_URI
+import app.k9mail.core.android.common.camera.io.CaptureImageFileWriter
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// Coverage for the process-death regression tracked in issue #11296:
+// the captured-image URI was held in memory only, so an activity result
+// arriving after process recreation threw
+// UninitializedPropertyAccessException. These tests lock in the nullable
+// getter and the save/restore round-trip that keeps the URI alive.
+@RunWith(RobolectricTestRunner::class)
+internal class CameraCaptureHandlerTest {
+
+    private val fileWriter: CaptureImageFileWriter = mock()
+
+    @Test
+    fun `getCapturedImageUri returns null before openCamera has been called`() {
+        val handler = CameraCaptureHandler(fileWriter)
+
+        assertNull(handler.getCapturedImageUri())
+    }
+
+    @Test
+    fun `getCapturedImageUri returns null after restoreInstanceState with a null bundle`() {
+        val handler = CameraCaptureHandler(fileWriter)
+
+        handler.restoreInstanceState(savedInstanceState = null)
+
+        assertNull(handler.getCapturedImageUri())
+    }
+
+    @Test
+    fun `restoreInstanceState rehydrates the URI a previous handler wrote out`() {
+        val savedUri = Uri.parse("content://k9.provider/captured/IMG_42.jpg")
+        val bundle = Bundle().apply {
+            putParcelable(STATE_KEY_CAPTURED_IMAGE_URI, savedUri)
+        }
+        val handler = CameraCaptureHandler(fileWriter)
+
+        handler.restoreInstanceState(bundle)
+
+        assertEquals(savedUri, handler.getCapturedImageUri())
+    }
+
+    @Test
+    fun `saveInstanceState omits the URI when nothing has been captured`() {
+        val handler = CameraCaptureHandler(fileWriter)
+        val outState = Bundle()
+
+        handler.saveInstanceState(outState)
+
+        assertNull(outState.getParcelable<Uri>(STATE_KEY_CAPTURED_IMAGE_URI))
+    }
+}

--- a/core/android/common/src/test/kotlin/app/k9mail/core/android/common/camera/CameraCaptureHandlerTest.kt
+++ b/core/android/common/src/test/kotlin/app/k9mail/core/android/common/camera/CameraCaptureHandlerTest.kt
@@ -4,12 +4,12 @@ import android.net.Uri
 import android.os.Bundle
 import app.k9mail.core.android.common.camera.CameraCaptureHandler.Companion.STATE_KEY_CAPTURED_IMAGE_URI
 import app.k9mail.core.android.common.camera.io.CaptureImageFileWriter
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 // Coverage for the process-death regression tracked in issue #11296:
 // the captured-image URI was held in memory only, so an activity result

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -305,11 +305,6 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        // Rehydrate the camera-capture handler's URI so the pending
-        // camera result can still be attached after process death. See
-        // issue #11296: without this the handler is a fresh singleton and
-        // getCapturedImageUri() used to throw.
         cameraCaptureHandler.restoreInstanceState(savedInstanceState);
 
         if (databaseUpgradeInterceptor.checkAndHandleUpgrade(this, getIntent())) {
@@ -987,12 +982,8 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
             }
 
             if (requestCode == REQUEST_IMAGE_CAPTURE && resultCode == Activity.RESULT_OK) {
-                android.net.Uri capturedImageUri = cameraCaptureHandler.getCapturedImageUri();
+                final Uri capturedImageUri = cameraCaptureHandler.getCapturedImageUri();
                 if (capturedImageUri == null) {
-                    // The URI wasn't restored after process death (issue
-                    // #11296). We can't attach an image we no longer know
-                    // the location of; surface a message instead of
-                    // crashing.
                     Toast.makeText(this, R.string.camera_capture_lost, Toast.LENGTH_LONG).show();
                     return;
                 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -306,6 +306,12 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        // Rehydrate the camera-capture handler's URI so the pending
+        // camera result can still be attached after process death. See
+        // issue #11296: without this the handler is a fresh singleton and
+        // getCapturedImageUri() used to throw.
+        cameraCaptureHandler.restoreInstanceState(savedInstanceState);
+
         if (databaseUpgradeInterceptor.checkAndHandleUpgrade(this, getIntent())) {
             finish();
             return;
@@ -723,6 +729,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         recipientPresenter.onSaveInstanceState(outState);
         quotedMessagePresenter.onSaveInstanceState(outState);
         attachmentPresenter.onSaveInstanceState(outState);
+        cameraCaptureHandler.saveInstanceState(outState);
     }
 
     @Override
@@ -980,8 +987,17 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
             }
 
             if (requestCode == REQUEST_IMAGE_CAPTURE && resultCode == Activity.RESULT_OK) {
+                android.net.Uri capturedImageUri = cameraCaptureHandler.getCapturedImageUri();
+                if (capturedImageUri == null) {
+                    // The URI wasn't restored after process death (issue
+                    // #11296). We can't attach an image we no longer know
+                    // the location of; surface a message instead of
+                    // crashing.
+                    Toast.makeText(this, R.string.camera_capture_lost, Toast.LENGTH_LONG).show();
+                    return;
+                }
                 Intent intent = new Intent();
-                intent.setData(cameraCaptureHandler.getCapturedImageUri());
+                intent.setData(capturedImageUri);
                 attachmentPresenter.onActivityResult(resultCode, REQUEST_CODE_ATTACHMENT_URI, intent);
                 return;
             }

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="open_camera">Open Camera</string>
     <string name="attach_file">Attach File</string>
     <string name="camera_permission_denied">Camera Permission Denied! Unable to take photo</string>
+    <string name="camera_capture_lost">Captured image was lost because the app was closed. Please try again.</string>
     <string name="source_code">Source code</string>
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="about_project_title">Open Source Project</string>


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #11296

#### Description

Thunderbird crashes when `MessageCompose` receives a successful camera activity result after the app process has been recreated. The captured-image URI lived only in the in-memory state of the `CameraCaptureHandler` Koin singleton, so on process death the fresh singleton had no URI and `getCapturedImageUri()` threw:

```
kotlin.UninitializedPropertyAccessException: Image Uri not initialized
  at app.k9mail.core.android.common.camera.CameraCaptureHandler.getCapturedImageUri(CameraCaptureHandler.kt:30)
  at com.fsck.k9.activity.MessageCompose.onActivityResult(MessageCompose.java:984)
```

This PR makes the handler recoverable across process death.

**`CameraCaptureHandler`:**
- `capturedImageUri` is now `Uri?` instead of `lateinit var`.
- `getCapturedImageUri()` returns `Uri?` instead of throwing.
- New `saveInstanceState(Bundle)` / `restoreInstanceState(Bundle?)` helpers round-trip the URI through a namespaced key (`STATE_KEY_CAPTURED_IMAGE_URI`).

**`MessageCompose`:**
- `onCreate(savedInstanceState)` calls `cameraCaptureHandler.restoreInstanceState(savedInstanceState)`.
- `onSaveInstanceState(outState)` calls `cameraCaptureHandler.saveInstanceState(outState)`.
- `onActivityResult` null-checks the URI. If it can't be recovered, the user sees a Toast (`camera_capture_lost`: "Captured image was lost because the app was closed. Please try again.") instead of a crash. This matches the issue's expected behaviour ("A missing or unrestored camera output URI should be handled without crashing").

**Tests:** `CameraCaptureHandlerTest` (Robolectric) covers four regressions:
- `getCapturedImageUri` returns null before `openCamera` has been called
- `getCapturedImageUri` returns null after `restoreInstanceState(null)`
- `restoreInstanceState` rehydrates the URI a previous handler wrote out
- `saveInstanceState` omits the URI when nothing has been captured

Locally verified:
- `./gradlew :core:android:common:testDebugUnitTest --tests "...CameraCaptureHandlerTest"` — passes
- `./gradlew :legacy:ui:legacy:compileDebugJavaWithJavac` — clean

**Notes for reviewers:**
- `getCapturedImageUri()` used to throw; call sites should now null-check. `MessageCompose` is the only in-tree caller and is updated in this PR.
- The Toast string is English-only in `legacy/ui/legacy/src/main/res/values/strings.xml` — happy to add translations if that's the convention.
- The Robolectric test uses `Bundle.getParcelable(String)` which is deprecated on API 33+. Kept for minimal-diff; can switch to `BundleCompat.getParcelable(bundle, key, Uri.class)` in a follow-up.

#### Screen Shots

_No UI changes — this is a crash fix. The only user-visible change on the recovery path is a Toast message on an edge case that previously crashed the app._

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla's Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible (handler + tests are Kotlin; `MessageCompose` is pre-existing Java)
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (verified locally)
- [x] This contribution does not break existing unit tests (`testDebugUnitTest` on the affected module passes)
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality
- [x] This contribution adheres to your Engineering process — this is a bugfix scoped to the referenced issue, no new architecture

---

_Note: `require-report-label` CI check needs a maintainer to apply one of `report: include` / `report: highlight` / `report: exclude`. This is a user-visible bug fix (crash on returning from the camera after process death), so `report: include` looks right — happy to adjust if that doesn't match your release-notes conventions._