### PR TITLE
refactor(db-repository): extract remote folder queries to dedicated repositories

### DIFF
--- a/app-common/src/main/kotlin/net/thunderbird/app/common/feature/mail/FeatureMailModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/feature/mail/FeatureMailModule.kt
@@ -17,10 +17,11 @@ internal val appCommonFeatureMailModule = module {
     factory<SpecialFolderUpdater.Factory> {
         DefaultSpecialFolderUpdater.Factory(
             accountManager = get(),
-            folderRepository = get(),
+            remoteFolderQueryRepository = get(),
             folderDetailsRepository = get(),
             specialFolderSelectionStrategy = get(),
             coroutineScope = get(named("AppCoroutineScope")),
+            logger = get(),
         )
     }
 

--- a/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/FolderDetails.kt
+++ b/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/FolderDetails.kt
@@ -4,19 +4,48 @@ import net.thunderbird.core.logging.LoggingPii
 
 @LoggingPii.HasPii
 data class FolderDetails(
-    val folder: Folder,
-    val isInTopGroup: Boolean,
-    val isIntegrate: Boolean,
-    val isSyncEnabled: Boolean,
-    val isVisible: Boolean,
-    val isNotificationsEnabled: Boolean,
-    val isPushEnabled: Boolean,
-)
+    override val folder: Folder,
+    override val isInTopGroup: Boolean,
+    override val isIntegrate: Boolean,
+    override val isSyncEnabled: Boolean,
+    override val isVisible: Boolean,
+    override val isNotificationsEnabled: Boolean,
+    override val isPushEnabled: Boolean,
+) : BaseFolderDetails<Folder>
+
+@LoggingPii.HasPii
+data class RemoteFolderDetails(
+    override val folder: RemoteFolder,
+    override val isInTopGroup: Boolean,
+    override val isIntegrate: Boolean,
+    override val isSyncEnabled: Boolean,
+    override val isVisible: Boolean,
+    override val isNotificationsEnabled: Boolean,
+    override val isPushEnabled: Boolean,
+) : BaseFolderDetails<RemoteFolder>
+
+sealed interface BaseFolderDetails<TFolder> {
+    val folder: TFolder
+    val isInTopGroup: Boolean
+    val isIntegrate: Boolean
+    val isSyncEnabled: Boolean
+    val isVisible: Boolean
+    val isNotificationsEnabled: Boolean
+    val isPushEnabled: Boolean
+}
 
 /*
  * TODO(#11493): The logging compiler plugin will automatically should auto-generate
  *  this method with the correct masking.
  */
 fun FolderDetails.toStringPiiSafe(): String = "FolderDetails(folder=${folder.toStringPiiSafe()}, " +
+    "isInTopGroup=$isInTopGroup, isIntegrate=$isIntegrate, isSyncEnabled=$isSyncEnabled, " +
+    "isVisible=$isVisible, isNotificationsEnabled=$isNotificationsEnabled, isPushEnabled=$isPushEnabled)"
+
+/*
+ * TODO(#11493): The logging compiler plugin will automatically should auto-generate
+ *  this method with the correct masking.
+ */
+fun RemoteFolderDetails.toStringPiiSafe(): String = "FolderDetails(folder=${folder.toStringPiiSafe()}, " +
     "isInTopGroup=$isInTopGroup, isIntegrate=$isIntegrate, isSyncEnabled=$isSyncEnabled, " +
     "isVisible=$isVisible, isNotificationsEnabled=$isNotificationsEnabled, isPushEnabled=$isPushEnabled)"

--- a/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/RemoteFolder.kt
+++ b/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/RemoteFolder.kt
@@ -1,8 +1,20 @@
 package net.thunderbird.feature.mail.folder.api
 
+import net.thunderbird.core.logging.LoggingPii
+
+@LoggingPii.HasPii
 data class RemoteFolder(
     val id: Long,
+    @get:LoggingPii.Mask
     val serverId: String,
+    @get:LoggingPii.Mask
     val name: String,
     val type: FolderType,
 )
+
+/*
+ * TODO(#11493): The logging compiler plugin will automatically should auto-generate
+ *  this method with the correct masking.
+ */
+fun RemoteFolder.toStringPiiSafe(): String =
+    "RemoteFolder(id=$id, serverId='<sensitive>', name='<sensitive>', type=$type)"

--- a/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/FolderError.kt
+++ b/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/FolderError.kt
@@ -5,4 +5,5 @@ sealed interface FolderError {
     data object NotFound : FolderError
     data object Unavailable : FolderError
     data class FailedPrecondition(val message: String, val throwable: Throwable? = null) : FolderError
+    data class FailedToQueryDatabase(val message: String, val throwable: Throwable) : FolderError
 }

--- a/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/FolderError.kt
+++ b/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/FolderError.kt
@@ -1,9 +1,11 @@
 package net.thunderbird.feature.mail.folder.api.data
 
 sealed interface FolderError {
-    data object AccountNotFound : FolderError
+    val throwable: Throwable? get() = null
+
+    data class AccountNotFound(override val throwable: Throwable) : FolderError
     data object NotFound : FolderError
     data object Unavailable : FolderError
-    data class FailedPrecondition(val message: String, val throwable: Throwable? = null) : FolderError
-    data class FailedToQueryDatabase(val message: String, val throwable: Throwable) : FolderError
+    data class FailedPrecondition(val message: String, override val throwable: Throwable) : FolderError
+    data class FailedToQueryDatabase(val message: String, override val throwable: Throwable) : FolderError
 }

--- a/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/repository/RemoteFolderDetailsRepository.kt
+++ b/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/repository/RemoteFolderDetailsRepository.kt
@@ -1,0 +1,17 @@
+package net.thunderbird.feature.mail.folder.api.data.repository
+
+import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.feature.account.AccountId
+import net.thunderbird.feature.mail.folder.api.FolderDetails
+import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.RemoteFolderDetails
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+
+interface RemoteFolderDetailsRepository {
+    /**
+     * Returns a list of [FolderDetails] of a [RemoteFolder] for the given [accountId].
+     *
+     * @param accountId The account identifier.
+     */
+    suspend fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolderDetails>, FolderError>
+}

--- a/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/repository/RemoteFolderQueryRepository.kt
+++ b/feature/mail/folder/api/src/commonMain/kotlin/net/thunderbird/feature/mail/folder/api/data/repository/RemoteFolderQueryRepository.kt
@@ -1,23 +1,17 @@
 package net.thunderbird.feature.mail.folder.api.data.repository
 
-import kotlinx.coroutines.flow.Flow
 import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
 import net.thunderbird.feature.mail.folder.api.data.FolderError
 
-interface PushFoldersQueryRepository {
+interface RemoteFolderQueryRepository {
     /**
-     * Returns a [Flow] of [RemoteFolder]s for the given [accountId] that should be used for push.
+     * Returns a list of [RemoteFolder]s for the given [accountId].
      *
      * @param accountId The account identifier.
-     */
-    fun observeAllByAccountId(accountId: AccountId): Flow<Outcome<List<RemoteFolder>, FolderError>>
-
-    /**
-     * Returns a list of [RemoteFolder]s for the given [accountId] that should be used for push.
-     *
-     * @param accountId The account identifier.
+     * @throws MessagingException if there's a problem accessing the folders.
      */
     suspend fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolder>, FolderError>
 }

--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/domain/DomainContract.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/domain/DomainContract.kt
@@ -55,7 +55,7 @@ interface DomainContract {
     }
 }
 
