### PR TITLE
fix(message-composer): collapse recipient expander when editing subject or body

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -60,6 +60,7 @@ import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.fsck.k9.activity.compose.MessageComposeInAppNotificationFragment;
+import com.fsck.k9.activity.listener.RecipientExpanderListener;
 import com.fsck.k9.ui.settings.account.AccountSettingsActivity;
 import com.fsck.k9.ui.settings.account.AccountSettingsFragment;
 import com.fsck.k9.message.html.DisplayHtml;
@@ -424,9 +425,21 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         quotedMessageMvpView.addTextChangedListener(new WrapUriTextWatcher());
 
         subjectView.addTextChangedListener(draftNeedsChangingTextWatcher);
+        subjectView.addTextChangedListener(
+            new RecipientExpanderListener(
+                recipientPresenter::isRecipientExpanderExpanded,
+                this::triggerNonRecipientFieldFocused
+            )
+        );
 
         messageContentView.addTextChangedListener(draftNeedsChangingTextWatcher);
         messageContentView.addTextChangedListener(new WrapUriTextWatcher());
+        messageContentView.addTextChangedListener(
+            new RecipientExpanderListener(
+                recipientPresenter::isRecipientExpanderExpanded,
+                this::triggerNonRecipientFieldFocused
+            )
+        );
 
         /*
          * We set this to invisible by default. Other methods will turn it back on if it's
@@ -1157,10 +1170,16 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         int id = v.getId();
         if (id == R.id.message_content || id == R.id.subject) {
             if (hasFocus) {
-                replyToPresenter.onNonRecipientFieldFocused();
-                recipientPresenter.onNonRecipientFieldFocused();
+                triggerNonRecipientFieldFocused();
             }
         }
+    }
+
+    // return Unit to allow this::triggerNonRecipientFieldFocused usage with () -> Unit
+    private Unit triggerNonRecipientFieldFocused() {
+        replyToPresenter.onNonRecipientFieldFocused();
+        recipientPresenter.onNonRecipientFieldFocused();
+        return Unit.INSTANCE;
     }
 
     @Override

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.kt
@@ -94,6 +94,8 @@ class RecipientPresenter(
     private val allRecipients: List<Recipient>
         get() = with(recipientMvpView) { toRecipients + ccRecipients + bccRecipients }
 
+    val isRecipientExpanderExpanded: Boolean get() = recipientMvpView.isCcVisible && recipientMvpView.isBccVisible
+
     private val openPgpCallback = object : OpenPgpApiManagerCallback {
         override fun onOpenPgpProviderStatusChanged() {
             if (openPgpApiManager.openPgpProviderState == OpenPgpProviderState.UI_REQUIRED) {
@@ -390,7 +392,7 @@ class RecipientPresenter(
     }
 
     private fun updateRecipientExpanderVisibility() {
-        val notBothAreVisible = !(recipientMvpView.isCcVisible && recipientMvpView.isBccVisible)
+        val notBothAreVisible = !isRecipientExpanderExpanded
         recipientMvpView.setRecipientExpanderVisibility(notBothAreVisible)
     }
 
@@ -549,9 +551,11 @@ class RecipientPresenter(
                 val recipientType = requestCode.toRecipientType()
                 addRecipientFromContactUri(recipientType, data.data)
             }
+
             OPENPGP_USER_INTERACTION -> {
                 openPgpApiManager.onUserInteractionResult()
             }
+
             REQUEST_CODE_AUTOCRYPT -> {
                 asyncUpdateCryptoStatus()
             }
@@ -569,14 +573,17 @@ class RecipientPresenter(
             OpenPgpProviderState.UNCONFIGURED -> {
                 Log.e("click on crypto status while unconfigured - this should not really happen?!")
             }
+
             OpenPgpProviderState.OK -> {
                 toggleEncryptionState(false)
             }
+
             OpenPgpProviderState.UI_REQUIRED -> {
                 // TODO show openpgp settings
                 val pendingIntent = openPgpApiManager.userInteractionPendingIntent
                 recipientMvpView.launchUserInteractionPendingIntent(pendingIntent, OPENPGP_USER_INTERACTION)
             }
+
             OpenPgpProviderState.UNINITIALIZED, OpenPgpProviderState.ERROR -> {
                 openPgpApiManager.refreshConnection()
             }
@@ -743,9 +750,11 @@ class RecipientPresenter(
             currentCryptoMode == CryptoMode.SIGN_ONLY -> {
                 recipientMvpView.showOpenPgpSignOnlyDialog(false)
             }
+
             isForceTextMessageFormat -> {
                 recipientMvpView.showOpenPgpInlineDialog(false)
             }
+
             else -> {
                 error("This icon should not be clickable while no special mode is active!")
             }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/listener/RecipientExpanderListener.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/listener/RecipientExpanderListener.kt
@@ -1,0 +1,14 @@
+package com.fsck.k9.activity.listener
+
+import com.fsck.k9.helper.SimpleTextWatcher
+
+class RecipientExpanderListener(
+    private val isRecipientExpanderExpanded: () -> Boolean,
+    private val onBeforeTextChanged: () -> Unit,
+) : SimpleTextWatcher() {
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+        if (isRecipientExpanderExpanded()) {
+            onBeforeTextChanged()
+        }
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #11375 

#### Description

This contribution fixes the recipient expander not collapsing when editing the subject or the body of a message

#### Screen Recording

https://github.com/user-attachments/assets/b45e91fa-9dde-4a5c-9fc1-311b4931157c


## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
