### PR TITLE
 chore(feature-flag): connect Secret Debug Screen with new Feature Flag architecture

### DIFF
--- a/app-k9mail/src/debug/kotlin/app/k9mail/dev/DebugConfig.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/dev/DebugConfig.kt
@@ -3,14 +3,8 @@ package app.k9mail.dev
 import app.k9mail.autodiscovery.api.AutoDiscovery
 import app.k9mail.autodiscovery.demo.DemoAutoDiscovery
 import net.thunderbird.backend.api.BackendFactory
-import net.thunderbird.core.featureflag.DefaultFeatureFlagOverrides
-import net.thunderbird.core.featureflag.FeatureFlagOverrides
-import net.thunderbird.core.featureflag.inject.qualifier.InjectQualifier
-import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
-import net.thunderbird.core.featureflag.provider.RuntimeDebugOverrideFeatureFlagProvider
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
-import org.koin.plugin.module.dsl.bind
 
 fun Module.developmentModuleAdditions() {
     single {
@@ -24,11 +18,4 @@ fun Module.developmentModuleAdditions() {
     single<List<AutoDiscovery>>(named("extraAutoDiscoveries")) {
         listOf(DemoAutoDiscovery())
     }
-    single<FeatureFlagOverrides> { DefaultFeatureFlagOverrides() }
-    single<CatalogFeatureFlagProvider>(named(InjectQualifier.InMemory)) {
-        RuntimeDebugOverrideFeatureFlagProvider(
-            configStore = get(),
-            logger = get(),
-        )
-    }.bind(RuntimeDebugOverrideFeatureFlagProvider::class)
 }

--- a/app-k9mail/src/main/kotlin/app/k9mail/featureflag/K9MailFeatureFlagModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/featureflag/K9MailFeatureFlagModule.kt
@@ -1,13 +1,26 @@
 package app.k9mail.featureflag
 
 import net.thunderbird.core.featureflag.inject.featureFlagModule
+import net.thunderbird.core.featureflag.inject.qualifier.InjectQualifier
 import net.thunderbird.core.featureflag.model.AppVariantOverrides
 import net.thunderbird.core.featureflag.model.EmptyAppVariantOverride
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.RuntimeDebugOverrideFeatureFlagProvider
 import net.thunderbird.core.featureflag.serialization.FlagRegistryOverrideSerializer
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val k9MailFeatureFlagModule = module {
     includes(featureFlagModule)
     factory<AppVariantOverrides.Factory> { K9MailOverrides.Factory }
     factory { FlagRegistryOverrideSerializer(k9Factory = get(), thunderbirdFactory = EmptyAppVariantOverride) }
+    single {
+        RuntimeDebugOverrideFeatureFlagProvider(
+            configStore = get(),
+            logger = get(),
+        )
+    }
+    single<CatalogFeatureFlagProvider>(named(InjectQualifier.InMemory)) {
+        get<RuntimeDebugOverrideFeatureFlagProvider>()
+    }
 }

--- a/app-thunderbird/src/debug/kotlin/net/thunderbird/android/dev/DebugConfig.kt
+++ b/app-thunderbird/src/debug/kotlin/net/thunderbird/android/dev/DebugConfig.kt
@@ -3,14 +3,8 @@ package net.thunderbird.android.dev
 import app.k9mail.autodiscovery.api.AutoDiscovery
 import app.k9mail.autodiscovery.demo.DemoAutoDiscovery
 import net.thunderbird.backend.api.BackendFactory
-import net.thunderbird.core.featureflag.DefaultFeatureFlagOverrides
-import net.thunderbird.core.featureflag.FeatureFlagOverrides
-import net.thunderbird.core.featureflag.inject.qualifier.InjectQualifier
-import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
-import net.thunderbird.core.featureflag.provider.RuntimeDebugOverrideFeatureFlagProvider
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
-import org.koin.plugin.module.dsl.bind
 
 fun Module.developmentModuleAdditions() {
     single {
@@ -24,11 +18,4 @@ fun Module.developmentModuleAdditions() {
     single<List<AutoDiscovery>>(named("extraAutoDiscoveries")) {
         listOf(DemoAutoDiscovery())
     }
-    single<FeatureFlagOverrides> { DefaultFeatureFlagOverrides() }
-    single<CatalogFeatureFlagProvider>(named(InjectQualifier.InMemory)) {
-        RuntimeDebugOverrideFeatureFlagProvider(
-            configStore = get(),
-            logger = get(),
-        )
-    }.bind(RuntimeDebugOverrideFeatureFlagProvider::class)
 }

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/featureflag/ThunderbirdFeatureFlagModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/featureflag/ThunderbirdFeatureFlagModule.kt
@@ -1,13 +1,26 @@
 package net.thunderbird.android.featureflag
 
 import net.thunderbird.core.featureflag.inject.featureFlagModule
+import net.thunderbird.core.featureflag.inject.qualifier.InjectQualifier
 import net.thunderbird.core.featureflag.model.AppVariantOverrides
 import net.thunderbird.core.featureflag.model.EmptyAppVariantOverride
+import net.thunderbird.core.featureflag.provider.CatalogFeatureFlagProvider
+import net.thunderbird.core.featureflag.provider.RuntimeDebugOverrideFeatureFlagProvider
 import net.thunderbird.core.featureflag.serialization.FlagRegistryOverrideSerializer
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val thunderbirdFeatureFlagModule = module {
     includes(featureFlagModule)
     factory<AppVariantOverrides.Factory> { ThunderbirdOverrides.Factory }
     factory { FlagRegistryOverrideSerializer(k9Factory = EmptyAppVariantOverride, thunderbirdFactory = get()) }
+    single {
+        RuntimeDebugOverrideFeatureFlagProvider(
+            configStore = get(),
+            logger = get(),
+        )
+    }
+    single<CatalogFeatureFlagProvider>(named(InjectQualifier.InMemory)) {
+        get<RuntimeDebugOverrideFeatureFlagProvider>()
+    }
 }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/inject/FeatureFlagModule.kt
@@ -15,7 +15,6 @@ import net.thunderbird.core.featureflag.serialization.FeatureFlagCatalogJsonPars
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
-import org.koin.plugin.module.dsl.bind
 
 val featureFlagModule = module {
     factory<FeatureFlagCatalogJsonParser> { DefaultFeatureFlagCatalogJsonParser(registrySerializer = get()) }
@@ -25,15 +24,20 @@ val featureFlagModule = module {
             provider = get(),
         )
     }
-    single<CatalogFeatureFlagProvider>(named(InjectQualifier.Local)) {
+    single {
         BundledCatalogFeatureFlagProvider(
             dataSource = get<FeatureFlagCatalogDataSource>(
                 named(InjectQualifier.Local),
             ),
             logger = get(),
         )
-    }.bind(BundledCatalogFeatureFlagProvider::class)
-    single<BundledFeatureFlagDefaults> { get<BundledCatalogFeatureFlagProvider>() }
+    }
+    single<CatalogFeatureFlagProvider>(named(InjectQualifier.Local)) {
+        get<BundledCatalogFeatureFlagProvider>()
+    }
+    single<BundledFeatureFlagDefaults> {
+        get<BundledCatalogFeatureFlagProvider>()
+    }
     single<MultiFeatureFlagProviderEvaluator> {
         DefaultMultiFeatureFlagProviderEvaluator(
             providers = buildList {

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProvider.kt
@@ -3,8 +3,10 @@ package net.thunderbird.core.featureflag.provider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import net.thunderbird.core.featureflag.FeatureFlagKey
@@ -44,7 +46,7 @@ class RuntimeDebugOverrideFeatureFlagProvider(
         )
 
     override var resolvedFlags: FlagOverrides = data.value.overrides
-    val overrides: FlagOverrides get() = resolvedFlags
+    val overrides: Flow<FlagOverrides> = data.map { it.overrides }
 
     override suspend fun initialize(initialContext: FeatureFlagContext) {
         super.initialize(initialContext)

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/provider/evaluator/MultiFeatureFlagProviderEvaluator.kt
@@ -32,7 +32,7 @@ interface MultiFeatureFlagProviderEvaluator : CatalogFeatureFlagProvider {
 internal class DefaultMultiFeatureFlagProviderEvaluator(
     private val providers: List<CatalogFeatureFlagProvider>,
     private val logger: Logger,
-    private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
+    mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : BaseCatalogFeatureFlagProvider(
     providerName = "multi_provider",
     logger = logger,

--- a/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProviderTest.kt
+++ b/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/provider/RuntimeDebugOverrideFeatureFlagProviderTest.kt
@@ -1,5 +1,6 @@
 package net.thunderbird.core.featureflag.provider
 
+import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.containsOnly
@@ -93,9 +94,12 @@ class RuntimeDebugOverrideFeatureFlagProviderTest {
             testSubject.setOverride(key = MESSAGE_VIEW_ACTION_EXPORT_EML, enabled = true)
 
             // Assert
-            assertThat(configStore.current.overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)
-            assertThat(testSubject.overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)
-            assertThat(testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)).isEqualTo(FeatureFlagResult.Enabled)
+            testSubject.overrides.test {
+                val overrides = awaitItem()
+                assertThat(configStore.current.overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)
+                assertThat(overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)
+                assertThat(testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)).isEqualTo(FeatureFlagResult.Enabled)
+            }
         }
 
     @Test
@@ -153,10 +157,13 @@ class RuntimeDebugOverrideFeatureFlagProviderTest {
             testSubject.clearAllOverrides()
 
             // Assert
-            assertThat(configStore.current.overrides).isEmpty()
-            assertThat(configStore.current.targetingKey).isEqualTo(TARGETING_UUID)
-            assertThat(testSubject.overrides).isEmpty()
-            assertThat(testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)).isEqualTo(FeatureFlagResult.Unavailable)
+            testSubject.overrides.test {
+                val overrides = awaitItem()
+                assertThat(configStore.current.overrides).isEmpty()
+                assertThat(configStore.current.targetingKey).isEqualTo(TARGETING_UUID)
+                assertThat(overrides).isEmpty()
+                assertThat(testSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML)).isEqualTo(FeatureFlagResult.Unavailable)
+            }
         }
 
     @Test
@@ -170,9 +177,12 @@ class RuntimeDebugOverrideFeatureFlagProviderTest {
             val recreatedTestSubject = createTestSubject(configStore)
 
             // Assert
-            assertThat(recreatedTestSubject.overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)
-            assertThat(recreatedTestSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML))
-                .isEqualTo(FeatureFlagResult.Enabled)
+            recreatedTestSubject.overrides.test {
+                val overrides = awaitItem()
+                assertThat(overrides).containsOnly(MESSAGE_VIEW_ACTION_EXPORT_EML.key to true)
+                assertThat(recreatedTestSubject.provide(MESSAGE_VIEW_ACTION_EXPORT_EML))
+                    .isEqualTo(FeatureFlagResult.Enabled)
+            }
         }
 
     @Test

--- a/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/inject/FeatureDebugSettingsModule.kt
+++ b/feature/debug-settings/src/debug/kotlin/net/thunderbird/feature/debug/settings/inject/FeatureDebugSettingsModule.kt
@@ -20,8 +20,8 @@ val featureDebugSettingsModule = module {
     }
     viewModel {
         DebugFeatureFlagSectionViewModel(
-            featureFlagFactory = get(),
-            featureFlagOverrides = get(),
+            bundleDefaults = get(),
+            runtimeProvider = get(),
         )
     }
 }

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/featureflag/DebugFeatureFlagSection.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/featureflag/DebugFeatureFlagSection.kt
@@ -1,6 +1,7 @@
 package net.thunderbird.feature.debug.settings.featureflag
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -31,10 +32,10 @@ import net.thunderbird.components.ui.bolt.atom.Switch
 import net.thunderbird.components.ui.bolt.atom.button.ButtonFilled
 import net.thunderbird.components.ui.bolt.atom.button.ButtonText
 import net.thunderbird.components.ui.bolt.atom.text.TextBodyLarge
+import net.thunderbird.components.ui.bolt.atom.text.TextBodySmall
 import net.thunderbird.components.ui.bolt.atom.text.TextLabelSmall
 import net.thunderbird.components.ui.bolt.organism.AlertDialog
 import net.thunderbird.components.ui.bolt.theme.BoltTheme
-import net.thunderbird.core.featureflag.FeatureFlag
 import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.ui.contract.mvi.observe
 import net.thunderbird.feature.debug.settings.R
@@ -64,7 +65,7 @@ fun DebugFeatureFlagSection(
         state = state.value,
         showUnsavedChangesDialog = showUnsavedChangesDialog,
         onNavigateBack = onNavigateBack,
-        onToggleFlagChange = { dispatchEvent(DebugFeatureFlagSectionContract.Event.OnToggle(flag = it)) },
+        onToggleFlagChange = { dispatchEvent(DebugFeatureFlagSectionContract.Event.OnToggle(key = it)) },
         onApplyChangesClick = { dispatchEvent(DebugFeatureFlagSectionContract.Event.ApplyChanges) },
         onRestoreDefaultClick = { dispatchEvent(DebugFeatureFlagSectionContract.Event.RestoreDefaults) },
         onStayClick = onStayClick,
@@ -78,7 +79,7 @@ internal fun DebugFeatureFlagSection(
     showUnsavedChangesDialog: Boolean,
     modifier: Modifier = Modifier,
     onNavigateBack: () -> Unit = {},
-    onToggleFlagChange: (FeatureFlag) -> Unit = {},
+    onToggleFlagChange: (FeatureFlagKey) -> Unit = {},
     onApplyChangesClick: () -> Unit = {},
     onRestoreDefaultClick: () -> Unit = {},
     onStayClick: () -> Unit = {},
@@ -126,15 +127,15 @@ internal fun DebugFeatureFlagSection(
                 bottom = BoltTheme.spacings.triple,
             ),
         ) {
-            itemsIndexed(items = flags) { index, (key, flag) ->
+            itemsIndexed(items = flags) { index, (key, flagEnabled) ->
                 val isOverridden = remember(state.overrides, state.pendingOverrides) {
                     val override = state.pendingOverrides[key] ?: state.overrides[key]
-                    override != null && override != flag.enabled
+                    override != null && override != flagEnabled
                 }
                 FeatureFlagItem(
                     state = state,
                     key = key,
-                    flag = flag,
+                    flagEnabled = flagEnabled,
                     isOverridden = isOverridden,
                     showDivider = index > 0,
                     onToggleFlagChange = onToggleFlagChange,
@@ -190,10 +191,10 @@ private fun ButtonRow(
 private fun FeatureFlagItem(
     state: DebugFeatureFlagSectionContract.State,
     key: FeatureFlagKey,
-    flag: FeatureFlag,
+    flagEnabled: Boolean,
     isOverridden: Boolean,
     showDivider: Boolean,
-    onToggleFlagChange: (FeatureFlag) -> Unit,
+    onToggleFlagChange: (FeatureFlagKey) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
@@ -203,7 +204,7 @@ private fun FeatureFlagItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(role = Role.Switch, onClick = { onToggleFlagChange(flag) })
+                .clickable(role = Role.Switch, onClick = { onToggleFlagChange(key) })
                 .padding(start = BoltTheme.spacings.default),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
@@ -223,7 +224,8 @@ private fun FeatureFlagItem(
                         append(key.key)
                     },
                 )
-                if (isOverridden) {
+                key.description?.let { description -> TextBodySmall(text = description) }
+                AnimatedVisibility(visible = isOverridden) {
                     TextLabelSmall(
                         text = buildAnnotatedString {
                             append(
@@ -233,7 +235,7 @@ private fun FeatureFlagItem(
                                 append(
                                     stringResource(
                                         R.string.debug_settings_feature_flag_default_value,
-                                        flag.enabled,
+                                        flagEnabled,
                                     ),
                                 )
                             }
@@ -243,8 +245,8 @@ private fun FeatureFlagItem(
             }
             Spacer(modifier = Modifier.width(BoltTheme.spacings.double))
             Switch(
-                checked = state.pendingOverrides[key] ?: state.overrides[key] ?: flag.enabled,
-                onCheckedChange = { onToggleFlagChange(flag) },
+                checked = state.pendingOverrides[key] ?: state.overrides[key] ?: flagEnabled,
+                onCheckedChange = { onToggleFlagChange(key) },
                 modifier = Modifier.padding(end = BoltTheme.spacings.default),
             )
         }

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/featureflag/DebugFeatureFlagSectionContract.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/featureflag/DebugFeatureFlagSectionContract.kt
@@ -10,14 +10,14 @@ interface DebugFeatureFlagSectionContract {
     interface ViewModel : UnidirectionalViewModel<State, Event, Effect>
 
     data class State(
-        val defaults: ImmutableMap<FeatureFlagKey, FeatureFlag> = persistentMapOf(),
+        val defaults: ImmutableMap<FeatureFlagKey, Boolean> = persistentMapOf(),
         val overrides: ImmutableMap<FeatureFlagKey, Boolean> = persistentMapOf(),
         val pendingOverrides: ImmutableMap<FeatureFlagKey, Boolean> = persistentMapOf(),
     )
 
     sealed interface Event {
         data object RestoreDefaults : Event
-        data class OnToggle(val flag: FeatureFlag) : Event
+        data class OnToggle(val key: FeatureFlagKey) : Event
         data object ApplyChanges : Event
     }
 

--- a/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/featureflag/DebugFeatureFlagSectionViewModel.kt
+++ b/feature/debug-settings/src/main/kotlin/net/thunderbird/feature/debug/settings/featureflag/DebugFeatureFlagSectionViewModel.kt
@@ -1,14 +1,17 @@
 package net.thunderbird.feature.debug.settings.featureflag
 
 import androidx.lifecycle.viewModelScope
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import net.thunderbird.core.featureflag.FeatureFlag
-import net.thunderbird.core.featureflag.FeatureFlagFactory
-import net.thunderbird.core.featureflag.FeatureFlagOverrides
+import kotlinx.coroutines.launch
+import net.thunderbird.core.featureflag.FeatureFlagKey
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey
+import net.thunderbird.core.featureflag.provider.BundledFeatureFlagDefaults
+import net.thunderbird.core.featureflag.provider.RuntimeDebugOverrideFeatureFlagProvider
 import net.thunderbird.core.ui.contract.mvi.BaseViewModel
 import net.thunderbird.feature.debug.settings.featureflag.DebugFeatureFlagSectionContract.Effect
 import net.thunderbird.feature.debug.settings.featureflag.DebugFeatureFlagSectionContract.Event
@@ -16,26 +19,23 @@ import net.thunderbird.feature.debug.settings.featureflag.DebugFeatureFlagSectio
 import net.thunderbird.feature.debug.settings.featureflag.DebugFeatureFlagSectionContract.ViewModel
 
 class DebugFeatureFlagSectionViewModel(
-    private val featureFlagFactory: FeatureFlagFactory,
-    private val featureFlagOverrides: FeatureFlagOverrides,
+    bundleDefaults: BundledFeatureFlagDefaults,
+    private val runtimeProvider: RuntimeDebugOverrideFeatureFlagProvider,
 ) : BaseViewModel<State, Event, Effect>(initialState = State()), ViewModel {
 
     init {
-        featureFlagFactory
-            .getCatalog()
-            .onEach { defaults ->
-                updateState { state ->
-                    state.copy(
-                        defaults = defaults.associateBy { it.key }.toPersistentMap(),
-                    )
-                }
-            }
-            .launchIn(viewModelScope)
+        val baseline = bundleDefaults.defaults()
+        val defaults = baseline.toFeatureFlagKeyMap()
+        updateState { state -> state.copy(defaults = defaults) }
 
-        featureFlagOverrides
+        runtimeProvider
             .overrides
             .onEach { overrides ->
-                updateState { it.copy(overrides = overrides.toImmutableMap()) }
+                updateState { state ->
+                    state.copy(
+                        overrides = overrides.mapKeys { (key, _) -> key.toFeatureFlagKey() }.toImmutableMap(),
+                    )
+                }
             }
             .launchIn(viewModelScope)
     }
@@ -43,41 +43,42 @@ class DebugFeatureFlagSectionViewModel(
     override fun event(event: Event) {
         when (event) {
             Event.ApplyChanges -> applyChanges()
-            is Event.OnToggle -> toggleFeatureFlag(event.flag)
+            is Event.OnToggle -> toggleFeatureFlag(event.key)
             Event.RestoreDefaults -> restoreDefaults()
         }
     }
 
     private fun applyChanges() {
-        val current = state.value
-        val defaults = current
-            .defaults
-            .mapValues { it.value.enabled }
-            .filter { it.key in current.pendingOverrides }
-        if (current.pendingOverrides == defaults) {
-            featureFlagOverrides.clearAll()
-        } else {
-            state.value.pendingOverrides.forEach { (key, enabled) ->
-                featureFlagOverrides[key] = enabled
+        viewModelScope.launch {
+            val current = state.value
+            val defaults = current
+                .defaults
+                .filter { it.key in current.pendingOverrides }
+            if (current.pendingOverrides == defaults) {
+                runtimeProvider.clearAllOverrides()
+            } else {
+                state.value.pendingOverrides.forEach { (key, enabled) ->
+                    runtimeProvider.setOverride(key, enabled)
+                }
             }
+            emitEffect(Effect.RestartMainActivity)
         }
-        emitEffect(Effect.RestartMainActivity)
     }
 
-    private fun toggleFeatureFlag(flag: FeatureFlag) {
+    private fun toggleFeatureFlag(flagKey: FeatureFlagKey) {
         updateState { state ->
-            val currentActiveValue = state.overrides[flag.key]
-                ?: state.defaults[flag.key]?.enabled
+            val currentActiveValue = state.overrides[flagKey]
+                ?: state.defaults[flagKey]
             val overrides = if (
-                flag.key in state.pendingOverrides &&
-                state.pendingOverrides[flag.key]?.not() == currentActiveValue
+                flagKey in state.pendingOverrides &&
+                state.pendingOverrides[flagKey]?.not() == currentActiveValue
             ) {
-                state.pendingOverrides - flag.key
+                state.pendingOverrides - flagKey
             } else {
-                val value = state.pendingOverrides[flag.key]
+                val value = state.pendingOverrides[flagKey]
                     ?: currentActiveValue
                     ?: false
-                state.pendingOverrides + (flag.key to !value)
+                state.pendingOverrides + (flagKey to !value)
             }
             emitEffect(Effect.NotifyPendingChanges(pendingOverrides = overrides.toPersistentMap()))
             state.copy(pendingOverrides = overrides.toPersistentMap())
@@ -94,7 +95,7 @@ class DebugFeatureFlagSectionViewModel(
                 val defaults = state.defaults.filter { (key, _) ->
                     key in pendingOverrides || key in currentOverrides
                 }
-                val defaultOverrides = defaults.mapValues { it.value.enabled }.toPersistentMap()
+                val defaultOverrides = defaults.mapValues { it.value }.toPersistentMap()
                 emitEffect(Effect.NotifyPendingChanges(pendingOverrides = defaultOverrides))
                 state.copy(
                     pendingOverrides = defaultOverrides,
@@ -102,4 +103,12 @@ class DebugFeatureFlagSectionViewModel(
             }
         }
     }
+
+    private fun Map<String, Boolean>.toFeatureFlagKeyMap(): ImmutableMap<FeatureFlagKey, Boolean> =
+        this.entries.associate { (key, value) ->
+            val flagKey: FeatureFlagKey = key.toFeatureFlagKey()
+            flagKey to value
+        }.toImmutableMap()
+
+    private fun String.toFeatureFlagKey(): FeatureFlagKey = GeneratedFeatureFlagKey.valueOf(uppercase())
 }


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Closes #11335 

RFC / Technical Design (if applicable): [RFC 0004: Add a Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/rfcs/0004-feature-flag-new-architecture.md) / [Technical Design 0002: Declarative Feature Flag Catalog](https://github.com/thunderbird/thunderbird-android/raw/refs/heads/main/docs/engineering/technical-designs/0002-feature-flag-declarative-catalog.md)

#### Description

This contribution connects the Secret Debug Screen with the new Feature Flag Architecture. 

With the new Feature Flag architecture, the Secret Debug Screen now also includes:
- Override persistence; the flags you enable/disable will survive the app lifecycle. You can always restore the default values
- Each Feature Flag key item will also display its description.

#### Screenshots

<img width="45%" alt="image" src="https://github.com/user-attachments/assets/9911e6a7-a2b8-4190-b0ca-4c7359c255df" />


## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).