-data class AccountFolderError(val exception: Exception)
+data class AccountFolderError(val exception: Throwable)
 
 sealed interface SetAccountFolderOutcome {
     data object Success : SetAccountFolderOutcome

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/FeatureMessageListModule.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/FeatureMessageListModule.kt
@@ -24,7 +24,7 @@ import org.koin.dsl.module
 
 val featureMessageListModule = module {
     includes(messageListSideEffectsModule)
-    factory<DomainContract.UseCase.GetAccountFolders> { GetAccountFolders(folderRepository = get()) }
+    factory<DomainContract.UseCase.GetAccountFolders> { GetAccountFolders(remoteFolderQueryRepository = get()) }
     factory<DomainContract.UseCase.CreateArchiveFolder> {
         CreateArchiveFolder(
             accountManager = get(),

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/domain/usecase/GetAccountFolders.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/domain/usecase/GetAccountFolders.kt
@@ -1,31 +1,39 @@
 package net.thunderbird.feature.mail.message.list.internal.domain.usecase
 
-import app.k9mail.legacy.mailstore.FolderRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.components.core.outcome.map
 import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderQueryRepository
 import net.thunderbird.feature.mail.message.list.domain.AccountFolderError
 import net.thunderbird.feature.mail.message.list.domain.DomainContract
 
 internal class GetAccountFolders(
-    private val folderRepository: FolderRepository,
+    private val remoteFolderQueryRepository: RemoteFolderQueryRepository,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : DomainContract.UseCase.GetAccountFolders {
     override suspend fun invoke(accountId: AccountId): Outcome<List<RemoteFolder>, AccountFolderError> =
         withContext(ioDispatcher) {
-            try {
-                Outcome.success(
-                    data = folderRepository
-                        .getRemoteFolders(accountId)
-                        .filter { it.type == FolderType.REGULAR || it.type == FolderType.ARCHIVE },
+            remoteFolderQueryRepository
+                .getAllByAccountId(accountId)
+                .map(
+                    transformSuccess = { remoteFolders ->
+                        remoteFolders.filter { it.type == FolderType.REGULAR || it.type == FolderType.ARCHIVE }
+                    },
+                    transformFailure = { error, _ ->
+                        AccountFolderError(
+                            exception = when (error) {
+                                is FolderError.FailedToQueryDatabase -> error.throwable
+                                else -> MessagingException("Failed to get account folders. Folder error = $error")
+                            },
+                        )
+                    },
                 )
-            } catch (e: MessagingException) {
-                Outcome.failure(error = AccountFolderError(exception = e))
-            }
         }
 }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffect.kt
@@ -4,11 +4,13 @@ import androidx.compose.ui.graphics.Color
 import app.k9mail.legacy.mailstore.FolderRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
+import net.thunderbird.components.core.outcome.fold
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.UnifiedAccountId
 import net.thunderbird.feature.account.profile.AccountProfileRepository
 import net.thunderbird.feature.mail.folder.api.FolderType
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderQueryRepository
 import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.FolderEvent
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
@@ -26,6 +28,7 @@ internal class LoadFolderInformationSideEffect(
     dispatch: suspend (MessageListEvent) -> Unit,
     private val logger: Logger,
     private val folderRepository: FolderRepository,
+    private val remoteFolderQueryRepository: RemoteFolderQueryRepository,
     private val profileRepository: AccountProfileRepository,
 ) : MessageListStateSideEffectHandler(logger, dispatch) {
     override fun accept(event: MessageListEvent, oldState: MessageListState, newState: MessageListState): Boolean =
@@ -64,7 +67,10 @@ internal class LoadFolderInformationSideEffect(
         val folder = folderRepository.getFolder(accountId, folderId)
         return if (folder != null) {
             val remoteFolder = if (!folder.isLocalOnly) {
-                folderRepository.getRemoteFolders(accountId).first { it.id == folderId }
+                remoteFolderQueryRepository
+                    .getAllByAccountId(accountId)
+                    .fold(onSuccess = { it }, onFailure = { emptyList() })
+                    .firstOrNull { it.id == folderId }
             } else {
                 null
             }
@@ -92,6 +98,7 @@ internal class LoadFolderInformationSideEffect(
         private val folderId: Long?,
         private val logger: Logger,
         private val folderRepository: FolderRepository,
+        private val remoteFolderQueryRepository: RemoteFolderQueryRepository,
         private val profileRepository: AccountProfileRepository,
     ) : MessageListStateSideEffectHandlerFactory {
         override fun create(
@@ -104,6 +111,7 @@ internal class LoadFolderInformationSideEffect(
             dispatch = dispatch,
             logger = logger,
             folderRepository = folderRepository,
+            remoteFolderQueryRepository = remoteFolderQueryRepository,
             profileRepository = profileRepository,
         )
     }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffect.kt
@@ -70,7 +70,7 @@ internal class LoadFolderInformationSideEffect(
                 remoteFolderQueryRepository
                     .getAllByAccountId(accountId)
                     .fold(onSuccess = { it }, onFailure = { emptyList() })
-                    .firstOrNull { it.id == folderId }
+                    .first { it.id == folderId }
             } else {
                 null
             }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/inject/MessageListSideEffectsModule.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/inject/MessageListSideEffectsModule.kt
@@ -54,6 +54,7 @@ internal val messageListSideEffectsModule = module {
                 folderId = args.folderId,
                 logger = get(),
                 folderRepository = get(),
+                remoteFolderQueryRepository = get(),
                 profileRepository = get(),
             )
         },

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/domain/usecase/GetAccountFoldersTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/domain/usecase/GetAccountFoldersTest.kt
@@ -1,6 +1,5 @@
 package net.thunderbird.feature.mail.message.list.internal.domain.usecase
 
-import app.k9mail.legacy.mailstore.FolderRepository
 import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
@@ -21,9 +20,7 @@ import net.thunderbird.feature.account.AccountIdFactory
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
 import net.thunderbird.feature.mail.message.list.domain.AccountFolderError
-import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
+import net.thunderbird.feature.mail.message.list.internal.fakes.FakeRemoteFolderQueryRepository
 
 private val VALID_ACCOUNT_ID = AccountIdFactory.create()
 private val INVALID_ACCOUNT_ID = AccountIdFactory.create()
@@ -243,14 +240,10 @@ class GetAccountFoldersTest {
         folders: List<RemoteFolder>,
         exception: Exception? = null,
     ): GetAccountFolders {
-        val folderRepository = mock<FolderRepository>()
-        if (exception != null) {
-            whenever(folderRepository.getRemoteFolders(any()))
-                .thenThrow(exception)
-        } else {
-            whenever(folderRepository.getRemoteFolders(any()))
-                .thenReturn(folders)
-        }
-        return GetAccountFolders(folderRepository, ioDispatcher = UnconfinedTestDispatcher())
+        val remoteFolderQueryRepository = FakeRemoteFolderQueryRepository(
+            remoteFolders = mapOf(VALID_ACCOUNT_ID to folders, INVALID_ACCOUNT_ID to folders),
+            exception = exception,
+        )
+        return GetAccountFolders(remoteFolderQueryRepository, ioDispatcher = UnconfinedTestDispatcher())
     }
 }

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/fakes/FakeFolderRepository.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/fakes/FakeFolderRepository.kt
@@ -1,46 +1,30 @@
 package net.thunderbird.feature.mail.message.list.internal.fakes
 
 import app.k9mail.legacy.mailstore.FolderRepository
-import app.k9mail.legacy.mailstore.RemoteFolderDetails
 import kotlinx.coroutines.flow.Flow
 import net.thunderbird.components.core.outcome.Outcome
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.folder.api.Folder
-import net.thunderbird.feature.mail.folder.api.RemoteFolder
 import net.thunderbird.feature.mail.folder.api.data.FolderError
 
 class FakeFolderRepository(
-    private val localFolders: Map<AccountId, List<Folder>>,
-    private val remoteFolders: Map<AccountId, List<RemoteFolder>>,
+    private val localFolders: Map<AccountId, List<Folder>> = emptyMap(),
 ) : FolderRepository {
     override suspend fun getFolder(
         accountId: AccountId,
         folderId: Long,
     ): Folder? = localFolders[accountId]?.find { it.id == folderId }
 
-    override fun getRemoteFolders(accountId: AccountId): List<RemoteFolder> = remoteFolders[accountId].orEmpty()
+    override fun getFolderServerId(accountId: AccountId, folderId: Long): String? = error("Not implemented")
 
-    override fun getRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails> = error("Not implemented")
+    override fun getFolderId(accountId: AccountId, folderServerId: String): Long? = error("Not implemented")
 
-    override fun getFolderServerId(
-        accountId: AccountId,
-        folderId: Long,
-    ): String? = error("Not implemented")
-
-    override fun getFolderId(
-        accountId: AccountId,
-        folderServerId: String,
-    ): Long? = error("Not implemented")
-
-    override fun isFolderPresent(
-        accountId: AccountId,
-        folderId: Long,
-    ): Boolean = error("Not implemented")
+    override fun isFolderPresent(accountId: AccountId, folderId: Long): Boolean = error("Not implemented")
 
     override fun observeEnabled(accountId: AccountId): Flow<Outcome<Boolean, FolderError>> =
-        error("Not yet implemented")
+        error("Not implemented")
 
-    override suspend fun isEnabled(accountId: AccountId): Outcome<Boolean, FolderError> = error("Not yet implemented")
+    override suspend fun isEnabled(accountId: AccountId): Outcome<Boolean, FolderError> = error("Not implemented")
 
-    override suspend fun disable(accountId: AccountId): Outcome<Unit, FolderError> = error("Not yet implemented")
+    override suspend fun disable(accountId: AccountId): Outcome<Unit, FolderError> = error("Not implemented")
 }

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/fakes/FakeRemoteFolderQueryRepository.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/fakes/FakeRemoteFolderQueryRepository.kt
@@ -1,0 +1,24 @@
+package net.thunderbird.feature.mail.message.list.internal.fakes
+
+import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.core.common.exception.MessagingException
+import net.thunderbird.feature.account.AccountId
+import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderQueryRepository
+
+class FakeRemoteFolderQueryRepository(
+    private val remoteFolders: Map<AccountId, List<RemoteFolder>> = emptyMap(),
+    private val exception: Exception? = null,
+) : RemoteFolderQueryRepository {
+    override suspend fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolder>, FolderError> =
+        when (exception) {
+            null -> Outcome.success(remoteFolders[accountId].orEmpty())
+
+            is MessagingException -> Outcome.failure(
+                FolderError.FailedToQueryDatabase(message = exception.message ?: "", throwable = exception),
+            )
+
+            else -> throw exception
+        }
+}

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffectTest.kt
@@ -11,7 +11,6 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -31,7 +30,9 @@ import net.thunderbird.feature.account.profile.AccountProfile
 import net.thunderbird.feature.account.profile.AccountProfileRepository
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderQueryRepository
 import net.thunderbird.feature.mail.message.list.internal.fakes.FakeFolderRepository
+import net.thunderbird.feature.mail.message.list.internal.fakes.FakeRemoteFolderQueryRepository
 import net.thunderbird.feature.mail.message.list.internal.fakes.RecordingSuspendFunction
 import net.thunderbird.feature.mail.message.list.ui.event.FolderEvent
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
@@ -244,6 +245,9 @@ class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
             accountId = accountId,
             folderId = folderId,
             folder = folder,
+        )
+        val remoteFolderQueryRepository = createRemoteFolderQueryRepository(
+            accountId = accountId,
             remoteFolders = listOf(remoteFolder),
         )
         val expectedColor = Color.Blue
@@ -252,6 +256,7 @@ class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
             folderId = folderId,
             dispatch = dispatch.function,
             folderRepository = folderRepository,
+            remoteFolderQueryRepository = remoteFolderQueryRepository,
             profileRepository = FakeAccountProfileRepository(
                 profiles = listOf(createAccountProfile(accountId = accountId, expectedColor)),
             ),
@@ -356,38 +361,59 @@ class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
     }
 
     @Test
-    fun `handle() should throw when remote folder is missing for non-local folder`() = runTest {
-        // Arrange
-        val accountId = AccountIdFactory.create()
-        val folderId = 11L
-        val folder = createMailFolder(id = folderId, name = "Remote", isLocalOnly = false)
-        val remoteFolder = RemoteFolder(
-            id = 999L,
-            serverId = "other",
-            name = "Other",
-            type = FolderType.INBOX,
-        )
-        val folderRepository = createFolderRepository(
-            accountId = accountId,
-            folderId = folderId,
-            folder = folder,
-            remoteFolders = listOf(remoteFolder),
-        )
-        val testSubject = createTestSubject(
-            accountIds = setOf(accountId),
-            folderId = folderId,
-            folderRepository = folderRepository,
-        )
+    fun `handle() should dispatch FolderLoaded with local_folder id when remote folder is missing for non-local folder`() =
+        runTest {
+            // Arrange
+            val accountId = AccountIdFactory.create()
+            val folderId = 11L
+            val folder = createMailFolder(id = folderId, name = "Remote", isLocalOnly = false)
+            val remoteFolder = RemoteFolder(
+                id = 999L,
+                serverId = "other",
+                name = "Other",
+                type = FolderType.INBOX,
+            )
+            val dispatch = RecordingSuspendFunction<MessageListEvent>()
+            val folderRepository = createFolderRepository(
+                accountId = accountId,
+                folderId = folderId,
+                folder = folder,
+            )
+            val remoteFolderQueryRepository = createRemoteFolderQueryRepository(
+                accountId = accountId,
+                remoteFolders = listOf(remoteFolder),
+            )
+            val expectedColor = Color.Cyan
+            val testSubject = createTestSubject(
+                accountIds = setOf(accountId),
+                folderId = folderId,
+                dispatch = dispatch.function,
+                folderRepository = folderRepository,
+                remoteFolderQueryRepository = remoteFolderQueryRepository,
+                profileRepository = FakeAccountProfileRepository(
+                    profiles = listOf(createAccountProfile(accountId = accountId, expectedColor)),
+                ),
+            )
 
-        // Act / Assert
-        assertFailsWith<NoSuchElementException> {
+            // Act
             testSubject.handle(
                 event = MessageListEvent.LoadConfigurations,
                 oldState = MessageListState.WarmingUp(),
                 newState = MessageListState.WarmingUp(),
             )
+
+            // Assert
+            assertThat(dispatch.calls).containsExactly(
+                FolderEvent.FolderLoaded(
+                    folder = Folder(
+                        id = "local_folder",
+                        account = Account(id = accountId, color = expectedColor),
+                        name = "Remote",
+                        type = FolderType.INBOX,
+                    ),
+                ),
+            )
         }
-    }
 
     @Test
     fun `factory should create LoadFolderInformationSideEffect`() {
@@ -401,6 +427,7 @@ class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
                 folderId = 1L,
                 folder = null,
             ),
+            remoteFolderQueryRepository = FakeRemoteFolderQueryRepository(),
             profileRepository = FakeAccountProfileRepository(),
         )
 
@@ -420,10 +447,8 @@ class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
         folderId: Long? = 1L,
         dispatch: suspend (MessageListEvent) -> Unit = {},
         logger: Logger = TestLogger(),
-        folderRepository: FolderRepository = FakeFolderRepository(
-            localFolders = emptyMap(),
-            remoteFolders = emptyMap(),
-        ),
+        folderRepository: FolderRepository = FakeFolderRepository(),
+        remoteFolderQueryRepository: RemoteFolderQueryRepository = FakeRemoteFolderQueryRepository(),
         profileRepository: AccountProfileRepository = FakeAccountProfileRepository(
             profiles = accountIds.map(::createAccountProfile),
         ),
@@ -433,6 +458,7 @@ class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
         dispatch = dispatch,
         logger = logger,
         folderRepository = folderRepository,
+        remoteFolderQueryRepository = remoteFolderQueryRepository,
         profileRepository = profileRepository,
     )
 
@@ -440,9 +466,14 @@ class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
         accountId: AccountId,
         folderId: Long,
         folder: MailFolder?,
-        remoteFolders: List<RemoteFolder> = emptyList(),
     ): FolderRepository = FakeFolderRepository(
         localFolders = mapOf(accountId to listOfNotNull(folder?.copy(id = folderId))),
+    )
+
+    private fun createRemoteFolderQueryRepository(
+        accountId: AccountId,
+        remoteFolders: List<RemoteFolder>,
+    ): RemoteFolderQueryRepository = FakeRemoteFolderQueryRepository(
         remoteFolders = mapOf(accountId to remoteFolders),
     )
 

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffectTest.kt
@@ -11,6 +11,7 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -361,7 +362,7 @@ class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
     }
 
     @Test
-    fun `handle() should dispatch FolderLoaded with local_folder id when remote folder is missing for non-local folder`() =
+    fun `handle() should throw NoSuchElementException when remote folder data is missing for non-local folder`() =
         runTest {
             // Arrange
             val accountId = AccountIdFactory.create()
@@ -395,24 +396,14 @@ class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
                 ),
             )
 
-            // Act
-            testSubject.handle(
-                event = MessageListEvent.LoadConfigurations,
-                oldState = MessageListState.WarmingUp(),
-                newState = MessageListState.WarmingUp(),
-            )
-
-            // Assert
-            assertThat(dispatch.calls).containsExactly(
-                FolderEvent.FolderLoaded(
-                    folder = Folder(
-                        id = "local_folder",
-                        account = Account(id = accountId, color = expectedColor),
-                        name = "Remote",
-                        type = FolderType.INBOX,
-                    ),
-                ),
-            )
+            // Act & Assert
+            assertFailsWith<NoSuchElementException> {
+                testSubject.handle(
+                    event = MessageListEvent.LoadConfigurations,
+                    oldState = MessageListState.WarmingUp(),
+                    newState = MessageListState.WarmingUp(),
+                )
+            }
         }
 
     @Test

--- a/feature/migration/provider/src/main/kotlin/app/k9mail/feature/migration/provider/SettingsProvider.kt
+++ b/feature/migration/provider/src/main/kotlin/app/k9mail/feature/migration/provider/SettingsProvider.kt
@@ -13,6 +13,7 @@ import com.fsck.k9.helper.MimeTypeUtil
 import com.fsck.k9.helper.mapToSet
 import com.fsck.k9.preferences.SettingsExporter
 import kotlin.concurrent.thread
+import kotlinx.coroutines.runBlocking
 import net.thunderbird.core.android.account.LegacyAccountDtoManager
 import net.thunderbird.legacy.logging.Log
 import okio.ByteString.Companion.toByteString
@@ -49,12 +50,14 @@ class SettingsProvider : ContentProvider(), KoinComponent {
         thread {
             val accountUuids = accountManager.getAccounts().mapToSet { it.uuid }
             ParcelFileDescriptor.AutoCloseOutputStream(writeFileDescriptor).use { outputStream ->
-                settingsExporter.exportPreferences(
-                    outputStream,
-                    includeGlobals = true,
-                    accountUuids,
-                    includePasswords = true,
-                )
+                runBlocking {
+                    settingsExporter.exportPreferences(
+                        outputStream,
+                        includeGlobals = true,
+                        accountUuids,
+                        includePasswords = true,
+                    )
+                }
             }
         }
 

--- a/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import net.thunderbird.core.logging.Logger
 import net.thunderbird.components.core.outcome.fold
+import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.folder.api.data.repository.PushFoldersQueryRepository
 
@@ -67,7 +67,9 @@ internal class AccountPushController(
                             updatePushFolders(folderServerIds)
                         },
                         onFailure = {
-                            logger.error { "Failed to start listening for push folders. Error: $it" }
+                            logger.error(throwable = it.throwable) {
+                                "Failed to start listening for push folders. Error: $it"
+                            }
                         },
                     )
                 }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdater.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdater.kt
