### PR TITLE
feat(feature-flag): add bundled catalog provider

### DIFF
--- a/app-common/src/main/kotlin/net/thunderbird/app/common/BaseApplication.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/BaseApplication.kt
@@ -42,7 +42,7 @@ abstract class BaseApplication : Application(), WorkManagerConfiguration.Provide
     private val notificationChannelManager: NotificationChannelManager by inject()
     private val messageListWidgetManager: MessageListWidgetManager by inject()
     private val workManagerConfigurationProvider: WorkManagerConfigurationProvider by inject()
-    private val logger: Logger by inject()
+    protected val logger: Logger by inject()
     private val syncDebugFileLogSink: FileLogSink by inject(named("syncDebug"))
 
     private val appCoroutineScope: CoroutineScope = MainScope()

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/FeatureFlagApplication.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/FeatureFlagApplication.kt
@@ -1,14 +1,13 @@
 package net.thunderbird.app.common
 
 import android.os.Build
-import kotlin.getValue
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigStore
-import net.thunderbird.core.featureflag.provider.BaseCatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.DataSourceCatalogFeatureFlagProvider
 import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext.Value
 import net.thunderbird.core.featureflag.provider.initializeFeatureFlags
 import org.koin.android.ext.android.inject
@@ -16,8 +15,8 @@ import org.koin.android.ext.android.inject
 abstract class FeatureFlagApplication : BaseApplication() {
     protected abstract val appName: String
     protected abstract val appVersion: String
-    private val featureFlagProvider: BaseCatalogFeatureFlagProvider by inject()
     private val targetingKeyStore: FeatureFlagConfigStore by inject()
+    private val featureFlagProvider: DataSourceCatalogFeatureFlagProvider by inject()
 
     private val featureFlagScope = CoroutineScope(
         SupervisorJob() + Dispatchers.Default +

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/FeatureFlagApplication.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/FeatureFlagApplication.kt
@@ -1,0 +1,42 @@
+package net.thunderbird.app.common
+
+import android.os.Build
+import kotlin.getValue
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigStore
+import net.thunderbird.core.featureflag.provider.BaseCatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext.Value
+import net.thunderbird.core.featureflag.provider.initializeFeatureFlags
+import org.koin.android.ext.android.inject
+
+abstract class FeatureFlagApplication : BaseApplication() {
+    protected abstract val appName: String
+    protected abstract val appVersion: String
+    private val featureFlagProvider: BaseCatalogFeatureFlagProvider by inject()
+    private val targetingKeyStore: FeatureFlagConfigStore by inject()
+
+    private val featureFlagScope = CoroutineScope(
+        SupervisorJob() + Dispatchers.Default +
+            CoroutineExceptionHandler { _, throwable ->
+                logger.error(throwable = throwable) { "Failed to initialize Feature flags" }
+            },
+    )
+
+    override fun onCreate() {
+        super.onCreate()
+        featureFlagScope.launch {
+            initializeFeatureFlags(
+                provider = featureFlagProvider,
+                featureFlagConfigStore = targetingKeyStore,
+                app = appName,
+                buildType = BuildConfig.BUILD_TYPE,
+                appVersion = appVersion,
+                extras = mapOf("os_sdk_int" to Value.Int(Build.VERSION.SDK_INT)),
+            )
+        }
+    }
+}

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/FeatureFlagApplication.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/FeatureFlagApplication.kt
@@ -19,9 +19,9 @@ abstract class FeatureFlagApplication : BaseApplication() {
     private val featureFlagProvider: DataSourceCatalogFeatureFlagProvider by inject()
 
     private val featureFlagScope = CoroutineScope(
-        SupervisorJob() + Dispatchers.Default +
+        SupervisorJob() + Dispatchers.Main +
             CoroutineExceptionHandler { _, throwable ->
-                logger.error(throwable = throwable) { "Failed to initialize Feature flags" }
+                logger.error(throwable = throwable) { "[feature-flag] Failed to initialize Feature flags" }
             },
     )
 

--- a/app-k9mail/src/main/kotlin/app/k9mail/K9App.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9App.kt
@@ -1,8 +1,12 @@
 package app.k9mail
 
-import net.thunderbird.app.common.BaseApplication
+import com.fsck.k9.BuildConfig
+import net.thunderbird.app.common.FeatureFlagApplication
 import org.koin.core.module.Module
 
-class K9App : BaseApplication() {
+class K9App : FeatureFlagApplication() {
+    override val appName: String = "k9"
+    override val appVersion: String = BuildConfig.VERSION_NAME
+
     override fun provideAppModule(): Module = appModule
 }

--- a/app-k9mail/src/test/kotlin/app/k9mail/DependencyInjectionTest.kt
+++ b/app-k9mail/src/test/kotlin/app/k9mail/DependencyInjectionTest.kt
@@ -25,6 +25,7 @@ import com.fsck.k9.view.MessageWebView
 import kotlin.test.Test
 import net.openid.appauth.AppAuthConfiguration
 import net.thunderbird.core.common.mail.html.HtmlSettings
+import net.thunderbird.core.configstore.ConfigId
 import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.changelog.internal.ChangelogViewModel
@@ -57,6 +58,7 @@ class DependencyInjectionTest {
                 NotificationManager::class,
                 Resources::class,
                 Storage::class,
+                ConfigId::class,
             ),
             injections = injectedParameters(
                 definition<AccountRemoverWorker>(WorkerParameters::class),

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdApp.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/ThunderbirdApp.kt
@@ -2,14 +2,16 @@ package net.thunderbird.android
 
 import app.k9mail.feature.telemetry.api.TelemetryManager
 import com.fsck.k9.K9
-import net.thunderbird.app.common.BaseApplication
+import net.thunderbird.app.common.FeatureFlagApplication
 import org.koin.android.ext.android.inject
 import org.koin.core.module.Module
 
-class ThunderbirdApp : BaseApplication() {
+class ThunderbirdApp : FeatureFlagApplication() {
     private val telemetryManager: TelemetryManager by inject()
 
     override fun provideAppModule(): Module = appModule
+    override val appName: String = "thunderbird"
+    override val appVersion: String = BuildConfig.VERSION_NAME
 
     override fun onCreate() {
         super.onCreate()

--- a/app-thunderbird/src/test/kotlin/net/thunderbird/android/DependencyInjectionTest.kt
+++ b/app-thunderbird/src/test/kotlin/net/thunderbird/android/DependencyInjectionTest.kt
@@ -25,6 +25,7 @@ import com.fsck.k9.view.MessageWebView
 import kotlin.test.Test
 import net.openid.appauth.AppAuthConfiguration
 import net.thunderbird.core.common.mail.html.HtmlSettings
+import net.thunderbird.core.configstore.ConfigId
 import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.changelog.internal.ChangelogViewModel
@@ -57,6 +58,7 @@ class DependencyInjectionTest {
                 NotificationManager::class,
                 Resources::class,
                 Storage::class,
+                ConfigId::class,
             ),
             injections = injectedParameters(
                 definition<AccountRemoverWorker>(WorkerParameters::class),

--- a/core/featureflag/build.gradle.kts
+++ b/core/featureflag/build.gradle.kts
@@ -21,6 +21,9 @@ kotlin {
             api(projects.core.configstore.api)
             implementation(projects.core.logging.api)
         }
+        commonTest.dependencies {
+            implementation(projects.core.logging.testing)
+        }
         androidHostTest.dependencies {
             implementation(libs.robolectric)
         }

--- a/core/featureflag/build.gradle.kts
+++ b/core/featureflag/build.gradle.kts
@@ -17,6 +17,10 @@ kotlin {
     }
 
     sourceSets {
+        commonMain.dependencies {
+            api(projects.core.configstore.api)
+            implementation(projects.core.logging.api)
+        }
         androidHostTest.dependencies {
             implementation(libs.robolectric)
         }

--- a/core/featureflag/src/androidMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.android.kt
+++ b/core/featureflag/src/androidMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.android.kt
@@ -1,0 +1,17 @@
+package net.thunderbird.core.featureflag.inject
+
+import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
+import net.thunderbird.core.featureflag.data.LocalFeatureFlagCatalogDataSource
+import org.koin.android.ext.koin.androidApplication
+import org.koin.core.module.Module
+import org.koin.core.qualifier.qualifier
+import org.koin.dsl.module
+
+actual val platformFeatureFlagModule: Module = module {
+    single<FeatureFlagCatalogDataSource>(qualifier(FeatureFlagCatalogDataSource.InjectQualifiers.Local)) {
+        LocalFeatureFlagCatalogDataSource(
+            applicationContext = androidApplication(),
+            jsonParser = get(),
+        )
+    }
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/FeatureFlagCatalogDataSource.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/FeatureFlagCatalogDataSource.kt
@@ -17,8 +17,12 @@ interface FeatureFlagCatalogDataSource {
      * @return A Flow that emits the feature flag catalog containing flag definitions and overrides.
      */
     fun load(): Flow<FeatureFlagCatalog>
-}
 
-internal expect class LocalFeatureFlagCatalogDataSource : FeatureFlagCatalogDataSource {
-    override fun load(): Flow<FeatureFlagCatalog>
+    /**
+     * Dependency injection qualifiers for distinguishing between local and remote data source implementations.
+     *
+     * Used to differentiate between [FeatureFlagCatalogDataSource] instances that load catalogs
+     * from local bundled resources versus remote servers during dependency injection.
+     */
+    enum class InjectQualifiers { Local, Remote }
 }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/LocalFeatureFlagCatalogDataSource.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/LocalFeatureFlagCatalogDataSource.kt
@@ -1,0 +1,16 @@
+package net.thunderbird.core.featureflag.data
+
+import kotlinx.coroutines.flow.Flow
+import net.thunderbird.core.featureflag.model.FeatureFlagCatalog
+
+/**
+ * Platform-specific implementation of [FeatureFlagCatalogDataSource] that loads the feature flag catalog
+ * from local bundled resources.
+ *
+ * This is an expect class with platform-specific actual implementations that retrieve and parse
+ * the catalog JSON from local application resources. The catalog is loaded asynchronously and
+ * emitted as a Flow.
+ */
+internal expect class LocalFeatureFlagCatalogDataSource : FeatureFlagCatalogDataSource {
+    override fun load(): Flow<FeatureFlagCatalog>
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/configstore/FeatureFlagConfigData.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/configstore/FeatureFlagConfigData.kt
@@ -1,0 +1,49 @@
+package net.thunderbird.core.featureflag.data.configstore
+
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.first
+import net.thunderbird.core.configstore.ConfigKey
+import net.thunderbird.core.configstore.ConfigStore
+
+/**
+ * Data class representing the configuration for feature flags.
+ *
+ * @property targetingKey A random UUID used only for rollout/experiment bucketing — never PII.
+ *  A `null` value means no key has been generated yet.
+ */
+data class FeatureFlagConfigData(
+    val targetingKey: Uuid? = null,
+) {
+    companion object {
+        val DEFAULT = FeatureFlagConfigData()
+    }
+}
+
+internal object FeatureFlagConfigKeys {
+    val TARGETING_KEY = ConfigKey.StringKey("targeting_key")
+}
+
+/**
+ * Updates the stored configuration by applying the provided transformation function
+ *
+ * @param transform A function that takes the current configuration, or default if null,
+ * and returns a new configuration.
+ */
+suspend fun ConfigStore<FeatureFlagConfigData>.update(transform: (FeatureFlagConfigData) -> FeatureFlagConfigData) =
+    update { nullableConfig ->
+        val config = nullableConfig ?: FeatureFlagConfigData.DEFAULT
+        transform(config)
+    }
+
+/** Returns the persisted per-install targeting key, generating and persisting one on first use. */
+internal suspend fun ConfigStore<FeatureFlagConfigData>.resolveTargetingKey(): Uuid {
+    val current = config.first().targetingKey ?: Uuid.random().also { generated ->
+        update {
+            val config = requireNotNull(it) {
+                "Feature flag configuration data was not properly initialized."
+            }
+            config.copy(targetingKey = generated)
+        }
+    }
+    return current
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/configstore/FeatureFlagConfigStore.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/configstore/FeatureFlagConfigStore.kt
@@ -1,0 +1,52 @@
+package net.thunderbird.core.featureflag.data.configstore
+
+import kotlin.uuid.Uuid
+import net.thunderbird.core.configstore.BaseConfigStore
+import net.thunderbird.core.configstore.Config
+import net.thunderbird.core.configstore.ConfigDefinition
+import net.thunderbird.core.configstore.ConfigId
+import net.thunderbird.core.configstore.ConfigKey
+import net.thunderbird.core.configstore.ConfigMapper
+import net.thunderbird.core.configstore.ConfigMigration
+import net.thunderbird.core.configstore.ConfigMigrationResult
+import net.thunderbird.core.configstore.backend.ConfigBackendProvider
+
+/**
+ * Configuration store for managing feature flag-related configuration data.
+ *
+ * This store handles persistence and retrieval of feature flag configuration,
+ * including the targeting key used for feature flag evaluation. It provides
+ * type-safe access to feature flag settings through the [FeatureFlagConfigData] model.
+ *
+ * @param provider The backend provider used to access the underlying storage mechanism.
+ */
+class FeatureFlagConfigStore(
+    id: ConfigId,
+    provider: ConfigBackendProvider,
+) : BaseConfigStore<FeatureFlagConfigData>(provider, FeatureFlagConfigDefinition(id))
+
+private class FeatureFlagConfigDefinition(override val id: ConfigId) : ConfigDefinition<FeatureFlagConfigData> {
+    override val version: Int = 1
+    override val defaultValue: FeatureFlagConfigData = FeatureFlagConfigData.DEFAULT
+    override val keys: List<ConfigKey<*>> = listOf(FeatureFlagConfigKeys.TARGETING_KEY)
+
+    override val mapper: ConfigMapper<FeatureFlagConfigData> = object : ConfigMapper<FeatureFlagConfigData> {
+        override fun toConfig(obj: FeatureFlagConfigData): Config = Config().apply {
+            if (obj.targetingKey != null) {
+                this[FeatureFlagConfigKeys.TARGETING_KEY] = obj.targetingKey.toString()
+            }
+        }
+
+        override fun fromConfig(config: Config): FeatureFlagConfigData = FeatureFlagConfigData(
+            targetingKey = config[FeatureFlagConfigKeys.TARGETING_KEY]?.let(Uuid::parse),
+        )
+    }
+
+    override val migration: ConfigMigration = object : ConfigMigration {
+        override suspend fun migrate(
+            currentVersion: Int,
+            newVersion: Int,
+            current: Config,
+        ): ConfigMigrationResult = ConfigMigrationResult.NoOp
+    }
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
@@ -6,12 +6,14 @@ import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigStore
 import net.thunderbird.core.featureflag.provider.BaseCatalogFeatureFlagProvider
 import net.thunderbird.core.featureflag.provider.BundledCatalogFeatureFlagProvider
 import net.thunderbird.core.featureflag.provider.BundledFeatureFlagDefaults
+import net.thunderbird.core.featureflag.provider.DataSourceCatalogFeatureFlagProvider
 import net.thunderbird.core.featureflag.provider.ProviderMetadata
 import net.thunderbird.core.featureflag.serialization.DefaultFeatureFlagCatalogJsonParser
 import net.thunderbird.core.featureflag.serialization.FeatureFlagCatalogJsonParser
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.bind
 
 val featureFlagModule = module {
     factory<FeatureFlagCatalogJsonParser> { DefaultFeatureFlagCatalogJsonParser(registrySerializer = get()) }
@@ -29,7 +31,7 @@ val featureFlagModule = module {
             ),
             logger = get(),
         )
-    }
+    }.bind(DataSourceCatalogFeatureFlagProvider::class)
     single<BundledFeatureFlagDefaults> { get<BundledCatalogFeatureFlagProvider>() }
     single<BaseCatalogFeatureFlagProvider> {
         // TODO(#11332): Later replaced by MultiFeatureFlagProviderEvaluator

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
@@ -1,9 +1,42 @@
 package net.thunderbird.core.featureflag.inject
 
+import net.thunderbird.core.configstore.ConfigId
+import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
+import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigStore
+import net.thunderbird.core.featureflag.provider.BaseCatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.BundledCatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.BundledFeatureFlagDefaults
+import net.thunderbird.core.featureflag.provider.ProviderMetadata
 import net.thunderbird.core.featureflag.serialization.DefaultFeatureFlagCatalogJsonParser
 import net.thunderbird.core.featureflag.serialization.FeatureFlagCatalogJsonParser
+import org.koin.core.module.Module
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val featureFlagModule = module {
     factory<FeatureFlagCatalogJsonParser> { DefaultFeatureFlagCatalogJsonParser(registrySerializer = get()) }
+    single {
+        val metadata = get<ProviderMetadata>()
+        FeatureFlagConfigStore(
+            id = ConfigId(backend = "feature_flag", feature = metadata.name),
+            provider = get(),
+        )
+    }
+    single {
+        BundledCatalogFeatureFlagProvider(
+            dataSource = get<FeatureFlagCatalogDataSource>(
+                named(FeatureFlagCatalogDataSource.InjectQualifiers.Local),
+            ),
+            logger = get(),
+        )
+    }
+    single<BundledFeatureFlagDefaults> { get<BundledCatalogFeatureFlagProvider>() }
+    single<BaseCatalogFeatureFlagProvider> {
+        // TODO(#11332): Later replaced by MultiFeatureFlagProviderEvaluator
+        get<BundledCatalogFeatureFlagProvider>()
+    }
+    single<ProviderMetadata> { get<BaseCatalogFeatureFlagProvider>().metadata }
+    includes(platformFeatureFlagModule)
 }
+
+expect val platformFeatureFlagModule: Module

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/model/FlagRegistryOverride.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/model/FlagRegistryOverride.kt
@@ -11,4 +11,10 @@ import kotlinx.serialization.Serializable
  *  [EmptyAppVariantOverride] if running inside K-9 mail.
  */
 @Serializable
-data class FlagRegistryOverride(val k9: AppVariantOverrides, val thunderbird: AppVariantOverrides)
+data class FlagRegistryOverride(val k9: AppVariantOverrides, val thunderbird: AppVariantOverrides) {
+    operator fun get(key: String): AppVariantOverrides? = when (key) {
+        ::k9.name -> k9
+        ::thunderbird.name -> thunderbird
+        else -> null
+    }
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/BaseCatalogFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/BaseCatalogFeatureFlagProvider.kt
@@ -1,0 +1,99 @@
+package net.thunderbird.core.featureflag.provider
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.FeatureFlagProvider
+import net.thunderbird.core.featureflag.FeatureFlagResult
+import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
+import net.thunderbird.core.featureflag.model.FeatureFlagCatalog
+import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext
+import net.thunderbird.core.logging.Logger
+
+/**
+ *
+ * Base [FeatureFlagCatalog] for a feature-flag catalog loaded through a [FeatureFlagCatalogDataSource].
+ *
+ * Effective flag values are the catalog [base defaults][FeatureFlagCatalog.flags] overlaid with the
+ * per-build-type overrides for the current build (`app`/`build_type` attributes from the
+ * [FeatureFlagContext]; overrides win), re-resolved whenever the context changes. Keys absent from
+ * the resolved catalog return [FeatureFlagResult.Unavailable], so a `MultiProvider` using first-match
+ * strategy falls through to the next provider.
+ *
+ * @param dataSource The data source from which to load the feature flag catalog.
+ * @param providerName The identifying name for this provider instance.
+ * @param logger Logger instance for diagnostic and error messages.
+ * @param scope Coroutine scope for managing asynchronous catalog loading operations.
+ */
+abstract class BaseCatalogFeatureFlagProvider(
+    private val dataSource: FeatureFlagCatalogDataSource,
+    providerName: String,
+    private val logger: Logger,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) : FeatureFlagProvider {
+
+    private var catalog: FeatureFlagCatalog? = null
+    private var resolvedFlags: Map<String, Boolean> = emptyMap()
+    private var context: FeatureFlagContext? = null
+
+    val metadata: ProviderMetadata = CatalogProviderMetadata(providerName)
+
+    /**
+     * Initializes the feature flag provider with the given context and loads the catalog.
+     *
+     * @param initialContext The evaluation context containing targeting key and attributes for flag resolution.
+     */
+    suspend fun initialize(initialContext: FeatureFlagContext) {
+        context = initialContext
+        loadCatalog()
+            .onEach { bundledCatalog ->
+                catalog = bundledCatalog
+                resolvedFlags = resolve(context)
+                logger.verbose { "Resolved feature flags: $resolvedFlags" }
+            }
+            .catch { cause ->
+                logger.error(throwable = cause) { "Failed to load feature flag catalog." }
+            }
+            .launchIn(scope)
+    }
+
+    override fun provide(key: FeatureFlagKey): FeatureFlagResult = when (resolvedFlags[key.key]) {
+        null -> FeatureFlagResult.Unavailable
+        true -> FeatureFlagResult.Enabled
+        false -> FeatureFlagResult.Disabled
+    }
+
+    /**
+     * Loads the catalog as a [Flow], to resolve. Defaults to [FeatureFlagCatalogDataSource.load].
+     *
+     * @return A Flow that emits the feature flag catalog containing flag definitions and overrides.
+     */
+    protected open suspend fun loadCatalog(): Flow<FeatureFlagCatalog> = dataSource.load()
+
+    /** The variant-resolved baseline values, for surfaces that enumerate all flags. */
+    protected fun resolvedFlags(): Map<String, Boolean> = resolvedFlags
+
+    private fun resolve(context: FeatureFlagContext?): Map<String, Boolean> {
+        val catalog = catalog ?: return emptyMap()
+        val base = catalog.flags.associate { it.key to it.default }
+
+        val app = context?.get(key = "app")?.asString()
+        val buildType = context?.get(key = "build_type")?.asString()
+        val overrides = if (app != null && buildType != null) {
+            catalog.overrides[app]?.get(buildType).orEmpty()
+        } else {
+            emptyMap()
+        }
+
+        return base + overrides
+    }
+
+    override fun toString(): String {
+        return "BaseCatalogFeatureFlagProvider('${metadata.name}', resolvedFlags=$resolvedFlags)"
+    }
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/BundledCatalogFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/BundledCatalogFeatureFlagProvider.kt
@@ -1,0 +1,38 @@
+package net.thunderbird.core.featureflag.provider
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
+import net.thunderbird.core.logging.Logger
+
+/**
+ * [FeatureFlagProvider][BaseCatalogFeatureFlagProvider] backed by the bundled (offline) catalog.
+ *
+ * The catalog is the offline floor of the evaluation chain and also exposes the
+ * resolved baseline via [BundledFeatureFlagDefaults] for the debug settings UI.
+ */
+class BundledCatalogFeatureFlagProvider(
+    dataSource: FeatureFlagCatalogDataSource,
+    logger: Logger,
+    scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) : BaseCatalogFeatureFlagProvider(
+    dataSource = dataSource,
+    providerName = "bundled_catalog",
+    logger = logger,
+    scope = scope,
+),
+    BundledFeatureFlagDefaults {
+    override fun defaults(): Map<String, Boolean> = resolvedFlags()
+}
+
+/**
+ * Exposes the variant-resolved baseline value of every catalog flag (before any runtime debug
+ * override), keyed by the flag key.
+ *
+ * Intended for surfaces such as the debug settings screen that need to enumerate all known flags
+ * and their default state without going through the override-aware evaluation stack.
+ */
+fun interface BundledFeatureFlagDefaults {
+    fun defaults(): Map<String, Boolean>
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/BundledCatalogFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/BundledCatalogFeatureFlagProvider.kt
@@ -16,7 +16,7 @@ class BundledCatalogFeatureFlagProvider(
     dataSource: FeatureFlagCatalogDataSource,
     logger: Logger,
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-) : BaseCatalogFeatureFlagProvider(
+) : DataSourceCatalogFeatureFlagProvider(
     dataSource = dataSource,
     providerName = "bundled_catalog",
     logger = logger,
@@ -24,6 +24,14 @@ class BundledCatalogFeatureFlagProvider(
 ),
     BundledFeatureFlagDefaults {
     override fun defaults(): Map<String, Boolean> = resolvedFlags()
+
+    override fun toString(): String {
+        return """
+            |feature-flag provider '${metadata.name}':
+            |   resolvedFlags = $resolvedFlags,
+            |   defaults = ${defaults()}
+        """.trimMargin()
+    }
 }
 
 /**

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/CatalogFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/CatalogFeatureFlagProvider.kt
@@ -1,19 +1,34 @@
 package net.thunderbird.core.featureflag.provider
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import androidx.annotation.CallSuper
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.featureflag.FeatureFlagResult
 import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
 import net.thunderbird.core.featureflag.model.FeatureFlagCatalog
+import net.thunderbird.core.featureflag.model.FlagOverrides
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider.State
 import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext
 import net.thunderbird.core.logging.Logger
+
+/**
+ * Extended interface for catalog-based feature flag providers.
+ *
+ * Provides feature flags loaded from a catalog data source while exposing
+ * provider metadata for identification and debugging purposes. Implementations
+ * include bundled catalogs (offline) and remote catalogs (fetched at runtime).
+ */
+interface CatalogFeatureFlagProvider : FeatureFlagProvider {
+    val state: StateFlow<State>
+    val metadata: ProviderMetadata
+
+    override fun toString(): String
+
+    enum class State { Initializing, ResolvingFlags, Resolved }
+}
 
 /**
  *
@@ -25,41 +40,31 @@ import net.thunderbird.core.logging.Logger
  * the resolved catalog return [FeatureFlagResult.Unavailable], so a `MultiProvider` using first-match
  * strategy falls through to the next provider.
  *
- * @param dataSource The data source from which to load the feature flag catalog.
  * @param providerName The identifying name for this provider instance.
  * @param logger Logger instance for diagnostic and error messages.
- * @param scope Coroutine scope for managing asynchronous catalog loading operations.
  */
-abstract class BaseCatalogFeatureFlagProvider(
-    private val dataSource: FeatureFlagCatalogDataSource,
+abstract class BaseCatalogFeatureFlagProvider internal constructor(
     providerName: String,
     private val logger: Logger,
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-) : FeatureFlagProvider {
+) : CatalogFeatureFlagProvider {
 
-    private var catalog: FeatureFlagCatalog? = null
-    private var resolvedFlags: Map<String, Boolean> = emptyMap()
-    private var context: FeatureFlagContext? = null
+    final override val state: StateFlow<State>
+        field: MutableStateFlow<State> = MutableStateFlow(State.Initializing)
 
-    val metadata: ProviderMetadata = CatalogProviderMetadata(providerName)
+    protected var catalog: FeatureFlagCatalog? = null
+    protected open var resolvedFlags: FlagOverrides = emptyMap()
+    protected var context: FeatureFlagContext? = null
+
+    override val metadata: ProviderMetadata = CatalogProviderMetadata(providerName)
 
     /**
      * Initializes the feature flag provider with the given context and loads the catalog.
      *
      * @param initialContext The evaluation context containing targeting key and attributes for flag resolution.
      */
-    suspend fun initialize(initialContext: FeatureFlagContext) {
+    @CallSuper
+    open fun initialize(initialContext: FeatureFlagContext) {
         context = initialContext
-        loadCatalog()
-            .onEach { bundledCatalog ->
-                catalog = bundledCatalog
-                resolvedFlags = resolve(context)
-                logger.verbose { "Resolved feature flags: $resolvedFlags" }
-            }
-            .catch { cause ->
-                logger.error(throwable = cause) { "Failed to load feature flag catalog." }
-            }
-            .launchIn(scope)
     }
 
     override fun provide(key: FeatureFlagKey): FeatureFlagResult = when (resolvedFlags[key.key]) {
@@ -68,32 +73,27 @@ abstract class BaseCatalogFeatureFlagProvider(
         false -> FeatureFlagResult.Disabled
     }
 
-    /**
-     * Loads the catalog as a [Flow], to resolve. Defaults to [FeatureFlagCatalogDataSource.load].
-     *
-     * @return A Flow that emits the feature flag catalog containing flag definitions and overrides.
-     */
-    protected open suspend fun loadCatalog(): Flow<FeatureFlagCatalog> = dataSource.load()
-
     /** The variant-resolved baseline values, for surfaces that enumerate all flags. */
     protected fun resolvedFlags(): Map<String, Boolean> = resolvedFlags
 
-    private fun resolve(context: FeatureFlagContext?): Map<String, Boolean> {
+    protected fun resolve(context: FeatureFlagContext?): Map<String, Boolean> {
+        state.update { State.ResolvingFlags }
+        logger.verbose { "[feature-flag] resolving feature flag catalog for '${metadata.name}' provider" }
         val catalog = catalog ?: return emptyMap()
         val base = catalog.flags.associate { it.key to it.default }
+        logger.verbose { "[feature-flag][${metadata.name}] base flags: $base" }
 
         val app = context?.get(key = "app")?.asString()
         val buildType = context?.get(key = "build_type")?.asString()
+        logger.verbose { "[feature-flag][${metadata.name}] fetching overrides for '$app/$buildType'" }
         val overrides = if (app != null && buildType != null) {
             catalog.overrides[app]?.get(buildType).orEmpty()
         } else {
             emptyMap()
         }
-
-        return base + overrides
-    }
-
-    override fun toString(): String {
-        return "BaseCatalogFeatureFlagProvider('${metadata.name}', resolvedFlags=$resolvedFlags)"
+        val resolvedFlags = base + overrides
+        logger.verbose { "[feature-flag][${metadata.name}] resolved flags: $resolvedFlags" }
+        state.update { State.Resolved }
+        return resolvedFlags
     }
 }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/DataSourceCatalogFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/DataSourceCatalogFeatureFlagProvider.kt
@@ -1,0 +1,56 @@
+package net.thunderbird.core.featureflag.provider
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
+import net.thunderbird.core.featureflag.model.FeatureFlagCatalog
+import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext
+import net.thunderbird.core.logging.Logger
+
+/**
+ * Base implementation of a catalog-based feature flag provider that loads flag
+ * definitions from a data source.
+ *
+ * @param dataSource The data source from which to load the feature flag catalog.
+ * @param providerName The identifying name for this provider instance.
+ * @param logger Logger instance for diagnostic and error messages.
+ * @param scope The coroutine scope used for catalog loading operations.
+ *  Defaults to a scope with [SupervisorJob] and Main.immediate dispatcher.
+ */
+abstract class DataSourceCatalogFeatureFlagProvider internal constructor(
+    private val dataSource: FeatureFlagCatalogDataSource,
+    providerName: String,
+    private val logger: Logger,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+) : BaseCatalogFeatureFlagProvider(providerName, logger) {
+    /**
+     * Initializes the feature flag provider with the given context and loads the catalog.
+     *
+     * @param initialContext The evaluation context containing targeting key and attributes for flag resolution.
+     */
+    override fun initialize(initialContext: FeatureFlagContext) {
+        super.initialize(initialContext)
+        loadCatalog()
+            .onEach { bundledCatalog ->
+                catalog = bundledCatalog
+                resolvedFlags = resolve(context)
+                logger.verbose { "[feature-flag] Resolved feature flags: $resolvedFlags" }
+            }
+            .catch { cause ->
+                logger.error(throwable = cause) { "[feature-flag] Failed to load feature flag catalog." }
+            }
+            .launchIn(scope)
+    }
+
+    /**
+     * Loads the catalog as a [Flow], to resolve. Defaults to [FeatureFlagCatalogDataSource.load].
+     *
+     * @return A Flow that emits the feature flag catalog containing flag definitions and overrides.
+     */
+    open fun loadCatalog(): Flow<FeatureFlagCatalog> = dataSource.load()
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/FeatureFlagInitializer.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/FeatureFlagInitializer.kt
@@ -1,0 +1,38 @@
+package net.thunderbird.core.featureflag.provider
+
+import net.thunderbird.core.configstore.ConfigStore
+import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigData
+import net.thunderbird.core.featureflag.data.configstore.resolveTargetingKey
+import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext.Value
+import net.thunderbird.core.featureflag.provider.context.ImmutableFeatureFlagContext
+
+/**
+ * Initializes a catalog-based feature flag provider with application context and targeting configuration.
+ *
+ * @param provider The catalog feature flag provider to initialize.
+ * @param featureFlagConfigStore Configuration store containing the persistent targeting key.
+ * @param app The application identifier used for feature flag targeting and build variant resolution.
+ * @param buildType The build type (e.g., debug, release) used for variant-specific flag overrides.
+ * @param appVersion The application version string for version-based feature flag targeting.
+ * @param extras Optional additional attributes to include in the feature flag evaluation context.
+ */
+suspend fun initializeFeatureFlags(
+    provider: BaseCatalogFeatureFlagProvider,
+    featureFlagConfigStore: ConfigStore<FeatureFlagConfigData>,
+    app: String,
+    buildType: String,
+    appVersion: String,
+    extras: Map<String, Value> = emptyMap(),
+) {
+    provider.initialize(
+        initialContext = ImmutableFeatureFlagContext(
+            targetingKey = featureFlagConfigStore.resolveTargetingKey().toString(),
+            attributes = mapOf(
+                "app" to Value.String(app),
+                "build_type" to Value.String(buildType),
+                "variant" to Value.String("$app-$buildType"),
+                "app_version" to Value.String(appVersion),
+            ) + extras,
+        ),
+    )
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/FeatureFlagInitializer.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/FeatureFlagInitializer.kt
@@ -17,7 +17,7 @@ import net.thunderbird.core.featureflag.provider.context.ImmutableFeatureFlagCon
  * @param extras Optional additional attributes to include in the feature flag evaluation context.
  */
 suspend fun initializeFeatureFlags(
-    provider: BaseCatalogFeatureFlagProvider,
+    provider: DataSourceCatalogFeatureFlagProvider,
     featureFlagConfigStore: ConfigStore<FeatureFlagConfigData>,
     app: String,
     buildType: String,

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/ProviderMetadata.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/ProviderMetadata.kt
@@ -1,0 +1,23 @@
+package net.thunderbird.core.featureflag.provider
+
+/**
+ * Metadata describing a feature flag provider implementation.
+ *
+ * Provides identifying information about the provider, primarily its name which
+ * distinguishes different provider implementations (e.g., "bundled-catalog", "remote").
+ */
+interface ProviderMetadata {
+    val name: String
+}
+
+/**
+ * Metadata for catalog-based feature flag providers.
+ *
+ * Identifies providers that load feature flags from a catalog data source,
+ * such as bundled or remote catalog implementations.
+ *
+ * @property name The provider's identifying name (e.g., "bundled-catalog", "remote-catalog").
+ */
+internal data class CatalogProviderMetadata(
+    override val name: String,
+) : ProviderMetadata

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/context/FeatureFlagContext.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/context/FeatureFlagContext.kt
@@ -1,0 +1,39 @@
+package net.thunderbird.core.featureflag.provider.context
+
+/**
+ * Evaluation context for feature flag resolution containing attributes that influence flag behaviour.
+ *
+ * Provides a type-safe container for context attributes used during feature flag evaluation,
+ * such as targeting key and custom attributes.
+ *
+ * @remarks sealed to prevent other modules to implement it.
+ */
+sealed class FeatureFlagContext(protected val wrapper: Map<String, Value>) :
+    Map<String, FeatureFlagContext.Value> by wrapper {
+    abstract val targetingKey: String
+
+    sealed interface Value {
+        fun asString(): kotlin.String? = if (this is String) value else null
+
+        @JvmInline
+        value class String(val value: kotlin.String) : Value
+
+        @JvmInline
+        value class Int(val value: kotlin.Int) : Value
+    }
+}
+
+/**
+ * An immutable implementation of FeatureFlagContext with a fixed targeting key and attributes.
+ *
+ * This implementation creates a snapshot of the context state at construction time,
+ * ensuring that the targeting key and attributes cannot be modified after instantiation.
+ * The attributes map is defensively copied to prevent external modifications.
+ *
+ * @param targetingKey The unique identifier used for feature flag targeting and evaluation.
+ * @param attributes Optional map of custom attributes that provide additional context for flag evaluation.
+ */
+class ImmutableFeatureFlagContext(
+    override val targetingKey: String,
+    attributes: Map<String, Value> = mapOf(),
+) : FeatureFlagContext(wrapper = attributes.toMap())

--- a/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/BundledCatalogFeatureFlagProviderTest.kt
+++ b/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/BundledCatalogFeatureFlagProviderTest.kt
@@ -1,0 +1,303 @@
+package net.thunderbird.core.featureflag.provider
+
+import assertk.assertThat
+import assertk.assertions.containsOnly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.FeatureFlagResult
+import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey.ARCHIVE_MARKS_AS_READ
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey.DISPLAY_IN_APP_NOTIFICATIONS
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey.MESSAGE_VIEW_ACTION_EXPORT_EML
+import net.thunderbird.core.featureflag.model.AppVariantOverridesRawType
+import net.thunderbird.core.featureflag.model.BaseAppVariantOverrides
+import net.thunderbird.core.featureflag.model.FeatureFlagCatalog
+import net.thunderbird.core.featureflag.model.FlagOverrides
+import net.thunderbird.core.featureflag.model.FlagRegistry
+import net.thunderbird.core.featureflag.model.FlagRegistryOverride
+import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext
+import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext.Value
+import net.thunderbird.core.featureflag.provider.context.ImmutableFeatureFlagContext
+import net.thunderbird.core.logging.testing.TestLogger
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BundledCatalogFeatureFlagProviderTest {
+
+    @Test
+    fun `provide should return Enabled when the catalog default is true`() = runTest(UnconfinedTestDispatcher()) {
+        // Arrange
+        val testSubject = createTestSubject(
+            catalog = catalog(flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = true))),
+        )
+        testSubject.initialize(initialContext = context())
+
+        // Act
+        val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(result).isEqualTo(FeatureFlagResult.Enabled)
+    }
+
+    @Test
+    fun `provide should return Disabled when the catalog default is false`() = runTest(UnconfinedTestDispatcher()) {
+        // Arrange
+        val testSubject = createTestSubject(
+            catalog = catalog(flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = false))),
+        )
+        testSubject.initialize(initialContext = context())
+
+        // Act
+        val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(result).isEqualTo(FeatureFlagResult.Disabled)
+    }
+
+    @Test
+    fun `provide should return Enabled when the build type override enables a disabled default`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                catalog = catalog(
+                    flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = false)),
+                    thunderbirdOverrides = mapOf(DEBUG to mapOf(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)),
+                ),
+            )
+            testSubject.initialize(initialContext = context(app = THUNDERBIRD, buildType = DEBUG))
+
+            // Act
+            val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+            // Assert
+            assertThat(result).isEqualTo(FeatureFlagResult.Enabled)
+        }
+
+    @Test
+    fun `provide should return Disabled when the build type override disables an enabled default`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                catalog = catalog(
+                    flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = true)),
+                    k9Overrides = mapOf(RELEASE to mapOf(MESSAGE_VIEW_ACTION_EXPORT_EML.key to false)),
+                ),
+            )
+            testSubject.initialize(initialContext = context(app = K9, buildType = RELEASE))
+
+            // Act
+            val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+            // Assert
+            assertThat(result).isEqualTo(FeatureFlagResult.Disabled)
+        }
+
+    @Test
+    fun `provide should return the default when the catalog has no override for the current build type`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                catalog = catalog(
+                    flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = false)),
+                    thunderbirdOverrides = mapOf(DEBUG to mapOf(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)),
+                ),
+            )
+            testSubject.initialize(initialContext = context(app = THUNDERBIRD, buildType = BETA))
+
+            // Act
+            val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+            // Assert
+            assertThat(result).isEqualTo(FeatureFlagResult.Disabled)
+        }
+
+    @Test
+    fun `provide should return the default when the build type override map is empty`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                catalog = catalog(
+                    flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = true)),
+                    thunderbirdOverrides = mapOf(RELEASE to emptyMap()),
+                ),
+            )
+            testSubject.initialize(initialContext = context(app = THUNDERBIRD, buildType = RELEASE))
+
+            // Act
+            val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+            // Assert
+            assertThat(result).isEqualTo(FeatureFlagResult.Enabled)
+        }
+
+    @Test
+    fun `provide should return the default when the context has no app and build type attributes`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                catalog = catalog(
+                    flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = false)),
+                    thunderbirdOverrides = mapOf(DEBUG to mapOf(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)),
+                ),
+            )
+            testSubject.initialize(initialContext = ImmutableFeatureFlagContext(targetingKey = TARGETING_KEY))
+
+            // Act
+            val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+            // Assert
+            assertThat(result).isEqualTo(FeatureFlagResult.Disabled)
+        }
+
+    @Test
+    fun `provide should return Unavailable when the key is not in the catalog`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                catalog = catalog(flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = true))),
+            )
+            testSubject.initialize(initialContext = context())
+
+            // Act
+            val result = testSubject.provide(FeatureFlagKey("unknown_feature_flag"))
+
+            // Assert
+            assertThat(result).isEqualTo(FeatureFlagResult.Unavailable)
+        }
+
+    @Test
+    fun `defaults should return every catalog flag with the build type overrides applied`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                catalog = catalog(
+                    flags = listOf(
+                        ARCHIVE_MARKS_AS_READ.toFlagRegistry(default = true),
+                        MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = false),
+                        DISPLAY_IN_APP_NOTIFICATIONS.toFlagRegistry(default = true),
+                    ),
+                    thunderbirdOverrides = mapOf(
+                        DEBUG to mapOf(
+                            MESSAGE_VIEW_ACTION_EXPORT_EML.key to true,
+                            DISPLAY_IN_APP_NOTIFICATIONS.key to false,
+                        ),
+                    ),
+                ),
+            )
+            testSubject.initialize(initialContext = context(app = THUNDERBIRD, buildType = DEBUG))
+
+            // Act
+            val result = testSubject.defaults()
+
+            // Assert
+            assertThat(result).containsOnly(
+                ARCHIVE_MARKS_AS_READ.key to true,
+                MESSAGE_VIEW_ACTION_EXPORT_EML.key to true,
+                DISPLAY_IN_APP_NOTIFICATIONS.key to false,
+            )
+        }
+
+    @Test
+    fun `defaults should be empty when the catalog was never loaded`() = runTest(UnconfinedTestDispatcher()) {
+        // Arrange
+        val testSubject = createTestSubject(
+            catalog = catalog(flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = true))),
+        )
+
+        // Act
+        val result = testSubject.defaults()
+
+        // Assert
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `initialize should load the catalog only once`() = runTest(UnconfinedTestDispatcher()) {
+        // Arrange
+        val dataSource = FakeFeatureFlagCatalogDataSource(
+            catalog = catalog(flags = listOf(MESSAGE_VIEW_ACTION_EXPORT_EML.toFlagRegistry(default = true))),
+        )
+        val testSubject = createTestSubject(dataSource = dataSource)
+        testSubject.initialize(initialContext = context())
+
+        // Act
+        repeat(times = 5) { testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML) }
+        testSubject.defaults()
+
+        // Assert
+        assertThat(dataSource.loadCount).isEqualTo(1)
+    }
+
+    private fun TestScope.createTestSubject(
+        catalog: FeatureFlagCatalog,
+    ): BundledCatalogFeatureFlagProvider = createTestSubject(FakeFeatureFlagCatalogDataSource(catalog))
+
+    private fun TestScope.createTestSubject(
+        dataSource: FeatureFlagCatalogDataSource,
+    ): BundledCatalogFeatureFlagProvider = BundledCatalogFeatureFlagProvider(
+        dataSource = dataSource,
+        logger = TestLogger(),
+        scope = backgroundScope,
+    )
+
+    private companion object {
+        const val CATALOG_VERSION = "2026-07-30.1"
+        const val TARGETING_KEY = "targeting-key"
+        const val THUNDERBIRD = "thunderbird"
+        const val K9 = "k9"
+        const val DEBUG = "debug"
+        const val BETA = "beta"
+        const val RELEASE = "release"
+
+        fun FeatureFlagKey.toFlagRegistry(default: Boolean): FlagRegistry = FlagRegistry(key = key, default = default)
+
+        fun catalog(
+            flags: List<FlagRegistry>,
+            thunderbirdOverrides: Map<String, FlagOverrides> = emptyMap(),
+            k9Overrides: Map<String, FlagOverrides> = emptyMap(),
+        ): FeatureFlagCatalog = FeatureFlagCatalog(
+            version = CATALOG_VERSION,
+            flags = flags,
+            overrides = FlagRegistryOverride(
+                k9 = FakeAppVariantOverrides(k9Overrides),
+                thunderbird = FakeAppVariantOverrides(thunderbirdOverrides),
+            ),
+        )
+
+        fun context(
+            app: String = THUNDERBIRD,
+            buildType: String = DEBUG,
+        ): FeatureFlagContext = ImmutableFeatureFlagContext(
+            targetingKey = TARGETING_KEY,
+            attributes = mapOf(
+                "app" to Value.String(app),
+                "build_type" to Value.String(buildType),
+            ),
+        )
+    }
+}
+
+/**
+ * Counts how often the catalog is actually collected, so tests can assert the provider caches the
+ * resolved flags instead of re-reading the catalog on every [BundledCatalogFeatureFlagProvider.provide].
+ */
+private class FakeFeatureFlagCatalogDataSource(
+    private val catalog: FeatureFlagCatalog,
+) : FeatureFlagCatalogDataSource {
+    var loadCount: Int = 0
+        private set
+
+    override fun load(): Flow<FeatureFlagCatalog> = flow {
+        loadCount++
+        emit(catalog)
+    }
+}
+
+private class FakeAppVariantOverrides(wrapper: AppVariantOverridesRawType) : BaseAppVariantOverrides(wrapper)

