### PR TITLE
fix(edge-to-edge): keep the status bar visible in message selection mode

### DIFF
--- a/legacy/ui/base/src/main/java/com/fsck/k9/ui/base/BaseActivity.kt
+++ b/legacy/ui/base/src/main/java/com/fsck/k9/ui/base/BaseActivity.kt
@@ -1,8 +1,10 @@
 package com.fsck.k9.ui.base
 
 import android.content.Context
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
 import androidx.activity.enableEdgeToEdge
 import androidx.annotation.LayoutRes
@@ -15,6 +17,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.children
 import androidx.core.view.updatePadding
 import androidx.lifecycle.asLiveData
 import com.fsck.k9.controller.push.PushController
@@ -134,8 +137,36 @@ abstract class BaseActivity(
                 bottom = max(insets.bottom, imeInsets.bottom),
             )
 
+            hideActionModeStatusGuard()
+
             WindowInsetsCompat.CONSUMED
         }
+    }
+
+    /**
+     * Hides the status bar guard AppCompat draws while a contextual action mode is visible.
+     *
+     * With `windowActionModeOverlay` enabled, AppCompat offsets the contextual action bar below the status bar and
+     * fills the space that is left over with an opaque view. It picks the colour of that view from the deprecated
+     * `SYSTEM_UI_FLAG_LIGHT_STATUS_BAR` flag. On API 35 and above nothing sets that flag any more, because
+     * `WindowInsetsControllerCompat` then applies the appearance only through `setSystemBarsAppearance()` instead of
+     * mirroring it onto the old flag, so the guard always ends up black and hides the clock and the status icons.
+     * This window is drawn edge-to-edge and the AppBarLayout behind the guard already covers that area, so the guard
+     * just needs to get out of the way.
+     *
+     * AppCompat updates the guard from its own insets listener on the sub decor, which runs before the insets reach the
+     * layout installed by [setLayout]. Doing this from there means the guard is cleared again every time AppCompat
+     * recolours it.
+     */
+    private fun hideActionModeStatusGuard() {
+        val subDecor = findViewById<View>(android.R.id.content)?.parent as? ViewGroup ?: return
+
+        // AppCompat adds the guard as an id-less, plain View child of the sub decor. The children it puts there
+        // otherwise are the content frame and the contextual action bar, which are both ViewGroups with an id.
+        // If that ever stops being unambiguous, leave every one of them alone rather than recolour a guess.
+        subDecor.children
+            .singleOrNull { it.javaClass == View::class.java && it.id == View.NO_ID }
+            ?.setBackgroundColor(Color.TRANSPARENT)
     }
 
     protected fun recreateCompat() {


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #11305 (#11323 was closed as a duplicate)
RFC / Technical Design (if applicable): n/a

#### Description

Selecting a message paints the status bar area solid black, and the clock and status icons disappear with it.

The black band is AppCompat's status guard. Both `Theme2.Main.Light.Common` and `Theme2.Main.Dark.Common` set `windowActionModeOverlay`, so when a contextual action mode starts, `AppCompatDelegateImpl.updateStatusGuard()` offsets the action bar below the status bar and puts an opaque view behind it. It picks that view's colour from the deprecated `SYSTEM_UI_FLAG_LIGHT_STATUS_BAR` flag. From API 35 nothing sets that flag any more, because `WindowInsetsControllerCompat` applies the appearance only through `setSystemBarsAppearance()`. So the guard comes out black every time, which is why only recent Android versions are affected.

The guard is not needed here at all. The window is drawn edge-to-edge and `setLayout()` already pads the `AppBarLayout` by the status bar inset, so the app bar is painting that area anyway; the guard only has to stop covering it. Its background is cleared from the insets listener `BaseActivity` installs, which runs after AppCompat has recoloured the guard in the same dispatch, so it gets cleared again on every pass.

#### Screen Shots

A message selected, before and after, on an Android 16 emulator in the light theme.

Before:
<img width="1080" height="560" alt="11305-before" src="https://github.com/user-attachments/assets/1b32575d-e461-435b-bba9-58c580e98462" />

After:
<img width="1080" height="560" alt="11305-after" src="https://github.com/user-attachments/assets/ec3eaab9-681b-49fa-9d57-fdc42cf7e3e3" />

Sampling the status bar area:

| | before | after |
|---|---|---|
| no selection | `#f1edec` | `#f1edec` |
| message selected | `#000000` | `#f1edec` |

`#f1edec` is `colorSurfaceContainer`, so selection mode now matches the rest of the app. I also checked three open/close cycles of selection mode, rotating to landscape while a message was selected, and the dark theme.

There is no test. `legacy/ui/base` has no test source set, and the behaviour only exists once AppCompat has created the guard during a real insets pass, which Robolectric does not do. A test there would pass without exercising anything.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [x] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
