### PR TITLE
docs(contributing): document Android SDK location for components build

### DIFF
--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -33,6 +33,17 @@ All contributions happen through a personal fork of the repository.
 3. Navigate to the cloned repository and open it
 4. Wait for project sync and indexing
 
+**If the sync fails with `SDK location not found`**, the `components/` build needs its own SDK location: Android Studio
+writes `sdk.dir` only into the `local.properties` in the repository root, which that separate included build does not read.
+
+1. Find your SDK path in Android Studio under **Settings/Preferences**, **Languages & Frameworks**, **Android SDK**, shown as **Android SDK Location**
+2. Add `systemProp.android.home=<sdk-path>` to your Gradle user properties file to cover all projects at once, or `sdk.dir=<sdk-path>` to `components/local.properties` for this repository only, creating the file if it does not exist yet
+3. Sync again
+
+The Gradle user properties file is `%USERPROFILE%\.gradle\gradle.properties` on Windows and `~/.gradle/gradle.properties`
+on Linux and macOS. Neither file is committed. In `.properties` files a single backslash is an escape character, so write
+Windows paths with forward slashes.
+
 ### 3. Configure Android Studio
 
 For the best development experience, we recommend the following settings:

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -12,6 +12,7 @@ Before you begin, ensure you have the following installed:
 - **[Git](https://git-scm.com/downloads)** - For version control
 - **Gradle** - Use the Gradle wrapper included in this repo (`./gradlew`); no separate install required
 - **Android SDK & command-line tools** – Installed and managed via Android Studio SDK Manager
+- **[ANDROID_HOME](https://developer.android.com/tools/variables#envar)** - Environment variable pointing to your SDK location; restart Android Studio after setting it
 
 ## 🔧 Setting Up the Development Environment
 
@@ -32,17 +33,6 @@ All contributions happen through a personal fork of the repository.
 2. Select **Open an Existing Project**
 3. Navigate to the cloned repository and open it
 4. Wait for project sync and indexing
-
-**If the sync fails with `SDK location not found`**, the `components/` build needs its own SDK location: Android Studio
-writes `sdk.dir` only into the `local.properties` in the repository root, which that separate included build does not read.
-
-1. Find your SDK path in Android Studio under **Settings/Preferences**, **Languages & Frameworks**, **Android SDK**, shown as **Android SDK Location**
-2. Add `systemProp.android.home=<sdk-path>` to your Gradle user properties file to cover all projects at once, or `sdk.dir=<sdk-path>` to `components/local.properties` for this repository only, creating the file if it does not exist yet
-3. Sync again
-
-The Gradle user properties file is `%USERPROFILE%\.gradle\gradle.properties` on Windows and `~/.gradle/gradle.properties`
-on Linux and macOS. Neither file is committed. In `.properties` files a single backslash is an escape character, so write
-Windows paths with forward slashes.
 
 ### 3. Configure Android Studio
 


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Resolves #11485
RFC / Technical Design (if applicable): n/a

#### Description

Adds `ANDROID_HOME` to the prerequisites in the development environment guide.

Without it the initial Gradle sync and any build touching `components/` fail. Setting `ANDROID_HOME` is what Google recommends and covers both the command line and the IDE.

Reproduced by all three of us on our own machines, two on macOS and one on Windows. Verified on macOS on commit 230a5c33aa with one SDK source at a time and the configuration cache cleared between runs: with none set, both `:components:ui:bolt:compileAndroidMain` and the Android Studio sync fail; with only `ANDROID_HOME` set, both pass.

Two observations from that run: the sync failure never names the SDK, it surfaces as a `MissingValueException` from the Android Gradle plugin, and only the command line reports `SDK location not found`. Android Studio also reads the environment at startup, so the variable needs a full IDE restart.

Gradle tasks run on this branch: `./gradlew spotlessFlexmarkCheck`, passes. Not run: `mdbook test docs`, mdbook is not installed locally; the change is a single line of Markdown with no code blocks.

#### Risks and trade-offs

Documentation only, no code or build behaviour changes.

The entry links to Google's documentation instead of spelling out the per-OS steps, matching how the other prerequisites in this file are written. Verified on macOS only, Windows and Linux rely on the linked documentation.

#### Screen Shots

n/a, documentation only.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to Mozilla's Community Participation Guidelines
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle
- [x] This contribution does not break existing unit tests
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality
- [x] This contribution adheres to our Engineering process (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes
