### PR TITLE
fix(widget): use theme-aware background for message list widget

### DIFF
--- a/feature/widget/message-list/src/main/res/layout/message_list_widget_layout.xml
+++ b/feature/widget/message-list/src/main/res/layout/message_list_widget_layout.xml
@@ -45,7 +45,7 @@
         android:id="@+id/listView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@android:color/white"
+        android:background="?android:attr/colorBackground"
         android:divider="@color/message_list_widget_divider"
         android:dividerHeight="0.5dp"
         />


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: resolves #11459

#### Description

The message-list home screen widget's ListView background was hardcoded to
`@android:color/white`, and there's no `drawable-night`/`values-night`
variant anywhere in the widget module. In dark mode this renders as a stark
white list against the rest of a dark-themed home screen.

Switched to `?android:attr/colorBackground`, matching the pattern the
widget's own `thread_count` TextView already uses correctly for its text
colour (`android:textColor="?android:attr/colorBackground"`) — so the fix
follows an existing, working convention in the same file rather than
introducing a new one.

#### Screen Shots

Confirmed on a real Pixel 10: adding the widget with the device in dark
mode showed a stark white row (screenshot on request). Not yet
re-verified against a built APK with this exact fix applied — a full app
build takes considerably longer than the module-level checks below; happy
to do that pass too if useful.

## AI Disclosure

- [x] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to Mozilla's Community Participation Guidelines
- [x] This contribution is in Kotlin where possible (XML-only resource change, no Kotlin involved)
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (`spotlessCheck` ran clean on `:feature:widget:message-list`)
- [x] This contribution does not break existing unit tests (`testDebugUnitTest` — NO-SOURCE, module has no unit tests)
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality (N/A — layout-attribute-only change, no new logic)
- [x] This contribution adheres to our Engineering process (single-attribute fix, no ADR needed)
- [x] This PR has a descriptive title and body that accurately outlines all changes made