### PR TITLE
feat(feature-flag): add runtime feature flag provider and multi-provider evaluator

### DIFF
--- a/app-common/src/main/kotlin/net/thunderbird/app/common/FeatureFlagApplication.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/FeatureFlagApplication.kt
@@ -7,16 +7,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigStore
-import net.thunderbird.core.featureflag.provider.DataSourceCatalogFeatureFlagProvider
 import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext.Value
+import net.thunderbird.core.featureflag.provider.evaluator.MultiFeatureFlagProviderEvaluator
 import net.thunderbird.core.featureflag.provider.initializeFeatureFlags
 import org.koin.android.ext.android.inject
 
 abstract class FeatureFlagApplication : BaseApplication() {
     protected abstract val appName: String
     protected abstract val appVersion: String
+    private val evaluator: MultiFeatureFlagProviderEvaluator by inject()
     private val targetingKeyStore: FeatureFlagConfigStore by inject()
-    private val featureFlagProvider: DataSourceCatalogFeatureFlagProvider by inject()
 
     private val featureFlagScope = CoroutineScope(
         SupervisorJob() + Dispatchers.Main +
@@ -29,7 +29,7 @@ abstract class FeatureFlagApplication : BaseApplication() {
         super.onCreate()
         featureFlagScope.launch {
             initializeFeatureFlags(
-                provider = featureFlagProvider,
+                evaluator = evaluator,
                 featureFlagConfigStore = targetingKeyStore,
                 app = appName,
                 buildType = BuildConfig.BUILD_TYPE,

--- a/app-k9mail/src/debug/kotlin/app/k9mail/dev/DebugConfig.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/dev/DebugConfig.kt
@@ -5,8 +5,12 @@ import app.k9mail.autodiscovery.demo.DemoAutoDiscovery
 import net.thunderbird.backend.api.BackendFactory
 import net.thunderbird.core.featureflag.DefaultFeatureFlagOverrides
 import net.thunderbird.core.featureflag.FeatureFlagOverrides
+import net.thunderbird.core.featureflag.inject.qualifier.InjectQualifier
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.RuntimeDebugOverrideFeatureFlagProvider
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
+import org.koin.plugin.module.dsl.bind
 
 fun Module.developmentModuleAdditions() {
     single {
@@ -21,4 +25,10 @@ fun Module.developmentModuleAdditions() {
         listOf(DemoAutoDiscovery())
     }
     single<FeatureFlagOverrides> { DefaultFeatureFlagOverrides() }
+    single<CatalogFeatureFlagProvider>(named(InjectQualifier.InMemory)) {
+        RuntimeDebugOverrideFeatureFlagProvider(
+            configStore = get(),
+            logger = get(),
+        )
+    }.bind(RuntimeDebugOverrideFeatureFlagProvider::class)
 }

--- a/app-thunderbird/src/debug/kotlin/net/thunderbird/android/dev/DebugConfig.kt
+++ b/app-thunderbird/src/debug/kotlin/net/thunderbird/android/dev/DebugConfig.kt
@@ -5,8 +5,12 @@ import app.k9mail.autodiscovery.demo.DemoAutoDiscovery
 import net.thunderbird.backend.api.BackendFactory
 import net.thunderbird.core.featureflag.DefaultFeatureFlagOverrides
 import net.thunderbird.core.featureflag.FeatureFlagOverrides
+import net.thunderbird.core.featureflag.inject.qualifier.InjectQualifier
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.RuntimeDebugOverrideFeatureFlagProvider
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
+import org.koin.plugin.module.dsl.bind
 
 fun Module.developmentModuleAdditions() {
     single {
@@ -21,4 +25,10 @@ fun Module.developmentModuleAdditions() {
         listOf(DemoAutoDiscovery())
     }
     single<FeatureFlagOverrides> { DefaultFeatureFlagOverrides() }
+    single<CatalogFeatureFlagProvider>(named(InjectQualifier.InMemory)) {
+        RuntimeDebugOverrideFeatureFlagProvider(
+            configStore = get(),
+            logger = get(),
+        )
+    }.bind(RuntimeDebugOverrideFeatureFlagProvider::class)
 }

--- a/core/featureflag/build.gradle.kts
+++ b/core/featureflag/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
             implementation(projects.core.logging.api)
         }
         commonTest.dependencies {
+            implementation(projects.core.configstore.testing)
             implementation(projects.core.logging.testing)
         }
         androidHostTest.dependencies {

--- a/core/featureflag/src/androidMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.android.kt
+++ b/core/featureflag/src/androidMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.android.kt
@@ -2,13 +2,14 @@ package net.thunderbird.core.featureflag.inject
 
 import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
 import net.thunderbird.core.featureflag.data.LocalFeatureFlagCatalogDataSource
+import net.thunderbird.core.featureflag.inject.qualifier.InjectQualifier
 import org.koin.android.ext.koin.androidApplication
 import org.koin.core.module.Module
 import org.koin.core.qualifier.qualifier
 import org.koin.dsl.module
 
 actual val platformFeatureFlagModule: Module = module {
-    single<FeatureFlagCatalogDataSource>(qualifier(FeatureFlagCatalogDataSource.InjectQualifiers.Local)) {
+    single<FeatureFlagCatalogDataSource>(qualifier(InjectQualifier.Local)) {
         LocalFeatureFlagCatalogDataSource(
             applicationContext = androidApplication(),
             jsonParser = get(),

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/FeatureFlagCatalogDataSource.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/FeatureFlagCatalogDataSource.kt
@@ -17,12 +17,4 @@ interface FeatureFlagCatalogDataSource {
      * @return A Flow that emits the feature flag catalog containing flag definitions and overrides.
      */
     fun load(): Flow<FeatureFlagCatalog>
-
-    /**
-     * Dependency injection qualifiers for distinguishing between local and remote data source implementations.
-     *
-     * Used to differentiate between [FeatureFlagCatalogDataSource] instances that load catalogs
-     * from local bundled resources versus remote servers during dependency injection.
-     */
-    enum class InjectQualifiers { Local, Remote }
 }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/configstore/FeatureFlagConfigData.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/configstore/FeatureFlagConfigData.kt
@@ -4,6 +4,7 @@ import kotlin.uuid.Uuid
 import kotlinx.coroutines.flow.first
 import net.thunderbird.core.configstore.ConfigKey
 import net.thunderbird.core.configstore.ConfigStore
+import net.thunderbird.core.featureflag.model.FlagOverrides
 
 /**
  * Data class representing the configuration for feature flags.
@@ -13,6 +14,7 @@ import net.thunderbird.core.configstore.ConfigStore
  */
 data class FeatureFlagConfigData(
     val targetingKey: Uuid? = null,
+    val overrides: FlagOverrides = emptyMap(),
 ) {
     companion object {
         val DEFAULT = FeatureFlagConfigData()
@@ -21,6 +23,9 @@ data class FeatureFlagConfigData(
 
 internal object FeatureFlagConfigKeys {
     val TARGETING_KEY = ConfigKey.StringKey("targeting_key")
+
+    /** JSON-encoded [FlagOverrides], since the backend only supports scalar values. */
+    val OVERRIDES = ConfigKey.StringKey("overrides")
 }
 
 /**

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/configstore/FeatureFlagConfigStore.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/data/configstore/FeatureFlagConfigStore.kt
@@ -1,6 +1,8 @@
 package net.thunderbird.core.featureflag.data.configstore
 
 import kotlin.uuid.Uuid
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import net.thunderbird.core.configstore.BaseConfigStore
 import net.thunderbird.core.configstore.Config
 import net.thunderbird.core.configstore.ConfigDefinition
@@ -9,7 +11,17 @@ import net.thunderbird.core.configstore.ConfigKey
 import net.thunderbird.core.configstore.ConfigMapper
 import net.thunderbird.core.configstore.ConfigMigration
 import net.thunderbird.core.configstore.ConfigMigrationResult
+import net.thunderbird.core.configstore.ConfigStore
 import net.thunderbird.core.configstore.backend.ConfigBackendProvider
+import net.thunderbird.core.featureflag.model.FlagOverrides
+
+/**
+ * A configuration store specialized for managing feature flag configuration data.
+ *
+ * Extends ConfigStore to provide type-safe access to feature flag-specific configuration,
+ * including targeting keys for rollout/experiment bucketing and flag overrides.
+ */
+interface FeatureFlagConfigStore : ConfigStore<FeatureFlagConfigData>
 
 /**
  * Configuration store for managing feature flag-related configuration data.
@@ -20,26 +32,40 @@ import net.thunderbird.core.configstore.backend.ConfigBackendProvider
  *
  * @param provider The backend provider used to access the underlying storage mechanism.
  */
-class FeatureFlagConfigStore(
+internal class DefaultFeatureFlagConfigStore(
     id: ConfigId,
     provider: ConfigBackendProvider,
-) : BaseConfigStore<FeatureFlagConfigData>(provider, FeatureFlagConfigDefinition(id))
+) : BaseConfigStore<FeatureFlagConfigData>(provider, FeatureFlagConfigDefinition(id)), FeatureFlagConfigStore
 
 private class FeatureFlagConfigDefinition(override val id: ConfigId) : ConfigDefinition<FeatureFlagConfigData> {
     override val version: Int = 1
     override val defaultValue: FeatureFlagConfigData = FeatureFlagConfigData.DEFAULT
-    override val keys: List<ConfigKey<*>> = listOf(FeatureFlagConfigKeys.TARGETING_KEY)
+    override val keys: List<ConfigKey<*>> = listOf(
+        FeatureFlagConfigKeys.TARGETING_KEY,
+        FeatureFlagConfigKeys.OVERRIDES,
+    )
 
     override val mapper: ConfigMapper<FeatureFlagConfigData> = object : ConfigMapper<FeatureFlagConfigData> {
         override fun toConfig(obj: FeatureFlagConfigData): Config = Config().apply {
             if (obj.targetingKey != null) {
                 this[FeatureFlagConfigKeys.TARGETING_KEY] = obj.targetingKey.toString()
             }
+            // Written even when empty: the backend only overwrites the keys it is handed, so omitting
+            // this would leave the previously persisted overrides in place.
+            this[FeatureFlagConfigKeys.OVERRIDES] = json.encodeToString(obj.overrides)
         }
 
         override fun fromConfig(config: Config): FeatureFlagConfigData = FeatureFlagConfigData(
             targetingKey = config[FeatureFlagConfigKeys.TARGETING_KEY]?.let(Uuid::parse),
+            overrides = config[FeatureFlagConfigKeys.OVERRIDES]?.let { rawJson -> decodeOverrides(rawJson) }.orEmpty(),
         )
+    }
+
+    /** Overrides are debug-only state, so unreadable data is dropped instead of failing the store. */
+    private fun decodeOverrides(rawJson: String): FlagOverrides = try {
+        json.decodeFromString<FlagOverrides>(rawJson)
+    } catch (_: SerializationException) {
+        emptyMap()
     }
 
     override val migration: ConfigMigration = object : ConfigMigration {
@@ -48,5 +74,9 @@ private class FeatureFlagConfigDefinition(override val id: ConfigId) : ConfigDef
             newVersion: Int,
             current: Config,
         ): ConfigMigrationResult = ConfigMigrationResult.NoOp
+    }
+
+    private companion object {
+        val json = Json
     }
 }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
@@ -27,7 +27,7 @@ val featureFlagModule = module {
     single {
         BundledCatalogFeatureFlagProvider(
             dataSource = get<FeatureFlagCatalogDataSource>(
-                named(FeatureFlagCatalogDataSource.InjectQualifiers.Local),
+                named(InjectQualifier.Local),
             ),
             logger = get(),
         )

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
@@ -2,12 +2,14 @@ package net.thunderbird.core.featureflag.inject
 
 import net.thunderbird.core.configstore.ConfigId
 import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
+import net.thunderbird.core.featureflag.data.configstore.DefaultFeatureFlagConfigStore
 import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigStore
-import net.thunderbird.core.featureflag.provider.BaseCatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.inject.qualifier.InjectQualifier
 import net.thunderbird.core.featureflag.provider.BundledCatalogFeatureFlagProvider
 import net.thunderbird.core.featureflag.provider.BundledFeatureFlagDefaults
-import net.thunderbird.core.featureflag.provider.DataSourceCatalogFeatureFlagProvider
-import net.thunderbird.core.featureflag.provider.ProviderMetadata
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.evaluator.DefaultMultiFeatureFlagProviderEvaluator
+import net.thunderbird.core.featureflag.provider.evaluator.MultiFeatureFlagProviderEvaluator
 import net.thunderbird.core.featureflag.serialization.DefaultFeatureFlagCatalogJsonParser
 import net.thunderbird.core.featureflag.serialization.FeatureFlagCatalogJsonParser
 import org.koin.core.module.Module
@@ -17,27 +19,32 @@ import org.koin.plugin.module.dsl.bind
 
 val featureFlagModule = module {
     factory<FeatureFlagCatalogJsonParser> { DefaultFeatureFlagCatalogJsonParser(registrySerializer = get()) }
-    single {
-        val metadata = get<ProviderMetadata>()
-        FeatureFlagConfigStore(
-            id = ConfigId(backend = "feature_flag", feature = metadata.name),
+    single<FeatureFlagConfigStore> {
+        DefaultFeatureFlagConfigStore(
+            id = ConfigId(backend = "feature_flag", feature = "storage"),
             provider = get(),
         )
     }
-    single {
+    single<CatalogFeatureFlagProvider>(named(InjectQualifier.Local)) {
         BundledCatalogFeatureFlagProvider(
             dataSource = get<FeatureFlagCatalogDataSource>(
                 named(InjectQualifier.Local),
             ),
             logger = get(),
         )
-    }.bind(DataSourceCatalogFeatureFlagProvider::class)
+    }.bind(BundledCatalogFeatureFlagProvider::class)
     single<BundledFeatureFlagDefaults> { get<BundledCatalogFeatureFlagProvider>() }
-    single<BaseCatalogFeatureFlagProvider> {
-        // TODO(#11332): Later replaced by MultiFeatureFlagProviderEvaluator
-        get<BundledCatalogFeatureFlagProvider>()
+    single<MultiFeatureFlagProviderEvaluator> {
+        DefaultMultiFeatureFlagProviderEvaluator(
+            providers = buildList {
+                getOrNull<CatalogFeatureFlagProvider>(named(InjectQualifier.InMemory))
+                    ?.let { add(it) }
+                // add(get<CatalogFeatureFlagProvider>(named(InjectQualifier.Remote)))
+                add(get<CatalogFeatureFlagProvider>(named(InjectQualifier.Local)))
+            },
+            logger = get(),
+        )
     }
-    single<ProviderMetadata> { get<BaseCatalogFeatureFlagProvider>().metadata }
     includes(platformFeatureFlagModule)
 }
 

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/qualifier/InjectQualifier.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/qualifier/InjectQualifier.kt
@@ -1,0 +1,9 @@
+package net.thunderbird.core.featureflag.inject.qualifier
+
+/**
+ * Qualifier for dependency injection to distinguish between different implementation types.
+ *
+ * Used to differentiate between in-memory, local, and remote implementations when
+ * injecting dependencies through a dependency injection framework.
+ */
+enum class InjectQualifier { InMemory, Local, Remote }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/FeatureFlagInitializer.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/FeatureFlagInitializer.kt
@@ -5,11 +5,12 @@ import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigData
 import net.thunderbird.core.featureflag.data.configstore.resolveTargetingKey
 import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext.Value
 import net.thunderbird.core.featureflag.provider.context.ImmutableFeatureFlagContext
+import net.thunderbird.core.featureflag.provider.evaluator.MultiFeatureFlagProviderEvaluator
 
 /**
  * Initializes a catalog-based feature flag provider with application context and targeting configuration.
  *
- * @param provider The catalog feature flag provider to initialize.
+ * @param evaluator The catalog feature flag provider evaluator to initialize.
  * @param featureFlagConfigStore Configuration store containing the persistent targeting key.
  * @param app The application identifier used for feature flag targeting and build variant resolution.
  * @param buildType The build type (e.g., debug, release) used for variant-specific flag overrides.
@@ -17,14 +18,14 @@ import net.thunderbird.core.featureflag.provider.context.ImmutableFeatureFlagCon
  * @param extras Optional additional attributes to include in the feature flag evaluation context.
  */
 suspend fun initializeFeatureFlags(
-    provider: DataSourceCatalogFeatureFlagProvider,
+    evaluator: MultiFeatureFlagProviderEvaluator,
     featureFlagConfigStore: ConfigStore<FeatureFlagConfigData>,
     app: String,
     buildType: String,
     appVersion: String,
     extras: Map<String, Value> = emptyMap(),
 ) {
-    provider.initialize(
+    evaluator.initialize(
         initialContext = ImmutableFeatureFlagContext(
             targetingKey = featureFlagConfigStore.resolveTargetingKey().toString(),
             attributes = mapOf(

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
@@ -83,6 +83,6 @@ class RuntimeDebugOverrideFeatureFlagProvider(
         return """
             |feature-flag provider '${metadata.name}':
             |   resolvedFlags = $resolvedFlags,
-            """.trimMargin()
+        """.trimMargin()
     }
 }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
@@ -1,0 +1,88 @@
+package net.thunderbird.core.featureflag.provider
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigData
+import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigStore
+import net.thunderbird.core.featureflag.data.configstore.update
+import net.thunderbird.core.featureflag.model.FlagOverrides
+import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext
+import net.thunderbird.core.logging.Logger
+
+/**
+ * Runtime feature-flag provider that owns the debug overrides.
+ */
+class RuntimeDebugOverrideFeatureFlagProvider(
+    private val configStore: FeatureFlagConfigStore,
+    private val logger: Logger,
+    // The dispatcher is inlined here on purpose: as a separate parameter its default would be
+    // evaluated even when a scope is supplied, which throws wherever Dispatchers.Main is absent.
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+) : BaseCatalogFeatureFlagProvider(
+    providerName = "runtime_catalog",
+    logger = logger,
+) {
+    /** The current debug overrides (flag key -> enabled), observable by the debug settings UI. */
+    val data: StateFlow<FeatureFlagConfigData> = configStore
+        .config
+        .onEach { data ->
+            logger.verbose { "[feature-flag] runtime override data update: $data" }
+            // Keeps flag evaluation in sync with the persisted overrides, so a toggle takes effect
+            // without recreating the provider.
+            resolvedFlags = data.overrides
+        }
+        .stateIn(
+            scope = scope,
+            started = SharingStarted.Eagerly,
+            initialValue = FeatureFlagConfigData.DEFAULT,
+        )
+
+    override var resolvedFlags: FlagOverrides = data.value.overrides
+    val overrides: FlagOverrides get() = resolvedFlags
+
+    override fun initialize(initialContext: FeatureFlagContext) {
+        super.initialize(initialContext)
+        resolve(initialContext)
+    }
+
+    /** Sets the override for [key] to [enabled] and persists it. */
+    suspend fun setOverride(key: FeatureFlagKey, enabled: Boolean) {
+        val key = key.key
+        logger.verbose { "[feature-flag] overriding '$key' with '$enabled' value" }
+        configStore.update { current: FeatureFlagConfigData ->
+            current.copy(overrides = current.overrides + (key to enabled))
+        }
+    }
+
+    /** Removes the override for [key] and persists the change. */
+    suspend fun clearOverride(key: FeatureFlagKey) {
+        val key = key.key
+        logger.verbose { "[feature-flag] clearing '$key' override" }
+        configStore.update { current: FeatureFlagConfigData ->
+            current.copy(overrides = current.overrides - key)
+        }
+    }
+
+    /** Removes all overrides and persists the change. */
+    suspend fun clearAllOverrides() {
+        logger.verbose { "[feature-flag] clearing all flag overrides" }
+        // Only the overrides are dropped; clearing the whole store would also discard the
+        // per-install targeting key used for rollout bucketing.
+        configStore.update { current: FeatureFlagConfigData ->
+            current.copy(overrides = emptyMap())
+        }
+    }
+
+    override fun toString(): String {
+        return """
+            |feature-flag provider '${metadata.name}':
+            |   resolvedFlags = $resolvedFlags,
+            """.trimMargin()
+    }
+}

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
@@ -29,7 +29,8 @@ internal class DefaultMultiFeatureFlagProviderEvaluator(
 ) : BaseCatalogFeatureFlagProvider(
     providerName = "multi_provider",
     logger = logger,
-), MultiFeatureFlagProviderEvaluator {
+),
+    MultiFeatureFlagProviderEvaluator {
 
     override fun provide(key: FeatureFlagKey): FeatureFlagResult {
         for (provider in providers) {

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
@@ -1,0 +1,60 @@
+package net.thunderbird.core.featureflag.provider.evaluator
+
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.FeatureFlagResult
+import net.thunderbird.core.featureflag.provider.BaseCatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.CatalogProviderMetadata
+import net.thunderbird.core.featureflag.provider.DataSourceCatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.ProviderMetadata
+import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext
+import net.thunderbird.core.logging.Logger
+
+/**
+ * Feature flag provider that coordinates multiple catalog providers and supports initialization with context.
+ */
+interface MultiFeatureFlagProviderEvaluator : CatalogFeatureFlagProvider {
+
+    /**
+     * Initializes the feature flag provider with the given context and loads the catalog.
+     *
+     * @param initialContext The evaluation context containing targeting key and attributes for flag resolution.
+     */
+    fun initialize(initialContext: FeatureFlagContext)
+}
+
+internal class DefaultMultiFeatureFlagProviderEvaluator(
+    private val providers: List<CatalogFeatureFlagProvider>,
+    private val logger: Logger,
+) : BaseCatalogFeatureFlagProvider(
+    providerName = "multi_provider",
+    logger = logger,
+), MultiFeatureFlagProviderEvaluator {
+
+    override fun provide(key: FeatureFlagKey): FeatureFlagResult {
+        for (provider in providers) {
+            val result = provider.provide(key)
+            logger.verbose { "[feature-flag][${provider.metadata.name}] providing '${key.key}' -> $result" }
+            if (result != FeatureFlagResult.Unavailable) {
+                return result
+            } else {
+                logger.verbose { "[feature-flag][${provider.metadata.name}] fetching '${key.key}' on next provider" }
+            }
+        }
+        return FeatureFlagResult.Unavailable
+    }
+
+    override val metadata: ProviderMetadata = CatalogProviderMetadata(name = "multi_provider")
+
+    override fun initialize(initialContext: FeatureFlagContext) {
+        super.initialize(initialContext)
+        val bundledCatalogProvider =
+            checkNotNull(providers.filterIsInstance<DataSourceCatalogFeatureFlagProvider>().singleOrNull()) {
+                "[feature-flag] A MultiFeatureFlagProviderEvaluator requires a one CatalogFeatureFlagProvider"
+            }
+
+        bundledCatalogProvider.initialize(initialContext)
+    }
+
+    override fun toString(): String = "feature-flag provider '${metadata.name}': ${providers.size} providers"
+}

--- a/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/data/configstore/DefaultFeatureFlagConfigStoreTest.kt
+++ b/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/data/configstore/DefaultFeatureFlagConfigStoreTest.kt
@@ -1,0 +1,99 @@
+package net.thunderbird.core.featureflag.data.configstore
+
+import assertk.assertThat
+import assertk.assertions.containsOnly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.configstore.Config
+import net.thunderbird.core.configstore.ConfigId
+import net.thunderbird.core.configstore.backend.ConfigBackend
+import net.thunderbird.core.configstore.backend.ConfigBackendProvider
+import net.thunderbird.core.configstore.testing.TestConfigBackend
+
+@OptIn(ExperimentalUuidApi::class)
+class DefaultFeatureFlagConfigStoreTest {
+
+    @Test
+    fun `config should round trip the overrides through the backend`() = runTest {
+        // Arrange
+        val backend = TestConfigBackend()
+        val testSubject = createTestSubject(backend)
+        testSubject.update { current: FeatureFlagConfigData ->
+            current.copy(overrides = mapOf("flag_a" to true, "flag_b" to false))
+        }
+
+        // Act
+        val result = createTestSubject(backend).config.first()
+
+        // Assert
+        assertThat(result.overrides).containsOnly("flag_a" to true, "flag_b" to false)
+    }
+
+    @Test
+    fun `config should round trip the targeting key together with the overrides`() = runTest {
+        // Arrange
+        val backend = TestConfigBackend()
+        val testSubject = createTestSubject(backend)
+        testSubject.update { current: FeatureFlagConfigData ->
+            current.copy(targetingKey = TARGETING_KEY, overrides = mapOf("flag_a" to true))
+        }
+
+        // Act
+        val result = createTestSubject(backend).config.first()
+
+        // Assert
+        assertThat(result.targetingKey).isEqualTo(TARGETING_KEY)
+        assertThat(result.overrides).containsOnly("flag_a" to true)
+    }
+
+    @Test
+    fun `config should drop the persisted overrides when they are removed`() = runTest {
+        // Arrange
+        val backend = TestConfigBackend()
+        val testSubject = createTestSubject(backend)
+        testSubject.update { current: FeatureFlagConfigData -> current.copy(overrides = mapOf("flag_a" to true)) }
+
+        // Act
+        testSubject.update { current: FeatureFlagConfigData -> current.copy(overrides = emptyMap()) }
+
+        // Assert
+        assertThat(createTestSubject(backend).config.first().overrides).isEmpty()
+    }
+
+    @Test
+    fun `config should return no overrides when the persisted value is not readable`() = runTest {
+        // Arrange
+        val backend = TestConfigBackend(
+            initialConfig = Config().apply {
+                this[FeatureFlagConfigKeys.OVERRIDES] = "not-json"
+            },
+        )
+
+        // Act
+        val result = createTestSubject(backend).config.first()
+
+        // Assert
+        assertThat(result.overrides).isEmpty()
+    }
+
+    private fun createTestSubject(backend: ConfigBackend): FeatureFlagConfigStore = DefaultFeatureFlagConfigStore(
+        id = CONFIG_ID,
+        provider = SingleBackendConfigBackendProvider(backend),
+    )
+
+    private companion object {
+        val CONFIG_ID = ConfigId(backend = "test", feature = "featureflag")
+        val TARGETING_KEY: Uuid = Uuid.parse("f2d9a9a0-6d3f-4b5e-9f4a-1d2c3b4a5e6f")
+    }
+}
+
+private class SingleBackendConfigBackendProvider(
+    private val backend: ConfigBackend,
+) : ConfigBackendProvider {
+    override fun provide(id: ConfigId): ConfigBackend = backend
+}

--- a/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProviderTest.kt
+++ b/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProviderTest.kt
@@ -1,0 +1,242 @@
+package net.thunderbird.core.featureflag.provider
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.containsOnly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.featureflag.FeatureFlagResult
+import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigData
+import net.thunderbird.core.featureflag.data.configstore.FeatureFlagConfigStore
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey.ARCHIVE_MARKS_AS_READ
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey.DISPLAY_IN_APP_NOTIFICATIONS
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey.MESSAGE_VIEW_ACTION_EXPORT_EML
+import net.thunderbird.core.featureflag.model.FlagOverrides
+import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext
+import net.thunderbird.core.featureflag.provider.context.ImmutableFeatureFlagContext
+import net.thunderbird.core.logging.testing.TestLogger
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalUuidApi::class)
+class RuntimeDebugOverrideFeatureFlagProviderTest {
+
+    @Test
+    fun `provide should return Enabled when the persisted override is enabled`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                configStore = FakeFeatureFlagConfigStore(
+                    overrides = mapOf(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true),
+                ),
+            )
+
+            // Act
+            val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+            // Assert
+            assertThat(result).isEqualTo(FeatureFlagResult.Enabled)
+        }
+
+    @Test
+    fun `provide should return Disabled when the persisted override is disabled`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                configStore = FakeFeatureFlagConfigStore(
+                    overrides = mapOf(MESSAGE_VIEW_ACTION_EXPORT_EML.key to false),
+                ),
+            )
+
+            // Act
+            val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+            // Assert
+            assertThat(result).isEqualTo(FeatureFlagResult.Disabled)
+        }
+
+    @Test
+    fun `provide should return Unavailable when there is no override for the key`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val testSubject = createTestSubject(
+                configStore = FakeFeatureFlagConfigStore(
+                    overrides = mapOf(ARCHIVE_MARKS_AS_READ.key to true),
+                ),
+            )
+
+            // Act
+            val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+            // Assert
+            assertThat(result).isEqualTo(FeatureFlagResult.Unavailable)
+        }
+
+    @Test
+    fun `setOverride should persist the override and expose it through provide`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val configStore = FakeFeatureFlagConfigStore()
+            val testSubject = createTestSubject(configStore)
+
+            // Act
+            testSubject.setOverride(key = MESSAGE_VIEW_ACTION_EXPORT_EML, enabled = true)
+
+            // Assert
+            assertThat(configStore.current.overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)
+            assertThat(testSubject.overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)
+            assertThat(testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)).isEqualTo(FeatureFlagResult.Enabled)
+        }
+
+    @Test
+    fun `setOverride should replace an existing override for the same key`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val configStore = FakeFeatureFlagConfigStore(
+                overrides = mapOf(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true),
+            )
+            val testSubject = createTestSubject(configStore)
+
+            // Act
+            testSubject.setOverride(key = MESSAGE_VIEW_ACTION_EXPORT_EML, enabled = false)
+
+            // Assert
+            assertThat(configStore.current.overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to false)
+            assertThat(testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)).isEqualTo(FeatureFlagResult.Disabled)
+        }
+
+    @Test
+    fun `clearOverride should remove only the given override`() = runTest(UnconfinedTestDispatcher()) {
+        // Arrange
+        val configStore = FakeFeatureFlagConfigStore(
+            overrides = mapOf(
+                MESSAGE_VIEW_ACTION_EXPORT_EML.key to true,
+                ARCHIVE_MARKS_AS_READ.key to false,
+            ),
+        )
+        val testSubject = createTestSubject(configStore)
+
+        // Act
+        testSubject.clearOverride(key = MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(configStore.current.overrides).containsOnly(ARCHIVE_MARKS_AS_READ.key to false)
+        assertThat(testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)).isEqualTo(FeatureFlagResult.Unavailable)
+        assertThat(testSubject.provide(ARCHIVE_MARKS_AS_READ)).isEqualTo(FeatureFlagResult.Disabled)
+    }
+
+    @Test
+    fun `clearAllOverrides should remove every override but keep the targeting key`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val configStore = FakeFeatureFlagConfigStore(
+                targetingKey = TARGETING_UUID,
+                overrides = mapOf(
+                    MESSAGE_VIEW_ACTION_EXPORT_EML.key to true,
+                    ARCHIVE_MARKS_AS_READ.key to false,
+                    DISPLAY_IN_APP_NOTIFICATIONS.key to true,
+                ),
+            )
+            val testSubject = createTestSubject(configStore)
+
+            // Act
+            testSubject.clearAllOverrides()
+
+            // Assert
+            assertThat(configStore.current.overrides).isEmpty()
+            assertThat(configStore.current.targetingKey).isEqualTo(TARGETING_UUID)
+            assertThat(testSubject.overrides).isEmpty()
+            assertThat(testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)).isEqualTo(FeatureFlagResult.Unavailable)
+        }
+
+    @Test
+    fun `overrides should be restored from the config store when the provider is recreated`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Arrange
+            val configStore = FakeFeatureFlagConfigStore()
+            createTestSubject(configStore).setOverride(key = MESSAGE_VIEW_ACTION_EXPORT_EML, enabled = true)
+
+            // Act
+            val recreatedTestSubject = createTestSubject(configStore)
+
+            // Assert
+            assertThat(recreatedTestSubject.overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)
+            assertThat(recreatedTestSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML))
+                .isEqualTo(FeatureFlagResult.Enabled)
+        }
+
+    @Test
+    fun `data should emit the overrides after each mutation`() = runTest(UnconfinedTestDispatcher()) {
+        // Arrange
+        val testSubject = createTestSubject(FakeFeatureFlagConfigStore())
+        val emissions = mutableListOf<FlagOverrides>()
+        testSubject.data
+            .onEach { data -> emissions += data.overrides }
+            .launchIn(backgroundScope)
+
+        // Act
+        testSubject.setOverride(key = MESSAGE_VIEW_ACTION_EXPORT_EML, enabled = true)
+        testSubject.setOverride(key = ARCHIVE_MARKS_AS_READ, enabled = false)
+        testSubject.clearOverride(key = MESSAGE_VIEW_ACTION_EXPORT_EML)
+        testSubject.clearAllOverrides()
+
+        // Assert
+        assertThat(emissions).containsExactly(
+            emptyMap<String, Boolean>(),
+            mapOf(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true),
+            mapOf(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true, ARCHIVE_MARKS_AS_READ.key to false),
+            mapOf(ARCHIVE_MARKS_AS_READ.key to false),
+            emptyMap<String, Boolean>(),
+        )
+    }
+
+    private fun TestScope.createTestSubject(
+        configStore: FeatureFlagConfigStore,
+    ): RuntimeDebugOverrideFeatureFlagProvider = RuntimeDebugOverrideFeatureFlagProvider(
+        configStore = configStore,
+        logger = TestLogger(),
+        scope = backgroundScope,
+    ).also { provider ->
+        provider.initialize(initialContext = context())
+    }
+
+    private companion object {
+        const val TARGETING_KEY = "targeting-key"
+        val TARGETING_UUID: Uuid = Uuid.parse("f2d9a9a0-6d3f-4b5e-9f4a-1d2c3b4a5e6f")
+
+        fun context(): FeatureFlagContext = ImmutableFeatureFlagContext(targetingKey = TARGETING_KEY)
+    }
+}
+
+@OptIn(ExperimentalUuidApi::class)
+private class FakeFeatureFlagConfigStore(
+    targetingKey: Uuid? = null,
+    overrides: FlagOverrides = emptyMap(),
+) : FeatureFlagConfigStore {
+    private val state = MutableStateFlow(
+        FeatureFlagConfigData(targetingKey = targetingKey, overrides = overrides),
+    )
+
+    override val config: Flow<FeatureFlagConfigData> = state
+
+    /** The currently persisted configuration, so tests can assert what was written to the store. */
+    val current: FeatureFlagConfigData get() = state.value
+
+    override suspend fun update(transform: (FeatureFlagConfigData?) -> FeatureFlagConfigData) {
+        state.update { current -> transform(current) }
+    }
+
+    override suspend fun clear() {
+        state.value = FeatureFlagConfigData.DEFAULT
+    }
+}

--- a/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluatorTest.kt
+++ b/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluatorTest.kt
@@ -1,0 +1,184 @@
+package net.thunderbird.core.featureflag.provider.evaluator
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.FeatureFlagResult
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey.MESSAGE_VIEW_ACTION_EXPORT_EML
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider.State
+import net.thunderbird.core.featureflag.provider.ProviderMetadata
+import net.thunderbird.core.logging.testing.TestLogger
+
+class MultiFeatureFlagProviderEvaluatorTest {
+
+    @Test
+    fun `provide should return Enabled when the first provider returns Enabled`() {
+        // Arrange
+        val recorder = InvocationRecorder()
+        val testSubject = createTestSubject(
+            recorder.provider(name = FIRST, result = FeatureFlagResult.Enabled),
+            recorder.provider(name = SECOND, result = FeatureFlagResult.Disabled),
+        )
+
+        // Act
+        val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(result).isEqualTo(FeatureFlagResult.Enabled)
+    }
+
+    @Test
+    fun `provide should return Disabled when the first provider returns Disabled`() {
+        // Arrange
+        val recorder = InvocationRecorder()
+        val testSubject = createTestSubject(
+            recorder.provider(name = FIRST, result = FeatureFlagResult.Disabled),
+            recorder.provider(name = SECOND, result = FeatureFlagResult.Enabled),
+        )
+
+        // Act
+        val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(result).isEqualTo(FeatureFlagResult.Disabled)
+    }
+
+    @Test
+    fun `provide should return Enabled when the first provider is Unavailable and the second returns Enabled`() {
+        // Arrange
+        val recorder = InvocationRecorder()
+        val testSubject = createTestSubject(
+            recorder.provider(name = FIRST, result = FeatureFlagResult.Unavailable),
+            recorder.provider(name = SECOND, result = FeatureFlagResult.Enabled),
+        )
+
+        // Act
+        val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(result).isEqualTo(FeatureFlagResult.Enabled)
+        assertThat(recorder.invocations).containsExactly(FIRST, SECOND)
+    }
+
+    @Test
+    fun `provide should return Disabled when the first provider is Unavailable and the second returns Disabled`() {
+        // Arrange
+        val recorder = InvocationRecorder()
+        val testSubject = createTestSubject(
+            recorder.provider(name = FIRST, result = FeatureFlagResult.Unavailable),
+            recorder.provider(name = SECOND, result = FeatureFlagResult.Disabled),
+        )
+
+        // Act
+        val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(result).isEqualTo(FeatureFlagResult.Disabled)
+        assertThat(recorder.invocations).containsExactly(FIRST, SECOND)
+    }
+
+    @Test
+    fun `provide should return Unavailable when every provider returns Unavailable`() {
+        // Arrange
+        val recorder = InvocationRecorder()
+        val testSubject = createTestSubject(
+            recorder.provider(name = FIRST, result = FeatureFlagResult.Unavailable),
+            recorder.provider(name = SECOND, result = FeatureFlagResult.Unavailable),
+            recorder.provider(name = THIRD, result = FeatureFlagResult.Unavailable),
+        )
+
+        // Act
+        val result = testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(result).isEqualTo(FeatureFlagResult.Unavailable)
+    }
+
+    @Test
+    fun `provide should query the providers in their configured order`() {
+        // Arrange
+        val recorder = InvocationRecorder()
+        val testSubject = createTestSubject(
+            recorder.provider(name = FIRST, result = FeatureFlagResult.Unavailable),
+            recorder.provider(name = SECOND, result = FeatureFlagResult.Unavailable),
+            recorder.provider(name = THIRD, result = FeatureFlagResult.Unavailable),
+        )
+
+        // Act
+        testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(recorder.invocations).containsExactly(FIRST, SECOND, THIRD)
+    }
+
+    @Test
+    fun `provide should not query the providers after a concrete result`() {
+        // Arrange
+        val recorder = InvocationRecorder()
+        val notQueriedProvider = recorder.provider(name = THIRD, result = FeatureFlagResult.Enabled)
+        val testSubject = createTestSubject(
+            recorder.provider(name = FIRST, result = FeatureFlagResult.Unavailable),
+            recorder.provider(name = SECOND, result = FeatureFlagResult.Disabled),
+            notQueriedProvider,
+        )
+
+        // Act
+        testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)
+
+        // Assert
+        assertThat(recorder.invocations).containsExactly(FIRST, SECOND)
+        assertThat(notQueriedProvider.provideCount).isEqualTo(0)
+    }
+
+    private fun createTestSubject(
+        vararg providers: CatalogFeatureFlagProvider,
+    ): MultiFeatureFlagProviderEvaluator = DefaultMultiFeatureFlagProviderEvaluator(
+        providers = providers.toList(),
+        logger = TestLogger(),
+    )
+
+    private companion object {
+        const val FIRST = "first"
+        const val SECOND = "second"
+        const val THIRD = "third"
+    }
+}
+
+/**
+ * Records the order in which the providers it creates are queried, so tests can assert both the
+ * first-match strategy and that later providers are left untouched.
+ */
+private class InvocationRecorder {
+    val invocations: MutableList<String> = mutableListOf()
+
+    fun provider(name: String, result: FeatureFlagResult): FakeCatalogFeatureFlagProvider =
+        FakeCatalogFeatureFlagProvider(name = name, result = result, invocations = invocations)
+}
+
+private class FakeCatalogFeatureFlagProvider(
+    private val name: String,
+    private val result: FeatureFlagResult,
+    private val invocations: MutableList<String>,
+) : CatalogFeatureFlagProvider {
+    var provideCount: Int = 0
+        private set
+
+    override val state: StateFlow<State> = MutableStateFlow(State.Resolved)
+
+    override val metadata: ProviderMetadata = FakeProviderMetadata(name)
+
+    override fun provide(key: FeatureFlagKey): FeatureFlagResult {
+        provideCount++
+        invocations += name
+        return result
+    }
+
+    override fun toString(): String = "fake feature-flag provider '$name'"
+}
+
+private data class FakeProviderMetadata(override val name: String) : ProviderMetadata

--- a/core/featureflag/src/jvmMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.jvm.kt
+++ b/core/featureflag/src/jvmMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.jvm.kt
@@ -2,12 +2,13 @@ package net.thunderbird.core.featureflag.inject
 
 import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
 import net.thunderbird.core.featureflag.data.LocalFeatureFlagCatalogDataSource
+import net.thunderbird.core.featureflag.inject.qualifier.InjectQualifier
 import org.koin.core.module.Module
 import org.koin.core.qualifier.qualifier
 import org.koin.dsl.module
 
 actual val platformFeatureFlagModule: Module = module {
-    single<FeatureFlagCatalogDataSource>(qualifier(FeatureFlagCatalogDataSource.InjectQualifiers.Local)) {
+    single<FeatureFlagCatalogDataSource>(qualifier(InjectQualifier.Local)) {
         LocalFeatureFlagCatalogDataSource(jsonParser = get())
     }
 }


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: 
- Closes #11331
- Closes #11332

RFC / Technical Design (if applicable): [RFC 0004: Add a Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/rfcs/0004-feature-flag-new-architecture.md) / [Technical Design 0002: Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/technical-designs/0002-feature-flag-declarative-catalog.md)

#### Description

This contribution adds the persisted debug-override and provider-composition layers for the declarative feature-flag catalog.

- Add `RuntimeDebugOverrideFeatureFlagProvider` to set, clear, and observe debug overrides.
- Persist overrides as JSON in `FeatureFlagConfigStore`, alongside the targeting key.
- Preserve the targeting key when clearing overrides and safely ignore malformed override data.
- Add `MultiFeatureFlagProviderEvaluator`, which resolves flags in priority order:
   1. Runtime debug overrides.
   2. The bundled feature-flag catalog.
- Continue to the next provider only for `Unavailable`; both `Enabled` and `Disabled` stop evaluation.
- Register the runtime override provider for Thunderbird and K-9 Mail debug builds.
- Initialize feature flags through the evaluator instead of directly through the bundled provider.
- Add unit tests covering persistence, override operations, provider precedence, and short-circuit behavior.

#### Risks and trade-offs

- Provider ordering directly affects flag resolution. 
- The configured runtime-to-bundled precedence is explicitly covered by unit tests. 
- Remote catalog evaluation remains out of scope.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).