### PR TITLE
fix(account drawer): Improved the handling of text on small displays

### DIFF
--- a/components/ui/bolt/src/commonMain/kotlin/net/thunderbird/components/ui/bolt/atom/text/TextAutoResize.kt
+++ b/components/ui/bolt/src/commonMain/kotlin/net/thunderbird/components/ui/bolt/atom/text/TextAutoResize.kt
@@ -1,0 +1,90 @@
+package net.thunderbird.components.ui.bolt.atom.text
+
+import androidx.compose.foundation.text.TextAutoSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.Text as Material3Text
+
+@Composable
+fun TextAutoResize(
+    text: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle,
+    color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
+    softWrap: Boolean = false,
+    maxLines: Int = 1,
+    minFontSizeModifier: Float = 0.75f,
+) {
+    val minLineHeightSizeModifier = if (minFontSizeModifier * 1.1f < 1.0f) {
+        minFontSizeModifier * 1.1f
+    } else {
+        1.0f
+    }
+    Material3Text(
+        text = text,
+        modifier = modifier,
+        style = style.merge(
+            color = color,
+            textAlign = textAlign ?: TextAlign.Unspecified,
+            lineHeight = if (maxLines > 0) {
+                style.lineHeight * minLineHeightSizeModifier
+            } else {
+                style.lineHeight
+            },
+        ),
+        softWrap = softWrap,
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
+        autoSize = TextAutoSize.StepBased(
+            minFontSize = style.fontSize * minFontSizeModifier,
+            maxFontSize = style.fontSize,
+            stepSize = 0.1.sp,
+        ),
+    )
+}
+
+@Composable
+fun TextAutoResize(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    style: TextStyle,
+    color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
+    softWrap: Boolean = false,
+    maxLines: Int = 1,
+    minFontSizeModifier: Float = 0.75f,
+) {
+    val minLineHeightSizeModifier = if (minFontSizeModifier * 1.1f < 1.0f) {
+        minFontSizeModifier * 1.1f
+    } else {
+        1.0f
+    }
+    Material3Text(
+        text = text,
+        modifier = modifier,
+        style = style.merge(
+            color = color,
+            textAlign = textAlign ?: TextAlign.Unspecified,
+            lineHeight = if (maxLines > 0) {
+                style.lineHeight * minLineHeightSizeModifier
+            } else {
+                style.lineHeight
+            },
+        ),
+        softWrap = softWrap,
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
+        autoSize = TextAutoSize.StepBased(
+            minFontSize = style.fontSize * minFontSizeModifier,
+            maxFontSize = style.fontSize,
+            stepSize = 0.1.sp,
+        ),
+    )
+}

--- a/components/ui/bolt/src/commonMain/kotlin/net/thunderbird/components/ui/bolt/atom/text/TextBodyLargeAutoResize.kt
+++ b/components/ui/bolt/src/commonMain/kotlin/net/thunderbird/components/ui/bolt/atom/text/TextBodyLargeAutoResize.kt
@@ -8,19 +8,19 @@ import androidx.compose.ui.text.style.TextAlign
 import net.thunderbird.components.ui.bolt.theme.BoltTheme
 
 @Composable
-fun TextDisplayMediumAutoResize(
+fun TextBodyLargeAutoResize(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
     textAlign: TextAlign? = null,
     softWrap: Boolean = false,
     maxLines: Int = 1,
-    minFontSizeModifier: Float = 0.35f,
+    minFontSizeModifier: Float = 0.75f,
 ) {
     TextAutoResize(
         text = text,
         modifier = modifier,
-        style = BoltTheme.typography.displayMedium,
+        style = BoltTheme.typography.bodyLarge,
         color = color,
         textAlign = textAlign,
         softWrap = softWrap,
@@ -30,19 +30,19 @@ fun TextDisplayMediumAutoResize(
 }
 
 @Composable
-fun TextDisplayMediumAutoResize(
+fun TextBodyLargeAutoResize(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
     textAlign: TextAlign? = null,
     softWrap: Boolean = false,
     maxLines: Int = 1,
-    minFontSizeModifier: Float = 0.35f,
+    minFontSizeModifier: Float = 0.75f,
 ) {
     TextAutoResize(
         text = text,
         modifier = modifier,
-        style = BoltTheme.typography.displayMedium,
+        style = BoltTheme.typography.bodyLarge,
         color = color,
         textAlign = textAlign,
         softWrap = softWrap,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItem.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountListItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.withStyle
 import net.thunderbird.components.ui.bolt.atom.icon.Icon
 import net.thunderbird.components.ui.bolt.atom.icon.Icons
 import net.thunderbird.components.ui.bolt.atom.text.TextBodyLarge
+import net.thunderbird.components.ui.bolt.atom.text.TextBodyLargeAutoResize
 import net.thunderbird.components.ui.bolt.atom.text.TextBodyMedium
 import net.thunderbird.components.ui.bolt.organism.drawer.NavigationDrawerItem
 import net.thunderbird.components.ui.bolt.theme.BoltTheme
@@ -84,12 +85,14 @@ private fun AccountLabel(
         verticalArrangement = Arrangement.spacedBy(BoltTheme.spacings.half),
         modifier = modifier.fillMaxWidth(),
     ) {
-        TextBodyLarge(
+        TextBodyLargeAutoResize(
             text = buildAnnotatedString {
                 withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
                     append(name)
                 }
             },
+            softWrap = true,
+            maxLines = 2,
         )
         if (account is MailDisplayAccount && account.name != account.email) {
             TextBodyMedium(

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/account/AccountView.kt
@@ -28,10 +28,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.LayoutDirection
 import net.thunderbird.components.ui.bolt.atom.text.TextBodyLarge
+import net.thunderbird.components.ui.bolt.atom.text.TextBodyLargeAutoResize
 import net.thunderbird.components.ui.bolt.atom.text.TextBodyMedium
+import net.thunderbird.components.ui.bolt.atom.text.TextDisplayMediumAutoResize
 import net.thunderbird.components.ui.bolt.theme.BoltTheme
 import net.thunderbird.feature.navigation.drawer.dropdown.R
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
@@ -111,12 +114,14 @@ private fun RowScope.AccountSelectedView(
                     .weight(1f),
             ) {
                 val name = getDisplayAccountName(targetAccount)
-                TextBodyLarge(
+                TextBodyLargeAutoResize(
                     text = buildAnnotatedString {
                         withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
                             append(name)
                         }
                     },
+                    softWrap = true,
+                    maxLines = 2,
                 )
                 if (targetAccount is MailDisplayAccount && targetAccount.name != targetAccount.email) {
                     TextBodyMedium(


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #10229 
RFC / Technical Design (if applicable): N/A

#### Description

#10229 showed an issue with the Thunderbird splash screen on a small display. This was fixed in [this PR](https://github.com/thunderbird/thunderbird-android/pull/11203). By adding more resizable text composables, including a generic one we could use for other text types, we can dramatically improve the appearance of the text for the account names in the account drawer. Where text previously could go on 3 lines or more, becoming an overlapping illegible mess, they will now be confined to two lines and the font size will resize, within reason, to show the text better.  

#### Screen Shots

<img width="1000" height="763" alt="smallScreenAccountNameImprovements" src="https://github.com/user-attachments/assets/036d3d2b-b8f6-4136-996f-e95a441243aa" />


## AI Disclosure

Select **one** of the following (mandatory)

- [X] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [X] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [X] This contribution is in Kotlin where possible
- [X] This contribution does not use merge commits
- [X] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [X] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [X] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [X] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [X] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