@@ -1,15 +1,16 @@
 package com.fsck.k9.mailstore
 
-import app.k9mail.legacy.mailstore.FolderRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import net.thunderbird.components.core.outcome.handleAsync
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountManager
 import net.thunderbird.core.common.mail.Protocols
+import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
@@ -17,6 +18,7 @@ import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection
 import net.thunderbird.feature.mail.folder.api.SpecialFolderUpdater
 import net.thunderbird.feature.mail.folder.api.data.repository.FolderDetailsRepository
 import net.thunderbird.feature.mail.folder.api.data.repository.PartialUpdatableFolderDetails
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderQueryRepository
 
 /**
  * Updates special folders in [LegacyAccountDto] if they are marked as [SpecialFolderSelection.AUTOMATIC] or if they
@@ -26,11 +28,12 @@ import net.thunderbird.feature.mail.folder.api.data.repository.PartialUpdatableF
 @Suppress("TooManyFunctions")
 class DefaultSpecialFolderUpdater(
     private val accountManager: LegacyAccountManager,
-    private val folderRepository: FolderRepository,
+    private val remoteFolderQueryRepository: RemoteFolderQueryRepository,
     private val folderDetailsRepository: FolderDetailsRepository,
     private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
     private val accountId: AccountId,
     private val coroutineScope: CoroutineScope,
+    private val logger: Logger,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : SpecialFolderUpdater {
 
@@ -48,21 +51,26 @@ class DefaultSpecialFolderUpdater(
 
     private suspend fun updateSpecialFoldersSynchronous() {
         var account: LegacyAccount = getAccountById(accountId)
-        val folders = folderRepository.getRemoteFolders(accountId)
+        remoteFolderQueryRepository.getAllByAccountId(accountId).handleAsync(
+            onSuccess = { folders ->
+                account = updateInbox(account, folders)
 
-        account = updateInbox(account, folders)
+                if (!account.isPop3()) {
+                    account = updateSpecialFolderSynchronous(account, FolderType.ARCHIVE, folders)
+                    account = updateSpecialFolderSynchronous(account, FolderType.DRAFTS, folders)
+                    account = updateSpecialFolderSynchronous(account, FolderType.SENT, folders)
+                    account = updateSpecialFolderSynchronous(account, FolderType.SPAM, folders)
+                    account = updateSpecialFolderSynchronous(account, FolderType.TRASH, folders)
+                }
 
-        if (!account.isPop3()) {
-            account = updateSpecialFolderSynchronous(account, FolderType.ARCHIVE, folders)
-            account = updateSpecialFolderSynchronous(account, FolderType.DRAFTS, folders)
-            account = updateSpecialFolderSynchronous(account, FolderType.SENT, folders)
-            account = updateSpecialFolderSynchronous(account, FolderType.SPAM, folders)
-            account = updateSpecialFolderSynchronous(account, FolderType.TRASH, folders)
-        }
+                account = removeImportedSpecialFoldersData(account)
 
-        account = removeImportedSpecialFoldersData(account)
-
-        updateAccount(account)
+                updateAccount(account)
+            },
+            onFailure = {
+                logger.error { "Failed to update special folders. Folder error: $it" }
+            },
+        )
     }
 
     private suspend fun updateInbox(account: LegacyAccount, folders: List<RemoteFolder>): LegacyAccount {
@@ -236,19 +244,21 @@ class DefaultSpecialFolderUpdater(
 
     class Factory(
         private val accountManager: LegacyAccountManager,
-        private val folderRepository: FolderRepository,
+        private val remoteFolderQueryRepository: RemoteFolderQueryRepository,
         private val folderDetailsRepository: FolderDetailsRepository,
         private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
         private val coroutineScope: CoroutineScope,
+        private val logger: Logger,
         private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     ) : SpecialFolderUpdater.Factory {
         override fun create(accountId: AccountId): SpecialFolderUpdater = DefaultSpecialFolderUpdater(
             accountManager = accountManager,
-            folderRepository = folderRepository,
+            remoteFolderQueryRepository = remoteFolderQueryRepository,
             folderDetailsRepository = folderDetailsRepository,
             specialFolderSelectionStrategy = specialFolderSelectionStrategy,
             accountId = accountId,
             coroutineScope = coroutineScope,
+            logger = logger,
             ioDispatcher = ioDispatcher,
         )
     }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdater.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdater.kt
@@ -67,8 +67,12 @@ class DefaultSpecialFolderUpdater(
 
                 updateAccount(account)
             },
-            onFailure = {
-                logger.error { "Failed to update special folders. Folder error: $it" }
+            onFailure = { error ->
+                logger.error { "Failed to update special folders. Folder error: $error" }
+                when (val throwable = error.throwable) {
+                    null -> error("Unknown error while loading folders. Error: $error")
+                    else -> throw throwable
+                }
             },
         )
     }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -6,19 +6,22 @@ import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.mailstore.MessageListRepository
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.mailstore.folder.DefaultFolderDetailsRepository
+import app.k9mail.legacy.mailstore.folder.DefaultRemoteFolderDetailsRepository
+import app.k9mail.legacy.mailstore.folder.DefaultRemoteFolderQueryRepository
 import app.k9mail.legacy.mailstore.folder.push.DefaultPushFolderTrackingRepository
 import app.k9mail.legacy.mailstore.folder.push.DefaultPushFoldersQueryRepository
 import com.fsck.k9.mailstore.folder.DefaultOutboxFolderManager
 import com.fsck.k9.message.extractors.AttachmentCounter
 import com.fsck.k9.message.extractors.MessageFulltextCreator
 import com.fsck.k9.message.extractors.MessagePreviewCreator
-import kotlin.time.ExperimentalTime
 import net.thunderbird.backend.api.BackendStorageFactory
 import net.thunderbird.core.common.cache.TimeLimitedCache
 import net.thunderbird.feature.mail.folder.api.OutboxFolderManager
 import net.thunderbird.feature.mail.folder.api.data.repository.FolderDetailsRepository
 import net.thunderbird.feature.mail.folder.api.data.repository.PushFolderTrackingRepository
 import net.thunderbird.feature.mail.folder.api.data.repository.PushFoldersQueryRepository
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderDetailsRepository
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderQueryRepository
 import org.koin.dsl.module
 
 val mailStoreModule = module {
@@ -26,10 +29,18 @@ val mailStoreModule = module {
         DefaultPushFolderTrackingRepository(logger = get(), messageStoreManager = get())
     }
     single<PushFoldersQueryRepository> {
-        DefaultPushFoldersQueryRepository(logger = get(), messageStoreManager = get())
+        DefaultPushFoldersQueryRepository(
+            logger = get(),
+            messageStoreManager = get(),
+            remoteFolderDetailsRepository = get(),
+        )
     }
     single<PushFoldersQueryRepository> {
-        DefaultPushFoldersQueryRepository(logger = get(), messageStoreManager = get())
+        DefaultPushFoldersQueryRepository(
+            logger = get(),
+            messageStoreManager = get(),
+            remoteFolderDetailsRepository = get(),
+        )
     }
     single<FolderDetailsRepository> {
         DefaultFolderDetailsRepository(
@@ -38,6 +49,15 @@ val mailStoreModule = module {
             outboxFolderManager = get(),
             messageStoreManager = get(),
         )
+    }
+    single<RemoteFolderDetailsRepository> {
+        DefaultRemoteFolderDetailsRepository(
+            logger = get(),
+            messageStoreManager = get(),
+        )
+    }
+    single<RemoteFolderQueryRepository> {
+        DefaultRemoteFolderQueryRepository(logger = get(), messageStoreManager = get())
     }
     single<FolderRepository> {
         DefaultFolderRepository(

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsProvider.kt
@@ -1,12 +1,15 @@
 package com.fsck.k9.preferences
 
-import app.k9mail.legacy.mailstore.FolderRepository
 import app.k9mail.legacy.mailstore.RemoteFolderDetails
+import net.thunderbird.components.core.outcome.fold
 import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderDetailsRepository
 
-class FolderSettingsProvider(private val folderRepository: FolderRepository) {
-    fun getFolderSettings(account: LegacyAccountDto): List<FolderSettings> {
-        return folderRepository.getRemoteFolderDetails(account.id)
+class FolderSettingsProvider(private val remoteFolderDetailsRepository: RemoteFolderDetailsRepository) {
+    suspend fun getFolderSettings(account: LegacyAccountDto): List<FolderSettings> {
+        return remoteFolderDetailsRepository
+            .getAllByAccountId(account.id)
+            .fold(onSuccess = { it }, onFailure = { emptyList() })
             .filterNot { it.containsOnlyDefaultValues() }
             .map { it.toFolderSettings() }
     }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsProvider.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/FolderSettingsProvider.kt
@@ -9,7 +9,15 @@ class FolderSettingsProvider(private val remoteFolderDetailsRepository: RemoteFo
     suspend fun getFolderSettings(account: LegacyAccountDto): List<FolderSettings> {
         return remoteFolderDetailsRepository
             .getAllByAccountId(account.id)
-            .fold(onSuccess = { it }, onFailure = { emptyList() })
+            .fold(
+                onSuccess = { it },
+                onFailure = { error ->
+                    when (val throwable = error.throwable) {
+                        null -> error("Unknown error while fetching remote folder details settings. Error: $error")
+                        else -> throw throwable
+                    }
+                },
+            )
             .filterNot { it.containsOnlyDefaultValues() }
             .map { it.toFolderSettings() }
     }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
@@ -47,7 +47,7 @@ val preferencesModule = module {
             filePrefixProvider = get(),
         )
     }
-    factory { FolderSettingsProvider(folderRepository = get()) }
+    factory { FolderSettingsProvider(remoteFolderDetailsRepository = get()) }
     factory<LegacyAccountDtoManager> { get<Preferences>() }
     single<PrivacySettingsPreferenceManager> {
         DefaultPrivacySettingsPreferenceManager(

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
@@ -30,7 +30,7 @@ class SettingsExporter(
     private val filePrefixProvider: FilePrefixProvider,
 ) {
     @Throws(SettingsImportExportException::class)
-    fun exportToUri(includeGlobals: Boolean, accountUuids: Set<String>, uri: Uri) {
+    suspend fun exportToUri(includeGlobals: Boolean, accountUuids: Set<String>, uri: Uri) {
         try {
             contentResolver.openOutputStream(uri, "wt")!!.use { outputStream ->
                 exportPreferences(outputStream, includeGlobals, accountUuids, includePasswords = false)
@@ -41,7 +41,7 @@ class SettingsExporter(
     }
 
     @Throws(SettingsImportExportException::class)
-    fun exportPreferences(
+    suspend fun exportPreferences(
         outputStream: OutputStream,
         includeGlobals: Boolean,
         accountUuids: Set<String>,
@@ -123,7 +123,7 @@ class SettingsExporter(
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod", "NestedBlockDepth")
-    private fun writeAccount(
+    private suspend fun writeAccount(
         serializer: XmlSerializer,
         account: LegacyAccountDto,
         prefs: Map<String, Any>,

--- a/legacy/core/src/test/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdaterTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/mailstore/DefaultSpecialFolderUpdaterTest.kt
@@ -1,7 +1,5 @@
 package com.fsck.k9.mailstore
 
-import app.k9mail.legacy.mailstore.FolderRepository
-import app.k9mail.legacy.mailstore.RemoteFolderDetails
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
@@ -18,13 +16,13 @@ import net.thunderbird.core.android.account.Identity
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountManager
 import net.thunderbird.core.common.mail.Protocols
+import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.components.core.outcome.Outcome
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.AccountIdFactory
 import net.thunderbird.feature.account.storage.profile.AvatarDto
 import net.thunderbird.feature.account.storage.profile.AvatarTypeDto
 import net.thunderbird.feature.account.storage.profile.ProfileDto
-import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderDetails
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
@@ -32,6 +30,7 @@ import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection
 import net.thunderbird.feature.mail.folder.api.data.FolderError
 import net.thunderbird.feature.mail.folder.api.data.repository.FolderDetailsRepository
 import net.thunderbird.feature.mail.folder.api.data.repository.PartialUpdatableFolderDetails
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderQueryRepository
 import org.junit.Test
 
 @OptIn(ExperimentalUuidApi::class, ExperimentalCoroutinesApi::class)
@@ -39,7 +38,7 @@ class DefaultSpecialFolderUpdaterTest {
     private val accountId = AccountIdFactory.create()
     private val account = createAccount(accountId)
     private val accountManager = FakeLegacyAccountManager(initialAccounts = listOf(account))
-    private val folderRepository = FakeFolderRepository()
+    private val remoteFolderQueryRepository = FakeRemoteFolderQueryRepository()
     private val folderDetailsRepository = FakeFolderDetailsRepository()
     private val specialFolderSelectionStrategy = SpecialFolderSelectionStrategy()
 
@@ -49,11 +48,12 @@ class DefaultSpecialFolderUpdaterTest {
 
     private val subject = DefaultSpecialFolderUpdater(
         accountManager = accountManager,
-        folderRepository = folderRepository,
+        remoteFolderQueryRepository = remoteFolderQueryRepository,
         folderDetailsRepository = folderDetailsRepository,
         specialFolderSelectionStrategy = specialFolderSelectionStrategy,
         accountId = accountId,
         coroutineScope = coroutineScope,
+        logger = TestLogger(),
         ioDispatcher = testDispatcher,
     )
 
@@ -67,7 +67,7 @@ class DefaultSpecialFolderUpdaterTest {
         val archiveFolder = createRemoteFolder(id = 5, type = FolderType.ARCHIVE, serverId = "Archive")
         val spamFolder = createRemoteFolder(id = 6, type = FolderType.SPAM, serverId = "Spam")
 
-        folderRepository.remoteFolders =
+        remoteFolderQueryRepository.remoteFolders =
             listOf(inboxFolder, draftsFolder, sentFolder, trashFolder, archiveFolder, spamFolder)
 
         // Act
@@ -88,7 +88,7 @@ class DefaultSpecialFolderUpdaterTest {
         // Arrange
         val inboxFolder = createRemoteFolder(id = 1, type = FolderType.INBOX, serverId = "INBOX")
         val draftsFolder = createRemoteFolder(id = 2, type = FolderType.DRAFTS, serverId = "Drafts")
-        folderRepository.remoteFolders = listOf(inboxFolder, draftsFolder)
+        remoteFolderQueryRepository.remoteFolders = listOf(inboxFolder, draftsFolder)
 
         // Act
         subject.updateSpecialFolders()
@@ -110,7 +110,7 @@ class DefaultSpecialFolderUpdaterTest {
         accountManager.updateSync(accountWithImports)
 
         val draftsFolder = createRemoteFolder(id = 10, type = FolderType.REGULAR, serverId = "ImportedDrafts")
-        folderRepository.remoteFolders = listOf(draftsFolder)
+        remoteFolderQueryRepository.remoteFolders = listOf(draftsFolder)
 
         // Act
         subject.updateSpecialFoldersSync()
@@ -132,7 +132,7 @@ class DefaultSpecialFolderUpdaterTest {
 
         // Remote folders do NOT include ID 99, but has a folder named "Drafts"
         val draftsFolder = createRemoteFolder(id = 2, type = FolderType.DRAFTS, serverId = "Drafts")
-        folderRepository.remoteFolders = listOf(draftsFolder)
+        remoteFolderQueryRepository.remoteFolders = listOf(draftsFolder)
 
         // Act
         subject.updateSpecialFoldersSync()
@@ -153,7 +153,7 @@ class DefaultSpecialFolderUpdaterTest {
 
         val inboxFolder = createRemoteFolder(id = 1, type = FolderType.INBOX, serverId = "INBOX")
         val draftsFolder = createRemoteFolder(id = 2, type = FolderType.DRAFTS, serverId = "Drafts")
-        folderRepository.remoteFolders = listOf(inboxFolder, draftsFolder)
+        remoteFolderQueryRepository.remoteFolders = listOf(inboxFolder, draftsFolder)
 
         // Act
         subject.updateSpecialFoldersSync()
@@ -206,26 +206,11 @@ class DefaultSpecialFolderUpdaterTest {
         return RemoteFolder(id, serverId, "Folder $serverId", type)
     }
 
-    private class FakeFolderRepository : FolderRepository {
+    private class FakeRemoteFolderQueryRepository : RemoteFolderQueryRepository {
         var remoteFolders: List<RemoteFolder> = emptyList()
 
-        override suspend fun getFolder(accountId: AccountId, folderId: Long): Folder? = null
-        override fun getRemoteFolders(accountId: AccountId): List<RemoteFolder> = remoteFolders
-        override fun getRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails> = emptyList()
-        override fun getFolderServerId(accountId: AccountId, folderId: Long): String? = null
-        override fun getFolderId(accountId: AccountId, folderServerId: String): Long? = null
-        override fun isFolderPresent(accountId: AccountId, folderId: Long): Boolean = false
-        override fun observeEnabled(accountId: AccountId): Flow<Outcome<Boolean, FolderError>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun isEnabled(accountId: AccountId): Outcome<Boolean, FolderError> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun disable(accountId: AccountId): Outcome<Unit, FolderError> {
-            TODO("Not yet implemented")
-        }
+        override suspend fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolder>, FolderError> =
+            Outcome.success(remoteFolders)
     }
 
     private class FakeFolderDetailsRepository : FolderDetailsRepository {

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isNull
 import com.fsck.k9.K9RobolectricTest
 import com.fsck.k9.Preferences
 import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.runBlocking
 import org.jdom2.Document
 import org.jdom2.input.SAXBuilder
 import org.junit.Test
@@ -64,8 +65,8 @@ class SettingsExporterTest : K9RobolectricTest() {
         assertThat(document.rootElement.getChild("global")).isNull()
     }
 
-    private fun exportPreferences(globalSettings: Boolean, accounts: Set<String>): Document {
-        return ByteArrayOutputStream().use { outputStream ->
+    private fun exportPreferences(globalSettings: Boolean, accounts: Set<String>): Document = runBlocking {
+        ByteArrayOutputStream().use { outputStream ->
             settingsExporter.exportPreferences(outputStream, globalSettings, accounts, includePasswords = false)
             parseXml(outputStream.toByteArray())
         }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/DefaultFolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/DefaultFolderRepository.kt
@@ -33,39 +33,6 @@ class DefaultFolderRepository(
         }
     }
 
-    @Throws(MessagingException::class)
-    override fun getRemoteFolders(accountId: AccountId): List<RemoteFolder> {
-        val messageStore = messageStoreManager.getMessageStore(accountId)
-        return messageStore.getFolders(excludeLocalOnly = true) { folder ->
-            RemoteFolder(
-                id = folder.id,
-                serverId = folder.serverIdOrThrow(),
-                name = folder.name,
-                type = folder.type.toFolderType(),
-            )
-        }
-    }
-
-    override fun getRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails> {
-        val messageStore = messageStoreManager.getMessageStore(accountId)
-        return messageStore.getFolders(excludeLocalOnly = true) { folder ->
-            RemoteFolderDetails(
-                folder = RemoteFolder(
-                    id = folder.id,
-                    serverId = folder.serverIdOrThrow(),
-                    name = folder.name,
-                    type = folder.type.toFolderType(),
-                ),
-                isInTopGroup = folder.isInTopGroup,
-                isIntegrate = folder.isIntegrate,
-                isSyncEnabled = folder.isSyncEnabled,
-                isVisible = folder.isVisible,
-                isNotificationsEnabled = folder.isNotificationsEnabled,
-                isPushEnabled = folder.isPushEnabled,
-            )
-        }
-    }
-
     override fun getFolderServerId(accountId: AccountId, folderId: Long): String? {
         val messageStore = messageStoreManager.getMessageStore(accountId)
         return messageStore.getFolder(folderId) { folder ->

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/FolderRepository.kt
@@ -1,10 +1,7 @@
 package app.k9mail.legacy.mailstore
 
-import kotlinx.coroutines.flow.Flow
-import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.folder.api.Folder
-import net.thunderbird.feature.mail.folder.api.RemoteFolder
 import net.thunderbird.feature.mail.folder.api.data.repository.PushFolderTrackingRepository
 
 /**
@@ -23,23 +20,6 @@ interface FolderRepository : PushFolderTrackingRepository {
      * @param folderId The folder identifier.
      */
     suspend fun getFolder(accountId: AccountId, folderId: Long): Folder?
