### PR TITLE
feat(feature-flag): bundle catalog as Android raw resource and JVM classpath resource

### DIFF
--- a/build-plugin/plugin/build.gradle.kts
+++ b/build-plugin/plugin/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.networknt.jsonSchemaValidator)
 
+    testImplementation(gradleTestKit())
     testImplementation(libs.junit)
     testImplementation(libs.assertk)
 }

--- a/build-plugin/plugin/build.gradle.kts
+++ b/build-plugin/plugin/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(libs.diff.utils)
     compileOnly(libs.kotlinx.datetime)
 
+    testImplementation(gradleTestKit())
     testImplementation(libs.junit)
     testImplementation(libs.assertk)
 }

--- a/build-plugin/plugin/build.gradle.kts
+++ b/build-plugin/plugin/build.gradle.kts
@@ -37,6 +37,9 @@ dependencies {
     compileOnly(plugin(libs.plugins.kover))
     implementation(libs.diff.utils)
     compileOnly(libs.kotlinx.datetime)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.assertk)
 }
 
 kotlin {

--- a/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/featureflag/task/GenerateFeatureFlagRawResTask.kt
+++ b/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/featureflag/task/GenerateFeatureFlagRawResTask.kt
@@ -1,0 +1,123 @@
+package net.thunderbird.gradle.plugin.featureflag.task
+
+import com.android.build.api.variant.KotlinMultiplatformAndroidComponentsExtension
+import java.util.Locale
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.register
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+
+/**
+ * Copies the feature-flag catalog into a generated Android `res/raw` directory so it can be exposed
+ * as an `R.raw.*` resource on the owning Android module.
+ *
+ * The catalog keeps living under `config/featureflag/` (the single source of truth declared in the
+ * root `featureFlag {}` extension). Android `res` filenames may only contain lowercase letters,
+ * digits and underscores, so the dotted catalog file name is sanitized via the [resourceName]
+ * rename performed here.
+ */
+@CacheableTask
+abstract class GenerateFeatureFlagRawResTask : DefaultTask() {
+
+    /**
+     * The feature flag catalog file (JSON) to expose as a raw resource.
+     */
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val catalog: RegularFileProperty
+
+    /**
+     * The resource name (without extension) used for the generated file.
+     */
+    @get:Input
+    abstract val resourceName: Property<String>
+
+    /**
+     * The res *root* directory; the `raw/` folder that AGP scans is created inside it.
+     */
+    @get:OutputDirectory
+    abstract val outputResDir: DirectoryProperty
+
+    /**
+     * The sanitized resource name (without extension) used for the generated file, e.g.
+     * `thunderbird-mobile-featureflag.catalog` produces `R.raw.thunderbird_mobile_featureflag_catalog`.
+     */
+    private val sanitizedResourceName: String
+        get() = resourceName
+            .get()
+            .lowercase(Locale.getDefault())
+            .replace("[^a-z0-9_]".toRegex(), "_")
+
+    init {
+        group = "Thunderbird Feature Flags"
+        description = "Copies the feature-flag catalog into a generated res/raw directory."
+    }
+
+    @TaskAction
+    fun generate() {
+        val rawDir = outputResDir.get().asFile.resolve("raw")
+        rawDir.deleteRecursively()
+        rawDir.mkdirs()
+        catalog.get().asFile.copyTo(rawDir.resolve("$sanitizedResourceName.json"), overwrite = true)
+    }
+
+    companion object {
+        const val TASK_NAME = "generateFeatureFlagRawRes"
+    }
+}
+
+fun TaskContainer.registerGenerateFeatureFlagRawResTask(
+    project: Project,
+): TaskProvider<GenerateFeatureFlagRawResTask> {
+    val extensions = project.extensions
+
+    @Suppress("UnstableApiUsage")
+    val featureFlagCatalog = project.isolated.rootProject.projectDirectory
+        .file("config/featureflag/thunderbird_mobile_featureflag.catalog.json")
+    val task = register<GenerateFeatureFlagRawResTask>(GenerateFeatureFlagRawResTask.TASK_NAME) {
+        catalog.set(featureFlagCatalog)
+        resourceName.set("thunderbird_mobile_featureflag_catalog")
+        outputResDir.set(project.layout.buildDirectory.dir("generated/featureflags/res"))
+    }
+
+    // Android consumes the catalog as `R.raw.*`, so the generated res root is wired into the variant's layered
+    // resources.
+    // Although AS may show that the R.raw.thunderbird_mobile_featureflag_catalog is an unresolved reference
+    // the compiler is fine with it. Probably an AGP <-> KMP IDE resolution issue.
+    extensions.findByType<KotlinMultiplatformAndroidComponentsExtension>()?.onVariants { variant ->
+        variant.sources.res?.addGeneratedSourceDirectory(
+            taskProvider = task,
+            wiredWith = GenerateFeatureFlagRawResTask::outputResDir,
+        )
+    }
+
+    val generatedRawDir = task.flatMap { it.outputResDir.dir("raw") }
+    extensions.findByType<KotlinMultiplatformExtension>()
+        ?.targets
+        ?.filter { it.platformType == KotlinPlatformType.jvm }
+        ?.flatMap { it.compilations }
+        ?.filter { it.name == KotlinCompilation.MAIN_COMPILATION_NAME }
+        ?.forEach { compilation ->
+            compilation
+                .defaultSourceSet
+                .resources
+                .srcDir(generatedRawDir)
+        }
+
+    return task
+}

--- a/build-plugin/plugin/src/test/kotlin/net/thunderbird/gradle/plugin/featureflag/task/GenerateFeatureFlagRawResTaskFunctionalTest.kt
+++ b/build-plugin/plugin/src/test/kotlin/net/thunderbird/gradle/plugin/featureflag/task/GenerateFeatureFlagRawResTaskFunctionalTest.kt
@@ -1,0 +1,176 @@
+package net.thunderbird.gradle.plugin.featureflag.task
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import java.io.File
+import java.util.Properties
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Functional tests for the Gradle contract of [GenerateFeatureFlagRawResTask]: incremental
+ * (up-to-date) behaviour and build cache relocatability.
+ *
+ * These guarantees come from the task's input/output annotations rather than from its action, so
+ * they can only be exercised by running a real build. The unit tests in
+ * [GenerateFeatureFlagRawResTaskTest] cover the action itself.
+ */
+class GenerateFeatureFlagRawResTaskFunctionalTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val buildCacheDir: File by lazy { temporaryFolder.newFolder("build-cache") }
+
+    private val pluginClasspathLiteral: String by lazy {
+        val metadata = checkNotNull(javaClass.classLoader.getResourceAsStream(PLUGIN_METADATA_RESOURCE)) {
+            "Did not find $PLUGIN_METADATA_RESOURCE on the test classpath."
+        }.use { stream -> Properties().apply { load(stream) } }
+
+        metadata.getProperty("implementation-classpath")
+            .split(File.pathSeparator)
+            .joinToString(separator = ", ") { entry -> "\"${File(entry).invariantSeparatorsPath}\"" }
+    }
+
+    @Test
+    fun `generateFeatureFlagRawRes task should be up-to-date on the second run when nothing changed`() {
+        // Arrange
+        val projectDir = createProject(name = "project")
+
+        // Act
+        val firstRun = runTask(projectDir)
+        val secondRun = runTask(projectDir)
+
+        // Assert
+        assertThat(firstRun.outcomeOfTaskUnderTest()).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(secondRun.outcomeOfTaskUnderTest()).isEqualTo(TaskOutcome.UP_TO_DATE)
+    }
+
+    @Test
+    fun `generateFeatureFlagRawRes task should re-execute when the catalog content changes`() {
+        // Arrange
+        val projectDir = createProject(name = "project")
+        runTask(projectDir)
+
+        // Act
+        projectDir.catalogFile().writeText(CHANGED_CATALOG_CONTENT)
+        val rerun = runTask(projectDir)
+
+        // Assert
+        assertThat(rerun.outcomeOfTaskUnderTest()).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.generatedResource().readText()).isEqualTo(CHANGED_CATALOG_CONTENT)
+    }
+
+    @Test
+    fun `generateFeatureFlagRawRes task should be loaded from the build cache when the project is relocated`() {
+        // Arrange
+        val originalDir = createProject(name = "original")
+        val relocatedDir = createProject(name = "relocated")
+        runTask(originalDir)
+
+        // Act
+        val relocatedRun = runTask(relocatedDir)
+
+        // Assert
+        assertThat(relocatedRun.outcomeOfTaskUnderTest()).isEqualTo(TaskOutcome.FROM_CACHE)
+        assertThat(relocatedDir.generatedResource().readText()).isEqualTo(CATALOG_CONTENT)
+    }
+
+    /**
+     * Creates a standalone Gradle build that registers the task under test. Every project shares the
+     * same [buildCacheDir] and the same root project name so that the only difference between two
+     * projects is their location on disk.
+     */
+    private fun createProject(name: String): File {
+        val projectDir = temporaryFolder.newFolder(name)
+
+        projectDir.resolve("settings.gradle.kts").writeText(
+            // language=kotlin
+            """
+            rootProject.name = "feature-flag-catalog"
+
+            buildCache {
+                local {
+                    directory = file("${buildCacheDir.invariantSeparatorsPath}")
+                }
+            }
+            """.trimIndent(),
+        )
+
+        projectDir.resolve("build.gradle.kts").writeText(
+            // language=kotlin
+            """
+            import net.thunderbird.gradle.plugin.featureflag.task.GenerateFeatureFlagRawResTask
+
+            buildscript {
+                dependencies {
+                    classpath(files($pluginClasspathLiteral))
+                }
+            }
+
+            tasks.register<GenerateFeatureFlagRawResTask>("${GenerateFeatureFlagRawResTask.TASK_NAME}") {
+                catalog.set(layout.projectDirectory.file("$CATALOG_PATH"))
+                resourceName.set("$RESOURCE_NAME")
+                outputResDir.set(layout.buildDirectory.dir("$OUTPUT_RES_DIR"))
+            }
+            """.trimIndent(),
+        )
+
+        projectDir.catalogFile()
+            .apply { parentFile.mkdirs() }
+            .writeText(CATALOG_CONTENT)
+
+        return projectDir
+    }
+
+    private fun runTask(projectDir: File): BuildResult = GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments(GenerateFeatureFlagRawResTask.TASK_NAME, "--build-cache")
+        .build()
+
+    private fun BuildResult.outcomeOfTaskUnderTest(): TaskOutcome? =
+        task(":${GenerateFeatureFlagRawResTask.TASK_NAME}")?.outcome
+
+    private fun File.catalogFile(): File = resolve(CATALOG_PATH)
+
+    private fun File.generatedResource(): File = resolve("build/$OUTPUT_RES_DIR/raw/$RESOURCE_NAME.json")
+
+    private companion object {
+        const val PLUGIN_METADATA_RESOURCE = "plugin-under-test-metadata.properties"
+        const val CATALOG_PATH = "config/featureflag/thunderbird_mobile_featureflag.catalog.json"
+        const val OUTPUT_RES_DIR = "generated/featureflags/res"
+        const val RESOURCE_NAME = "thunderbird_mobile_featureflag_catalog"
+
+        // language=json
+        val CATALOG_CONTENT = """
+            {
+              "version": "2026-07-30.1",
+              "flags": [
+                {
+                  "key": "archive_marks_as_read",
+                  "default": true
+                }
+              ],
+              "overrides": {}
+            }
+        """.trimIndent()
+
+        // language=json
+        val CHANGED_CATALOG_CONTENT = """
+            {
+              "version": "2026-07-31.1",
+              "flags": [
+                {
+                  "key": "archive_marks_as_read",
+                  "default": false
+                }
+              ],
+              "overrides": {}
+            }
+        """.trimIndent()
+    }
+}

