### PR TITLE
fix(identity): use correct sender identity for non-draft messages edited as new messages

### DIFF
--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountDto.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountDto.kt
@@ -548,7 +548,12 @@ open class LegacyAccountDto(
 
     @Synchronized
     fun findIdentity(address: Address): Identity? {
+        // Prefer to match by email and name.
+        // Fall back to email only if no identity's name matches (e.g. a renamed identity).
         return identities.find { identity ->
+            identity.email.equals(address.address, ignoreCase = true) &&
+                identity.name.equals(address.personal, ignoreCase = true)
+        } ?: identities.find { identity ->
             identity.email.equals(address.address, ignoreCase = true)
         }
     }

--- a/legacy/core/src/main/java/com/fsck/k9/helper/IdentityHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/helper/IdentityHelper.kt
@@ -37,4 +37,22 @@ object IdentityHelper {
 
         return recipient ?: account.getIdentity(0)
     }
+
+    /**
+     * Find the identity a message was sent from.
+     *
+     * @param account
+     * The account the message belongs to.
+     * @param message
+     * The message to get the sender from.
+     *
+     * @return The identity the message was sent from, or `null` if it couldn't be determined which
+     * identity sent this message.
+     *
+     * @see LegacyAccountDto.findIdentity
+     */
+    @JvmStatic
+    fun getSenderIdentityFromMessage(account: LegacyAccountDto, message: Message): Identity? {
+        return message.from.firstNotNullOfOrNull { address -> account.findIdentity(address) }
+    }
 }

--- a/legacy/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
@@ -2,6 +2,9 @@ package com.fsck.k9.helper
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.prop
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.Message.RecipientType
@@ -115,6 +118,33 @@ class IdentityHelperTest : RobolectricTest() {
         assertThat(identity.email).isEqualTo(DEFAULT_ADDRESS)
     }
 
+    @Test
+    fun getSenderIdentityFromMessage_withKnownSender_returnsMatchingIdentity() {
+        val message = messageWithSender(IDENTITY_1_ADDRESS)
+
+        val identity = IdentityHelper.getSenderIdentityFromMessage(account, message)
+
+        assertThat(identity).isNotNull().prop(Identity::email).isEqualTo(IDENTITY_1_ADDRESS)
+    }
+
+    @Test
+    fun getSenderIdentityFromMessage_withUnknownSender_returnsNull() {
+        val message = messageWithSender("unrelated@example.org")
+
+        val identity = IdentityHelper.getSenderIdentityFromMessage(account, message)
+
+        assertThat(identity).isNull()
+    }
+
+    @Test
+    fun getSenderIdentityFromMessage_withoutFromHeader_returnsNull() {
+        val emptyMessage = MimeMessage()
+
+        val identity = IdentityHelper.getSenderIdentityFromMessage(account, emptyMessage)
+
+        assertThat(identity).isNull()
+    }
+
     private fun createDummyAccount() = LegacyAccountDto(UUID.randomUUID().toString()).apply {
         replaceIdentities(
             listOf(
@@ -139,6 +169,12 @@ class IdentityHelperTest : RobolectricTest() {
                 val headerName = recipientType.toHeaderName()
                 addHeader(headerName, AddressHeaderBuilder.createHeaderValue(arrayOf(Address(email))))
             }
+        }
+    }
+
+    private fun messageWithSender(email: String): Message {
+        return MimeMessage().apply {
+            setFrom(Address(email))
         }
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1560,6 +1560,15 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
 
         if (identityHeaders.length > 0 && identityHeaders[0] != null) {
             k9identity = IdentityHeaderParser.parse(identityHeaders[0]);
+        } else {
+            // This message has no identity metadata because it wasn't saved as a draft. That's
+            // true of any message we sent (including one stuck in the Outbox after a failed
+            // send), and also of any message we received. Fall back to matching the message's
+            // sender against the account's identities.
+            Identity senderIdentity = IdentityHelper.getSenderIdentityFromMessage(account, message);
+            if (senderIdentity != null) {
+                identity = senderIdentity;
+            }
         }
 
         Identity newIdentity = new Identity();


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: #11348
RFC / Technical Design (if applicable):

#### Description

This PR fixes issue #11348 by getting the correct sender identity for non-draft messages edited as new messages. It: 
- Adds an else block in the `processDraftMessage` method of `MessageCompose` which assigns the correct sender identity
- Creates a new `getSenderIdentityFromMessage` function in `IdentityHelper`
- Modifies the existing `findIdentity` method in `LegacyAccountDto` to first match an identity by email and name before matching by only email
- Adds unit tests for the new `IdentityHelper` function

Problem:
Messages edited as new messages go through the same code path as draft messages opened for editing, starting from the call to `MessageActions.actionEditDraft` they both make (see `openMessage` and `onEditAsNewMessage` in `MessageHomeActivity`). At some point after this call they both go through the `processDraftMessage` method in `MessageCompose`. Here is where the problem is. In `processDraftMessage` the identity metadata is extracted from the K9 identity header if it's attached to the message being processed. This K9 identity header is only attached to messages saved as drafts which means that since this was the only way of getting the identity metadata, in `processDraftMessage`, non-draft messages ended up using the default identity set in the `onCreate` method of `MessageCompose` (line 497).

Approach:
I added an else block to the if statement in `processDraftMessage` (line 1561) that basically checks if there's an available k9 identity header. In this else block a call to a new function I wrote, `IdentityHelper.getSenderIdentityFromMessage`, is made. This function takes in the account the message belongs to and the message itself as arguments. It then gets the `Address` object corresponding to the sender of the message and passes it to the updated `findIdentity` method which returns the matching identity. The `identity` field in `MessageCompose` is set to this returned matching identity in the else block and from there the rest of the code takes care of updating the screen so that the right identity metadata is displayed.

I noticed the `findIdentity` method didn't take into account the `personal` field of the passed in `Address` object (corresponds to the `name` field of an `Identity` object), so I updated it so that it first tries to match an identity to both email and name, and if that doesn't work then it finds an identity that just matches the email. At first I removed matching by email only but that failed existing tests, and I later found that names for identities aren't required, and that identity names can be edited. That's why I decided to leave the email only matching because it's necessary. For the case where identity names can be edited, the default identity is still returned if the edited identity shares the same email as the default identity. I don't know if that matters, but the only way to get around that with my current approach would be if the `Address` object corresponding to the sender of the message contained some sort of ID that doesn't change. Of course the `Identity` objects would also need this same kind of ID in order for matching to work.

Tests:
I created 3 new tests and a private helper function, in the existing `IdentityHelperTest` file, for the new `getSenderIdentityFromMessage` function which also happen to indirectly test the updated `findIdentity` method. These tests follow the same style of tests in the existing test file, but I can update them to follow the AAA pattern mentioned in the test guide.

I couldn't find an existing test file for `LegacyAccountDto` to directly test `findIdentity` after updating it. I can also add tests for it, but since I couldn't find them I first want to make sure I'm not doing anything wrong. Similarly, I couldn't find existing tests for the `processDraftMessage` method of `MessageCompose`, but I'm not exactly sure how the testing would work there.

Notes:
- The update to `findIdentity` also fixed a bug where clicking the message header of an email you sent with a second identity (sharing the same email as the default identity) showed a bottom sheet displaying the default identity
- The new code in `MessageCompose` solves this issue #11348 which happens to occur for any message edited as a new message, not just for failed messages in the Outbox which are edited as new messages.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
