### PR TITLE
refactor(db-repository): extract push folders query logic to PushFoldersQueryRepository

### DIFF
--- a/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/repository/PushFoldersQueryRepository.kt
+++ b/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/repository/PushFoldersQueryRepository.kt
@@ -1,0 +1,23 @@
+package net.thunderbird.feature.mail.folder.api.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.account.AccountId
+import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+
+interface PushFoldersQueryRepository {
+    /**
+     * Returns a [Flow] of [RemoteFolder]s for the given [accountId] that should be used for push.
+     *
+     * @param accountId The account identifier.
+     */
+    fun observeAllByAccountId(accountId: AccountId): Flow<Outcome<List<RemoteFolder>, FolderError>>
+
+    /**
+     * Returns a list of [RemoteFolder]s for the given [accountId] that should be used for push.
+     *
+     * @param accountId The account identifier.
+     */
+    fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolder>, FolderError>
+}

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/fakes/FakeFolderRepository.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/fakes/FakeFolderRepository.kt
@@ -22,10 +22,6 @@ class FakeFolderRepository(
 
     override fun getRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails> = error("Not implemented")
 
-    override fun getPushFoldersFlow(accountId: AccountId): Flow<List<RemoteFolder>> = error("Not implemented")
-
-    override fun getPushFolders(accountId: AccountId): List<RemoteFolder> = error("Not implemented")
-
     override fun getFolderServerId(
         accountId: AccountId,
         folderId: Long,

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9.controller.push
 
-import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.backend.api.BackendPusher
 import com.fsck.k9.backend.api.BackendPusherCallback
@@ -10,13 +9,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import net.thunderbird.core.logging.Logger
+import net.thunderbird.core.outcome.fold
 import net.thunderbird.feature.account.AccountId
+import net.thunderbird.feature.mail.folder.api.data.repository.PushFoldersQueryRepository
 
 private const val TAG = "AccountPushController"
 
 internal class AccountPushController(
     private val backendManager: BackendManager,
-    private val folderRepository: FolderRepository,
+    private val pushFoldersQueryRepository: PushFoldersQueryRepository,
     private val backendPusherCallback: BackendPusherCallback,
     private val accountId: AccountId,
     private val logger: Logger,
@@ -58,10 +59,18 @@ internal class AccountPushController(
 
     private fun startListeningForPushFolders() {
         coroutineScope.launch {
-            folderRepository.getPushFoldersFlow(accountId).collect { remoteFolders ->
-                val folderServerIds = remoteFolders.map { it.serverId }
-                updatePushFolders(folderServerIds)
-            }
+            pushFoldersQueryRepository.observeAllByAccountId(accountId)
+                .collect { outcome ->
+                    outcome.fold(
+                        onSuccess = { remoteFolders ->
+                            val folderServerIds = remoteFolders.map { it.serverId }
+                            updatePushFolders(folderServerIds)
+                        },
+                        onFailure = {
+                            logger.error { "Failed to start listening for push folders. Error: $it" }
+                        },
+                    )
+                }
         }
     }
 

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushControllerFactory.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushControllerFactory.kt
@@ -6,18 +6,20 @@ import com.fsck.k9.controller.MessagingController
 import net.thunderbird.core.android.account.LegacyAccountDtoManager
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.account.AccountId
+import net.thunderbird.feature.mail.folder.api.data.repository.PushFoldersQueryRepository
 
 internal class AccountPushControllerFactory(
     private val accountManager: LegacyAccountDtoManager,
     private val backendManager: BackendManager,
     private val messagingController: MessagingController,
     private val folderRepository: FolderRepository,
+    private val pushFoldersQueryRepository: PushFoldersQueryRepository,
     private val logger: Logger,
 ) {
     fun create(accountId: AccountId): AccountPushController {
         return AccountPushController(
             backendManager,
-            folderRepository,
+            pushFoldersQueryRepository,
             backendPusherCallback = AccountBackendPusherCallback(
                 accountManager = accountManager,
                 messagingController = messagingController,

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/KoinModule.kt
@@ -12,6 +12,7 @@ internal val controllerPushModule = module {
             backendManager = get(),
             messagingController = get(),
             folderRepository = get(),
+            pushFoldersQueryRepository = get(),
             logger = get(),
         )
     }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -7,6 +7,7 @@ import app.k9mail.legacy.mailstore.MessageListRepository
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.mailstore.folder.DefaultFolderDetailsRepository
 import app.k9mail.legacy.mailstore.folder.push.DefaultPushFolderTrackingRepository
+import app.k9mail.legacy.mailstore.folder.push.DefaultPushFoldersQueryRepository
 import com.fsck.k9.mailstore.folder.DefaultOutboxFolderManager
 import com.fsck.k9.message.extractors.AttachmentCounter
 import com.fsck.k9.message.extractors.MessageFulltextCreator
@@ -17,11 +18,18 @@ import net.thunderbird.core.common.cache.TimeLimitedCache
 import net.thunderbird.feature.mail.folder.api.OutboxFolderManager
 import net.thunderbird.feature.mail.folder.api.data.repository.FolderDetailsRepository
 import net.thunderbird.feature.mail.folder.api.data.repository.PushFolderTrackingRepository
+import net.thunderbird.feature.mail.folder.api.data.repository.PushFoldersQueryRepository
 import org.koin.dsl.module
 
 val mailStoreModule = module {
     single<PushFolderTrackingRepository> {
         DefaultPushFolderTrackingRepository(logger = get(), messageStoreManager = get())
+    }
+    single<PushFoldersQueryRepository> {
+        DefaultPushFoldersQueryRepository(logger = get(), messageStoreManager = get())
+    }
+    single<PushFoldersQueryRepository> {
+        DefaultPushFoldersQueryRepository(logger = get(), messageStoreManager = get())
     }
     single<FolderDetailsRepository> {
         DefaultFolderDetailsRepository(

--- a/legacy/core/src/test/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdaterTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdaterTest.kt
@@ -212,11 +212,6 @@ class DefaultSpecialFolderUpdaterTest {
         override suspend fun getFolder(accountId: AccountId, folderId: Long): Folder? = null
         override fun getRemoteFolders(accountId: AccountId): List<RemoteFolder> = remoteFolders
         override fun getRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails> = emptyList()
-        override fun getPushFoldersFlow(
-            accountId: AccountId,
-        ): Flow<List<RemoteFolder>> = throw UnsupportedOperationException()
-
-        override fun getPushFolders(accountId: AccountId): List<RemoteFolder> = emptyList()
         override fun getFolderServerId(accountId: AccountId, folderId: Long): String? = null
         override fun getFolderId(accountId: AccountId, folderServerId: String): Long? = null
         override fun isFolderPresent(accountId: AccountId, folderId: Long): Boolean = false

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/DefaultFolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/DefaultFolderRepository.kt
@@ -2,17 +2,7 @@ package app.k9mail.legacy.mailstore
 
 import app.k9mail.legacy.mailstore.RemoteFolderTypeMapper.toFolderType
 import app.k9mail.legacy.mailstore.folder.extension.getFolderType
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.channels.trySendBlocking
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.flowOn
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountManager
 import net.thunderbird.core.common.exception.MessagingException
@@ -28,7 +18,6 @@ class DefaultFolderRepository(
     private val messageStoreManager: MessageStoreManager,
     private val outboxFolderManager: OutboxFolderManager,
     private val aggregateRepositories: AggregateRepositories,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : FolderRepository, PushFolderTrackingRepository by aggregateRepositories.pushFolderTrackingRepository {
     override suspend fun getFolder(accountId: AccountId, folderId: Long): Folder? {
         val account = getAccountById(accountId)
@@ -75,32 +64,6 @@ class DefaultFolderRepository(
                 isPushEnabled = folder.isPushEnabled,
             )
         }
-    }
-
-    override fun getPushFoldersFlow(accountId: AccountId): Flow<List<RemoteFolder>> {
-        val messageStore = messageStoreManager.getMessageStore(accountId)
-        return callbackFlow {
-            send(getPushFolders(accountId))
-
-            val listener = FolderSettingsChangedListener {
-                trySendBlocking(getPushFolders(accountId))
-            }
-            messageStore.addFolderSettingsChangedListener(listener)
-
-            awaitClose {
-                messageStore.removeFolderSettingsChangedListener(listener)
-            }
-        }.buffer(capacity = Channel.CONFLATED)
-            .distinctUntilChanged()
-            .flowOn(ioDispatcher)
-    }
-
-    override fun getPushFolders(accountId: AccountId): List<RemoteFolder> {
-        return getRemoteFolderDetails(accountId)
-            .asSequence()
-            .filter { folderDetails -> folderDetails.isPushEnabled }
-            .map { folderDetails -> folderDetails.folder }
-            .toList()
     }
 
     override fun getFolderServerId(accountId: AccountId, folderId: Long): String? {

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
@@ -40,19 +40,6 @@ interface FolderRepository : PushFolderTrackingRepository {
      */
     fun getRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails>
 
-    /**
-     * Returns a [Flow] of [RemoteFolder]s for the given [accountId] that should be used for push.
-     *
-     * @param accountId The account identifier.
-     */
-    fun getPushFoldersFlow(accountId: AccountId): Flow<List<RemoteFolder>>
-
-    /**
-     * Returns a list of [RemoteFolder]s for the given [accountId] that should be used for push.
-     *
-     * @param accountId The account identifier.
-     */
-    fun getPushFolders(accountId: AccountId): List<RemoteFolder>
 
     /**
      * Returns the server ID for the given [accountId] and [folderId].

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepository.kt
@@ -1,0 +1,101 @@
+package app.k9mail.legacy.mailstore.folder.push
+
+import app.k9mail.legacy.mailstore.FolderSettingsChangedListener
+import app.k9mail.legacy.mailstore.MessageStoreManager
+import app.k9mail.legacy.mailstore.RemoteFolderDetails
+import app.k9mail.legacy.mailstore.RemoteFolderTypeMapper.toFolderType
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
+import net.thunderbird.core.common.exception.MessagingException
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.account.AccountId
+import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+import net.thunderbird.feature.mail.folder.api.data.repository.PushFoldersQueryRepository
+
+class DefaultPushFoldersQueryRepository(
+    private val logger: Logger,
+    private val messageStoreManager: MessageStoreManager,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : PushFoldersQueryRepository {
+    override fun observeAllByAccountId(accountId: AccountId): Flow<Outcome<List<RemoteFolder>, FolderError>> =
+        callbackFlow {
+            val messageStore = messageStoreManager.getMessageStore(accountId)
+            send(getAllByAccountId(accountId))
+
+            val listener = FolderSettingsChangedListener {
+                trySendBlocking(getAllByAccountId(accountId))
+            }
+            messageStore.addFolderSettingsChangedListener(listener)
+
+            awaitClose {
+                messageStore.removeFolderSettingsChangedListener(listener)
+            }
+
+        }.buffer(capacity = Channel.CONFLATED)
+            .distinctUntilChanged()
+            .flowOn(ioDispatcher)
+
+    override fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolder>, FolderError> {
+        logger.verbose { "$LOG_ID getting push folders for account '$accountId'" }
+        val pushFolders = getAllRemoteFolderDetails(accountId)
+            .asSequence()
+            .filter { folderDetails -> folderDetails.isPushEnabled }
+            .map { folderDetails -> folderDetails.folder }
+            .toList()
+
+        return if (pushFolders.isEmpty()) {
+            logger.warn { "$LOG_ID could not find any push folders with the given account id '$accountId'" }
+            Outcome.failure(FolderError.NotFound)
+        } else {
+            logger.verbose { "$LOG_ID found push folder: $pushFolders" }
+            Outcome.success(pushFolders)
+        }
+    }
+
+    private fun getAllRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails> {
+        logger.verbose { "$LOG_ID fetching remote folders details" }
+        return try {
+            val messageStore = messageStoreManager.getMessageStore(accountId)
+            messageStore.getFolders(excludeLocalOnly = true) { folder ->
+                RemoteFolderDetails(
+                    folder = RemoteFolder(
+                        id = folder.id,
+                        serverId = folder.serverIdOrThrow(),
+                        name = folder.name,
+                        type = folder.type.toFolderType(),
+                    ),
+                    isInTopGroup = folder.isInTopGroup,
+                    isIntegrate = folder.isIntegrate,
+                    isSyncEnabled = folder.isSyncEnabled,
+                    isVisible = folder.isVisible,
+                    isNotificationsEnabled = folder.isNotificationsEnabled,
+                    isPushEnabled = folder.isPushEnabled,
+                )
+            }
+        } catch (e: MessagingException) {
+            logger.error(throwable = e) {
+                "$LOG_ID Failed to get remote folders details for account '$accountId'"
+            }
+            throw e
+        } catch (e: IllegalStateException) {
+            logger.error(throwable = e) {
+                "$LOG_ID Failed to get remote folders details for account '$accountId'"
+            }
+            throw e
+        }
+    }
+
+    companion object {
+        private const val LOG_ID = "[repository][push-folders-query]"
+    }
+}

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepositoryTest.kt
@@ -1,0 +1,294 @@
+package app.k9mail.legacy.mailstore.folder.push
+
+import app.cash.turbine.test
+import app.k9mail.legacy.mailstore.FolderDetailsAccessor
+import app.k9mail.legacy.mailstore.FolderMapper
+import app.k9mail.legacy.mailstore.FolderSettingsChangedListener
+import app.k9mail.legacy.mailstore.ListenableMessageStore
+import app.k9mail.legacy.mailstore.MessageStoreFactory
+import app.k9mail.legacy.mailstore.MessageStoreManager
+import app.k9mail.legacy.mailstore.MoreMessages
+import app.k9mail.legacy.mailstore.RemoteFolderDetails
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_OTHER_RAW
+import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
+import net.thunderbird.core.android.account.AccountRemovedListener
+import net.thunderbird.core.android.account.AccountsChangeListener
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.android.account.LegacyAccountDtoManager
+import net.thunderbird.core.common.exception.MessagingException
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.feature.account.AccountIdFactory
+import net.thunderbird.feature.mail.folder.api.FolderType
+import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+private const val INBOX_FOLDER_ID = 1L
+private const val ARCHIVE_FOLDER_ID = 2L
+
+class DefaultPushFoldersQueryRepositoryTest {
+    private val account = LegacyAccountDto(ACCOUNT_ID_RAW)
+    private val accountId = account.id
+    private val messageStore = mock<ListenableMessageStore>()
+    private val accountManager = FakePushFoldersLegacyAccountDtoManager(accounts = listOf(account))
+    private val messageStoreFactory = FakePushFoldersMessageStoreFactory(
+        messageStoresByUuid = mapOf(account.uuid to messageStore),
+    )
+    private val messageStoreManager = MessageStoreManager(accountManager, messageStoreFactory)
+    private val testSubject = DefaultPushFoldersQueryRepository(
+        logger = TestLogger(),
+        messageStoreManager = messageStoreManager,
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
+    @Test
+    fun `getAllByAccountId should return Success with push enabled folders`() {
+        // Arrange
+        stubGetFolders(
+            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+            FakeFolderDetailsAccessor(id = ARCHIVE_FOLDER_ID, name = "Archive", isPushEnabled = false),
+        )
+
+        // Act
+        val result = testSubject.getAllByAccountId(accountId)
+
+        // Assert
+        assertThat(result).isEqualTo(
+            Outcome.success(
+                listOf(
+                    RemoteFolder(
+                        id = INBOX_FOLDER_ID,
+                        serverId = "serverId",
+                        name = "Inbox",
+                        type = FolderType.REGULAR,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `getAllByAccountId should return Failure with NotFound when there are no push enabled folders`() {
+        // Arrange
+        stubGetFolders(
+            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = false),
+        )
+
+        // Act
+        val result = testSubject.getAllByAccountId(accountId)
+
+        // Assert
+        assertThat(result).isEqualTo(Outcome.failure(FolderError.NotFound))
+    }
+
+    @Test
+    fun `getAllByAccountId should return Failure with NotFound when there are no folders at all`() {
+        // Arrange
+        stubGetFolders()
+
+        // Act
+        val result = testSubject.getAllByAccountId(accountId)
+
+        // Assert
+        assertThat(result).isEqualTo(Outcome.failure(FolderError.NotFound))
+    }
+
+    @Test
+    fun `getAllByAccountId should throw when account does not exist`() {
+        // Arrange
+        val unknownAccountId = AccountIdFactory.of(ACCOUNT_ID_OTHER_RAW)
+
+        // Act & Assert
+        assertFailure {
+            testSubject.getAllByAccountId(unknownAccountId)
+        }.isInstanceOf<IllegalStateException>()
+    }
+
+    @Test
+    fun `getAllByAccountId should rethrow MessagingException thrown by the message store`() {
+        // Arrange
+        val exception = MessagingException("failed to fetch folders")
+        doThrow(exception).whenever(messageStore).getFolders<RemoteFolderDetails>(any(), any())
+
+        // Act & Assert
+        assertFailure {
+            testSubject.getAllByAccountId(accountId)
+        }.isEqualTo(exception)
+    }
+
+    @Test
+    fun `observeAllByAccountId should emit the current push folders on subscription`() = runTest {
+        // Arrange
+        stubGetFolders(
+            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+        )
+
+        // Act & Assert
+        testSubject.observeAllByAccountId(accountId).test {
+            assertThat(awaitItem()).isEqualTo(
+                Outcome.success(
+                    listOf(
+                        RemoteFolder(
+                            id = INBOX_FOLDER_ID,
+                            serverId = "serverId",
+                            name = "Inbox",
+                            type = FolderType.REGULAR,
+                        ),
+                    ),
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeAllByAccountId should emit an updated result when folder settings change`() = runTest {
+        // Arrange
+        stubGetFolders(
+            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = false),
+        )
+        val listenerCaptor = argumentCaptor<FolderSettingsChangedListener>()
+
+        // Act & Assert
+        testSubject.observeAllByAccountId(accountId).test {
+            assertThat(awaitItem()).isEqualTo(Outcome.failure(FolderError.NotFound))
+
+            verify(messageStore).addFolderSettingsChangedListener(listenerCaptor.capture())
+            stubGetFolders(
+                FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+            )
+            listenerCaptor.firstValue.onFolderSettingsChanged()
+
+            assertThat(awaitItem()).isEqualTo(
+                Outcome.success(
+                    listOf(
+                        RemoteFolder(
+                            id = INBOX_FOLDER_ID,
+                            serverId = "serverId",
+                            name = "Inbox",
+                            type = FolderType.REGULAR,
+                        ),
+                    ),
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeAllByAccountId should not emit duplicate consecutive results`() = runTest {
+        // Arrange
+        stubGetFolders(
+            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+        )
+        val listenerCaptor = argumentCaptor<FolderSettingsChangedListener>()
+
+        // Act & Assert
+        testSubject.observeAllByAccountId(accountId).test {
+            assertThat(awaitItem()).isInstanceOf(Outcome.Success::class)
+
+            verify(messageStore).addFolderSettingsChangedListener(listenerCaptor.capture())
+            listenerCaptor.firstValue.onFolderSettingsChanged()
+
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeAllByAccountId should remove the folder settings listener when the flow is cancelled`() = runTest {
+        // Arrange
+        stubGetFolders(
+            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+        )
+        val listenerCaptor = argumentCaptor<FolderSettingsChangedListener>()
+
+        // Act
+        testSubject.observeAllByAccountId(accountId).test {
+            awaitItem()
+            verify(messageStore).addFolderSettingsChangedListener(listenerCaptor.capture())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Assert
+        verify(messageStore).removeFolderSettingsChangedListener(listenerCaptor.firstValue)
+    }
+
+    @Test
+    fun `observeAllByAccountId should throw when account does not exist`() = runTest {
+        // Arrange
+        val unknownAccountId = AccountIdFactory.of(ACCOUNT_ID_OTHER_RAW)
+
+        // Act & Assert
+        testSubject.observeAllByAccountId(unknownAccountId).test {
+            assertThat(awaitError()).isInstanceOf(IllegalStateException::class)
+        }
+    }
+
+    private fun stubGetFolders(vararg accessors: FolderDetailsAccessor) {
+        whenever(messageStore.getFolders<RemoteFolderDetails>(eq(true), any())).thenAnswer { invocation ->
+            val mapper = invocation.getArgument<FolderMapper<RemoteFolderDetails>>(1)
+            accessors.map { mapper.map(it) }
+        }
+    }
+}
+
+private class FakeFolderDetailsAccessor(
+    override val id: Long,
+    override val name: String = "Folder",
+    override val serverId: String? = "serverId",
+    override val type: com.fsck.k9.mail.FolderType = com.fsck.k9.mail.FolderType.REGULAR,
+    override val isLocalOnly: Boolean = false,
+    override val isInTopGroup: Boolean = false,
+    override val isIntegrate: Boolean = false,
+    override val isSyncEnabled: Boolean = true,
+    override val isVisible: Boolean = true,
+    override val isNotificationsEnabled: Boolean = true,
+    override val isPushEnabled: Boolean = false,
+    override val visibleLimit: Int = 25,
+    override val moreMessages: MoreMessages = MoreMessages.UNKNOWN,
+    override val lastChecked: Long? = null,
+    override val unreadMessageCount: Int = 0,
+    override val starredMessageCount: Int = 0,
+) : FolderDetailsAccessor {
+    override fun serverIdOrThrow(): String = serverId ?: error("serverId is null")
+}
+
+private class FakePushFoldersLegacyAccountDtoManager(
+    accounts: List<LegacyAccountDto> = emptyList(),
+) : LegacyAccountDtoManager {
+    private val accountsByUuid = accounts.associateBy { it.uuid }
+
+    override fun getAccounts(): List<LegacyAccountDto> = accountsByUuid.values.toList()
+    override fun getAccountsFlow(): Flow<List<LegacyAccountDto>> = flowOf(getAccounts())
+    override fun getAccount(accountUuid: String): LegacyAccountDto? = accountsByUuid[accountUuid]
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccountDto?> = flowOf(getAccount(accountUuid))
+    override fun addAccountRemovedListener(listener: AccountRemovedListener) = Unit
+    override fun moveAccount(account: LegacyAccountDto, newPosition: Int) = Unit
+    override fun addOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) = Unit
+    override fun removeOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) = Unit
+    override fun saveAccount(account: LegacyAccountDto) = Unit
+}
+
+private class FakePushFoldersMessageStoreFactory(
+    private val messageStoresByUuid: Map<String, ListenableMessageStore>,
+) : MessageStoreFactory {
+    override fun create(account: LegacyAccountDto): ListenableMessageStore = messageStoresByUuid.getValue(account.uuid)
+}
+


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Part of #11470

#### Description

- Add PushFoldersQueryRepository interface with observeAllByAccountId and getAllByAccountId methods
- Add DefaultPushFoldersQueryRepository implementation
- Remove getPushFoldersFlow and getPushFolders from FolderRepository
- Update AccountPushController to use new repository and handle Outcome
- Add comprehensive tests for DefaultPushFoldersQueryRepository

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>