### PR TITLE
fix(recipient-completion): show which suggestion the keyboard has selected

### DIFF
--- a/legacy/ui/legacy/src/main/res/drawable/recipient_dropdown_item_background.xml
+++ b/legacy/ui/legacy/src/main/res/drawable/recipient_dropdown_item_background.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Marks the recipient completion suggestion that the keyboard has selected.
+
+    The selection has to be drawn by the row rather than by the list selector. ListView.setupChild() calls
+    child.setSelected() on the row, which is correct from the first selection onwards, whereas the selector's
+    drawable state is the list's own state (AbsListView.getDrawableStateForSelector) and DropDownListView
+    reports itself as focused for as long as the popup exists, so a stateful selector cannot tell a selected
+    row from a cleared one. The list selector is deliberately left alone, so touch feedback is unchanged.
+
+    The fill on its own is only 1.22:1 against the popup background in the light theme, so the outline carries
+    the contrast: colorPrimary is 7.7:1 there and 14.1:1 in the dark theme. colorSecondaryContainer, the
+    Material token for a selected list item, is not usable here because the rows take their text colour from
+    textColorPrimaryRecipientDropdown, which is pinned to black in the light theme and reaches only 3.3:1 on it.
+
+    Note that state_selected also propagates to the row's TextViews. It does not change their colour today
+    because @android:color/primary_text_* matches its state_window_focused="false" entry first, and this popup
+    is never focusable, but making the popup focusable would turn the selected row's text black on black.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_selected="true">
+        <inset android:inset="2dp">
+            <shape android:shape="rectangle">
+                <solid android:color="?attr/colorSurfaceContainerHighest" />
+                <stroke
+                    android:width="2dp"
+                    android:color="?attr/colorPrimary"
+                    />
+                <corners android:radius="4dp" />
+            </shape>
+        </inset>
+    </item>
+
+    <item>
+        <color android:color="@android:color/transparent" />
+    </item>
+
+</selector>

--- a/legacy/ui/legacy/src/main/res/layout/recipient_dropdown_item.xml
+++ b/legacy/ui/legacy/src/main/res/layout/recipient_dropdown_item.xml
@@ -8,6 +8,7 @@
     android:minHeight="?android:listPreferredItemHeight"
     android:gravity="center"
     android:orientation="horizontal"
+    android:background="@drawable/recipient_dropdown_item_background"
     >
 
     <de.hdodenhof.circleimageview.CircleImageView


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: follow-up to #11413 (issue #8231)
RFC / Technical Design (if applicable): n/a

#### Description

Now that #11413 has landed, tab selects a suggestion in the recipient completion list. Walking that list with a keyboard barely shows up on screen, though. The first key press leaves no mark at all, and later presses only produce a faint grey fill, so it is hard to tell which suggestion is about to be picked. #11413 makes the list navigable. This makes the selection visible.

The list selector cannot do the job. `setListSelection()` reaches `ListView.layoutChildren`, which positions the selector with `positionSelector(INVALID_POSITION, sel)`, and `AbsListView.positionSelector` then skips the block that refreshes the selector's drawable state, because `position != mSelectorPosition` is false. Its state is the list's own state too, and `DropDownListView` reports itself as focused for as long as the popup exists, so a stateful selector cannot tell a selected row from a cleared one.

The row can. `ListView.setupChild` calls `child.setSelected(selected && shouldShowSelector())`, and that is right from the first selection onwards. So the row background draws the selection, and the list selector is left alone so touch feedback stays as it is.

A word on the colours. `colorSecondaryContainer` is the Material token for a selected list item, but it does not work here: the rows take their text colour from `?attr/textColorPrimaryRecipientDropdown`, which is pinned to black in the light theme and only reaches 3.3:1 on it. `colorSurfaceContainerHighest` keeps the text at 16:1, but on its own it is a 3% lightness step, 1.22:1 against the popup background. So the selected row gets a `colorPrimary` outline as well: 7.7:1 in the light theme and 14.1:1 in the dark one, which meets WCAG 1.4.11 for a state indicator.

#### Screen Shots

The first suggestion selected with one tab press, on an Android 16 emulator.

Before:
<img width="1080" height="560" alt="11416-before" src="https://github.com/user-attachments/assets/31ea7f60-93fe-46bc-b5db-959df483213a" />

After, light theme:
<img width="1080" height="560" alt="11416-after-light" src="https://github.com/user-attachments/assets/de945929-83df-49c7-88d4-2f9eda0a18b4" />

After, dark theme:
<img width="1080" height="560" alt="11416-after-dark" src="https://github.com/user-attachments/assets/65d7c4c7-16dd-4ccb-82b8-65361e5d3f8a" />

Verified in both themes. The selected row picks up the fill and the outline on the first key press, follows further presses onto the next row, clears when the list is touched, and tab, tab, enter still commits the second suggestion.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [x] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).

Two things to flag:

- **This does nothing without #11413.** With only this change, the arrow keys move focus out of the field rather than into the list, so nothing is ever selected. Please merge it after #11413, or tell me to fold it in there.
- **A screen reader still gets nothing.** `setSelected(true)` fires `TYPE_VIEW_SELECTED`, which TalkBack ignores for an unfocused view in a non-focusable window, and focus never enters the popup. An `announceForAccessibility()` of the selected suggestion would fix it, and belongs in #11413. Happy to add it if you want.

One thing to flag. A screen reader still gets nothing, because `setSelected(true)` fires `TYPE_VIEW_SELECTED`, which TalkBack ignores for an unfocused view in a non-focusable window, and focus never enters the popup. An `announceForAccessibility()` of the selected suggestion would fix that, and it belongs in #11413; happy to add it if you want it.

This is a drawable and a layout attribute, so there is nothing a unit test would pin that `ListView` does not already guarantee. I verified it on device instead.