--- a/core/featureflag/src/jvmMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.jvm.kt
+++ b/core/featureflag/src/jvmMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.jvm.kt
@@ -1,0 +1,13 @@
+package net.thunderbird.core.featureflag.inject
+
+import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
+import net.thunderbird.core.featureflag.data.LocalFeatureFlagCatalogDataSource
+import org.koin.core.module.Module
+import org.koin.core.qualifier.qualifier
+import org.koin.dsl.module
+
+actual val platformFeatureFlagModule: Module = module {
+    single<FeatureFlagCatalogDataSource>(qualifier(FeatureFlagCatalogDataSource.InjectQualifiers.Local)) {
+        LocalFeatureFlagCatalogDataSource(jsonParser = get())
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Closes #11330 
RFC / Technical Design (if applicable): [RFC 0004: Add a Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/rfcs/0004-feature-flag-new-architecture.md) / [Technical Design 0002: Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/technical-designs/0002-feature-flag-declarative-catalog.md)

#### Description

Adds the bundled, offline catalog provider needed to migrate feature-flag resolution away from per-app and per-build-type factories.

- Resolves catalog defaults and app/build-type overrides.
- Stores a random per-install targeting key.
- Initializes the provider for Thunderbird and K-9 Mail.

No remote catalog fetching or transmission is introduced. The targeting key is only persisted and added to the local evaluation context by this change.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).