### PR TITLE
chore: enable memtag for all variants

### DIFF
--- a/app-common/src/main/AndroidManifest.xml
+++ b/app-common/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:enableOnBackInvokedCallback="false"
         android:intentMatchingFlags="enforceIntentFilter"
         tools:targetApi="36"
+        android:memtagMode="async"
         >
 
         <activity

--- a/app-thunderbird/src/daily/AndroidManifest.xml
+++ b/app-thunderbird/src/daily/AndroidManifest.xml
@@ -6,7 +6,6 @@
 
     <application
         tools:ignore="MissingApplicationIcon"
-        android:memtagMode="async"
         >
 
         <!-- This component is disabled by default (if possible). It will be enabled programmatically if necessary. -->

--- a/app-thunderbird/src/debug/AndroidManifest.xml
+++ b/app-thunderbird/src/debug/AndroidManifest.xml
@@ -6,7 +6,6 @@
 
     <application
         tools:ignore="MissingApplicationIcon"
-        android:memtagMode="async"
         >
 
         <!-- This component is disabled by default (if possible). It will be enabled programmatically if necessary. -->


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Resolves #10056 
RFC / Technical Design (if applicable):

#### Description

Re-enabled MTE for all variants. Tested with Google Pixel 10 Pro, Android 17 (CP2A.260805.005); all good.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
