### PR TITLE
chore(feature-flag): wire multi provider feature flag with apps

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
 
     implementation(projects.feature.thundermail.internal.common)
 
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.work.runtime)
     implementation(libs.androidx.lifecycle.process)
 

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/MainActivity.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/MainActivity.kt
@@ -1,26 +1,49 @@
 package net.thunderbird.app.common
 
 import android.os.Bundle
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
 import com.fsck.k9.ui.base.BaseActivity
-import kotlin.getValue
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import net.thunderbird.app.common.startup.StartupRouter
 import net.thunderbird.core.android.common.startup.DatabaseUpgradeInterceptor
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.evaluator.MultiFeatureFlagProviderEvaluator
+import net.thunderbird.core.logging.Logger
 import org.koin.android.ext.android.inject
 
 class MainActivity : BaseActivity() {
 
     private val startupRouter: StartupRouter by inject()
     private val databaseUpgradeInterceptor: DatabaseUpgradeInterceptor by inject()
+    private val featureFlagProvider: MultiFeatureFlagProviderEvaluator by inject()
+    private val logger: Logger by inject()
+    private var ready = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+        featureFlagProvider
+            .state
+            .onEach { state ->
+                logger.verbose { "[feature-flag][${featureFlagProvider.metadata.name}] state = $state" }
+                if (state == CatalogFeatureFlagProvider.State.Resolved) {
+                    ready = true
+                    if (databaseUpgradeInterceptor.checkAndHandleUpgrade(this@MainActivity, intent)) {
+                        finish()
+                        return@onEach
+                    }
 
-        if (databaseUpgradeInterceptor.checkAndHandleUpgrade(this, intent)) {
-            finish()
-            return
+                    startupRouter.routeToNextScreen(this@MainActivity)
+                    finish()
+                }
+            }
+            .launchIn(lifecycleScope)
+
+        splashScreen.setKeepOnScreenCondition {
+            logger.verbose { "[feature-flag] keep on screen; ready = $ready" }
+            !ready
         }
-
-        startupRouter.routeToNextScreen(this)
-        finish()
     }
 }

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/core/configstore/ConfigStoreModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/core/configstore/ConfigStoreModule.kt
@@ -6,13 +6,14 @@ import net.thunderbird.core.configstore.backend.ConfigBackendFileManager
 import net.thunderbird.core.configstore.backend.ConfigBackendProvider
 import net.thunderbird.core.configstore.backend.DataStoreConfigBackendFactory
 import net.thunderbird.core.configstore.backend.DefaultConfigBackendProvider
