### PR TITLE
fix(weblate): add missing 'many' quantity forms for Hebrew strings

### DIFF
--- a/feature/account/setup/src/main/res/values-iw/strings.xml
+++ b/feature/account/setup/src/main/res/values-iw/strings.xml
@@ -32,16 +32,19 @@
     <plurals name="account_setup_options_email_check_frequency_hours">
         <item quantity="one">כל שעה</item>
         <item quantity="two">כל שעתיים</item>
+        <item quantity="many">כל %d שעות</item>
         <item quantity="other">כל %d שעות</item>
     </plurals>
     <plurals name="account_setup_options_email_check_frequency_minutes">
         <item quantity="one">כל דקה</item>
         <item quantity="two">כל שתי דקות</item>
+        <item quantity="many">כל %d דקות</item>
         <item quantity="other">כל %d דקות</item>
     </plurals>
     <plurals name="account_setup_options_email_display_count_messages">
         <item quantity="one">הודעה אחת</item>
         <item quantity="two">שתי הודעות</item>
+        <item quantity="many">%d הודעות</item>
         <item quantity="other">%d הודעות</item>
     </plurals>
     <string name="account_setup_options_show_notifications_label">הצג התראות</string>

--- a/feature/notification/api/src/commonMain/composeResources/values-iw/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-iw/strings.xml
@@ -40,6 +40,7 @@
     <plurals name="notification_new_messages_title">
         <item quantity="one">הודעה חדשה %1$d</item>
         <item quantity="two">%1$d הודעות חדשות</item>
+        <item quantity="many">%1$d הודעות חדשות</item>
         <item quantity="other">%1$d הודעות חדשות</item>
     </plurals>
     <string name="notification_action_retry">נסה שוב</string>

--- a/feature/settings/import/src/main/res/values-iw/strings.xml
+++ b/feature/settings/import/src/main/res/values-iw/strings.xml
@@ -35,6 +35,7 @@
     <plurals name="settings_import_password_prompt">
         <item quantity="one">על מנת להשתמש בחשבון \"<xliff:g id="account">%s</xliff:g>\" עליך לספק את סיסמת השרת.</item>
         <item quantity="two">על מנת להשתמש בחשבונות \"<xliff:g id="account">%s</xliff:g>\" עליך לספק את סיסמאות השרת.</item>
+        <item quantity="many">על מנת להשתמש בחשבונות \"<xliff:g id="account">%s</xliff:g>\" עליך לספק את סיסמאות השרת.</item>
         <item quantity="other">על מנת להשתמש בחשבונות \"<xliff:g id="account">%s</xliff:g>\" עליך לספק את סיסמאות השרת.</item>
     </plurals>
     <string name="settings_import_pick_app_button">ייבא מיישום</string>

--- a/legacy/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-iw/strings.xml
@@ -580,9 +580,9 @@
     </plurals>
     <plurals name="remote_search_downloading_limited">
         <item quantity="one">מביא תוצאה %1$d מתוך %2$d</item>
-        <item quantity="two">מביא %1$d תוצאות מתוך%2$d</item>
-        <item quantity="many">מביא %1$d תוצאות מתוך%2$d</item>
-        <item quantity="other">מביא %1$d תוצאות מתוך%2$d</item>
+        <item quantity="two">מביא %1$d תוצאות מתוך %2$d</item>
+        <item quantity="many">מביא %1$d תוצאות מתוך %2$d</item>
+        <item quantity="other">מביא %1$d תוצאות מתוך %2$d</item>
     </plurals>
     <string name="upgrade_databases_unspecified">משדרג מסדי נתונים…</string>
     <string name="upgrade_database_format">משדרג מסד נתונים של חשבון \"<xliff:g id="account">%s</xliff:g>\"</string>

--- a/legacy/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-iw/strings.xml
@@ -66,6 +66,7 @@
     <plurals name="copy_address_to_clipboard">
         <item quantity="one">כתובת הועתקה ללוח</item>
         <item quantity="two">כתובות הועתקו ללוח</item>