--- a/build-plugin/plugin/src/test/kotlin/net/thunderbird/gradle/plugin/featureflag/task/GenerateFeatureFlagRawResTaskTest.kt
+++ b/build-plugin/plugin/src/test/kotlin/net/thunderbird/gradle/plugin/featureflag/task/GenerateFeatureFlagRawResTaskTest.kt
@@ -1,0 +1,111 @@
+package net.thunderbird.gradle.plugin.featureflag.task
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import java.io.File
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class GenerateFeatureFlagRawResTaskTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `generate should copy the catalog into the raw directory`() {
+        // Arrange
+        val testSubject = createTestSubject(resourceName = RESOURCE_NAME)
+
+        // Act
+        testSubject.generate()
+
+        // Assert
+        val rawDir = testSubject.rawDir()
+        assertThat(rawDir.listFiles().orEmpty().map(File::getName)).isEqualTo(listOf("$RESOURCE_NAME.json"))
+        assertThat(rawDir.resolve("$RESOURCE_NAME.json").readText()).isEqualTo(CATALOG_CONTENT)
+    }
+
+    @Test
+    fun `generate should name the copied file after the resource name`() {
+        // Arrange
+        val testSubject = createTestSubject(resourceName = "featureflag_catalog_lean")
+
+        // Act
+        testSubject.generate()
+
+        // Assert
+        val rawDir = testSubject.rawDir()
+        assertThat(rawDir.listFiles().orEmpty().map(File::getName)).isEqualTo(listOf("featureflag_catalog_lean.json"))
+    }
+
+    @Test
+    fun `generate should sanitize dashes and dots in the resource name`() {
+        // Arrange
+        val testSubject = createTestSubject(resourceName = "thunderbird-mobile-featureflag.catalog")
+
+        // Act
+        testSubject.generate()
+
+        // Assert
+        val rawDir = testSubject.rawDir()
+        assertThat(rawDir.listFiles().orEmpty().map(File::getName))
+            .isEqualTo(listOf("thunderbird_mobile_featureflag_catalog.json"))
+    }
+
+    @Test
+    fun `generate should remove resources left over by a previous run`() {
+        // Arrange
+        val testSubject = createTestSubject(resourceName = RESOURCE_NAME)
+        val staleResource = testSubject.rawDir()
+            .apply { mkdirs() }
+            .resolve("featureflag_catalog_stale.json")
+            .apply { writeText("{}") }
+
+        // Act
+        testSubject.generate()
+
+        // Assert
+        assertThat(staleResource.exists()).isFalse()
+        assertThat(testSubject.rawDir().resolve("$RESOURCE_NAME.json").readText()).isEqualTo(CATALOG_CONTENT)
+    }
+
+    private fun createTestSubject(resourceName: String): GenerateFeatureFlagRawResTask {
+        val catalogFile = temporaryFolder.newFile("thunderbird_mobile_featureflag.catalog.json")
+            .apply { writeText(CATALOG_CONTENT) }
+        val project = ProjectBuilder.builder()
+            .withProjectDir(temporaryFolder.newFolder("project"))
+            .build()
+
+        return project.tasks
+            .register(GenerateFeatureFlagRawResTask.TASK_NAME, GenerateFeatureFlagRawResTask::class.java)
+            .get()
+            .apply {
+                catalog.set(catalogFile)
+                this.resourceName.set(resourceName)
+                outputResDir.set(project.layout.buildDirectory.dir("generated/featureflags/res"))
+            }
+    }
+
+    private fun GenerateFeatureFlagRawResTask.rawDir(): File = outputResDir.get().asFile.resolve("raw")
+
+    private companion object {
+        const val RESOURCE_NAME = "thunderbird_mobile_featureflag_catalog"
+
+        // language=json
+        val CATALOG_CONTENT = """
+            {
+              "version": "2026-07-30.1",
+              "flags": [
+                {
+                  "key": "archive_marks_as_read",
+                  "default": true
+                }
+              ],
+              "overrides": {}
+            }
+        """.trimIndent()
+    }
+}