-
-    /**
-     * Returns a list of [RemoteFolder]s for the given [accountId].
-     *
-     * @param accountId The account identifier.
-     * @throws MessagingException if there's a problem accessing the folders.
-     */
-    @Throws(MessagingException::class)
-    fun getRemoteFolders(accountId: AccountId): List<RemoteFolder>
-
-    /**
-     * Returns a list of [RemoteFolderDetails] for the given [accountId].
-     *
-     * @param accountId The account identifier.
-     */
-    fun getRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails>
-
 
     /**
      * Returns the server ID for the given [accountId] and [folderId].

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/ListenableMessageStore.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/ListenableMessageStore.kt
@@ -1,10 +1,19 @@
 package app.k9mail.legacy.mailstore
 
 import java.util.concurrent.CopyOnWriteArraySet
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import net.thunderbird.feature.mail.folder.api.FolderDetails
 
 @Suppress("TooManyFunctions")
-class ListenableMessageStore(private val messageStore: MessageStore) : MessageStore by messageStore {
+class ListenableMessageStore(
+    private val messageStore: MessageStore,
+    mainImmediateDispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
+) : MessageStore by messageStore {
+    private val scope = CoroutineScope(SupervisorJob() + mainImmediateDispatcher)
     private val folderSettingsListener = CopyOnWriteArraySet<FolderSettingsChangedListener>()
 
     override fun createFolders(folders: List<CreateFolderInfo>): Set<Long> {
@@ -62,12 +71,14 @@ class ListenableMessageStore(private val messageStore: MessageStore) : MessageSt
     }
 
     private fun notifyFolderSettingsChanged() {
-        for (listener in folderSettingsListener) {
-            listener.onFolderSettingsChanged()
+        scope.launch {
+            for (listener in folderSettingsListener) {
+                listener.onFolderSettingsChanged()
+            }
         }
     }
 }
 
 fun interface FolderSettingsChangedListener {
-    fun onFolderSettingsChanged()
+    suspend fun onFolderSettingsChanged()
 }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/RemoteFolderDetails.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/RemoteFolderDetails.kt
@@ -1,13 +1,3 @@
 package app.k9mail.legacy.mailstore
 
-import net.thunderbird.feature.mail.folder.api.RemoteFolder
-
-data class RemoteFolderDetails(
-    val folder: RemoteFolder,
-    val isInTopGroup: Boolean,
-    val isIntegrate: Boolean,
-    val isSyncEnabled: Boolean,
-    val isVisible: Boolean,
-    val isNotificationsEnabled: Boolean,
-    val isPushEnabled: Boolean,
-)
+typealias RemoteFolderDetails = net.thunderbird.feature.mail.folder.api.RemoteFolderDetails

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultFolderDetailsRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultFolderDetailsRepository.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
+import net.thunderbird.components.core.outcome.Outcome
 import net.thunderbird.core.android.account.LegacyAccountManager
 import net.thunderbird.core.logging.Logger
-import net.thunderbird.components.core.outcome.Outcome
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.folder.api.Folder
 import net.thunderbird.feature.mail.folder.api.FolderDetails
@@ -34,7 +34,9 @@ class DefaultFolderDetailsRepository(
                 "$LOG_ID finding folder details for account '$accountId' and folder '$folderId'"
             }
             val account = accountManager.getById(accountId).firstOrNull()
-                ?: return@withContext Outcome.failure(FolderError.AccountNotFound)
+                ?: return@withContext Outcome.failure(
+                    FolderError.AccountNotFound(throwable = IllegalStateException("Account not found: $accountId")),
+                )
 
             val messageStore = messageStoreManager.getMessageStore(accountId)
             val outboxFolderId = outboxFolderManager.getOutboxFolderId(accountId)
@@ -77,7 +79,7 @@ class DefaultFolderDetailsRepository(
                 logger.error(throwable = e) {
                     "$LOG_ID Failed to update folder with id '${folderDetails.folder.id}' and account id '$accountId'"
                 }
-                Outcome.failure(FolderError.AccountNotFound)
+                Outcome.failure(FolderError.AccountNotFound(throwable = e))
             } catch (e: IllegalArgumentException) {
                 val msg = "Executed a full 'update' without all the required parameters."
                 logger.error(throwable = e) {
@@ -107,7 +109,7 @@ class DefaultFolderDetailsRepository(
                 logger.error(throwable = e) {
                     "$LOG_ID Failed to update folder with id '${partialUpdate.folderId}' and account id '$accountId'"
                 }
-                Outcome.failure(FolderError.AccountNotFound)
+                Outcome.failure(FolderError.AccountNotFound(throwable = e))
             } catch (e: IllegalArgumentException) {
                 val msg = "Executed a full 'update' without all the required parameters."
                 logger.error(throwable = e) {

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderDetailsRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderDetailsRepository.kt
@@ -1,0 +1,59 @@
+package app.k9mail.legacy.mailstore.folder
+
+import app.k9mail.legacy.mailstore.MessageStoreManager
+import app.k9mail.legacy.mailstore.RemoteFolderTypeMapper.toFolderType
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.core.common.exception.MessagingException
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.account.AccountId
+import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.RemoteFolderDetails
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderDetailsRepository
+import net.thunderbird.feature.mail.folder.api.toStringPiiSafe
+
+private const val LOG_ID = "[repository][remote-folder-details]"
+
+class DefaultRemoteFolderDetailsRepository(
+    private val logger: Logger,
+    private val messageStoreManager: MessageStoreManager,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : RemoteFolderDetailsRepository {
+    override suspend fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolderDetails>, FolderError> =
+        withContext(ioDispatcher) {
+            logger.verbose { "$LOG_ID getting all remote folders details for account '$accountId'" }
+            try {
+                val messageStore = messageStoreManager.getMessageStore(accountId)
+                val folderDetails = messageStore.getFolders(excludeLocalOnly = true) { folder ->
+                    RemoteFolderDetails(
+                        folder = RemoteFolder(
+                            id = folder.id,
+                            serverId = folder.serverIdOrThrow(),
+                            name = folder.name,
+                            type = folder.type.toFolderType(),
+                        ),
+                        isInTopGroup = folder.isInTopGroup,
+                        isIntegrate = folder.isIntegrate,
+                        isSyncEnabled = folder.isSyncEnabled,
+                        isVisible = folder.isVisible,
+                        isNotificationsEnabled = folder.isNotificationsEnabled,
+                        isPushEnabled = folder.isPushEnabled,
+                    )
+                }
+                logger.verbose {
+                    "$LOG_ID remote folder details = ${folderDetails.joinToString() { it.toStringPiiSafe() }}"
+                }
+                Outcome.success(folderDetails)
+            } catch (e: MessagingException) {
+                logger.error(throwable = e) { "$LOG_ID Failed to get remote folders details for account '$accountId'" }
+
+                Outcome.failure(FolderError.FailedToQueryDatabase(message = "Failed to query database.", throwable = e))
+            } catch (e: IllegalStateException) {
+                logger.error(throwable = e) { "$LOG_ID Failed to get remote folders details for account '$accountId'" }
+                Outcome.failure(FolderError.AccountNotFound)
+            }
+        }
+}

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderDetailsRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderDetailsRepository.kt
@@ -53,7 +53,7 @@ class DefaultRemoteFolderDetailsRepository(
                 Outcome.failure(FolderError.FailedToQueryDatabase(message = "Failed to query database.", throwable = e))
             } catch (e: IllegalStateException) {
                 logger.error(throwable = e) { "$LOG_ID Failed to get remote folders details for account '$accountId'" }
-                Outcome.failure(FolderError.AccountNotFound)
+                Outcome.failure(FolderError.AccountNotFound(throwable = e))
             }
         }
 }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderQueryRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderQueryRepository.kt
@@ -45,7 +45,7 @@ class DefaultRemoteFolderQueryRepository(
                 logger.error(throwable = e) {
                     "$LOG_ID Failed to get remote folders for account '$accountId'"
                 }
-                Outcome.failure(FolderError.AccountNotFound)
+                Outcome.failure(FolderError.AccountNotFound(throwable = e))
             }
         }
 }

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderQueryRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderQueryRepository.kt
@@ -1,0 +1,51 @@
+package app.k9mail.legacy.mailstore.folder
+
+import app.k9mail.legacy.mailstore.MessageStoreManager
+import app.k9mail.legacy.mailstore.RemoteFolderTypeMapper.toFolderType
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.core.common.exception.MessagingException
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.account.AccountId
+import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderQueryRepository
+
+private const val LOG_ID = "[repository][remote-folder]"
+
+class DefaultRemoteFolderQueryRepository(
+    private val logger: Logger,
+    private val messageStoreManager: MessageStoreManager,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : RemoteFolderQueryRepository {
+    override suspend fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolder>, FolderError> =
+        withContext(ioDispatcher) {
+            logger.verbose { "$LOG_ID getting all remote folders for account '$accountId'" }
+            try {
+                val messageStore = messageStoreManager.getMessageStore(accountId)
+                Outcome.success(
+                    messageStore.getFolders(excludeLocalOnly = true) { folder ->
+                        RemoteFolder(
+                            id = folder.id,
+                            serverId = folder.serverIdOrThrow(),
+                            name = folder.name,
+                            type = folder.type.toFolderType(),
+                        )
+                    },
+                )
+            } catch (e: MessagingException) {
+                logger.error(throwable = e) {
+                    "$LOG_ID Failed to get remote folders for account '$accountId'"
+                }
+
+                Outcome.failure(FolderError.FailedToQueryDatabase(message = "Failed to query database.", throwable = e))
+            } catch (e: IllegalStateException) {
+                logger.error(throwable = e) {
+                    "$LOG_ID Failed to get remote folders for account '$accountId'"
+                }
+                Outcome.failure(FolderError.AccountNotFound)
+            }
+        }
+}

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFolderTrackingRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFolderTrackingRepository.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.components.core.outcome.Outcome
 import net.thunderbird.feature.account.AccountId
@@ -35,7 +36,9 @@ class DefaultPushFolderTrackingRepository(
         send(enabled)
 
         val listener = FolderSettingsChangedListener {
-            trySendBlocking(isEnabled(accountId, messageStore))
+            withContext(ioDispatcher) {
+                trySendBlocking(isEnabled(accountId, messageStore))
+            }
         }
         messageStore.addFolderSettingsChangedListener(listener)
 

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFolderTrackingRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFolderTrackingRepository.kt
@@ -54,7 +54,7 @@ class DefaultPushFolderTrackingRepository(
                 "$LOG_ID Failed to observe push enabled for account id: $accountId"
             }
             when (throwable) {
-                is IllegalStateException -> emit(Outcome.failure(FolderError.AccountNotFound))
+                is IllegalStateException -> emit(Outcome.failure(FolderError.AccountNotFound(throwable)))
             }
         }
         .flowOn(ioDispatcher)
@@ -66,7 +66,7 @@ class DefaultPushFolderTrackingRepository(
             logger.error(throwable = e) {
                 "$LOG_ID Failed to disable push for account id: $accountId"
             }
-            Outcome.failure(FolderError.AccountNotFound)
+            Outcome.failure(FolderError.AccountNotFound(e))
         }
     }
 
@@ -80,7 +80,7 @@ class DefaultPushFolderTrackingRepository(
         logger.error(throwable = e) {
             "$LOG_ID Failed to disable push for account id: $accountId"
         }
-        Outcome.failure(FolderError.AccountNotFound)
+        Outcome.failure(FolderError.AccountNotFound(e))
     }
 
     private fun isEnabled(

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepository.kt
@@ -3,7 +3,6 @@ package app.k9mail.legacy.mailstore.folder.push
 import app.k9mail.legacy.mailstore.FolderSettingsChangedListener
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.mailstore.RemoteFolderDetails
-import app.k9mail.legacy.mailstore.RemoteFolderTypeMapper.toFolderType
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -14,22 +13,25 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
-import net.thunderbird.core.common.exception.MessagingException
-import net.thunderbird.core.logging.Logger
 import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.components.core.outcome.fold
+import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
 import net.thunderbird.feature.mail.folder.api.data.FolderError
 import net.thunderbird.feature.mail.folder.api.data.repository.PushFoldersQueryRepository
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderDetailsRepository
 
 class DefaultPushFoldersQueryRepository(
     private val logger: Logger,
     private val messageStoreManager: MessageStoreManager,
+    private val remoteFolderDetailsRepository: RemoteFolderDetailsRepository,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : PushFoldersQueryRepository {
     override fun observeAllByAccountId(accountId: AccountId): Flow<Outcome<List<RemoteFolder>, FolderError>> =
         callbackFlow {
             val messageStore = messageStoreManager.getMessageStore(accountId)
+
             send(getAllByAccountId(accountId))
 
             val listener = FolderSettingsChangedListener {
@@ -45,7 +47,7 @@ class DefaultPushFoldersQueryRepository(
             .distinctUntilChanged()
             .flowOn(ioDispatcher)
 
-    override fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolder>, FolderError> {
+    override suspend fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolder>, FolderError> {
         logger.verbose { "$LOG_ID getting push folders for account '$accountId'" }
         val pushFolders = getAllRemoteFolderDetails(accountId)
             .asSequence()
@@ -62,37 +64,24 @@ class DefaultPushFoldersQueryRepository(
         }
     }
 
-    private fun getAllRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails> {
+    private suspend fun getAllRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails> {
         logger.verbose { "$LOG_ID fetching remote folders details" }
-        return try {
-            val messageStore = messageStoreManager.getMessageStore(accountId)
-            messageStore.getFolders(excludeLocalOnly = true) { folder ->
-                RemoteFolderDetails(
-                    folder = RemoteFolder(
-                        id = folder.id,
-                        serverId = folder.serverIdOrThrow(),
-                        name = folder.name,
-                        type = folder.type.toFolderType(),
-                    ),
-                    isInTopGroup = folder.isInTopGroup,
-                    isIntegrate = folder.isIntegrate,
-                    isSyncEnabled = folder.isSyncEnabled,
-                    isVisible = folder.isVisible,
-                    isNotificationsEnabled = folder.isNotificationsEnabled,
-                    isPushEnabled = folder.isPushEnabled,
-                )
-            }
-        } catch (e: MessagingException) {
-            logger.error(throwable = e) {
-                "$LOG_ID Failed to get remote folders details for account '$accountId'"
-            }
-            throw e
-        } catch (e: IllegalStateException) {
-            logger.error(throwable = e) {
-                "$LOG_ID Failed to get remote folders details for account '$accountId'"
-            }
-            throw e
-        }
+        val outcome = remoteFolderDetailsRepository.getAllByAccountId(accountId)
+        return outcome.fold(
+            onSuccess = { it },
+            onFailure = { error ->
+                when (error) {
+                    is FolderError.FailedToQueryDatabase -> {
+                        logger.error(throwable = error.throwable) {
+                            "$LOG_ID Failed to get remote folders details for account '$accountId'"
+                        }
+                        throw error.throwable
+                    }
+
+                    else -> emptyList()
+                }
+            },
+        )
     }
 
     companion object {

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepository.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepository.kt
@@ -2,7 +2,6 @@ package app.k9mail.legacy.mailstore.folder.push
 
 import app.k9mail.legacy.mailstore.FolderSettingsChangedListener
 import app.k9mail.legacy.mailstore.MessageStoreManager
-import app.k9mail.legacy.mailstore.RemoteFolderDetails
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -49,38 +48,20 @@ class DefaultPushFoldersQueryRepository(
 
     override suspend fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolder>, FolderError> {
         logger.verbose { "$LOG_ID getting push folders for account '$accountId'" }
-        val pushFolders = getAllRemoteFolderDetails(accountId)
-            .asSequence()
-            .filter { folderDetails -> folderDetails.isPushEnabled }
-            .map { folderDetails -> folderDetails.folder }
-            .toList()
 
-        return if (pushFolders.isEmpty()) {
-            logger.warn { "$LOG_ID could not find any push folders with the given account id '$accountId'" }
-            Outcome.failure(FolderError.NotFound)
-        } else {
-            logger.verbose { "$LOG_ID found push folder: $pushFolders" }
-            Outcome.success(pushFolders)
-        }
-    }
+        return remoteFolderDetailsRepository.getAllByAccountId(accountId).fold(
+            onSuccess = { folderDetails ->
+                val pushFolders = folderDetails
+                    .filter { it.isPushEnabled }
+                    .map { it.folder }
 
-    private suspend fun getAllRemoteFolderDetails(accountId: AccountId): List<RemoteFolderDetails> {
-        logger.verbose { "$LOG_ID fetching remote folders details" }
-        val outcome = remoteFolderDetailsRepository.getAllByAccountId(accountId)
-        return outcome.fold(
-            onSuccess = { it },
-            onFailure = { error ->
-                when (error) {
-                    is FolderError.FailedToQueryDatabase -> {
-                        logger.error(throwable = error.throwable) {
-                            "$LOG_ID Failed to get remote folders details for account '$accountId'"
-                        }
-                        throw error.throwable
-                    }
-
-                    else -> emptyList()
+                if (pushFolders.isEmpty()) {
+                    Outcome.failure(FolderError.NotFound)
+                } else {
+                    Outcome.success(pushFolders)
                 }
             },
+            onFailure = { error -> Outcome.failure(error) },
         )
     }
 

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultFolderDetailsRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultFolderDetailsRepositoryTest.kt
@@ -83,7 +83,8 @@ class DefaultFolderDetailsRepositoryTest {
         val result = testSubject.findById(unknownAccountId, REGULAR_FOLDER_ID)
 
         // Assert
-        assertThat(result).isEqualTo(Outcome.failure(FolderError.AccountNotFound))
+        assertThat(result).isInstanceOf(Outcome.Failure::class)
+        assertThat((result as Outcome.Failure).error).isInstanceOf(FolderError.AccountNotFound::class)
     }
 
     @Test
@@ -180,7 +181,8 @@ class DefaultFolderDetailsRepositoryTest {
         val result = testSubject.update(unknownAccountId, folderDetails)
 
         // Assert
-        assertThat(result).isEqualTo(Outcome.failure(FolderError.AccountNotFound))
+        assertThat(result).isInstanceOf(Outcome.Failure::class)
+        assertThat((result as Outcome.Failure).error).isInstanceOf(FolderError.AccountNotFound::class)
     }
 
     @Test
@@ -263,7 +265,8 @@ class DefaultFolderDetailsRepositoryTest {
         val result = testSubject.update(unknownAccountId, partialUpdate)
 
         // Assert
-        assertThat(result).isEqualTo(Outcome.failure(FolderError.AccountNotFound))
+        assertThat(result).isInstanceOf(Outcome.Failure::class)
+        assertThat((result as Outcome.Failure).error).isInstanceOf(FolderError.AccountNotFound::class)
     }
 
     @Test

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderDetailsRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderDetailsRepositoryTest.kt
@@ -8,6 +8,7 @@ import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.mailstore.MoreMessages
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import kotlin.test.Test
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -139,7 +140,8 @@ class DefaultRemoteFolderDetailsRepositoryTest {
         val result = testSubject.getAllByAccountId(unknownAccountId)
 
         // Assert
-        assertThat(result).isEqualTo(Outcome.failure(FolderError.AccountNotFound))
+        assertThat(result).isInstanceOf(Outcome.Failure::class)
+        assertThat((result as Outcome.Failure).error).isInstanceOf(FolderError.AccountNotFound::class)
     }
 
     @Test

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderDetailsRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderDetailsRepositoryTest.kt
@@ -1,0 +1,213 @@
+package app.k9mail.legacy.mailstore.folder
+
+import app.k9mail.legacy.mailstore.FolderDetailsAccessor
+import app.k9mail.legacy.mailstore.FolderMapper
+import app.k9mail.legacy.mailstore.ListenableMessageStore
+import app.k9mail.legacy.mailstore.MessageStoreFactory
+import app.k9mail.legacy.mailstore.MessageStoreManager
+import app.k9mail.legacy.mailstore.MoreMessages
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_OTHER_RAW
+import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
+import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.core.android.account.AccountRemovedListener
+import net.thunderbird.core.android.account.AccountsChangeListener
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.android.account.LegacyAccountDtoManager
+import net.thunderbird.core.common.exception.MessagingException
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.feature.account.AccountIdFactory
+import net.thunderbird.feature.mail.folder.api.FolderType
+import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.RemoteFolderDetails
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+private const val INBOX_FOLDER_ID = 1L
+private const val ARCHIVE_FOLDER_ID = 2L
+
+@Suppress("MaxLineLength")
+class DefaultRemoteFolderDetailsRepositoryTest {
+    private val account = LegacyAccountDto(ACCOUNT_ID_RAW)
+    private val accountId = account.id
+    private val messageStore = mock<ListenableMessageStore>()
+    private val accountManager = FakeRemoteFolderDetailsLegacyAccountDtoManager(accounts = listOf(account))
+    private val messageStoreFactory = FakeRemoteFolderDetailsMessageStoreFactory(
+        messageStoresByUuid = mapOf(account.uuid to messageStore),
+    )
+    private val messageStoreManager = MessageStoreManager(accountManager, messageStoreFactory)
+    private val testSubject = DefaultRemoteFolderDetailsRepository(
+        logger = TestLogger(),
+        messageStoreManager = messageStoreManager,
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
+    @Test
+    fun `getAllByAccountId should return Success with all remote folder details`() = runTest {
+        // Arrange
+        stubGetFolders(
+            FakeRemoteFolderDetailsAccessor(
+                id = INBOX_FOLDER_ID,
+                name = "Inbox",
+                isInTopGroup = true,
+                isIntegrate = true,
+                isSyncEnabled = true,
+                isVisible = true,
+                isNotificationsEnabled = false,
+                isPushEnabled = true,
+            ),
+            FakeRemoteFolderDetailsAccessor(
+                id = ARCHIVE_FOLDER_ID,
+                name = "Archive",
+                isInTopGroup = false,
+                isIntegrate = false,
+                isSyncEnabled = false,
+                isVisible = false,
+                isNotificationsEnabled = false,
+                isPushEnabled = false,
+            ),
+        )
+
+        // Act
+        val result = testSubject.getAllByAccountId(accountId)
+
+        // Assert
+        assertThat(result).isEqualTo(
+            Outcome.success(
+                listOf(
+                    RemoteFolderDetails(
+                        folder = RemoteFolder(
+                            id = INBOX_FOLDER_ID,
+                            serverId = "serverId",
+                            name = "Inbox",
+                            type = FolderType.REGULAR,
+                        ),
+                        isInTopGroup = true,
+                        isIntegrate = true,
+                        isSyncEnabled = true,
+                        isVisible = true,
+                        isNotificationsEnabled = false,
+                        isPushEnabled = true,
+                    ),
+                    RemoteFolderDetails(
+                        folder = RemoteFolder(
+                            id = ARCHIVE_FOLDER_ID,
+                            serverId = "serverId",
+                            name = "Archive",
+                            type = FolderType.REGULAR,
+                        ),
+                        isInTopGroup = false,
+                        isIntegrate = false,
+                        isSyncEnabled = false,
+                        isVisible = false,
+                        isNotificationsEnabled = false,
+                        isPushEnabled = false,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `getAllByAccountId should return Success with an empty list when there are no folders`() = runTest {
+        // Arrange
+        stubGetFolders()
+
+        // Act
+        val result = testSubject.getAllByAccountId(accountId)
+
+        // Assert
+        assertThat(result).isEqualTo(Outcome.success(emptyList()))
+    }
+
+    @Test
+    fun `getAllByAccountId should return Failure with AccountNotFound when account does not exist`() = runTest {
+        // Arrange
+        val unknownAccountId = AccountIdFactory.of(ACCOUNT_ID_OTHER_RAW)
+
+        // Act
+        val result = testSubject.getAllByAccountId(unknownAccountId)
+
+        // Assert
+        assertThat(result).isEqualTo(Outcome.failure(FolderError.AccountNotFound))
+    }
+
+    @Test
+    fun `getAllByAccountId should return Failure with FailedToQueryDatabase when the message store throws MessagingException`() =
+        runTest {
+            // Arrange
+            val exception = MessagingException("failed to fetch folder details")
+            doThrow(exception).whenever(messageStore).getFolders<RemoteFolderDetails>(any(), any())
+
+            // Act
+            val result = testSubject.getAllByAccountId(accountId)
+
+            // Assert
+            assertThat(result).isEqualTo(
+                Outcome.failure(
+                    FolderError.FailedToQueryDatabase(message = "Failed to query database.", throwable = exception),
+                ),
+            )
+        }
+
+    private fun stubGetFolders(vararg accessors: FolderDetailsAccessor) {
+        whenever(messageStore.getFolders<RemoteFolderDetails>(eq(true), any())).thenAnswer { invocation ->
+            val mapper = invocation.getArgument<FolderMapper<RemoteFolderDetails>>(1)
+            accessors.map { mapper.map(it) }
+        }
+    }
+}
+
+private class FakeRemoteFolderDetailsAccessor(
+    override val id: Long,
+    override val name: String = "Folder",
+    override val serverId: String? = "serverId",
+    override val type: com.fsck.k9.mail.FolderType = com.fsck.k9.mail.FolderType.REGULAR,
+    override val isLocalOnly: Boolean = false,
+    override val isInTopGroup: Boolean = false,
+    override val isIntegrate: Boolean = false,
+    override val isSyncEnabled: Boolean = true,
+    override val isVisible: Boolean = true,
+    override val isNotificationsEnabled: Boolean = true,
+    override val isPushEnabled: Boolean = false,
+    override val visibleLimit: Int = 25,
+    override val moreMessages: MoreMessages = MoreMessages.UNKNOWN,
+    override val lastChecked: Long? = null,
+    override val unreadMessageCount: Int = 0,
+    override val starredMessageCount: Int = 0,
+) : FolderDetailsAccessor {
+    override fun serverIdOrThrow(): String = serverId ?: error("serverId is null")
+}
+
+private class FakeRemoteFolderDetailsLegacyAccountDtoManager(
+    accounts: List<LegacyAccountDto> = emptyList(),
+) : LegacyAccountDtoManager {
+    private val accountsByUuid = accounts.associateBy { it.uuid }
+
+    override fun getAccounts(): List<LegacyAccountDto> = accountsByUuid.values.toList()
+    override fun getAccountsFlow(): Flow<List<LegacyAccountDto>> = flowOf(getAccounts())
+    override fun getAccount(accountUuid: String): LegacyAccountDto? = accountsByUuid[accountUuid]
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccountDto?> = flowOf(getAccount(accountUuid))
+    override fun addAccountRemovedListener(listener: AccountRemovedListener) = Unit
+    override fun moveAccount(account: LegacyAccountDto, newPosition: Int) = Unit
+    override fun addOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) = Unit
+    override fun removeOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) = Unit
+    override fun saveAccount(account: LegacyAccountDto) = Unit
+}
+
+private class FakeRemoteFolderDetailsMessageStoreFactory(
+    private val messageStoresByUuid: Map<String, ListenableMessageStore>,
+) : MessageStoreFactory {
+    override fun create(account: LegacyAccountDto): ListenableMessageStore =
+        messageStoresByUuid.getValue(account.uuid)
+}

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderQueryRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderQueryRepositoryTest.kt
@@ -1,0 +1,178 @@
+package app.k9mail.legacy.mailstore.folder
+
+import app.k9mail.legacy.mailstore.FolderDetailsAccessor
+import app.k9mail.legacy.mailstore.FolderMapper
+import app.k9mail.legacy.mailstore.ListenableMessageStore
+import app.k9mail.legacy.mailstore.MessageStoreFactory
+import app.k9mail.legacy.mailstore.MessageStoreManager
+import app.k9mail.legacy.mailstore.MoreMessages
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_OTHER_RAW
+import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
+import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.core.android.account.AccountRemovedListener
+import net.thunderbird.core.android.account.AccountsChangeListener
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.android.account.LegacyAccountDtoManager
+import net.thunderbird.core.common.exception.MessagingException
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.feature.account.AccountIdFactory
+import net.thunderbird.feature.mail.folder.api.FolderType
+import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.data.FolderError
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+private const val INBOX_FOLDER_ID = 1L
+private const val ARCHIVE_FOLDER_ID = 2L
+
+@Suppress("MaxLineLength")
+class DefaultRemoteFolderQueryRepositoryTest {
+    private val account = LegacyAccountDto(ACCOUNT_ID_RAW)
+    private val accountId = account.id
+    private val messageStore = mock<ListenableMessageStore>()
+    private val accountManager = FakeRemoteFolderLegacyAccountDtoManager(accounts = listOf(account))
+    private val messageStoreFactory = FakeRemoteFolderMessageStoreFactory(
+        messageStoresByUuid = mapOf(account.uuid to messageStore),
+    )
+    private val messageStoreManager = MessageStoreManager(accountManager, messageStoreFactory)
+    private val testSubject = DefaultRemoteFolderQueryRepository(
+        logger = TestLogger(),
+        messageStoreManager = messageStoreManager,
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
+    @Test
+    fun `getAllByAccountId should return Success with all remote folders`() = runTest {
+        // Arrange
+        stubGetFolders(
+            FakeRemoteFolderAccessor(id = INBOX_FOLDER_ID, name = "Inbox"),
+            FakeRemoteFolderAccessor(id = ARCHIVE_FOLDER_ID, name = "Archive"),
+        )
+
+        // Act
+        val result = testSubject.getAllByAccountId(accountId)
+
+        // Assert
+        assertThat(result).isEqualTo(
+            Outcome.success(
+                listOf(
+                    RemoteFolder(
+                        id = INBOX_FOLDER_ID,
+                        serverId = "serverId",
+                        name = "Inbox",
+                        type = FolderType.REGULAR,
+                    ),
+                    RemoteFolder(
+                        id = ARCHIVE_FOLDER_ID,
+                        serverId = "serverId",
+                        name = "Archive",
+                        type = FolderType.REGULAR,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `getAllByAccountId should return Success with an empty list when there are no folders`() = runTest {
+        // Arrange
+        stubGetFolders()
+
+        // Act
+        val result = testSubject.getAllByAccountId(accountId)
+
+        // Assert
+        assertThat(result).isEqualTo(Outcome.success(emptyList()))
+    }
+
+    @Test
+    fun `getAllByAccountId should return Failure with AccountNotFound when account does not exist`() = runTest {
+        // Arrange
+        val unknownAccountId = AccountIdFactory.of(ACCOUNT_ID_OTHER_RAW)
+
+        // Act
+        val result = testSubject.getAllByAccountId(unknownAccountId)
+
+        // Assert
+        assertThat(result).isEqualTo(Outcome.failure(FolderError.AccountNotFound))
+    }
+
+    @Test
+    fun `getAllByAccountId should return Failure with FailedToQueryDatabase when the message store throws MessagingException`() =
+        runTest {
+            // Arrange
+            val exception = MessagingException("failed to fetch folders")
+            doThrow(exception).whenever(messageStore).getFolders<RemoteFolder>(any(), any())
+
+            // Act
+            val result = testSubject.getAllByAccountId(accountId)
+
+            // Assert
+            assertThat(result).isEqualTo(
+                Outcome.failure(
+                    FolderError.FailedToQueryDatabase(message = "Failed to query database.", throwable = exception),
+                ),
+            )
+        }
+
+    private fun stubGetFolders(vararg accessors: FolderDetailsAccessor) {
+        whenever(messageStore.getFolders<RemoteFolder>(eq(true), any())).thenAnswer { invocation ->
+            val mapper = invocation.getArgument<FolderMapper<RemoteFolder>>(1)
+            accessors.map { mapper.map(it) }
+        }
+    }
+}
+
+private class FakeRemoteFolderAccessor(
+    override val id: Long,
+    override val name: String = "Folder",
+    override val serverId: String? = "serverId",
+    override val type: com.fsck.k9.mail.FolderType = com.fsck.k9.mail.FolderType.REGULAR,
+    override val isLocalOnly: Boolean = false,
+    override val isInTopGroup: Boolean = false,
+    override val isIntegrate: Boolean = false,
+    override val isSyncEnabled: Boolean = true,
+    override val isVisible: Boolean = true,
+    override val isNotificationsEnabled: Boolean = true,
+    override val isPushEnabled: Boolean = false,
+    override val visibleLimit: Int = 25,
+    override val moreMessages: MoreMessages = MoreMessages.UNKNOWN,
+    override val lastChecked: Long? = null,
+    override val unreadMessageCount: Int = 0,
+    override val starredMessageCount: Int = 0,
+) : FolderDetailsAccessor {
+    override fun serverIdOrThrow(): String = serverId ?: error("serverId is null")
+}
+
+private class FakeRemoteFolderLegacyAccountDtoManager(
+    accounts: List<LegacyAccountDto> = emptyList(),
+) : LegacyAccountDtoManager {
+    private val accountsByUuid = accounts.associateBy { it.uuid }
+
+    override fun getAccounts(): List<LegacyAccountDto> = accountsByUuid.values.toList()
+    override fun getAccountsFlow(): Flow<List<LegacyAccountDto>> = flowOf(getAccounts())
+    override fun getAccount(accountUuid: String): LegacyAccountDto? = accountsByUuid[accountUuid]
+    override fun getAccountFlow(accountUuid: String): Flow<LegacyAccountDto?> = flowOf(getAccount(accountUuid))
+    override fun addAccountRemovedListener(listener: AccountRemovedListener) = Unit
+    override fun moveAccount(account: LegacyAccountDto, newPosition: Int) = Unit
+    override fun addOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) = Unit
+    override fun removeOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener) = Unit
+    override fun saveAccount(account: LegacyAccountDto) = Unit
+}
+
+private class FakeRemoteFolderMessageStoreFactory(
+    private val messageStoresByUuid: Map<String, ListenableMessageStore>,
+) : MessageStoreFactory {
+    override fun create(account: LegacyAccountDto): ListenableMessageStore =
+        messageStoresByUuid.getValue(account.uuid)
+}

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderQueryRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultRemoteFolderQueryRepositoryTest.kt
@@ -8,6 +8,7 @@ import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.mailstore.MoreMessages
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import kotlin.test.Test
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -104,7 +105,8 @@ class DefaultRemoteFolderQueryRepositoryTest {
         val result = testSubject.getAllByAccountId(unknownAccountId)
 
         // Assert
-        assertThat(result).isEqualTo(Outcome.failure(FolderError.AccountNotFound))
+        assertThat(result).isInstanceOf(Outcome.Failure::class)
+        assertThat((result as Outcome.Failure).error).isInstanceOf(FolderError.AccountNotFound::class)
     }
 
     @Test

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFolderTrackingRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFolderTrackingRepositoryTest.kt
@@ -76,7 +76,8 @@ class DefaultPushFolderTrackingRepositoryTest {
         val result = testSubject.isEnabled(unknownAccountId)
 
         // Assert
-        assertThat(result).isEqualTo(Outcome.failure(FolderError.AccountNotFound))
+        assertThat(result).isInstanceOf(Outcome.Failure::class)
+        assertThat((result as Outcome.Failure).error).isInstanceOf(FolderError.AccountNotFound::class)
     }
 
     @Test
@@ -98,7 +99,8 @@ class DefaultPushFolderTrackingRepositoryTest {
         val result = testSubject.disable(unknownAccountId)
 
         // Assert
-        assertThat(result).isEqualTo(Outcome.failure(FolderError.AccountNotFound))
+        assertThat(result).isInstanceOf(Outcome.Failure::class)
+        assertThat((result as Outcome.Failure).error).isInstanceOf(FolderError.AccountNotFound::class)
     }
 
     @Test

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepositoryTest.kt
@@ -1,13 +1,10 @@
 package app.k9mail.legacy.mailstore.folder.push
 
 import app.cash.turbine.test
-import app.k9mail.legacy.mailstore.FolderDetailsAccessor
-import app.k9mail.legacy.mailstore.FolderMapper
 import app.k9mail.legacy.mailstore.FolderSettingsChangedListener
 import app.k9mail.legacy.mailstore.ListenableMessageStore
 import app.k9mail.legacy.mailstore.MessageStoreFactory
 import app.k9mail.legacy.mailstore.MessageStoreManager
-import app.k9mail.legacy.mailstore.MoreMessages
 import app.k9mail.legacy.mailstore.RemoteFolderDetails
 import assertk.assertFailure
 import assertk.assertThat
@@ -27,21 +24,20 @@ import net.thunderbird.core.android.account.LegacyAccountDtoManager
 import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.components.core.outcome.Outcome
+import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.AccountIdFactory
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
 import net.thunderbird.feature.mail.folder.api.data.FolderError
-import org.mockito.kotlin.any
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderDetailsRepository
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doThrow
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 
 private const val INBOX_FOLDER_ID = 1L
 private const val ARCHIVE_FOLDER_ID = 2L
 
+@Suppress("MaxLineLength")
 class DefaultPushFoldersQueryRepositoryTest {
     private val account = LegacyAccountDto(ACCOUNT_ID_RAW)
     private val accountId = account.id
@@ -51,18 +47,22 @@ class DefaultPushFoldersQueryRepositoryTest {
         messageStoresByUuid = mapOf(account.uuid to messageStore),
     )
     private val messageStoreManager = MessageStoreManager(accountManager, messageStoreFactory)
+    private val remoteFolderDetailsRepository = FakeRemoteFolderDetailsRepository()
     private val testSubject = DefaultPushFoldersQueryRepository(
         logger = TestLogger(),
         messageStoreManager = messageStoreManager,
+        remoteFolderDetailsRepository = remoteFolderDetailsRepository,
         ioDispatcher = Dispatchers.Unconfined,
     )
 
     @Test
-    fun `getAllByAccountId should return Success with push enabled folders`() {
+    fun `getAllByAccountId should return Success with push enabled folders`() = runTest {
         // Arrange
-        stubGetFolders(
-            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
-            FakeFolderDetailsAccessor(id = ARCHIVE_FOLDER_ID, name = "Archive", isPushEnabled = false),
+        remoteFolderDetailsRepository.outcome = Outcome.success(
+            listOf(
+                createRemoteFolderDetails(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+                createRemoteFolderDetails(id = ARCHIVE_FOLDER_ID, name = "Archive", isPushEnabled = false),
+            ),
         )
 
         // Act
@@ -84,10 +84,10 @@ class DefaultPushFoldersQueryRepositoryTest {
     }
 
     @Test
-    fun `getAllByAccountId should return Failure with NotFound when there are no push enabled folders`() {
+    fun `getAllByAccountId should return Failure with NotFound when there are no push enabled folders`() = runTest {
         // Arrange
-        stubGetFolders(
-            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = false),
+        remoteFolderDetailsRepository.outcome = Outcome.success(
+            listOf(createRemoteFolderDetails(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = false)),
         )
 
         // Act
@@ -98,9 +98,9 @@ class DefaultPushFoldersQueryRepositoryTest {
     }
 
     @Test
-    fun `getAllByAccountId should return Failure with NotFound when there are no folders at all`() {
+    fun `getAllByAccountId should return Failure with NotFound when there are no folders at all`() = runTest {
         // Arrange
-        stubGetFolders()
+        remoteFolderDetailsRepository.outcome = Outcome.success(emptyList())
 
         // Act
         val result = testSubject.getAllByAccountId(accountId)
@@ -110,33 +110,38 @@ class DefaultPushFoldersQueryRepositoryTest {
     }
 
     @Test
-    fun `getAllByAccountId should throw when account does not exist`() {
-        // Arrange
-        val unknownAccountId = AccountIdFactory.of(ACCOUNT_ID_OTHER_RAW)
+    fun `getAllByAccountId should return Failure with NotFound when the folder details repository returns AccountNotFound`() =
+        runTest {
+            // Arrange
+            remoteFolderDetailsRepository.outcome = Outcome.failure(FolderError.AccountNotFound)
 
-        // Act & Assert
-        assertFailure {
-            testSubject.getAllByAccountId(unknownAccountId)
-        }.isInstanceOf<IllegalStateException>()
-    }
+            // Act
+            val result = testSubject.getAllByAccountId(accountId)
+
+            // Assert
+            assertThat(result).isEqualTo(Outcome.failure(FolderError.NotFound))
+        }
 
     @Test
-    fun `getAllByAccountId should rethrow MessagingException thrown by the message store`() {
-        // Arrange
-        val exception = MessagingException("failed to fetch folders")
-        doThrow(exception).whenever(messageStore).getFolders<RemoteFolderDetails>(any(), any())
+    fun `getAllByAccountId should rethrow the throwable when the folder details repository returns FailedToQueryDatabase`() =
+        runTest {
+            // Arrange
+            val exception = MessagingException("failed to fetch folders")
+            remoteFolderDetailsRepository.outcome = Outcome.failure(
+                FolderError.FailedToQueryDatabase(message = "Failed to query database.", throwable = exception),
+            )
 
-        // Act & Assert
-        assertFailure {
-            testSubject.getAllByAccountId(accountId)
-        }.isEqualTo(exception)
-    }
+            // Act & Assert
+            assertFailure {
+                testSubject.getAllByAccountId(accountId)
+            }.isEqualTo(exception)
+        }
 
     @Test
     fun `observeAllByAccountId should emit the current push folders on subscription`() = runTest {
         // Arrange
-        stubGetFolders(
-            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+        remoteFolderDetailsRepository.outcome = Outcome.success(
+            listOf(createRemoteFolderDetails(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true)),
         )
 
         // Act & Assert
@@ -160,8 +165,8 @@ class DefaultPushFoldersQueryRepositoryTest {
     @Test
     fun `observeAllByAccountId should emit an updated result when folder settings change`() = runTest {
         // Arrange
-        stubGetFolders(
-            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = false),
+        remoteFolderDetailsRepository.outcome = Outcome.success(
+            listOf(createRemoteFolderDetails(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = false)),
         )
         val listenerCaptor = argumentCaptor<FolderSettingsChangedListener>()
 
@@ -170,8 +175,8 @@ class DefaultPushFoldersQueryRepositoryTest {
             assertThat(awaitItem()).isEqualTo(Outcome.failure(FolderError.NotFound))
 
             verify(messageStore).addFolderSettingsChangedListener(listenerCaptor.capture())
-            stubGetFolders(
-                FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+            remoteFolderDetailsRepository.outcome = Outcome.success(
+                listOf(createRemoteFolderDetails(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true)),
             )
             listenerCaptor.firstValue.onFolderSettingsChanged()
 
@@ -194,8 +199,8 @@ class DefaultPushFoldersQueryRepositoryTest {
     @Test
     fun `observeAllByAccountId should not emit duplicate consecutive results`() = runTest {
         // Arrange
-        stubGetFolders(
-            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+        remoteFolderDetailsRepository.outcome = Outcome.success(
+            listOf(createRemoteFolderDetails(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true)),
         )
         val listenerCaptor = argumentCaptor<FolderSettingsChangedListener>()
 
@@ -214,8 +219,8 @@ class DefaultPushFoldersQueryRepositoryTest {
     @Test
     fun `observeAllByAccountId should remove the folder settings listener when the flow is cancelled`() = runTest {
         // Arrange
-        stubGetFolders(
-            FakeFolderDetailsAccessor(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true),
+        remoteFolderDetailsRepository.outcome = Outcome.success(
+            listOf(createRemoteFolderDetails(id = INBOX_FOLDER_ID, name = "Inbox", isPushEnabled = true)),
         )
         val listenerCaptor = argumentCaptor<FolderSettingsChangedListener>()
 
@@ -241,33 +246,26 @@ class DefaultPushFoldersQueryRepositoryTest {
         }
     }
 
-    private fun stubGetFolders(vararg accessors: FolderDetailsAccessor) {
-        whenever(messageStore.getFolders<RemoteFolderDetails>(eq(true), any())).thenAnswer { invocation ->
-            val mapper = invocation.getArgument<FolderMapper<RemoteFolderDetails>>(1)
-            accessors.map { mapper.map(it) }
-        }
-    }
+    private fun createRemoteFolderDetails(
+        id: Long,
+        name: String,
+        isPushEnabled: Boolean,
+    ): RemoteFolderDetails = RemoteFolderDetails(
+        folder = RemoteFolder(id = id, serverId = "serverId", name = name, type = FolderType.REGULAR),
+        isInTopGroup = false,
+        isIntegrate = false,
+        isSyncEnabled = true,
+        isVisible = true,
+        isNotificationsEnabled = true,
+        isPushEnabled = isPushEnabled,
+    )
 }
 
-private class FakeFolderDetailsAccessor(
-    override val id: Long,
-    override val name: String = "Folder",
-    override val serverId: String? = "serverId",
-    override val type: com.fsck.k9.mail.FolderType = com.fsck.k9.mail.FolderType.REGULAR,
-    override val isLocalOnly: Boolean = false,
-    override val isInTopGroup: Boolean = false,
-    override val isIntegrate: Boolean = false,
-    override val isSyncEnabled: Boolean = true,
-    override val isVisible: Boolean = true,
-    override val isNotificationsEnabled: Boolean = true,
-    override val isPushEnabled: Boolean = false,
-    override val visibleLimit: Int = 25,
-    override val moreMessages: MoreMessages = MoreMessages.UNKNOWN,
-    override val lastChecked: Long? = null,
-    override val unreadMessageCount: Int = 0,
-    override val starredMessageCount: Int = 0,
-) : FolderDetailsAccessor {
-    override fun serverIdOrThrow(): String = serverId ?: error("serverId is null")
+private class FakeRemoteFolderDetailsRepository(
+    var outcome: Outcome<List<RemoteFolderDetails>, FolderError> = Outcome.success(emptyList()),
+) : RemoteFolderDetailsRepository {
+    override suspend fun getAllByAccountId(accountId: AccountId): Outcome<List<RemoteFolderDetails>, FolderError> =
+        outcome
 }
 
 private class FakePushFoldersLegacyAccountDtoManager(
@@ -289,6 +287,6 @@ private class FakePushFoldersLegacyAccountDtoManager(
 private class FakePushFoldersMessageStoreFactory(
     private val messageStoresByUuid: Map<String, ListenableMessageStore>,
 ) : MessageStoreFactory {
-    override fun create(account: LegacyAccountDto): ListenableMessageStore = messageStoresByUuid.getValue(account.uuid)
+    override fun create(account: LegacyAccountDto): ListenableMessageStore =
+        messageStoresByUuid.getValue(account.uuid)
 }
-

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/push/DefaultPushFoldersQueryRepositoryTest.kt
@@ -6,10 +6,11 @@ import app.k9mail.legacy.mailstore.ListenableMessageStore
 import app.k9mail.legacy.mailstore.MessageStoreFactory
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.mailstore.RemoteFolderDetails
-import assertk.assertFailure
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
 import kotlin.test.Test
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -17,13 +18,13 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_OTHER_RAW
 import net.thunderbird.account.fake.FakeAccountData.ACCOUNT_ID_RAW
+import net.thunderbird.components.core.outcome.Outcome
 import net.thunderbird.core.android.account.AccountRemovedListener
 import net.thunderbird.core.android.account.AccountsChangeListener
 import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountDtoManager
 import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.core.logging.testing.TestLogger
-import net.thunderbird.components.core.outcome.Outcome
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.AccountIdFactory
 import net.thunderbird.feature.mail.folder.api.FolderType
@@ -110,31 +111,39 @@ class DefaultPushFoldersQueryRepositoryTest {
     }
 
     @Test
-    fun `getAllByAccountId should return Failure with NotFound when the folder details repository returns AccountNotFound`() =
+    fun `getAllByAccountId should return Failure with AccountNotFound when the folder details repository returns AccountNotFound`() =
         runTest {
             // Arrange
-            remoteFolderDetailsRepository.outcome = Outcome.failure(FolderError.AccountNotFound)
+            val error = FolderError.AccountNotFound(throwable = IllegalStateException("Account not found: $accountId"))
+            remoteFolderDetailsRepository.outcome = Outcome.failure(error)
 
             // Act
             val result = testSubject.getAllByAccountId(accountId)
 
             // Assert
-            assertThat(result).isEqualTo(Outcome.failure(FolderError.NotFound))
+            assertThat(result).isEqualTo(Outcome.failure(error))
         }
 
     @Test
-    fun `getAllByAccountId should rethrow the throwable when the folder details repository returns FailedToQueryDatabase`() =
+    fun `getAllByAccountId should return Failure with FailedToQueryDatabase when the folder details repository returns FailedToQueryDatabase`() =
         runTest {
             // Arrange
             val exception = MessagingException("failed to fetch folders")
-            remoteFolderDetailsRepository.outcome = Outcome.failure(
-                FolderError.FailedToQueryDatabase(message = "Failed to query database.", throwable = exception),
-            )
+            val failure =
+                FolderError.FailedToQueryDatabase(message = "Failed to query database.", throwable = exception)
+            remoteFolderDetailsRepository.outcome = Outcome.failure(failure)
 
-            // Act & Assert
-            assertFailure {
-                testSubject.getAllByAccountId(accountId)
-            }.isEqualTo(exception)
+            // Act
+            val outcome = testSubject.getAllByAccountId(accountId)
+            // Assert
+            assertThat(outcome)
+                .isInstanceOf<Outcome.Failure<FolderError>>()
+                .prop(Outcome.Failure<FolderError>::error).all {
+                    isEqualTo(failure)
+                    isInstanceOf<FolderError.FailedToQueryDatabase>()
+                        .prop(FolderError.FailedToQueryDatabase::throwable)
+                        .isEqualTo(exception)
+                }
         }
 
     @Test

--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
@@ -6,7 +6,7 @@ import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.message.controller.MessagingControllerRegistry
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
 import java.text.Collator
-import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountDtoManager
 import net.thunderbird.feature.mail.folder.api.Folder
@@ -28,7 +29,7 @@ class DefaultDisplayFolderRepository(
     private val messagingController: MessagingControllerRegistry,
     private val messageStoreManager: MessageStoreManager,
     private val outboxFolderManager: OutboxFolderManager,
-    private val coroutineContext: CoroutineContext = Dispatchers.IO,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : DisplayFolderRepository {
     private val sortForDisplay =
         compareByDescending<DisplayFolder> { it.folder.type == FolderType.INBOX }
@@ -88,7 +89,9 @@ class DefaultDisplayFolderRepository(
             messagingController.addListener(folderStatusChangedListener)
 
             val folderSettingsChangedListener = FolderSettingsChangedListener {
-                trySendBlocking(getDisplayFolders(account, outboxFolderId, includeHiddenFolders))
+                withContext(ioDispatcher) {
+                    trySendBlocking(getDisplayFolders(account, outboxFolderId, includeHiddenFolders))
+                }
             }
             messageStore.addFolderSettingsChangedListener(folderSettingsChangedListener)
 
@@ -98,7 +101,7 @@ class DefaultDisplayFolderRepository(
             }
         }.buffer(capacity = Channel.CONFLATED)
             .distinctUntilChanged()
-            .flowOn(coroutineContext)
+            .flowOn(ioDispatcher)
     }
 
     override fun getDisplayFoldersFlow(accountUuid: String): Flow<List<DisplayFolder>> {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -5,20 +5,21 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import app.k9mail.legacy.mailstore.FolderRepository
 import com.fsck.k9.mailstore.SpecialFolderSelectionStrategy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import net.thunderbird.components.core.outcome.fold
 import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountDtoManager
 import net.thunderbird.feature.mail.folder.api.FolderType
 import net.thunderbird.feature.mail.folder.api.RemoteFolder
+import net.thunderbird.feature.mail.folder.api.data.repository.RemoteFolderQueryRepository
 
 class AccountSettingsViewModel(
     private val accountManager: LegacyAccountDtoManager,
-    private val folderRepository: FolderRepository,
+    private val remoteFolderQueryRepository: RemoteFolderQueryRepository,
     private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
     private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
@@ -69,7 +70,8 @@ class AccountSettingsViewModel(
     private fun loadFolders(account: LegacyAccountDto) {
         viewModelScope.launch {
             val remoteFolderInfo = withContext(backgroundDispatcher) {
-                val folders = folderRepository.getRemoteFolders(account.id)
+                val folders = remoteFolderQueryRepository.getAllByAccountId(account.id)
+                    .fold(onSuccess = { it }, onFailure = { emptyList() })
                     .sortedWith(
                         compareByDescending<RemoteFolder> { it.type == FolderType.INBOX }
                             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name },

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -71,7 +71,15 @@ class AccountSettingsViewModel(
         viewModelScope.launch {
             val remoteFolderInfo = withContext(backgroundDispatcher) {
                 val folders = remoteFolderQueryRepository.getAllByAccountId(account.id)
-                    .fold(onSuccess = { it }, onFailure = { emptyList() })
+                    .fold(
+                        onSuccess = { it },
+                        onFailure = { error ->
+                            when (val throwable = error.throwable) {
+                                null -> error("Unknown error while loading folders. Error: $error")
+                                else -> throw throwable
+                            }
+                        },
+                    )
                     .sortedWith(
                         compareByDescending<RemoteFolder> { it.type == FolderType.INBOX }
                             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name },


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Part of #11470

#### Description

- Add RemoteFolderQueryRepository interface with getAllByAccountId method
- Add RemoteFolderDetailsRepository interface with getAllByAccountId method
- Add DefaultRemoteFolderQueryRepository and DefaultRemoteFolderDetailsRepository implementations
- Remove getRemoteFolders and getRemoteFolderDetails from FolderRepository
- Update GetAccountFolders, AccountSettingsViewModel, DefaultDisplayFolderRepository, DefaultSpecialFolderUpdater, and FolderSettingsProvider to use new repositories
- Make SettingsExporter.exportPreferences and related methods suspend functions
- Make FolderSettingsChangedListener.onFolderSettingsChanged suspend function and notify on main immediate dispatcher
- Migrate RemoteFolderDetails from data class to typealias referencing API module

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>