### PR TITLE
Add configurable catch-all addresses for Replies

### DIFF
--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/DefaultAccountDefaultsProvider.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/DefaultAccountDefaultsProvider.kt
@@ -16,6 +16,7 @@ import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.DE
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.DEFAULT_SORT_TYPE
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.DEFAULT_STRIP_SIGNATURE
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.DEFAULT_SYNC_INTERVAL
+import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.DEFAULT_USE_RECIPIENT_ADDRESS_FOR_REPLY
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.DEFAULT_VISIBLE_LIMIT
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.UNASSIGNED_ACCOUNT_NUMBER
@@ -93,6 +94,8 @@ internal class DefaultAccountDefaultsProvider(
         messageFormat = DEFAULT_MESSAGE_FORMAT
         isMessageFormatAuto = DEFAULT_MESSAGE_FORMAT_AUTO
         isMessageReadReceipt = DEFAULT_MESSAGE_READ_RECEIPT
+        useRecipientAddressForReply = DEFAULT_USE_RECIPIENT_ADDRESS_FOR_REPLY
+        recipientAddressReplyDomain = ""
         quoteStyle = DEFAULT_QUOTE_STYLE
         quotePrefix = DEFAULT_QUOTE_PREFIX
         isDefaultQuotedTextShown = DEFAULT_QUOTED_TEXT_SHOWN

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountDefaultsProvider.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountDefaultsProvider.kt
@@ -25,6 +25,7 @@ interface AccountDefaultsProvider {
 
         const val DEFAULT_MESSAGE_FORMAT_AUTO = false
         const val DEFAULT_MESSAGE_READ_RECEIPT = false
+        const val DEFAULT_USE_RECIPIENT_ADDRESS_FOR_REPLY = false
         const val DEFAULT_QUOTED_TEXT_SHOWN = true
         const val DEFAULT_QUOTE_PREFIX = ">"
 

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccount.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccount.kt
@@ -79,6 +79,8 @@ data class LegacyAccount(
     val messageFormat: MessageFormat = MessageFormat.HTML,
     val isMessageFormatAuto: Boolean = false,
     val isMessageReadReceipt: Boolean = false,
+    val useRecipientAddressForReply: Boolean = false,
+    val recipientAddressReplyDomain: String = "",
     val quoteStyle: QuoteStyle = QuoteStyle.PREFIX,
     val quotePrefix: String? = null,
     val isDefaultQuotedTextShown: Boolean = false,

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountDto.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountDto.kt
@@ -291,6 +291,14 @@ open class LegacyAccountDto(
 
     @get:Synchronized
     @set:Synchronized
+    var useRecipientAddressForReply = false
+
+    @get:Synchronized
+    @set:Synchronized
+    var recipientAddressReplyDomain = ""
+
+    @get:Synchronized
+    @set:Synchronized
     var quoteStyle = QuoteStyle.PREFIX
 
     @get:Synchronized

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAccountStorageHandler.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAccountStorageHandler.kt
@@ -151,6 +151,14 @@ class LegacyAccountStorageHandler(
                 keyGen.create("messageReadReceipt"),
                 AccountDefaultsProvider.Companion.DEFAULT_MESSAGE_READ_RECEIPT,
             )
+            useRecipientAddressForReply = storage.getBoolean(
+                keyGen.create("useRecipientAddressForReply"),
+                AccountDefaultsProvider.Companion.DEFAULT_USE_RECIPIENT_ADDRESS_FOR_REPLY,
+            )
+            recipientAddressReplyDomain = storage.getStringOrDefault(
+                keyGen.create("recipientAddressReplyDomain"),
+                "",
+            )
             quoteStyle = getEnumStringPref<QuoteStyle>(
                 storage,
                 keyGen.create("quoteStyle"),
@@ -385,6 +393,8 @@ class LegacyAccountStorageHandler(
             }
             editor.putBoolean(keyGen.create("messageFormatAuto"), messageFormatAuto)
             editor.putBoolean(keyGen.create("messageReadReceipt"), isMessageReadReceipt)
+            editor.putBoolean(keyGen.create("useRecipientAddressForReply"), useRecipientAddressForReply)
+            editor.putString(keyGen.create("recipientAddressReplyDomain"), recipientAddressReplyDomain)
             editor.putString(keyGen.create("quoteStyle"), quoteStyle.name)
             editor.putString(keyGen.create("quotePrefix"), quotePrefix)
             editor.putBoolean(keyGen.create("defaultQuotedTextShown"), isDefaultQuotedTextShown)
@@ -523,6 +533,8 @@ class LegacyAccountStorageHandler(
         editor.remove(keyGen.create("inboxFolderName"))
         editor.remove(keyGen.create("messageFormat"))
         editor.remove(keyGen.create("messageReadReceipt"))
+        editor.remove(keyGen.create("useRecipientAddressForReply"))
+        editor.remove(keyGen.create("recipientAddressReplyDomain"))
         editor.remove(keyGen.create("notifyMailCheck"))
         editor.remove(keyGen.create("inboxFolderId"))
         editor.remove(keyGen.create("outboxFolderId"))

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountDataMapper.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountDataMapper.kt
@@ -74,6 +74,8 @@ internal class DefaultLegacyAccountDataMapper : LegacyAccountDataMapper {
             messageFormat = dto.messageFormat,
             isMessageFormatAuto = dto.isMessageFormatAuto,
             isMessageReadReceipt = dto.isMessageReadReceipt,
+            useRecipientAddressForReply = dto.useRecipientAddressForReply,
+            recipientAddressReplyDomain = dto.recipientAddressReplyDomain,
             quoteStyle = dto.quoteStyle,
             quotePrefix = dto.quotePrefix,
             isDefaultQuotedTextShown = dto.isDefaultQuotedTextShown,
@@ -180,6 +182,8 @@ internal class DefaultLegacyAccountDataMapper : LegacyAccountDataMapper {
             messageFormat = domain.messageFormat
             isMessageFormatAuto = domain.isMessageFormatAuto
             isMessageReadReceipt = domain.isMessageReadReceipt
+            useRecipientAddressForReply = domain.useRecipientAddressForReply
+            recipientAddressReplyDomain = domain.recipientAddressReplyDomain
             quoteStyle = domain.quoteStyle
             quotePrefix = domain.quotePrefix
             isDefaultQuotedTextShown = domain.isDefaultQuotedTextShown

--- a/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAccountStorageHandlerTest.kt
+++ b/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAccountStorageHandlerTest.kt
@@ -1,0 +1,105 @@
+package net.thunderbird.feature.account.storage.legacy
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
+import kotlin.test.Test
+import net.thunderbird.core.android.account.Identity
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.logging.LogMessage
+import net.thunderbird.core.logging.LogTag
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.account.storage.legacy.fake.FakeStorage
+import net.thunderbird.feature.account.storage.legacy.fake.FakeStorageEditor
+import net.thunderbird.feature.account.storage.legacy.serializer.ServerSettingsDtoSerializer
+
+class LegacyAccountStorageHandlerTest {
+    private val serverSettingsSerializer = ServerSettingsDtoSerializer()
+    private val testSubject = LegacyAccountStorageHandler(
+        serverSettingsDtoSerializer = serverSettingsSerializer,
+        profileDtoStorageHandler = LegacyProfileDtoStorageHandler(LegacyAvatarDtoStorageHandler()),
+        logger = NO_OP_LOGGER,
+    )
+
+    @Test
+    fun `load should read use recipient address for reply`() {
+        val account = createAccount()
+        val storage = createStorage(mapOf("$ACCOUNT_UUID.useRecipientAddressForReply" to "true"))
+
+        testSubject.load(account, storage)
+
+        assertThat(account.useRecipientAddressForReply).isEqualTo(true)
+    }
+
+    @Test
+    fun `load should default use recipient address for reply to false`() {
+        val account = createAccount().apply { useRecipientAddressForReply = true }
+
+        testSubject.load(account, createStorage())
+
+        assertThat(account.useRecipientAddressForReply).isEqualTo(false)
+    }
+
+    @Test
+    fun `save should store use recipient address for reply`() {
+        val account = createAccount().apply { useRecipientAddressForReply = true }
+        val editor = FakeStorageEditor()
+
+        testSubject.save(account, FakeStorage(), editor)
+
+        assertThat(editor.values["$ACCOUNT_UUID.useRecipientAddressForReply"]).isEqualTo("true")
+    }
+
+    @Test
+    fun `delete should remove use recipient address for reply`() {
+        val account = createAccount()
+        val editor = FakeStorageEditor()
+
+        testSubject.delete(account, FakeStorage(), editor)
+
+        assertThat(editor.removedKeys).contains("$ACCOUNT_UUID.useRecipientAddressForReply")
+    }
+
+    private fun createStorage(additionalValues: Map<String, String> = emptyMap()): FakeStorage {
+        val serializedSettings = serverSettingsSerializer.serialize(SERVER_SETTINGS)
+        return FakeStorage(
+            mapOf(
+                "$ACCOUNT_UUID.incomingServerSettings" to serializedSettings,
+                "$ACCOUNT_UUID.outgoingServerSettings" to serializedSettings,
+                "$ACCOUNT_UUID.email.0" to "user@example.org",
+            ) + additionalValues,
+        )
+    }
+
+    private fun createAccount() = LegacyAccountDto(ACCOUNT_UUID).apply {
+        incomingServerSettings = SERVER_SETTINGS
+        outgoingServerSettings = SERVER_SETTINGS
+        replaceIdentities(listOf(Identity(email = "user@example.org")))
+    }
+
+    private companion object {
+        const val ACCOUNT_UUID = "00000000-0000-0000-0000-000000000000"
+
+        val SERVER_SETTINGS = ServerSettings(
+            type = "imap",
+            host = "mail.example.org",
+            port = 993,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "user@example.org",
+            password = null,
+            clientCertificateAlias = null,
+        )
+
+        val NO_OP_LOGGER = object : Logger {
+            override fun verbose(tag: LogTag?, throwable: Throwable?, message: () -> LogMessage) = Unit
+            override fun debug(tag: LogTag?, throwable: Throwable?, message: () -> LogMessage) = Unit
+            override fun info(tag: LogTag?, throwable: Throwable?, message: () -> LogMessage) = Unit
+            override fun warn(tag: LogTag?, throwable: Throwable?, message: () -> LogMessage) = Unit
+            override fun error(tag: LogTag?, throwable: Throwable?, message: () -> LogMessage) = Unit
+        }
+    }
+}

--- a/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapperTest.kt
+++ b/feature/account/storage/legacy/src/test/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountWrapperDataMapperTest.kt
@@ -113,6 +113,7 @@ class DefaultLegacyAccountWrapperDataMapperTest {
         assertThat(result.messageFormat).isEqualTo(MessageFormat.TEXT)
         assertThat(result.isMessageFormatAuto).isEqualTo(true)
         assertThat(result.isMessageReadReceipt).isEqualTo(true)
+        assertThat(result.useRecipientAddressForReply).isEqualTo(true)
         assertThat(result.quoteStyle).isEqualTo(QuoteStyle.HEADER)
         assertThat(result.quotePrefix).isEqualTo("quotePrefix")
         assertThat(result.isDefaultQuotedTextShown).isEqualTo(true)
@@ -257,6 +258,7 @@ class DefaultLegacyAccountWrapperDataMapperTest {
                 messageFormat = MessageFormat.TEXT
                 isMessageFormatAuto = true
                 isMessageReadReceipt = true
+                useRecipientAddressForReply = true
                 quoteStyle = QuoteStyle.HEADER
                 quotePrefix = "quotePrefix"
                 isDefaultQuotedTextShown = true
@@ -371,6 +373,7 @@ class DefaultLegacyAccountWrapperDataMapperTest {
                 messageFormat = MessageFormat.TEXT,
                 isMessageFormatAuto = true,
                 isMessageReadReceipt = true,
+                useRecipientAddressForReply = true,
                 quoteStyle = QuoteStyle.HEADER,
                 quotePrefix = "quotePrefix",
                 isDefaultQuotedTextShown = true,

--- a/legacy/core/src/main/java/com/fsck/k9/helper/IdentityHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/helper/IdentityHelper.kt
@@ -28,13 +28,66 @@ object IdentityHelper {
      * @see LegacyAccountDto.findIdentity
      */
     @JvmStatic
-    fun getRecipientIdentityFromMessage(account: LegacyAccountDto, message: Message): Identity {
+    @JvmOverloads
+    fun getRecipientIdentityFromMessage(
+        account: LegacyAccountDto,
+        message: Message,
+        allowRecipientAddressForReply: Boolean = false,
+    ): Identity {
         val recipient: Identity? = RECIPIENT_TYPES.asSequence()
             .flatMap { recipientType -> message.getRecipients(recipientType).asSequence() }
-            .map { address -> account.findIdentity(address) }
+            .map { address ->
+                account.findIdentity(address)
+                    ?: createRecipientIdentity(account, address.address, allowRecipientAddressForReply)
+            }
             .filterNotNull()
             .firstOrNull()
 
         return recipient ?: account.getIdentity(0)
+    }
+
+    private fun createRecipientIdentity(
+        account: LegacyAccountDto,
+        recipientAddress: String,
+        allowRecipientAddressForReply: Boolean,
+    ): Identity? {
+        if (!allowRecipientAddressForReply || !account.useRecipientAddressForReply) return null
+
+        val configuredDomain = account.recipientAddressReplyDomain
+            .trim()
+            .takeIf { it.isValidDomain() }
+            ?.lowercase()
+        val recipientDomain = recipientAddress.domainOrNull()
+        val domainsMatch = configuredDomain != null && recipientDomain?.equals(configuredDomain, ignoreCase = true) == true
+        val sourceIdentity = if (domainsMatch) {
+            account.identities.firstOrNull { identity ->
+                identity.email?.domainOrNull()?.equals(configuredDomain, ignoreCase = true) == true
+            } ?: account.getIdentity(0)
+        } else {
+            null
+        }
+
+        return sourceIdentity?.copy(email = recipientAddress)
+    }
+
+    private fun String.domainOrNull(): String? {
+        val separatorIndex = lastIndexOf('@')
+        val domain = substring(separatorIndex + 1)
+        return domain.takeIf { candidate ->
+            separatorIndex > 0 && indexOf('@') == separatorIndex && candidate.isNotEmpty() &&
+                none { character -> character.isWhitespace() }
+        }
+    }
+
+    private fun String.isValidDomain(): Boolean {
+        if (isEmpty() || length > 253 || any { it.isWhitespace() } || contains('@') || contains('/') || contains(':')) {
+            return false
+        }
+
+        return split('.').size >= 2 && split('.').all { label ->
+            label.isNotEmpty() && label.length <= 63 &&
+                label.first().isLetterOrDigit() && label.last().isLetterOrDigit() &&
+                label.all { it.isLetterOrDigit() || it == '-' }
+        }
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -47,6 +47,7 @@ import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAU
 import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAULT_REPLY_AFTER_QUOTE;
 import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAULT_SORT_ASCENDING;
 import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAULT_STRIP_SIGNATURE;
+import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAULT_USE_RECIPIENT_ADDRESS_FOR_REPLY;
 import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAULT_VISIBLE_LIMIT;
 import static net.thunderbird.feature.account.storage.legacy.LegacyAccountStorageHandler.FOLDER_PATH_DELIMITER_KEY;
 import static net.thunderbird.feature.mail.folder.api.FolderPathDelimiterKt.FOLDER_DEFAULT_PATH_DELIMITER;
@@ -156,6 +157,12 @@ class AccountSettingsDescriptions {
         ));
         s.put("messageReadReceipt", Settings.versions(
                 new V(1, new BooleanSetting(DEFAULT_MESSAGE_READ_RECEIPT))
+        ));
+        s.put("useRecipientAddressForReply", Settings.versions(
+                new V(112, new BooleanSetting(DEFAULT_USE_RECIPIENT_ADDRESS_FOR_REPLY))
+        ));
+        s.put("recipientAddressReplyDomain", Settings.versions(
+                new V(112, new StringSetting(""))
         ));
         s.put("notifyMailCheck", Settings.versions(
                 new V(1, new BooleanSetting(false))

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 111;
+    public static final int VERSION = 112;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription<?>>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/legacy/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
@@ -115,7 +115,155 @@ class IdentityHelperTest : RobolectricTest() {
         assertThat(identity.email).isEqualTo(DEFAULT_ADDRESS)
     }
 
+    @Test
+    fun getRecipientIdentityFromMessage_withOptionDisabled_ignoresSameDomainRecipient() {
+        val message = messageWithRecipients(RecipientType.TO to "catch-all@catch-all.example")
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(
+            account = account,
+            message = message,
+            allowRecipientAddressForReply = true,
+        )
+
+        assertThat(identity.email).isEqualTo(DEFAULT_ADDRESS)
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forReply_usesSameDomainRecipient() {
+        account.useRecipientAddressForReply = true
+        val message = messageWithRecipients(RecipientType.TO to "catch-all@catch-all.example")
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(
+            account = account,
+            message = message,
+            allowRecipientAddressForReply = true,
+        )
+
+        assertThat(identity.email).isEqualTo("catch-all@catch-all.example")
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forReplyAll_usesSameDomainRecipient() {
+        account.useRecipientAddressForReply = true
+        val message = messageWithRecipients(RecipientType.CC to "catch-all@catch-all.example")
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(
+            account = account,
+            message = message,
+            allowRecipientAddressForReply = true,
+        )
+
+        assertThat(identity.email).isEqualTo("catch-all@catch-all.example")
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forForward_doesNotUseSameDomainRecipient() {
+        account.useRecipientAddressForReply = true
+        val message = messageWithRecipients(RecipientType.TO to "catch-all@catch-all.example")
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(account, message)
+
+        assertThat(identity.email).isEqualTo(DEFAULT_ADDRESS)
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forForward_preservesExactIdentitySelection() {
+        account.useRecipientAddressForReply = true
+        val message = messageWithRecipients(RecipientType.TO to IDENTITY_1_ADDRESS)
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(account, message)
+
+        assertThat(identity.email).isEqualTo(IDENTITY_1_ADDRESS)
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forReply_preservesExactForeignDomainIdentitySelection() {
+        account.useRecipientAddressForReply = true
+        val foreignIdentity = newIdentity("Foreign identity", "configured@other.example")
+        account.replaceIdentities(account.identities + foreignIdentity)
+        val message = messageWithRecipients(RecipientType.TO to "configured@other.example")
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(account, message, true)
+
+        assertThat(identity).isEqualTo(foreignIdentity)
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forReply_ignoresForeignDomainRecipient() {
+        account.useRecipientAddressForReply = true
+        val message = messageWithRecipients(RecipientType.TO to "catch-all@other.example")
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(account, message, true)
+
+        assertThat(identity.email).isEqualTo(DEFAULT_ADDRESS)
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forReply_matchesDomainCaseInsensitively() {
+        account.useRecipientAddressForReply = true
+        val message = messageWithRecipients(RecipientType.TO to "catch-all@CATCH-ALL.EXAMPLE")
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(account, message, true)
+
+        assertThat(identity.email).isEqualTo("catch-all@CATCH-ALL.EXAMPLE")
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forReply_inheritsConfiguredIdentityMetadata() {
+        account.useRecipientAddressForReply = true
+        val defaultIdentity = Identity(
+            description = "Default description",
+            name = "Trusted name",
+            email = DEFAULT_ADDRESS,
+            signature = "Default signature",
+            signatureUse = true,
+            replyTo = "reply-to@example.org",
+        )
+        account.replaceIdentities(listOf(defaultIdentity))
+        val message = MimeMessage().apply {
+            addHeader(
+                "To",
+                AddressHeaderBuilder.createHeaderValue(arrayOf(Address("catch-all@catch-all.example", "Untrusted name"))),
+            )
+        }
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(account, message, true)
+
+        assertThat(identity).isEqualTo(defaultIdentity.copy(email = "catch-all@catch-all.example"))
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forReply_usesFirstEligibleRecipientInHeader() {
+        account.useRecipientAddressForReply = true
+        val message = MimeMessage().apply {
+            addHeader(
+                "To",
+                AddressHeaderBuilder.createHeaderValue(
+                    arrayOf(Address("first@catch-all.example"), Address("second@catch-all.example")),
+                ),
+            )
+        }
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(account, message, true)
+
+        assertThat(identity.email).isEqualTo("first@catch-all.example")
+    }
+
+    @Test
+    fun getRecipientIdentityFromMessage_forReply_preservesHeaderPrecedenceForDynamicAddress() {
+        account.useRecipientAddressForReply = true
+        val message = messageWithRecipients(
+            RecipientType.TO to "to@catch-all.example",
+            RecipientType.CC to IDENTITY_2_ADDRESS,
+        )
+
+        val identity = IdentityHelper.getRecipientIdentityFromMessage(account, message, true)
+
+        assertThat(identity.email).isEqualTo("to@catch-all.example")
+    }
+
     private fun createDummyAccount() = LegacyAccountDto(UUID.randomUUID().toString()).apply {
+        recipientAddressReplyDomain = "catch-all.example"
         replaceIdentities(
             listOf(
                 newIdentity("Default", DEFAULT_ADDRESS),

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.kt
@@ -7,6 +7,9 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.fsck.k9.K9RobolectricTest
 import com.fsck.k9.Preferences
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
 import java.io.ByteArrayOutputStream
 import org.jdom2.Document
 import org.jdom2.input.SAXBuilder
@@ -64,6 +67,27 @@ class SettingsExporterTest : K9RobolectricTest() {
         assertThat(document.rootElement.getChild("global")).isNull()
     }
 
+    @Test
+    fun exportPreferences_exportsUseRecipientAddressForReply() {
+        val account = preferences.newAccount().apply {
+            email = "user@example.org"
+            incomingServerSettings = SERVER_SETTINGS.copy(type = "imap")
+            outgoingServerSettings = SERVER_SETTINGS.copy(type = "smtp")
+            useRecipientAddressForReply = true
+        }
+        preferences.saveAccount(account)
+
+        val document = exportPreferences(false, setOf(account.uuid))
+
+        val exportedSetting = document.rootElement
+            .getChild("accounts")
+            .getChild("account")
+            .getChild("settings")
+            .getChildren("value")
+            .first { it.getAttributeValue("key") == "useRecipientAddressForReply" }
+        assertThat(exportedSetting.text).isEqualTo("true")
+    }
+
     private fun exportPreferences(globalSettings: Boolean, accounts: Set<String>): Document {
         return ByteArrayOutputStream().use { outputStream ->
             settingsExporter.exportPreferences(outputStream, globalSettings, accounts, includePasswords = false)
@@ -73,5 +97,18 @@ class SettingsExporterTest : K9RobolectricTest() {
 
     private fun parseXml(xml: ByteArray): Document {
         return SAXBuilder().build(xml.inputStream())
+    }
+
+    private companion object {
+        val SERVER_SETTINGS = ServerSettings(
+            type = "imap",
+            host = "mail.example.org",
+            port = 993,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "user@example.org",
+            password = null,
+            clientCertificateAlias = null,
+        )
     }
 }

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.kt
@@ -339,4 +339,50 @@ class SettingsImporterTest : K9RobolectricTest() {
             settingsImporter.getImportStreamContents(inputStream)
         }.isInstanceOf<SettingsImportExportException>()
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `importSettings should import use recipient address for reply from version 112`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val accountUuid = UUID.randomUUID().toString()
+            val inputStream =
+                """
+                <k9settings format="1" version="112">
+                  <accounts>
+                    <account uuid="$accountUuid">
+                      <name>Account</name>
+                      <incoming-server type="IMAP">
+                        <connection-security>SSL_TLS_REQUIRED</connection-security>
+                        <username>user@example.org</username>
+                        <authentication-type>PLAIN</authentication-type>
+                        <password>password</password>
+                        <host>mail.example.org</host>
+                        <port>993</port>
+                      </incoming-server>
+                      <outgoing-server type="SMTP">
+                        <connection-security>SSL_TLS_REQUIRED</connection-security>
+                        <username>user@example.org</username>
+                        <authentication-type>PLAIN</authentication-type>
+                        <password>password</password>
+                        <host>mail.example.org</host>
+                        <port>465</port>
+                      </outgoing-server>
+                      <settings>
+                        <value key="useRecipientAddressForReply">true</value>
+                      </settings>
+                      <identities>
+                        <identity>
+                          <email>user@example.org</email>
+                        </identity>
+                      </identities>
+                    </account>
+                  </accounts>
+                </k9settings>
+                """.trimIndent().byteInputStream()
+
+            val results = settingsImporter.importSettings(inputStream, globalSettings = false, listOf(accountUuid))
+
+            assertThat(results.erroneousAccounts).isEmpty()
+            assertThat(Preferences.getPreferences().getAccounts().single().useRecipientAddressForReply).isTrue()
+        }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -516,6 +516,12 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         updateFrom();
         replyToPresenter.setIdentity(identity);
 
+        if ((action == Action.REPLY || action == Action.REPLY_ALL) && !relatedMessageProcessed) {
+            // The source message is loaded asynchronously. Don't briefly show the default
+            // identity before we can select the identity used for the reply.
+            chooseIdentityView.setVisibility(View.INVISIBLE);
+        }
+
         if (!relatedMessageProcessed) {
             if (action == Action.REPLY || action == Action.REPLY_ALL ||
                     action == Action.FORWARD || action == Action.FORWARD_AS_ATTACHMENT ||
@@ -1482,7 +1488,8 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         quotedMessagePresenter.initFromReplyToMessage(messageViewInfo, action);
 
         if (action == Action.REPLY || action == Action.REPLY_ALL) {
-            setIdentityFromMessage(message);
+            setIdentityFromMessage(message, true);
+            chooseIdentityView.setVisibility(View.VISIBLE);
         }
 
     }
@@ -1515,11 +1522,12 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
             quotedMessagePresenter.processMessageToForward(messageViewInfo);
             attachmentPresenter.processMessageToForward(messageViewInfo);
         }
-        setIdentityFromMessage(message);
+        setIdentityFromMessage(message, false);
     }
 
-    private void setIdentityFromMessage(Message message) {
-        Identity useIdentity = IdentityHelper.getRecipientIdentityFromMessage(account, message);
+    private void setIdentityFromMessage(Message message, boolean allowRecipientAddressForReply) {
+        Identity useIdentity = IdentityHelper.getRecipientIdentityFromMessage(
+                account, message, allowRecipientAddressForReply);
         Identity defaultIdentity = account.getIdentity(0);
         if (useIdentity != defaultIdentity) {
             switchToIdentity(useIdentity);
@@ -1837,6 +1845,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         @Override
         public void onMessageDataLoadFailed() {
             internalMessageHandler.sendEmptyMessage(MSG_PROGRESS_OFF);
+            chooseIdentityView.setVisibility(View.VISIBLE);
             Toast.makeText(MessageCompose.this, R.string.status_invalid_id_error, Toast.LENGTH_LONG).show();
         }
 
@@ -1844,6 +1853,9 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         public void onMessageViewInfoLoadFinished(MessageViewInfo messageViewInfo) {
             internalMessageHandler.sendEmptyMessage(MSG_PROGRESS_OFF);
             loadLocalMessageForDisplay(messageViewInfo, action);
+            if (action == Action.REPLY || action == Action.REPLY_ALL) {
+                chooseIdentityView.setVisibility(View.VISIBLE);
+            }
 
             if(!recipientPresenter.isToAddressAdded()) {
                 recipientMvpView.requestFocusOnToField();
@@ -1857,6 +1869,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         @Override
         public void onMessageViewInfoLoadFailed(MessageViewInfo messageViewInfo) {
             internalMessageHandler.sendEmptyMessage(MSG_PROGRESS_OFF);
+            chooseIdentityView.setVisibility(View.VISIBLE);
             Toast.makeText(MessageCompose.this, R.string.status_invalid_id_error, Toast.LENGTH_LONG).show();
         }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -35,6 +35,7 @@ class AccountSettingsDataStore(
             "account_sync_remote_deletetions" -> account.isSyncRemoteDeletions
             "always_show_cc_bcc" -> account.isAlwaysShowCcBcc
             "message_read_receipt" -> account.isMessageReadReceipt
+            "use_recipient_address_for_reply" -> account.useRecipientAddressForReply
             "default_quoted_text_shown" -> account.isDefaultQuotedTextShown
             "reply_after_quote" -> account.isReplyAfterQuote
             "strip_signature" -> account.isStripSignature
@@ -60,6 +61,7 @@ class AccountSettingsDataStore(
             "account_sync_remote_deletetions" -> account.isSyncRemoteDeletions = value
             "always_show_cc_bcc" -> account.isAlwaysShowCcBcc = value
             "message_read_receipt" -> account.isMessageReadReceipt = value
+            "use_recipient_address_for_reply" -> account.useRecipientAddressForReply = value
             "default_quoted_text_shown" -> account.isDefaultQuotedTextShown = value
             "reply_after_quote" -> account.isReplyAfterQuote = value
             "strip_signature" -> account.isStripSignature = value
@@ -126,6 +128,7 @@ class AccountSettingsDataStore(
             "idle_refresh_period" -> account.idleRefreshMinutes.toString()
             "message_format" -> account.messageFormat.name
             "quote_style" -> account.quoteStyle.name
+            "recipient_address_reply_domain" -> account.recipientAddressReplyDomain
             "account_quote_prefix" -> account.quotePrefix
             "auto_select_folder" -> {
                 loadSpecialFolder(account.autoExpandFolderId, SpecialFolderSelection.MANUAL)
@@ -163,6 +166,9 @@ class AccountSettingsDataStore(
             "idle_refresh_period" -> account.idleRefreshMinutes = value.toInt()
             "message_format" -> account.messageFormat = MessageFormat.valueOf(value)
             "quote_style" -> account.quoteStyle = QuoteStyle.valueOf(value)
+            "recipient_address_reply_domain" -> {
+                RecipientAddressReplyDomain.normalize(value)?.let { account.recipientAddressReplyDomain = it }
+            }
             "account_quote_prefix" -> account.quotePrefix = value
             "auto_select_folder" -> account.autoExpandFolderId = extractFolderId(value)
             "archive_folder" -> saveSpecialFolderSelection(value, account::setArchiveFolderId)
@@ -286,5 +292,28 @@ class AccountSettingsDataStore(
 
             messagingController.refreshFolderList(account)
         }
+    }
+}
+
+internal object RecipientAddressReplyDomain {
+    fun normalize(value: String): String? {
+        val domain = value.trim()
+        if (domain.isEmpty() || domain.length > 253 || domain.any { it.isWhitespace() } ||
+            domain.contains('@') || domain.contains('/') || domain.contains(':') || domain.endsWith('.')
+        ) {
+            return null
+        }
+
+        val labels = domain.split('.')
+        if (labels.size < 2 || labels.any { label ->
+                label.isEmpty() || label.length > 63 ||
+                    !label.first().isLetterOrDigit() || !label.last().isLetterOrDigit() ||
+                    label.any { character -> !character.isLetterOrDigit() && character != '-' }
+            }
+        ) {
+            return null
+        }
+
+        return domain.lowercase()
     }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -99,6 +99,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         initializeSearch()
         initializeIncomingServer()
         initializeComposition()
+        initializeRecipientAddressReplyDomain()
         initializeManageIdentities()
         initializeUploadSentMessages(account)
         initializeOutgoingServer()
@@ -212,6 +213,14 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     private fun initializeComposition() {
         findPreference<Preference>(PREFERENCE_COMPOSITION)?.onClick {
             AccountSetupComposition.actionEditCompositionSettings(requireActivity(), accountUuid)
+        }
+    }
+
+    private fun initializeRecipientAddressReplyDomain() {
+        findPreference<Preference>(PREFERENCE_RECIPIENT_ADDRESS_REPLY_DOMAIN)?.setOnPreferenceChangeListener { _, value ->
+            val normalized = RecipientAddressReplyDomain.normalize(value.toString()) ?: return@setOnPreferenceChangeListener false
+            dataStore.putString(PREFERENCE_RECIPIENT_ADDRESS_REPLY_DOMAIN, normalized)
+            true
         }
     }
 
@@ -526,6 +535,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         private const val PREFERENCE_SEARCH = "search"
         private const val PREFERENCE_INCOMING_SERVER = "incoming"
         private const val PREFERENCE_COMPOSITION = "composition"
+        private const val PREFERENCE_RECIPIENT_ADDRESS_REPLY_DOMAIN = "recipient_address_reply_domain"
         private const val PREFERENCE_MANAGE_IDENTITIES = "manage_identities"
         private const val PREFERENCE_OUTGOING_SERVER = "outgoing"
         private const val PREFERENCE_UPLOAD_SENT_MESSAGES = "upload_sent_messages"

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -590,6 +590,9 @@
     <string name="account_settings_composition_title">Message composition options</string>
     <string name="account_settings_composition_label">Composition defaults</string>
     <string name="account_settings_composition_summary">Set your default From, Bcc and signature</string>
+    <string name="account_settings_use_recipient_address_for_reply_label">Reply from recipient address</string>
+    <string name="account_settings_use_recipient_address_for_reply_summary">Use the address that received the message when it matches the default identity’s domain. This supports catch-all addresses.</string>
+    <string name="account_settings_recipient_address_reply_domain_label">Catch-all reply domain</string>
 
     <string name="account_settings_identities_label">Manage identities</string>
     <string name="account_settings_identities_summary">Set up alternate \'From\' addresses and signatures</string>

--- a/legacy/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/account_settings.xml
@@ -64,6 +64,20 @@
             android:title="@string/account_settings_message_read_receipt_label"
             />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="use_recipient_address_for_reply"
+            android:summary="@string/account_settings_use_recipient_address_for_reply_summary"
+            android:title="@string/account_settings_use_recipient_address_for_reply_label"
+            />
+
+        <com.takisoft.preferencex.AutoSummaryEditTextPreference
+            android:dependency="use_recipient_address_for_reply"
+            android:dialogTitle="@string/account_settings_recipient_address_reply_domain_label"
+            android:key="recipient_address_reply_domain"
+            android:title="@string/account_settings_recipient_address_reply_domain_label"
+            />
+
         <ListPreference
             android:entries="@array/quote_style_entries"
             android:entryValues="@array/quote_style_values"

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreTest.kt
@@ -1,0 +1,42 @@
+package com.fsck.k9.ui.settings.account
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.fsck.k9.Preferences
+import com.fsck.k9.controller.MessagingController
+import com.fsck.k9.job.K9JobManager
+import com.fsck.k9.notification.NotificationChannelManager
+import com.fsck.k9.notification.NotificationController
+import java.util.concurrent.ExecutorService
+import net.thunderbird.core.android.account.LegacyAccountDto
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class AccountSettingsDataStoreTest {
+    private val account = LegacyAccountDto("00000000-0000-0000-0000-000000000000")
+    private val testSubject = AccountSettingsDataStore(
+        preferences = mock<Preferences>(),
+        executorService = mock<ExecutorService>(),
+        account = account,
+        jobManager = mock<K9JobManager>(),
+        notificationChannelManager = mock<NotificationChannelManager>(),
+        notificationController = mock<NotificationController>(),
+        messagingController = mock<MessagingController>(),
+    )
+
+    @Test
+    fun `getBoolean should read use recipient address for reply`() {
+        account.useRecipientAddressForReply = true
+
+        val result = testSubject.getBoolean("use_recipient_address_for_reply", false)
+
+        assertThat(result).isEqualTo(true)
+    }
+
+    @Test
+    fun `putBoolean should update use recipient address for reply`() {
+        testSubject.putBoolean("use_recipient_address_for_reply", true)
+
+        assertThat(account.useRecipientAddressForReply).isEqualTo(true)
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: None
RFC / Technical Design (if applicable): Not applicable

#### Description

This contribution adds configurable catch-all reply addresses per account.

Under **Settings → Account → Sending mail**, users can enable **Reply from recipient address** and configure a
catch-all domain. For Reply and Reply all, the app uses the address that originally received the message when its
domain matches the configured domain.

The contribution:

- Adds the default-empty `recipientAddressReplyDomain` account setting and persists it through account storage,
  account mapping, cleanup, settings import/export, and the account settings data store.
- Keeps the existing opt-in toggle disabled by default and settings format version 112 unchanged.
- Adds a domain input beneath the toggle that is enabled only when the feature is active.
- Trims and lowercases valid domains and rejects empty values, email addresses, URLs, whitespace, and malformed
  domains.
- Matches recipient domains case-insensitively and exactly, without matching subdomains.
- Preserves exact configured-identity matching independently of the catch-all setting.
- Creates dynamic identities using trusted name, signature, and Reply-To metadata from the first configured identity on
  the catch-all domain, falling back to the default identity. Only the email address is taken from the message.
- Keeps forwarding behavior and recipient-header priority unchanged.
- Hides the identity field while a reply's source message is loading, preventing the default identity from briefly
  appearing before the correct reply identity is selected.
- Adds and updates tests for identity selection, persistence, mapping, import/export, and settings data-store behavior.



## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [c] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