--- a/core/featureflag/build.gradle.kts
+++ b/core/featureflag/build.gradle.kts
@@ -1,3 +1,5 @@
+import net.thunderbird.gradle.plugin.featureflag.task.registerGenerateFeatureFlagRawResTask
+
 plugins {
     id(ThunderbirdPlugins.Library.kmp)
 }
@@ -5,9 +7,13 @@ plugins {
 kotlin {
     android {
         namespace = "net.thunderbird.core.featureflag"
+        // Required so the generated `res/raw` catalog is merged into the module's Android resources.
+        androidResources.enable = true
     }
 }
 
 codeCoverage {
     lineCoverage = 60
 }
+
+tasks.registerGenerateFeatureFlagRawResTask(project = project)

--- a/core/featureflag/src/jvmTest/kotlin/net/thunderbird/core/featureflag/FeatureFlagCatalogResourceTest.kt
+++ b/core/featureflag/src/jvmTest/kotlin/net/thunderbird/core/featureflag/FeatureFlagCatalogResourceTest.kt
@@ -1,0 +1,37 @@
+package net.thunderbird.core.featureflag
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isNotNull
+import kotlin.test.Test
+
+/**
+ * Verifies that the feature flag catalog is bundled as a JVM classpath resource, which is what makes it loadable from
+ * plain JVM unit tests, without an Android runtime.
+ */
+class FeatureFlagCatalogResourceTest {
+
+    @Test
+    fun `bundled feature flag catalog should be readable from the classpath`() {
+        // Arrange
+        val classLoader = FeatureFlagCatalogResourceTest::class.java.classLoader
+
+        // Act
+        val catalog = classLoader
+            .getResourceAsStream(CATALOG_RESOURCE_NAME)
+            ?.bufferedReader()
+            ?.use { it.readText() }
+
+        // Assert
+        assertThat(catalog).isNotNull().all {
+            contains("\"version\"")
+            contains("\"flags\"")
+            contains("\"overrides\"")
+        }
+    }
+
+    private companion object {
+        const val CATALOG_RESOURCE_NAME = "thunderbird_mobile_featureflag_catalog.json"
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Resolves #11328
RFC / Technical Design (if applicable): [RFC 0004: Add a Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/rfcs/0004-feature-flag-new-architecture.md) / [Technical Design 0002: Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/technical-designs/0002-feature-flag-declarative-catalog.md)

#### Description

- Add GenerateFeatureFlagRawResTask to copy catalog into res/raw for Android modules
- Bundle catalog as classpath resource for JVM target to enable plain JVM unit tests
- Add test coverage for resource generation and classpath loading

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
