### PR TITLE
fix(TokenCompleteTextView): let the tab key move focus out of the field

### DIFF
--- a/library/token-auto-complete/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/token-auto-complete/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -34,6 +34,7 @@ import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputConnectionWrapper;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Filter;
+import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
 
@@ -68,7 +69,7 @@ public abstract class TokenCompleteTextView<T> extends AppCompatAutoCompleteText
     private boolean initialized = false;
     private boolean performBestGuess = true;
     private boolean savingState = false;
-    private boolean shouldFocusNext = false;
+    private boolean completeOnKeyUp = false;
     private boolean allowCollapse = true;
     private boolean internalEditInProgress = false;
 
@@ -520,23 +521,29 @@ public abstract class TokenCompleteTextView<T> extends AppCompatAutoCompleteText
 
     @Override
     public boolean onKeyUp(int keyCode, @NonNull KeyEvent event) {
-        boolean handled = super.onKeyUp(keyCode, event);
-        if (shouldFocusNext) {
-            shouldFocusNext = false;
+        // A completion armed by an enter or dpad centre key down is finished off here. It is drained before the
+        // tab key is looked at, so that a tab key up arriving while enter is still held cannot leave it armed to
+        // fire on some later, unrelated key up.
+        if (completeOnKeyUp) {
+            completeOnKeyUp = false;
             handleDone();
         }
-        return handled;
+
+        if (keyCode == KeyEvent.KEYCODE_TAB && event.hasNoModifiers()) {
+            return handleTabInCompletionList();
+        }
+
+        return super.onKeyUp(keyCode, event);
     }
 
     @Override
     public boolean onKeyDown(int keyCode, @NonNull KeyEvent event) {
         boolean handled = false;
         switch (keyCode) {
-            case KeyEvent.KEYCODE_TAB:
             case KeyEvent.KEYCODE_ENTER:
             case KeyEvent.KEYCODE_DPAD_CENTER:
                 if (event.hasNoModifiers()) {
-                    shouldFocusNext = true;
+                    completeOnKeyUp = true;
                     handled = true;
                 }
                 break;
@@ -545,7 +552,43 @@ public abstract class TokenCompleteTextView<T> extends AppCompatAutoCompleteText
                 break;
         }
 
+        // The tab key is deliberately not handled here. AutoCompleteTextView consumes it while the completion
+        // list is open and leaves it alone otherwise, which is what lets the framework move the focus on to the
+        // next view. Consuming it here would trap the focus in this field.
         return handled || super.onKeyDown(keyCode, event);
+    }
+
+    /**
+     * Handles the tab key while the completion list is open.
+     *
+     * {@link android.widget.AutoCompleteTextView} completes straight away on tab, which takes the choice away
+     * from the user as soon as there is more than one suggestion. Instead a single suggestion is completed and
+     * several suggestions move the selection into the list, so it can be walked with tab or the arrow keys and
+     * confirmed with enter.
+     *
+     * @return true if the key was consumed.
+     */
+    private boolean handleTabInCompletionList() {
+        ListAdapter adapter = getAdapter();
+        if (!isPopupShowing() || adapter == null || adapter.getCount() == 0) {
+            return false;
+        }
+
+        if (adapter.getCount() == 1) {
+            // Nothing to choose between, complete the only suggestion and stay in this field.
+            setListSelection(0);
+            performCompletion();
+            return true;
+        }
+
+        if (getListSelection() == ListView.INVALID_POSITION) {
+            // The drop down keeps its selection hidden, and ignores key events, until something is selected.
+            // Selecting the first suggestion here is what makes it navigable in the first place.
+            setListSelection(0);
+        }
+        // With a selection in place the list moves it along itself, so there is nothing left to do but keep
+        // the key away from AutoCompleteTextView's complete-on-tab handling.
+        return true;
     }
 
     @Override

--- a/library/token-auto-complete/src/test/java/com/tokenautocomplete/TokenCompleteTextViewBehaviorTest.java
+++ b/library/token-auto-complete/src/test/java/com/tokenautocomplete/TokenCompleteTextViewBehaviorTest.java
@@ -11,9 +11,11 @@ import android.os.Looper;
 import android.os.SystemClock;
 import android.text.Editable;
 import android.text.SpannableStringBuilder;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -284,5 +286,161 @@ public class TokenCompleteTextViewBehaviorTest {
 
         e.resetFromOther();
         e.tapAndAssert(xEmpty, yLast, null, 1);
+    }
+
+    private static KeyEvent tab(int action) {
+        return new KeyEvent(action, KeyEvent.KEYCODE_TAB);
+    }
+
+    private static KeyEvent shiftTab(int action) {
+        return new KeyEvent(0, 0, action, KeyEvent.KEYCODE_TAB, 0, KeyEvent.META_SHIFT_ON);
+    }
+
+    private static void openCompletionList(Env e, String... suggestions) {
+        e.v.setAdapter(new ArrayAdapter<>(e.a, android.R.layout.simple_list_item_1, suggestions));
+        e.v.showDropDown();
+        e.idle();
+        assertTrue("Expected the completion list to be open", e.v.isPopupShowing());
+    }
+
+    @Test
+    public void tab_withCompletionListClosed_isNotConsumed() {
+        Env e = new Env();
+        e.focusTokens();
+        assertFalse(e.v.isPopupShowing());
+
+        // Not consuming the key is what lets the framework move the focus on to the next view.
+        assertFalse(e.v.onKeyDown(KeyEvent.KEYCODE_TAB, tab(KeyEvent.ACTION_DOWN)));
+        assertEquals(0, e.spans().length);
+    }
+
+    @Test
+    public void shiftTab_withCompletionListClosed_isNotConsumed() {
+        Env e = new Env();
+        e.focusTokens();
+
+        assertFalse(e.v.onKeyDown(KeyEvent.KEYCODE_TAB, shiftTab(KeyEvent.ACTION_DOWN)));
+    }
+
+    @Test
+    public void tab_withSingleSuggestion_completesIt() {
+        Env e = new Env();
+        e.focusTokens();
+        openCompletionList(e, "one@example.com");
+
+        assertTrue(e.v.onKeyUp(KeyEvent.KEYCODE_TAB, tab(KeyEvent.ACTION_UP)));
+        e.layout();
+
+        assertEquals(1, e.spans().length);
+        assertEquals("one@example.com", e.v.getObjects().get(0));
+    }
+
+    @Test
+    public void tab_withSeveralSuggestions_selectsTheFirstOneInsteadOfCompleting() {
+        Env e = new Env();
+        e.focusTokens();
+        openCompletionList(e, "one@example.com", "two@example.com");
+
+        assertTrue(e.v.onKeyUp(KeyEvent.KEYCODE_TAB, tab(KeyEvent.ACTION_UP)));
+        e.layout();
+
+        assertEquals(0, e.v.getListSelection());
+        assertEquals("Nothing should be completed yet", 0, e.spans().length);
+    }
+
+    @Test
+    public void tab_withSeveralSuggestions_neverCompletesOnItsOwn() {
+        Env e = new Env();
+        e.focusTokens();
+        openCompletionList(e, "one@example.com", "two@example.com");
+        e.v.setListSelection(1);
+        e.idle();
+
+        assertTrue(e.v.onKeyUp(KeyEvent.KEYCODE_TAB, tab(KeyEvent.ACTION_UP)));
+        e.layout();
+
+        assertEquals("The selection is left for the list to move", 1, e.v.getListSelection());
+        assertEquals("Picking a suggestion is enter's job", 0, e.spans().length);
+    }
+
+    @Test
+    public void enter_completesTheSelectedSuggestion() {
+        Env e = new Env();
+        e.focusTokens();
+        openCompletionList(e, "one@example.com", "two@example.com");
+        e.v.setListSelection(1);
+        e.idle();
+
+        e.v.onKeyDown(KeyEvent.KEYCODE_ENTER, new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER));
+        e.v.onKeyUp(KeyEvent.KEYCODE_ENTER, new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER));
+        e.layout();
+
+        assertEquals(1, e.spans().length);
+        assertEquals("two@example.com", e.v.getObjects().get(0));
+    }
+
+    @Test
+    public void enter_stillCompletesTheCurrentText() {
+        Env e = new Env();
+        e.focusTokens();
+        e.v.append("one@example.com");
+        e.layout();
+
+        assertTrue(e.v.onKeyDown(KeyEvent.KEYCODE_ENTER, new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER)));
+        e.v.onKeyUp(KeyEvent.KEYCODE_ENTER, new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER));
+        e.layout();
+
+        assertEquals(1, e.spans().length);
+    }
+
+    @Test
+    public void tab_downThenUp_withSeveralSuggestions_selectsWithoutCompleting() {
+        Env e = new Env();
+        e.focusTokens();
+        e.v.append("one");
+        e.layout();
+        openCompletionList(e, "one@example.com", "two@example.com");
+
+        // The real key sequence: the down leg goes through the drop down, which may already move the selection.
+        e.v.onKeyDown(KeyEvent.KEYCODE_TAB, tab(KeyEvent.ACTION_DOWN));
+        assertTrue(e.v.onKeyUp(KeyEvent.KEYCODE_TAB, tab(KeyEvent.ACTION_UP)));
+        e.layout();
+
+        assertTrue("A suggestion should be selected", e.v.getListSelection() >= 0);
+        assertEquals("Picking one is enter's job", 0, e.spans().length);
+    }
+
+    @Test
+    public void tab_downThenUp_withSingleSuggestion_completesIt() {
+        Env e = new Env();
+        e.focusTokens();
+        e.v.append("one");
+        e.layout();
+        openCompletionList(e, "one@example.com");
+
+        e.v.onKeyDown(KeyEvent.KEYCODE_TAB, tab(KeyEvent.ACTION_DOWN));
+        assertTrue(e.v.onKeyUp(KeyEvent.KEYCODE_TAB, tab(KeyEvent.ACTION_UP)));
+        e.layout();
+
+        assertEquals(1, e.spans().length);
+        assertEquals("one@example.com", e.v.getObjects().get(0));
+    }
+
+    @Test
+    public void tab_doesNotLeaveAnEnterCompletionArmedForALaterKey() {
+        Env e = new Env();
+        e.focusTokens();
+        openCompletionList(e, "one@example.com", "two@example.com");
+
+        // Enter arms a completion for its own key up. A tab key up arriving first must not leave it armed.
+        e.v.onKeyDown(KeyEvent.KEYCODE_ENTER, new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER));
+        e.v.onKeyUp(KeyEvent.KEYCODE_TAB, tab(KeyEvent.ACTION_UP));
+        e.layout();
+        int spansAfterTab = e.spans().length;
+
+        e.v.onKeyUp(KeyEvent.KEYCODE_A, new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_A));
+        e.layout();
+
+        assertEquals("An unrelated key up must not complete anything", spansAfterTab, e.spans().length);
     }
 }


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #8231
RFC / Technical Design (if applicable): n/a, behaviour agreed in [this comment](https://github.com/thunderbird/thunderbird-android/issues/8231#issuecomment-5316227853)

#### Description

With a hardware keyboard the focus could not leave To, Cc or Bcc.

`TokenCompleteTextView.onKeyDown` consumed the tab key along with enter and dpad centre. `ViewRootImpl` only moves focus for a key that comes back unhandled, so consuming it trapped the focus. Shift+tab kept working, because `hasNoModifiers()` is false for it. That is the "only way out is backwards" from the first comment on the issue.

`AutoCompleteTextView` already gets tab right. It consumes the key while the completion list is open and leaves it alone otherwise, and `TextView` deliberately returns it unhandled so that focus can move. So tab is no longer touched in `onKeyDown`.

It is handled in `onKeyUp` instead. Left alone, `AutoCompleteTextView` completes on tab immediately, which picks a suggestion for the user as soon as there is more than one to pick from. Now: with the list closed the key falls through and the framework moves the focus on. With a single suggestion tab completes it and the focus stays in the field. With several, tab selects into the list, and you walk it with tab or the arrow keys and confirm with enter.

Enter and dpad centre behave as they did.

#### Screen Shots

Verified on an Android 16 emulator with a real tab key (`adb shell input keyevent 61`), and two contacts so the number of suggestions could be controlled. Before, tab did nothing at all. After, it walks To, the Cc/Bcc expander, Subject and then Message text; a single suggestion gets completed; and tab, tab, enter commits the second of two.

Tests are in `TokenCompleteTextViewBehaviorTest`, on the Robolectric harness that was already there. Five of them fail against the current code.

Two things worth knowing. Tab no longer hides the soft keyboard, which used to happen through `handleDone()`. With an external keyboard there is nothing to hide, and once tab lands on Subject you want the keyboard up anyway, so I left it that way; say the word if you would rather have the old behaviour back. The other is that the selected suggestion still is not highlighted. That turned out to be a separate problem in the drop down's styling, and #11416 fixes it.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [x] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [ ] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).

The Kotlin box is unticked because this changes the vendored `token-auto-complete` widget, which is Java, and its tests sit alongside it.
