### PR TITLE
chore(ci): update merge script to match b0 beta suffix coming from main

### DIFF
--- a/scripts/ci/merges/merge_gradle.py
+++ b/scripts/ci/merges/merge_gradle.py
@@ -8,6 +8,9 @@ import sys
 ours = sys.argv[1]
 theirs = sys.argv[2]
 
+BETA_SUFFIX = r"versionNameSuffix = \"b\d+\""
+MAIN_SUFFIX = r"versionNameSuffix = \"a1\""
+
 
 def get_current_branch():
     result = subprocess.run(
@@ -43,6 +46,24 @@ def replace_matching_line(file_path, search_term, new_line):
                 file.write(line)
 
 
+def set_version_name_suffix(file_path, search_term, suffix):
+    """Rewrites the versionNameSuffix line matching search_term.
+
+    Sets the suffix to `suffix`, or drops the line entirely when `suffix` is
+    None. Raises if the line is missing.
+    """
+    found_line = find_matching_line(file_path, search_term)
+    if not found_line:
+        raise SystemExit(f"Search term '{search_term}' not found in merge result.")
+    if suffix is None:
+        replace_matching_line(file_path, search_term, "")
+        return
+    if f'"{suffix}"' in found_line:
+        return
+    new_line = '{}= "{}"\n'.format(found_line.split("=")[0], suffix)
+    replace_matching_line(file_path, search_term, new_line)
+
+
 branch = get_current_branch()
 
 search_term = "com.fsck.k9"
@@ -62,28 +83,11 @@ else:
     raise SystemExit(f"Search term '{search_term}' not found in ours file.")
 
 if branch == "beta":
-    if is_k9:
-        # main carries "a1";
-        search_term = r"versionNameSuffix = \"a1\""
-        found_line = find_matching_line(theirs, search_term)
-        if not found_line:
-            raise SystemExit(f"Search term '{search_term}' not found in theirs file.")
-        new_line = "{}{}\n".format(found_line.split("=")[0], '= "b1"')
-        replace_matching_line(ours, search_term, new_line)
-    else:
-        # beta always starts at "b0"; the shippable build workflow
-        # bumps the suffix per beta release.
-        search_term = r"versionNameSuffix = \"b\d+\""
-        found_line = find_matching_line(ours, search_term)
-        if not found_line:
-            raise SystemExit(f"Search term '{search_term}' not found in merge result.")
-        if '"b0"' not in found_line:
-            new_line = "{}{}\n".format(found_line.split("=")[0], '= "b0"')
-            replace_matching_line(ours, search_term, new_line)
+    # beta always starts at "b0"; the shippable build workflow bumps the suffix
+    # per beta release. k9 has no beta build, so main carries its suffix in
+    # defaultConfig as "a1" rather than "b0". The suffix is dropped on release
+    # for both apps below.
+    set_version_name_suffix(ours, MAIN_SUFFIX if is_k9 else BETA_SUFFIX, "b0")
 elif branch == "release":
-    search_term = r"versionNameSuffix = \"b[1-9]\""
-    found_line = find_matching_line(theirs, search_term)
-    if found_line:
-        replace_matching_line(ours, search_term, "")
-    else:
-        raise SystemExit(f"Search term '{search_term}' not found in theirs file.")
+    # release ships without a suffix, so drop the line beta was carrying.
+    set_version_name_suffix(ours, BETA_SUFFIX, suffix=None)

--- a/scripts/ci/merges/merge_gradle.py
+++ b/scripts/ci/merges/merge_gradle.py
@@ -63,16 +63,23 @@ else:
 
 if branch == "beta":
     if is_k9:
+        # main carries "a1";
         search_term = r"versionNameSuffix = \"a1\""
+        found_line = find_matching_line(theirs, search_term)
+        if not found_line:
+            raise SystemExit(f"Search term '{search_term}' not found in theirs file.")
+        new_line = "{}{}\n".format(found_line.split("=")[0], '= "b1"')
+        replace_matching_line(ours, search_term, new_line)
     else:
-        search_term = r"versionNameSuffix = \"b[1-9]\""
-    found_line = find_matching_line(theirs, search_term)
-    if found_line:
-        if "b1" not in found_line:
-            new_line = "{}{}\n".format(found_line.split("=")[0], '= "b1"')
+        # beta always starts at "b0"; the shippable build workflow
+        # bumps the suffix per beta release.
+        search_term = r"versionNameSuffix = \"b\d+\""
+        found_line = find_matching_line(ours, search_term)
+        if not found_line:
+            raise SystemExit(f"Search term '{search_term}' not found in merge result.")
+        if '"b0"' not in found_line:
+            new_line = "{}{}\n".format(found_line.split("=")[0], '= "b0"')
             replace_matching_line(ours, search_term, new_line)
-    else:
-        raise SystemExit(f"Search term '{search_term}' not found in theirs file.")
 elif branch == "release":
     search_term = r"versionNameSuffix = \"b[1-9]\""
     found_line = find_matching_line(theirs, search_term)


### PR DESCRIPTION
Fixes: https://github.com/thunderbird/thunderbird-android/issues/11500

## Problem

The beta path of `merge_gradle.py` searched `theirs` (main's `app-thunderbird/build.gradle.kts`) for `versionNameSuffix = "b[1-9]"`.  Since `main` carries `b0`, which `b[1-9]` never matches, so the search failed and the path raised `SystemExit`, causing git to mark the file as conflicted, so every `main -> beta` merge needed manual fixing.

## Fix

Search for `b\d+` (e.g b1, b2, b11, etc) so main's value matches whatever it is, and normalize the merge result to `b0` for both apps. The "Bump version suffix" step in `shippable_builds.yml` bumps the suffix per Thunderbird beta release, so the merge result has to start at `b0` for the first beta release to produce `b1`. We don't ship betas for k9, and the beta suffix is dropped on a release. 

I've created a `set_version_name_suffix()` helper to be used for both branch logic, and two new constants: `BETA_SUFFIX` and `MAIN_SUFFIX`.

Three details:

- The search now targets `ours` rather than `theirs`. `shutil.copyfile(theirs, ours)` runs first, so the two are identical in content, but `ours` is the file being patched and the one whose final state matters.
- `SystemExit` is now reserved for the case where the searched suffix line doesn't exist at all: `a1` on the app-k9mail path, `b\d+` on app-thunderbird.
- The release path uses `b\d+` too, replacing `b[1-9]`, so it no longer breaks once a cycle reaches `b10`.

## Testing

Ran the driver directly against the pre-merge branch tips:

| | ours (beta) | theirs (main) | result |
|---|---|---|---|
| app-thunderbird | 23.0 / code 58 / `b1` | 24.0 / code 4 / `b0` | 24.0 / code 58 / `b0` |
| app-k9mail | 23.0 / code 39021 / `b1` | 24.0 / code 39004 / `a1` | 24.0 / code 39021 / `b0` |