### PR TITLE
l10n: add weblate placeholder

### DIFF
--- a/config/weblate/README.md
+++ b/config/weblate/README.md
@@ -1,0 +1,15 @@
+# Weblate configuration
+
+This directory contains resource files used only to configure Weblate.
+
+The Compose resource at:
+
+```text
+composeResources/values/values.xml
+```
+
+provides a minimal base-language file for a Weblate base component. It exists to work around Weblate’s requirement for 
+a valid source file when creating a component whose configuration is reused by other components.
+
+The resource is not part of any application module and must not be included in a build. Its string is marked 
+with `translatable="false"` because it is only a configuration placeholder.

--- a/config/weblate/composeResources/values/strings.xml
+++ b/config/weblate/composeResources/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="weblate_base_component" translatable="false">Weblate base component</string>
+</resources>


### PR DESCRIPTION
## Contribution Summary

#### Description

Add placeholder resource for Weblate. This helps with the new setup for Weblate and the [thunderbird-android-l10n](https://github.com/thunderbird/thunderbird-android-l10n) repository.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.
