### PR TITLE
fix(ui) changed drawer to follow expected behavior for auto closing

### DIFF
--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarLayout.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/ui/AvatarLayout.kt
@@ -40,9 +40,12 @@ internal fun AvatarLayout(
                 shape = CircleShape,
                 color = color,
             )
-            .clickable(
-                enabled = onClick != null,
-                onClick = { onClick?.invoke() },
+            .then(
+                if (onClick != null) {
+                    Modifier.clickable(onClick = onClick)
+                } else {
+                    Modifier
+                },
             ),
         contentAlignment = Alignment.Center,
     ) {

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
@@ -227,9 +227,14 @@ internal class DrawerViewModel(
     private fun openAccount(account: DisplayAccount?) {
         if (account != null) {
             emitEffect(Effect.OpenAccount(account.id))
-            if (account is MailDisplayAccount && account.hasAutoExpandFolder) {
-                viewModelScope.launch {
-                    delay(DRAWER_CLOSE_DELAY)
+            viewModelScope.launch {
+                delay(DRAWER_CLOSE_DELAY)
+                updateState {
+                    it.copy(
+                        showAccountSelection = false,
+                    )
+                }
+                if (account is MailDisplayAccount && account.hasAutoExpandFolder) {
                     emitEffect(Effect.CloseDrawer)
                 }
             }

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
@@ -289,6 +289,34 @@ internal class DrawerViewModelTest {
             isEqualTo(Effect.CloseDrawer)
         }
     }
+    @Test
+    fun `should not emit CloseDrawer effect after emitting OpenAccount if AutoExpandFolder is None`() = runMviTest {
+        val displayAccounts = createDisplayAccountList(1) + createDisplayAccount(
+            id = "uuid-1",
+            hasAutoExpandFolder = false,
+        )
+        val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
+        val testSubject = createTestSubject(
+            displayAccountsFlow = getDisplayAccountsFlow,
+        )
+        val turbines = turbinesWithInitialStateCheck(
+            testSubject,
+            State(
+                accounts = displayAccounts.toImmutableList(),
+                selectedAccountId = displayAccounts.first().id,
+            ),
+        )
+        advanceUntilIdle()
+
+        testSubject.event(Event.OnAccountClick(displayAccounts[1]))
+
+        assertThat(turbines.awaitEffectItem()).isEqualTo(
+            Effect.OpenAccount(displayAccounts[1].id),
+        )
+
+        advanceUntilIdle()
+        turbines.effectTurbine.expectNoEvents()
+    }
 
     @Test
     fun `should collect display folders for selected account`() = runTest {

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
@@ -289,6 +289,7 @@ internal class DrawerViewModelTest {
             isEqualTo(Effect.CloseDrawer)
         }
     }
+
     @Test
     fun `should not emit CloseDrawer effect after emitting OpenAccount if AutoExpandFolder is None`() = runMviTest {
         val displayAccounts = createDisplayAccountList(1) + createDisplayAccount(

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
@@ -298,6 +298,7 @@ internal class DrawerViewModelTest {
         )
         val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
         val testSubject = createTestSubject(
+            initialState = State(showAccountSelection = true),
             displayAccountsFlow = getDisplayAccountsFlow,
         )
         val turbines = turbinesWithInitialStateCheck(
@@ -305,6 +306,7 @@ internal class DrawerViewModelTest {
             State(
                 accounts = displayAccounts.toImmutableList(),
                 selectedAccountId = displayAccounts.first().id,
+                showAccountSelection = true,
             ),
         )
         advanceUntilIdle()
@@ -314,6 +316,7 @@ internal class DrawerViewModelTest {
         assertThat(turbines.awaitEffectItem()).isEqualTo(
             Effect.OpenAccount(displayAccounts[1].id),
         )
+        assertThat(turbines.stateTurbine.awaitItem().showAccountSelection).isEqualTo(false)
 
         advanceUntilIdle()
         turbines.effectTurbine.expectNoEvents()


### PR DESCRIPTION
-Added a state change to selection of an account
-Changed the AvatarLayout click event to make the whole box clickable for account selection 
-Added a new test to confirm drawer close behavior



## Contribution Summary

Linked Issue/Ticket:  Fixes #11461

RFC / Technical Design (if applicable): n/a


#### Description

The drawer previously properly closed itself after selecting a user account but the expanded account selection was still expanded even after the drawer has already been closed. I fixed this by setting the state correctly before emitting the drawer close event. This only applies when the auto select folders account setting is set to anything but "none". If "none" is selected the account selection closes and the drawer still remains open.

I also adjusted the second stated Problem with the avatar icon not being clickable while selecting an account. This was the case due to the AvatarLayout always setting an onClick event even though it may be initialized without one by the caller. This caused the icon to just take up the click and doing nothing with it. I changed the modifier to only be set when an onClick is explicitly given.

A Test to confirm the changed account selection drawer behavior was added as well.

#### Screen Shots

Nothing visual was changed, just ui behavior.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
