### PR TITLE
fix(thundermail): center wrapped buttons in Thundermail panel

### DIFF
--- a/feature/thundermail/api/src/main/kotlin/net/thunderbird/feature/thundermail/ui/component/ThundermailButtonPanel.kt
+++ b/feature/thundermail/api/src/main/kotlin/net/thunderbird/feature/thundermail/ui/component/ThundermailButtonPanel.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,7 +34,10 @@ fun ThundermailButtonPanel(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             FlowRow(
-                horizontalArrangement = Arrangement.Center,
+                horizontalArrangement = Arrangement.spacedBy(
+                    space = BoltTheme.spacings.double,
+                    alignment = Alignment.CenterHorizontally,
+                ),
                 verticalArrangement = Arrangement.spacedBy(BoltTheme.spacings.default),
             ) {
                 ButtonOutlined(
@@ -52,7 +53,6 @@ fun ThundermailButtonPanel(
                     ),
                     icon = Icons.Filled.Thundermail,
                 )
-                Spacer(modifier = Modifier.width(BoltTheme.spacings.double))
                 ButtonOutlined(
                     text = stringResource(R.string.feature_thundermail_button_panel_scan_qr_code),
                     onClick = onScanQrCodeClick,


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #11363
RFC / Technical Design (if applicable): n/a

#### Description

On the "Add account" screen the "Sign in with Thundermail" button is drawn slightly left of centre, while the "Scan QR code" button below it is centred. The two buttons therefore look misaligned with each other (this is what the orange markers in the issue's screenshot highlight — the left/right edges are inset by different amounts).

Root cause is in `ThundermailButtonPanel`: the two buttons live in a `FlowRow` with `horizontalArrangement = Arrangement.Center`, and the gap between them is produced by a `Spacer(Modifier.width(spacings.double))` placed between them as a third child.

When the buttons fit on one line the spacer behaves as intended. When they don't fit — which is the common case on a phone — `FlowRow` wraps and the spacer stays behind as a *trailing* item on the first line. `Arrangement.Center` then centres "button + 16dp spacer", pushing the "Sign in with Thundermail" button 8dp to the left of the true centre. The second line contains only the QR button, so it is centred correctly, and the mismatch becomes visible.

The fix removes the `Spacer` and moves the gap onto the layout itself:

```kotlin
horizontalArrangement = Arrangement.spacedBy(
    space = BoltTheme.spacings.double,
    alignment = Alignment.CenterHorizontally,
),
```

`spacedBy` inserts the spacing *between* items on each line rather than after the last one, so both lines are centred whether or not the row wraps. Spacing is unchanged (still `BoltTheme.spacings.double`) when the buttons do fit on a single line.

One file changed, no behaviour or string changes:
`feature/thundermail/api/src/main/kotlin/net/thunderbird/feature/thundermail/ui/component/ThundermailButtonPanel.kt`

#### Screen Shots

Before (from the issue report): the "Sign in with Thundermail" button is off-centre relative to "Scan QR code".

I don't have a device/emulator handy to attach an "after" capture — happy to add one if a reviewer would like it. The change is a pure layout-arrangement swap: the first line no longer carries a trailing 16dp spacer, so its content is centred on the same axis as the wrapped second line.

#### Testing

1. Open the app on a screen narrow enough that the two buttons wrap onto separate lines (e.g. a phone in portrait) and go to "Add account".
2. Both the "Sign in with Thundermail" and "Scan QR code" buttons are horizontally centred and share a common centre line.
3. On a wide enough layout (e.g. tablet/landscape) the two buttons still sit side by side with a 16dp gap, centred as a group.

Verification run locally:

- `./gradlew :feature:thundermail:api:compileDebugKotlin` — BUILD SUCCESSFUL
- `./gradlew :feature:thundermail:api:spotlessCheck` — BUILD SUCCESSFUL
- `./gradlew :feature:thundermail:api:testDebugUnitTest` — BUILD SUCCESSFUL

There are no existing unit or screenshot tests covering `ThundermailButtonPanel`, so none needed updating.

#### A note on triage

This issue is currently labelled `unconfirmed`, and I'm aware the contribution docs ask contributors to leave those alone. I opened this anyway because the screenshot pinned the cause down to a specific composable and the fix is a two-line layout change — please feel free to close it if you'd rather triage the report first.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla's Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