+        <item quantity="many">כתובות הועתקו ללוח</item>
         <item quantity="other">כתובות הועתקו ללוח</item>
     </plurals>
     <string name="copy_subject_to_clipboard">הנושא הועתק ללוח</string>
@@ -94,6 +95,7 @@
     <plurals name="notification_new_messages_title">
         <item quantity="one"><xliff:g id="new_message_count">%d</xliff:g> הודעה חדשה</item>
         <item quantity="two"><xliff:g id="new_message_count">%d</xliff:g> הודעות חדשות</item>
+        <item quantity="many"><xliff:g id="new_message_count">%d</xliff:g> הודעות חדשות</item>
         <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> הודעות חדשות</item>
     </plurals>
     <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%1$d</xliff:g> עוד עלינו<xliff:g id="account">%2$s</xliff:g></string>
@@ -451,6 +453,7 @@
     <plurals name="dialog_confirm_spam_message">
         <item quantity="one">אתה בטוח שאתה רוצה להעביר את ההודעות האלו לתיקיית דואר הזבל?</item>
         <item quantity="two">אתה בטוח שאתה רוצה להעביר <xliff:g id="message_count">%1$d</xliff:g> הודעות לתיקיית דואר הזבל?</item>
+        <item quantity="many">אתה בטוח שאתה רוצה להעביר <xliff:g id="message_count">%1$d</xliff:g> הודעות לתיקיית דואר הזבל?</item>
         <item quantity="other">אתה בטוח שאתה רוצה להעביר <xliff:g id="message_count">%1$d</xliff:g> הודעות לתיקיית דואר הזבל?</item>
     </plurals>
     <string name="dialog_confirm_spam_confirm_button">כן</string>
@@ -572,11 +575,13 @@
     <plurals name="remote_search_downloading">
         <item quantity="one">מביא תוצאה %d</item>
         <item quantity="two">מביא %d תוצאות</item>
+        <item quantity="many">מביא %d תוצאות</item>
         <item quantity="other">מביא %d תוצאות</item>
     </plurals>
     <plurals name="remote_search_downloading_limited">
         <item quantity="one">מביא תוצאה %1$d מתוך %2$d</item>
         <item quantity="two">מביא %1$d תוצאות מתוך%2$d</item>
+        <item quantity="many">מביא %1$d תוצאות מתוך%2$d</item>
         <item quantity="other">מביא %1$d תוצאות מתוך%2$d</item>
     </plurals>
     <string name="upgrade_databases_unspecified">משדרג מסדי נתונים…</string>
@@ -679,6 +684,7 @@
     <plurals name="dialog_confirm_delete_messages">
         <item quantity="one">בטוח שברצונך למחוק הודעה זו?</item>
         <item quantity="two">בטוח שברצונך למחוק <xliff:g id="message_count">%1$d</xliff:g> הודעות?</item>
+        <item quantity="many">בטוח שברצונך למחוק <xliff:g id="message_count">%1$d</xliff:g> הודעות?</item>
         <item quantity="other">בטוח שברצונך למחוק <xliff:g id="message_count">%1$d</xliff:g> הודעות?</item>
     </plurals>
     <string name="account_settings_remote_search_num_results_entries_10">10</string>
@@ -925,6 +931,7 @@
     <plurals name="message_view_attachment_summary">
         <item quantity="one">צרופה<xliff:g id="count">%1$d</xliff:g> (<xliff:g id="size">%2$s</xliff:g>)</item>
         <item quantity="two"><xliff:g id="count">%1$d</xliff:g> צרופות (<xliff:g id="size">%2$s</xliff:g>)</item>
+        <item quantity="many"><xliff:g id="count">%1$d</xliff:g> צרופות (<xliff:g id="size">%2$s</xliff:g>)</item>
         <item quantity="other"><xliff:g id="count">%1$d</xliff:g> צרופות (<xliff:g id="size">%2$s</xliff:g>)</item>
     </plurals>
     <string name="message_view_single_attachment_summary"><xliff:g id="name">%1$s</xliff:g> (<xliff:g id="size">%2$s</xliff:g>)</string>


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: #11365 

#### Description

Fix missing Hebrew plural quantities removed by last Weblate syncs

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