+import org.koin.android.ext.koin.androidApplication
 import org.koin.dsl.module
 
 val appCommonCoreConfigStoreModule = module {
 
     single<ConfigBackendFileManager> {
         AndroidConfigBackendFileManager(
-            context = get(),
+            context = androidApplication(),
         )
     }
 

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/CatalogFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/CatalogFeatureFlagProvider.kt
@@ -77,7 +77,7 @@ abstract class BaseCatalogFeatureFlagProvider internal constructor(
     protected fun resolvedFlags(): Map<String, Boolean> = resolvedFlags
 
     protected fun resolve(context: FeatureFlagContext?): Map<String, Boolean> {
-        state.update { State.ResolvingFlags }
+        updateState { State.ResolvingFlags }
         logger.verbose { "[feature-flag] resolving feature flag catalog for '${metadata.name}' provider" }
         val catalog = catalog ?: return emptyMap()
         val base = catalog.flags.associate { it.key to it.default }
@@ -93,7 +93,11 @@ abstract class BaseCatalogFeatureFlagProvider internal constructor(
         }
         val resolvedFlags = base + overrides
         logger.verbose { "[feature-flag][${metadata.name}] resolved flags: $resolvedFlags" }
-        state.update { State.Resolved }
+        updateState { State.Resolved }
         return resolvedFlags
+    }
+
+    protected fun updateState(function: (State) -> State) {
+        state.update(function)
     }
 }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/CatalogFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/CatalogFeatureFlagProvider.kt
@@ -63,7 +63,7 @@ abstract class BaseCatalogFeatureFlagProvider internal constructor(
      * @param initialContext The evaluation context containing targeting key and attributes for flag resolution.
      */
     @CallSuper
-    open fun initialize(initialContext: FeatureFlagContext) {
+    open suspend fun initialize(initialContext: FeatureFlagContext) {
         context = initialContext
     }
 

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/DataSourceCatalogFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/DataSourceCatalogFeatureFlagProvider.kt
@@ -1,12 +1,11 @@
 package net.thunderbird.core.featureflag.provider
 
+import java.io.IOException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.first
 import net.thunderbird.core.featureflag.data.FeatureFlagCatalogDataSource
 import net.thunderbird.core.featureflag.model.FeatureFlagCatalog
 import net.thunderbird.core.featureflag.provider.context.FeatureFlagContext
@@ -33,18 +32,15 @@ abstract class DataSourceCatalogFeatureFlagProvider internal constructor(
      *
      * @param initialContext The evaluation context containing targeting key and attributes for flag resolution.
      */
-    override fun initialize(initialContext: FeatureFlagContext) {
+    override suspend fun initialize(initialContext: FeatureFlagContext) {
         super.initialize(initialContext)
-        loadCatalog()
-            .onEach { bundledCatalog ->
-                catalog = bundledCatalog
-                resolvedFlags = resolve(context)
-                logger.verbose { "[feature-flag] Resolved feature flags: $resolvedFlags" }
-            }
-            .catch { cause ->
-                logger.error(throwable = cause) { "[feature-flag] Failed to load feature flag catalog." }
-            }
-            .launchIn(scope)
+        try {
+            catalog = loadCatalog()
+            resolvedFlags = resolve(context)
+            logger.verbose { "[feature-flag] Resolved feature flags: $resolvedFlags" }
+        } catch (e: IOException) {
+            logger.error(throwable = e) { "[feature-flag] Failed to load feature flag catalog." }
+        }
     }
 
     /**
@@ -52,5 +48,5 @@ abstract class DataSourceCatalogFeatureFlagProvider internal constructor(
      *
      * @return A Flow that emits the feature flag catalog containing flag definitions and overrides.
      */
-    open fun loadCatalog(): Flow<FeatureFlagCatalog> = dataSource.load()
+    open suspend fun loadCatalog(): FeatureFlagCatalog = dataSource.load().first()
 }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
@@ -46,7 +46,7 @@ class RuntimeDebugOverrideFeatureFlagProvider(
     override var resolvedFlags: FlagOverrides = data.value.overrides
     val overrides: FlagOverrides get() = resolvedFlags
 
-    override fun initialize(initialContext: FeatureFlagContext) {
+    override suspend fun initialize(initialContext: FeatureFlagContext) {
         super.initialize(initialContext)
         updateState { CatalogFeatureFlagProvider.State.Resolved }
     }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
@@ -48,7 +48,7 @@ class RuntimeDebugOverrideFeatureFlagProvider(
 
     override fun initialize(initialContext: FeatureFlagContext) {
         super.initialize(initialContext)
-        resolve(initialContext)
+        updateState { CatalogFeatureFlagProvider.State.Resolved }
     }
 
     /** Sets the override for [key] to [enabled] and persists it. */

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
@@ -1,5 +1,11 @@
 package net.thunderbird.core.featureflag.provider.evaluator
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.FeatureFlagResult
 import net.thunderbird.core.featureflag.provider.BaseCatalogFeatureFlagProvider
@@ -26,11 +32,35 @@ interface MultiFeatureFlagProviderEvaluator : CatalogFeatureFlagProvider {
 internal class DefaultMultiFeatureFlagProviderEvaluator(
     private val providers: List<CatalogFeatureFlagProvider>,
     private val logger: Logger,
+    private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : BaseCatalogFeatureFlagProvider(
     providerName = "multi_provider",
     logger = logger,
 ),
     MultiFeatureFlagProviderEvaluator {
+    private val scope: CoroutineScope = CoroutineScope(mainDispatcher)
+
+    init {
+        scope.launch {
+            combine(
+                flows = providers.map { provider -> provider.state.map { provider.metadata.name to it } },
+            ) { providerStates -> providerStates }
+                .collect { providerStates ->
+                    var resolved = 0
+                    for ((provider, state) in providerStates) {
+                        logger.verbose { "[feature-flag][${metadata.name}] provider '$provider' state: $state" }
+                        if (state == CatalogFeatureFlagProvider.State.Resolved) {
+                            resolved++
+                        }
+                    }
+
+                    val isResolved = resolved == providers.size
+                    if (isResolved) {
+                        updateState { CatalogFeatureFlagProvider.State.Resolved }
+                    }
+                }
+        }
+    }
 
     override fun provide(key: FeatureFlagKey): FeatureFlagResult {
         for (provider in providers) {
@@ -55,6 +85,11 @@ internal class DefaultMultiFeatureFlagProviderEvaluator(
             }
 
         bundledCatalogProvider.initialize(initialContext)
+
+        providers
+            .filterNot { it == bundledCatalogProvider }
+            .filterIsInstance<BaseCatalogFeatureFlagProvider>()
+            .forEach { it.initialize(initialContext) }
     }
 
     override fun toString(): String = "feature-flag provider '${metadata.name}': ${providers.size} providers"

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
@@ -26,7 +26,7 @@ interface MultiFeatureFlagProviderEvaluator : CatalogFeatureFlagProvider {
      *
      * @param initialContext The evaluation context containing targeting key and attributes for flag resolution.
      */
-    fun initialize(initialContext: FeatureFlagContext)
+    suspend fun initialize(initialContext: FeatureFlagContext)
 }
 
 internal class DefaultMultiFeatureFlagProviderEvaluator(
@@ -77,7 +77,7 @@ internal class DefaultMultiFeatureFlagProviderEvaluator(
 
     override val metadata: ProviderMetadata = CatalogProviderMetadata(name = "multi_provider")
 
-    override fun initialize(initialContext: FeatureFlagContext) {
+    override suspend fun initialize(initialContext: FeatureFlagContext) {
         super.initialize(initialContext)
         val bundledCatalogProvider =
             checkNotNull(providers.filterIsInstance<DataSourceCatalogFeatureFlagProvider>().singleOrNull()) {

--- a/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProviderTest.kt
+++ b/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProviderTest.kt
@@ -200,7 +200,7 @@ class RuntimeDebugOverrideFeatureFlagProviderTest {
         )
     }
 
-    private fun TestScope.createTestSubject(
+    private suspend fun TestScope.createTestSubject(
         configStore: FeatureFlagConfigStore,
     ): RuntimeDebugOverrideFeatureFlagProvider = RuntimeDebugOverrideFeatureFlagProvider(
         configStore = configStore,

--- a/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluatorTest.kt
+++ b/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluatorTest.kt
@@ -3,9 +3,14 @@ package net.thunderbird.core.featureflag.provider.evaluator
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.setMain
 import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.FeatureFlagResult
 import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey.MESSAGE_VIEW_ACTION_EXPORT_EML
@@ -15,6 +20,12 @@ import net.thunderbird.core.featureflag.provider.ProviderMetadata
 import net.thunderbird.core.logging.testing.TestLogger
 
 class MultiFeatureFlagProviderEvaluatorTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
 
     @Test
     fun `provide should return Enabled when the first provider returns Enabled`() {

--- a/legacy/common/src/main/java/com/fsck/k9/LegacyCommonAppModule.kt
+++ b/legacy/common/src/main/java/com/fsck/k9/LegacyCommonAppModule.kt
@@ -13,7 +13,7 @@ import com.fsck.k9.preferences.K9StoragePersister
 import com.fsck.k9.resources.resourcesModule
 import com.fsck.k9.storage.storageModule
 import net.thunderbird.core.featureflag.FeatureFlagProvider
-import net.thunderbird.core.featureflag.InMemoryFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.evaluator.MultiFeatureFlagProviderEvaluator
 import net.thunderbird.core.preference.storage.StoragePersister
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -31,12 +31,7 @@ val legacyCommonAppModule = module {
     single<StoragePersister> {
         K9StoragePersister(get(), get())
     }
-    single<FeatureFlagProvider>(createdAtStart = true) {
-        InMemoryFeatureFlagProvider(
-            featureFlagFactory = get(),
-            featureFlagOverrides = get(),
-        )
-    }
+    single<FeatureFlagProvider> { get<MultiFeatureFlagProviderEvaluator>() }
 }
 
 val legacyCommonAppModules = listOf(

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -12,8 +12,6 @@ import com.fsck.k9.mailstore.LocalStore
 import com.fsck.k9.preferences.DefaultGeneralSettingsManager
 import net.thunderbird.core.android.account.AccountDefaultsProvider
 import net.thunderbird.core.android.account.SortType
-import net.thunderbird.core.featureflag.FeatureFlagProvider
-import net.thunderbird.core.featureflag.toFeatureFlagKey
 import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.core.preference.storage.StorageEditor
 import net.thunderbird.core.preference.storage.getEnumOrDefault
@@ -25,7 +23,6 @@ import timber.log.Timber
 object K9 : KoinComponent {
     private val generalSettingsManager: DefaultGeneralSettingsManager by inject()
     private val telemetryManager: TelemetryManager by inject()
-    private val featureFlagProvider: FeatureFlagProvider by inject()
 
     /**
      * Name of the [SharedPreferences] file used to store the last known version of the
@@ -173,11 +170,6 @@ object K9 : KoinComponent {
 
         val sortAscendingSetting = storage.getBoolean("sortAscending", AccountDefaultsProvider.DEFAULT_SORT_ASCENDING)
         sortAscending[sortType] = sortAscendingSetting
-
-        featureFlagProvider.provide("disable_font_size_config".toFeatureFlagKey())
-            .onDisabledOrUnavailable {
-                fontSizes.load(storage)
-            }
 
         pgpInlineDialogCounter = storage.getInt("pgpInlineDialogCounter", 0)
         pgpSignOnlyDialogCounter = storage.getInt("pgpSignOnlyDialogCounter", 0)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeActivity.kt
@@ -33,6 +33,7 @@ import app.k9mail.feature.launcher.FeatureLauncherActivity
 import app.k9mail.feature.launcher.FeatureLauncherTarget
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.CoreResourceProvider
+import com.fsck.k9.K9.fontSizes
 import com.fsck.k9.Preferences
 import com.fsck.k9.activity.compose.MessageActions
 import com.fsck.k9.controller.MessagingController
@@ -57,12 +58,14 @@ import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountDtoManager
 import net.thunderbird.core.android.common.startup.DatabaseUpgradeInterceptor
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey
+import net.thunderbird.core.featureflag.provider.evaluator.MultiFeatureFlagProviderEvaluator
 import net.thunderbird.core.logging.Logger
-import net.thunderbird.legacy.logging.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.core.preference.SplitViewMode
 import net.thunderbird.core.preference.interaction.PostMarkAsUnreadNavigation
 import net.thunderbird.core.preference.interaction.PostRemoveNavigation
+import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.feature.account.storage.legacy.mapper.LegacyAccountDataMapper
 import net.thunderbird.feature.funding.api.FundingManager
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawer
@@ -74,6 +77,7 @@ import net.thunderbird.feature.search.legacy.api.MessageSearchField
 import net.thunderbird.feature.search.legacy.api.SearchAttribute
 import net.thunderbird.feature.search.legacy.api.SearchCondition
 import net.thunderbird.feature.search.legacy.serialization.LocalMessageSearchSerializer
+import net.thunderbird.legacy.logging.Log
 import org.koin.android.ext.android.inject
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -116,6 +120,8 @@ open class MessageHomeActivity :
     private val databaseUpgradeInterceptor: DatabaseUpgradeInterceptor by inject()
 
     private val foldableStateObserver: FoldableStateObserver by inject { parametersOf(this) }
+    private val featureFlagProvider: MultiFeatureFlagProviderEvaluator by inject()
+    private val storage: Storage by inject()
 
     private lateinit var actionBar: ActionBar
 
@@ -154,6 +160,9 @@ open class MessageHomeActivity :
     @Suppress("ReturnCount")
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        featureFlagProvider.provide(GeneratedFeatureFlagKey.DISABLE_FONT_SIZE_CONFIG)
+            .onDisabledOrUnavailable { fontSizes.load(storage) }
 
         if (databaseUpgradeInterceptor.checkAndHandleUpgrade(this, intent)) {
             finish()


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: 
- Closes #11333
- Closes #11334

RFC / Technical Design (if applicable): [RFC 0004: Add a Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/rfcs/0004-feature-flag-new-architecture.md) / [Technical Design 0002: Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/technical-designs/0002-feature-flag-declarative-catalog.md)

#### Description

This contribution wires both apps with `MultiFeatureFlagProviderEvaluator`, making both apps rely on the new feature flag JSON catalog instead of the old split approach.

Changes included in this PR:
- Wire `MultiFeatureFlagProviderEvaluator` on K9-Mail and Thunderbird
- Change `ConfigBackendFileManager` from using `get()` to `androidApplication()` for `Context` argument
- Change `BaseCatalogFeatureFlagProvider`'s initialize method to a suspending function
- Change `DataSourceCatalogFeatureFlagProvider`'s loadConfig method to a suspending function
- Make sure all `BaseCatalogFeatureFlagProvider`s are properly initialized after `BundledCatalogFeatureFlag` is initialized. 

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).