### PR TITLE
fix: keep dark-mode message text readable on light sender backgrounds

### DIFF
--- a/feature/mail/message/reader/impl/src/androidHostTest/kotlin/net/thunderbird/feature/mail/message/reader/impl/css/DefaultGlobalCssStyleProviderTest.kt
+++ b/feature/mail/message/reader/impl/src/androidHostTest/kotlin/net/thunderbird/feature/mail/message/reader/impl/css/DefaultGlobalCssStyleProviderTest.kt
@@ -2,6 +2,7 @@ package net.thunderbird.feature.mail.message.reader.impl.css
 
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.doesNotContain
 import kotlin.test.Test
 import net.thunderbird.core.common.mail.html.HtmlSettings
 import net.thunderbird.feature.mail.message.reader.api.css.CssClassNameProvider
@@ -10,15 +11,41 @@ import net.thunderbird.feature.mail.message.reader.api.css.CssVariableNameProvid
 class DefaultGlobalCssStyleProviderTest {
 
     @Test
+    fun `style should advertise light only color scheme when dark mode is enabled`() {
+        // Arrange
+        val testSubject = createTestSubject()
+
+        // Act
+        val style = testSubject.create(createHtmlSettings(useDarkMode = true)).style
+
+        // Assert
+        assertThat(style).contains(":root { color-scheme: only light; }")
+    }
+
+    @Test
+    fun `style should not override color scheme when dark mode is disabled`() {
+        // Arrange
+        val testSubject = createTestSubject()
+
+        // Act
+        val style = testSubject.create(createHtmlSettings(useDarkMode = false)).style
+
+        // Assert
+        assertThat(style).doesNotContain("color-scheme")
+    }
+
+    @Test
     fun `style should set main content box sizing to border box`() {
         // Arrange
         val testSubject = createTestSubject()
 
         // Act
-        val style = testSubject.create(createHtmlSettings()).style
+        val styles = createStylesForBothThemeConfigurations(testSubject)
 
         // Assert
-        assertThat(style).contains("box-sizing: border-box")
+        styles.forEach { style ->
+            assertThat(style).contains("box-sizing: border-box")
+        }
     }
 
     @Test
@@ -27,12 +54,16 @@ class DefaultGlobalCssStyleProviderTest {
         val testSubject = createTestSubject()
 
         // Act
-        val style = testSubject.create(createHtmlSettings()).style
-        val mainContentRule = style.mainContentRule()
+        val styles = createStylesForBothThemeConfigurations(testSubject)
 
         // Assert
-        assertThat(mainContentRule).contains("width: 100%")
-        assertThat(mainContentRule).contains("padding: 0 8px")
+        styles.forEach { style ->
+            val mainContentRule = style.mainContentRule()
+
+            assertThat(mainContentRule).contains("width: 100%")
+            assertThat(mainContentRule).contains("overflow-wrap: break-word")
+            assertThat(mainContentRule).contains("padding: 0 8px")
+        }
     }
 
     @Test
@@ -41,10 +72,45 @@ class DefaultGlobalCssStyleProviderTest {
         val testSubject = createTestSubject()
 
         // Act
-        val style = testSubject.create(createHtmlSettings()).style
+        val styles = createStylesForBothThemeConfigurations(testSubject)
 
         // Assert
-        assertThat(style).contains("white-space: pre-wrap")
+        styles.forEach { style ->
+            assertThat(style).contains("white-space: pre-wrap")
+        }
+    }
+
+    @Test
+    fun `style should preserve selectable content`() {
+        // Arrange
+        val testSubject = createTestSubject()
+
+        // Act
+        val styles = createStylesForBothThemeConfigurations(testSubject)
+
+        // Assert
+        styles.forEach { style ->
+            assertThat(style).contains("\n    user-select: auto;\n")
+            assertThat(style).contains("-webkit-user-select: auto")
+        }
+    }
+
+    @Test
+    fun `style should preserve blockquote styling`() {
+        // Arrange
+        val testSubject = createTestSubject()
+
+        // Act
+        val styles = createStylesForBothThemeConfigurations(testSubject)
+
+        // Assert
+        styles.forEach { style ->
+            assertThat(style).contains("margin: auto 0 auto 0.8ex !important")
+            assertThat(style).contains("padding-left: 1ex !important")
+            assertThat(style).contains("border-left-width: 1px !important")
+            assertThat(style).contains("border-left-style: solid !important")
+            assertThat(style).contains("border-left-color: var(--blockquote-default-border-left-color, #ccc)")
+        }
     }
 
     private fun createTestSubject(): DefaultGlobalCssStyleProvider.Factory {
@@ -54,9 +120,18 @@ class DefaultGlobalCssStyleProviderTest {
         )
     }
 
-    private fun createHtmlSettings(): HtmlSettings {
+    private fun createStylesForBothThemeConfigurations(
+        testSubject: DefaultGlobalCssStyleProvider.Factory,
+    ): List<String> {
+        return listOf(
+            testSubject.create(createHtmlSettings(useDarkMode = false)).style,
+            testSubject.create(createHtmlSettings(useDarkMode = true)).style,
+        )
+    }
+
+    private fun createHtmlSettings(useDarkMode: Boolean): HtmlSettings {
         return HtmlSettings(
-            useDarkMode = false,
+            useDarkMode = useDarkMode,
             useFixedWidthFont = false,
         )
     }

--- a/feature/mail/message/reader/impl/src/commonMain/kotlin/net/thunderbird/feature/mail/message/reader/impl/css/DefaultGlobalCssStyleProvider.kt
+++ b/feature/mail/message/reader/impl/src/commonMain/kotlin/net/thunderbird/feature/mail/message/reader/impl/css/DefaultGlobalCssStyleProvider.kt
@@ -10,10 +10,12 @@ import org.intellij.lang.annotations.Language
 internal class DefaultGlobalCssStyleProvider private constructor(
     cssClassNameProvider: CssClassNameProvider,
     cssVariableNameProvider: CssVariableNameProvider,
+    useDarkMode: Boolean,
 ) : GlobalCssStyleProvider {
     @Language("HTML")
     override val style: String = """
         |<style>
+        |${if (useDarkMode) "  :root { color-scheme: only light; }" else ""}
         |  body { font-size: 0.9rem; }
         |  .clear:after {
         |    content: "";
@@ -51,6 +53,7 @@ internal class DefaultGlobalCssStyleProvider private constructor(
         override fun create(htmlSettings: HtmlSettings): CssStyleProvider = DefaultGlobalCssStyleProvider(
             cssClassNameProvider = cssClassNameProvider,
             cssVariableNameProvider = cssVariableNameProvider,
+            useDarkMode = htmlSettings.useDarkMode,
         )
     }
 }


### PR DESCRIPTION
## Contribution Summary

Amazon Pay messages can render white default text over an explicitly white message container when Thunderbird for Android uses dark mode, leaving most content visible only when selected. The message advertises both light and dark color-scheme support while retaining light inline backgrounds, so WebView treats its default foreground as dark-mode content without consistently transforming the sender-defined background.

This updates `DefaultGlobalCssStyleProvider` to read `HtmlSettings.useDarkMode` and, only in dark mode, emit a document-level rule advertising a light-only author color scheme, so the existing WebView algorithmic-darkening path transforms foregrounds and backgrounds as one unit. The rule is document-scoped and carries no Amazon-specific selectors, colors, or markup, so any message that claims dark-mode support while keeping light containers gets the same treatment. Light mode emits no color-scheme override, and the existing global layout, selection, blockquote, and wrapping rules are unchanged.

Closes #11381

#### Description

Three added lines in `DefaultGlobalCssStyleProvider` (`commonMain`), plus tests covering the dark-mode and light-mode branches in `DefaultGlobalCssStyleProviderTest`.

#### Screen Shots

N/A: I could not capture device screenshots for this change. The effect is a document-level `color-scheme` declaration in the generated reader CSS; the added tests assert the emitted CSS for both the dark-mode and light-mode branches.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [x] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla's Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [ ] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI). Not verified locally: `spotlessCheck` was not run in my environment, so I am relying on CI for this.
- [ ] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI). Not verified locally: `testDebugUnitTest` was not run in my environment, so I am relying on CI for this.
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [ ] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR). Not claimed: no RFC/ADR was filed for this bug fix; happy to follow up if one is expected.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).

AI was used for assistance.
