### PR TITLE
feat: add progress indicator for encrypting messages

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -207,6 +207,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
             "com.fsck.k9.activity.MessageCompose.activeInAppNotifications";
 
     private static final String FRAGMENT_WAITING_FOR_ATTACHMENT = "waitingForAttachment";
+    private static final String FRAGMENT_ENCRYPTING_MESSAGE = "encryptingMessage";
 
     private static final int MSG_PROGRESS_ON = 1;
     private static final int MSG_PROGRESS_OFF = 2;
@@ -922,7 +923,34 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
             sendMessageHasBeenTriggered = true;
             changesMadeSinceLastSave = false;
             setProgressBarIndeterminateVisibility(true);
+            showEncryptedMessageProgressIndicatorIfNeeded();
             currentMessageBuilder.buildAsync(this);
+        }
+    }
+
+    private void showEncryptedMessageProgressIndicatorIfNeeded() {
+        ComposeCryptoStatus cryptoStatus = recipientPresenter.getCurrentCachedCryptoStatus();
+        boolean hasAttachments = !attachmentPresenter.getAttachments().isEmpty();
+        if (cryptoStatus == null || !cryptoStatus.isEncryptionEnabled() || !hasAttachments) {
+            return;
+        }
+
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        if (fragmentManager.findFragmentByTag(FRAGMENT_ENCRYPTING_MESSAGE) != null) {
+            return;
+        }
+
+        ProgressDialogFragment fragment = ProgressDialogFragment.Companion.newInstance(
+                getString(R.string.fetching_attachment_dialog_title_send),
+                getString(R.string.message_compose_encrypting_message));
+        fragment.setCancelable(false);
+        fragment.show(fragmentManager, FRAGMENT_ENCRYPTING_MESSAGE);
+    }
+
+    private void dismissEncryptedMessageProgressIndicator() {
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(FRAGMENT_ENCRYPTING_MESSAGE);
+        if (fragment instanceof ProgressDialogFragment) {
+            ((ProgressDialogFragment) fragment).dismiss();
         }
     }
 
@@ -978,6 +1006,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
                             "this is an illegal state!");
                     return;
                 }
+                showEncryptedMessageProgressIndicatorIfNeeded();
                 currentMessageBuilder.onActivityResult(requestCode, resultCode, data, this);
                 return;
             }
@@ -1785,6 +1814,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
 
     @Override
     public void onMessageBuildSuccess(MimeMessage message, boolean isDraft) {
+        dismissEncryptedMessageProgressIndicator();
         String plaintextSubject =
                 (currentMessageBuilder instanceof PgpMessageBuilder) ? currentMessageBuilder.getSubject() : null;
 
@@ -1809,6 +1839,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
 
     @Override
     public void onMessageBuildCancel() {
+        dismissEncryptedMessageProgressIndicator();
         sendMessageHasBeenTriggered = false;
         currentMessageBuilder = null;
         setProgressBarIndeterminateVisibility(false);
@@ -1816,6 +1847,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
 
     @Override
     public void onMessageBuildException(MessagingException me) {
+        dismissEncryptedMessageProgressIndicator();
         Log.e(me, "Error sending message");
         Toast.makeText(MessageCompose.this,
                 getString(R.string.send_failed_reason, me.getLocalizedMessage()), Toast.LENGTH_LONG).show();
@@ -1826,6 +1858,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
 
     @Override
     public void onMessageBuildReturnPendingIntent(PendingIntent pendingIntent, int requestCode) {
+        dismissEncryptedMessageProgressIndicator();
         requestCode |= REQUEST_MASK_MESSAGE_BUILDER;
         try {
             OpenPgpIntentStarter.startIntentSenderForResult(this, pendingIntent.getIntentSender(), requestCode);

--- a/legacy/ui/legacy/src/main/res/values-de/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-de/strings.xml
@@ -654,6 +654,7 @@
     <string name="fetching_attachment_dialog_title_send">Nachricht senden</string>
     <string name="fetching_attachment_dialog_title_save">Entwurf speichern</string>
     <string name="fetching_attachment_dialog_message">Anhang wird heruntergeladen…</string>
+    <string name="message_compose_encrypting_message">Nachricht verschlüsseln…</string>
     <!--Note: This references message_view_download_remainder-->
     <string name="preview_encrypted">*Verschlüsselt*</string>
     <string name="add_from_contacts">Vom Adressbuch hinzufügen</string>

--- a/legacy/ui/legacy/src/main/res/values-de/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-de/strings.xml
@@ -654,7 +654,6 @@
     <string name="fetching_attachment_dialog_title_send">Nachricht senden</string>
     <string name="fetching_attachment_dialog_title_save">Entwurf speichern</string>
     <string name="fetching_attachment_dialog_message">Anhang wird heruntergeladen…</string>
-    <string name="message_compose_encrypting_message">Nachricht verschlüsseln…</string>
     <!--Note: This references message_view_download_remainder-->
     <string name="preview_encrypted">*Verschlüsselt*</string>
     <string name="add_from_contacts">Vom Adressbuch hinzufügen</string>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -904,6 +904,7 @@
     <string name="fetching_attachment_dialog_title_send">Sending message</string>
     <string name="fetching_attachment_dialog_title_save">Saving draft</string>
     <string name="fetching_attachment_dialog_message">Fetching attachment…</string>
+    <string name="message_compose_encrypting_message">Encrypting message…</string>
 
     <!-- Note: This references message_view_download_remainder -->
     <string name="preview_encrypted">*Encrypted*</string>


### PR DESCRIPTION
**Thank you for your contribution!**

## Contribution Summary

Linked Issue/Ticket: #5763
RFC / Technical Design (if applicable):

#### Description

When sending images (> 5 MB) with enabled PGP encryption, it takes a while until the mail is sent, but no progress is reported to the user. This is misleading, as nothing happens on the screen until the email has been sent. This change introduces a simple progress indicator while encryption is running.

#### Screen Shots
<img width="349" height="446" alt="Unbenannt" src="https://github.com/user-attachments/assets/e022c5e0-e043-46d9-8719-eb3a6d443d69" />


## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
