### PR TITLE
fix: utf8 decoding

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Stack;
 
 import com.fsck.k9.mail.Body;
@@ -26,6 +27,7 @@ import org.apache.james.mime4j.parser.MimeStreamParser;
 import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
+import org.apache.james.mime4j.util.ContentUtil;
 
 public class MimePartStreamParser {
 
@@ -130,7 +132,7 @@ public class MimePartStreamParser {
         @Override
         public void field(Field parsedField) throws MimeException {
             String name = parsedField.getName();
-            String raw = parsedField.getRaw().toString();
+            String raw = ContentUtil.decode(StandardCharsets.UTF_8, parsedField.getRaw());
 
             Part part = (Part) stack.peek();
             part.addRawHeader(name, raw);

--- a/legacy/core/src/test/java/com/fsck/k9/mailstore/MimePartStreamParserTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/mailstore/MimePartStreamParserTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import com.fsck.k9.mail.internet.MimeMessage
 import com.fsck.k9.mail.internet.MimeMultipart
+import com.fsck.k9.mail.internet.MimeUtility
 import com.fsck.k9.mail.testing.assertk.body
 import com.fsck.k9.mail.testing.assertk.bodyPart
 import com.fsck.k9.mail.testing.assertk.bodyParts
@@ -16,6 +17,29 @@ import java.io.ByteArrayInputStream
 import org.junit.Test
 
 class MimePartStreamParserTest {
+    @Test
+    fun `parse should preserve UTF-8 attachment filename`() {
+        // Arrange
+        val expectedFilename = "Wspaniały świat.mp3"
+        val messageContent =
+            """
+            Content-Type: audio/mpeg
+            Content-Disposition: attachment; filename="$expectedFilename"
+
+            attachment content
+            """.trimIndent().crlf()
+
+        // Act
+        val bodyPart = MimePartStreamParser.parse(
+            null,
+            ByteArrayInputStream(messageContent.toByteArray(Charsets.UTF_8)),
+        )
+        val filename = MimeUtility.getHeaderParameter(bodyPart.disposition, "filename")
+
+        // Assert
+        assertThat(filename).isEqualTo(expectedFilename)
+    }
+
     @Test
     fun innerMessage_DispositionInline() {
         val messageContent =

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.LinkedList;
@@ -37,6 +38,7 @@ import org.apache.james.mime4j.parser.MimeStreamParser;
 import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
+import org.apache.james.mime4j.util.ContentUtil;
 import org.jetbrains.annotations.NotNull;
 import net.thunderbird.core.common.exception.MessagingException;
 
@@ -607,7 +609,7 @@ public class MimeMessage extends Message {
         public void field(Field parsedField) throws MimeException {
             expect(Part.class);
             String name = parsedField.getName();
-            String raw = parsedField.getRaw().toString();
+            String raw = ContentUtil.decode(StandardCharsets.UTF_8, parsedField.getRaw());
             ((Part) stack.peek()).addRawHeader(name, raw);
         }
     }

--- a/mail/common/src/main/java/com/fsck/k9/mail/message/MessageHeaderParser.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/message/MessageHeaderParser.kt
@@ -8,6 +8,7 @@ import org.apache.james.mime4j.parser.AbstractContentHandler
 import org.apache.james.mime4j.parser.MimeStreamParser
 import org.apache.james.mime4j.stream.Field
 import org.apache.james.mime4j.stream.MimeConfig
+import org.apache.james.mime4j.util.ContentUtil
 
 object MessageHeaderParser {
     @Throws(MessagingException::class)
@@ -41,7 +42,7 @@ object MessageHeaderParser {
     ) : AbstractContentHandler() {
         override fun field(rawField: Field) {
             val name = rawField.name
-            val raw = rawField.raw.toString()
+            val raw = ContentUtil.decode(Charsets.UTF_8, rawField.raw)
             collector.addRawHeader(name, raw)
         }
     }

--- a/mail/common/src/test/java/com/fsck/k9/mail/internet/MimeMessageUtf8HeaderTest.kt
+++ b/mail/common/src/test/java/com/fsck/k9/mail/internet/MimeMessageUtf8HeaderTest.kt
@@ -1,0 +1,43 @@
+package com.fsck.k9.mail.internet
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import java.io.ByteArrayInputStream
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class MimeMessageUtf8HeaderTest {
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    @Before
+    fun setUp() {
+        BinaryTempFileBody.setTempDirectory(tempFolder.root)
+    }
+
+    @Test
+    fun `parse should preserve UTF-8 attachment filename`() {
+        // Arrange
+        val expectedFilename = "Wspaniały świat.mp3"
+        val messageData =
+            """
+            Content-Type: audio/mpeg
+            Content-Disposition: attachment; filename="$expectedFilename"
+
+            attachment content
+            """.trimIndent()
+
+        // Act
+        val testSubject = MimeMessage.parseMimeMessage(
+            ByteArrayInputStream(messageData.toByteArray(Charsets.UTF_8)),
+            false,
+        )
+        val filename = MimeUtility.getHeaderParameter(testSubject.disposition, "filename")
+
+        // Assert
+        assertThat(filename).isEqualTo(expectedFilename)
+    }
+}

--- a/mail/common/src/test/java/com/fsck/k9/mail/message/MessageHeaderParserTest.kt
+++ b/mail/common/src/test/java/com/fsck/k9/mail/message/MessageHeaderParserTest.kt
@@ -1,0 +1,28 @@
+package com.fsck.k9.mail.message
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.fsck.k9.mail.internet.MimeHeader
+import com.fsck.k9.mail.internet.MimeUtility
+import java.io.ByteArrayInputStream
+import org.junit.Test
+
+class MessageHeaderParserTest {
+    @Test
+    fun `parse should preserve UTF-8 attachment filename`() {
+        // Arrange
+        val expectedFilename = "Wspaniały świat.mp3"
+        val headerData = "Content-Disposition: attachment; filename=\"$expectedFilename\"\r\n\r\n"
+        val header = MimeHeader()
+
+        // Act
+        MessageHeaderParser.parse(ByteArrayInputStream(headerData.toByteArray(Charsets.UTF_8))) { name, raw ->
+            header.addRawHeader(name, raw)
+        }
+        val contentDisposition = header.getFirstHeader(MimeHeader.HEADER_CONTENT_DISPOSITION)
+        val filename = MimeUtility.getHeaderParameter(contentDisposition, "filename")
+
+        // Assert
+        assertThat(filename).isEqualTo(expectedFilename)
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: resolves #11508 

#### Description

Fix UTF-8 MIME header decoding broken by the Mime4j 0.8.14 update. Raw headers are now explicitly decoded as UTF-8 instead of relying on Mime4j’s ISO-8859-1 toString() behavior.                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                  
Adds regression tests for attachment filenames across all affected parsing paths.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.
