### PR TITLE
fix(launcher): handle QR code navigation

### DIFF
--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/navigation/FeatureLauncherNavHost.kt
@@ -161,6 +161,9 @@ private fun NavGraphBuilder.registerThundermailNavigation(
                 is ThundermailRoute.SignInWithThundermail ->
                     navController.navigate(ThundermailRoute.SignInWithThundermail)
 
+                is ThundermailRoute.ScanQrCode ->
+                    navController.navigate(ThundermailRoute.ScanQrCode)
+
                 else -> Unit
             }
         },


### PR DESCRIPTION
Handle ScanQrCode emitted by the Thunderbird account setup flow so the QR import screen opens when no account is configured.

## Contribution Summary

Linked Issue/Ticket: Fixes #11276

#### Description

Handle `ThundermailRoute.ScanQrCode` in the launcher navigation flow.

Previously, when no account was configured, the account setup flow emitted
`ThundermailRoute.ScanQrCode`, but the launcher did not handle that route and
the action fell through without navigation.

This adds the missing navigation branch so the QR import screen opens correctly.

#### Screen Recording

https://github.com/user-attachments/assets/610490c8-4fd3-4aa8-9d67-6d7f7a4b31f3

#### Testing

- Reproduced the issue with no configured accounts.
- Verified that Scan QR code opens after the fix.
- Verified that the existing-account QR flow still works.
- I couldn't find existing tests covering this launcher navigation path. Happy to add regression coverage if there is a preferred testing approach for this area.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
