### PR TITLE
fix(funding): center last row of contribution items

### DIFF
--- a/feature/funding/googleplay/src/main/kotlin/net/thunderbird/feature/funding/googleplay/ui/contribution/list/ContributionList.kt
+++ b/feature/funding/googleplay/src/main/kotlin/net/thunderbird/feature/funding/googleplay/ui/contribution/list/ContributionList.kt
@@ -4,8 +4,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -22,6 +21,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.Constraints
 import app.k9mail.core.ui.compose.common.resources.annotatedStringResource
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -111,28 +111,82 @@ internal fun ContributionList(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
+/**
+ * Lays the contribution items out on a grid of equally sized cells that fills the available width.
+ *
+ * A row that is not filled completely keeps the cell width of the rows above and is centered below them, instead of
+ * having its items stretched over the full width.
+ */
 @Composable
-private fun ChoicesRow(
+private fun ChoicesGrid(
     contributions: ImmutableList<Contribution>,
     onItemClick: (Contribution) -> Unit,
     selectedItemId: ContributionId?,
     modifier: Modifier = Modifier,
 ) {
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(BoltTheme.spacings.default),
-        verticalArrangement = Arrangement.spacedBy(BoltTheme.spacings.default),
+    val spacing = BoltTheme.spacings.default
+
+    Layout(
+        content = {
+            contributions.forEach {
+                ContributionListItem(
+                    text = it.priceFormatted,
+                    onClick = { onItemClick(it) },
+                    isSelected = it.id == selectedItemId,
+                )
+            }
+        },
         modifier = modifier,
-    ) {
-        contributions.forEach {
-            ContributionListItem(
-                text = it.priceFormatted,
-                onClick = { onItemClick(it) },
-                isSelected = it.id == selectedItemId,
-                modifier = Modifier.weight(1f),
-            )
+    ) { measurables, constraints ->
+        if (measurables.isEmpty()) {
+            return@Layout layout(width = 0, height = 0) {}
+        }
+
+        val spacingPx = spacing.roundToPx()
+        val widestItem = measurables.maxOf { it.maxIntrinsicWidth(Constraints.Infinity) }
+        val itemsPerRow = itemsPerRow(constraints, widestItem, spacingPx, measurables.size)
+        val width = if (constraints.hasBoundedWidth) {
+            constraints.maxWidth
+        } else {
+            itemsPerRow * widestItem + (itemsPerRow - 1) * spacingPx
+        }
+
+        // The division remainder goes to the leftmost columns, so a filled row uses the width exactly.
+        val widthForItems = width - spacingPx * (itemsPerRow - 1)
+        val itemWidth = widthForItems / itemsPerRow
+        val remainder = widthForItems % itemsPerRow
+
+        val rows = measurables
+            .mapIndexed { index, measurable ->
+                val columnWidth = if (index % itemsPerRow < remainder) itemWidth + 1 else itemWidth
+                measurable.measure(constraints.copy(minWidth = columnWidth, maxWidth = columnWidth))
+            }
+            .chunked(itemsPerRow)
+        val rowHeight = rows.maxOf { row -> row.maxOf { it.height } }
+
+        layout(width = width, height = rows.size * rowHeight + (rows.size - 1) * spacingPx) {
+            rows.forEachIndexed { rowIndex, row ->
+                val rowWidth = row.sumOf { it.width } + (row.size - 1) * spacingPx
+                var x = (width - rowWidth) / 2
+
+                row.forEach { placeable ->
+                    placeable.placeRelative(x = x, y = rowIndex * (rowHeight + spacingPx))
+                    x += placeable.width + spacingPx
+                }
+            }
         }
     }
+}
+
+/**
+ * The number of items that fit into a row when every item is as wide as the widest one.
+ */
+private fun itemsPerRow(constraints: Constraints, widestItem: Int, spacing: Int, itemCount: Int): Int {
+    if (!constraints.hasBoundedWidth) {
+        return itemCount
+    }
+
+    return ((constraints.maxWidth + spacing) / (widestItem + spacing)).coerceIn(1, itemCount)
 }
 
 @Composable
@@ -162,7 +216,7 @@ private fun ListContentView(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        ChoicesRow(
+        ChoicesGrid(
             contributions = if (state.selectedType == ContributionType.Recurring) {
                 state.contributions.recurringContributions
             } else {

--- a/feature/funding/googleplay/src/test/kotlin/net/thunderbird/feature/funding/googleplay/ui/contribution/list/ContributionListKtTest.kt
+++ b/feature/funding/googleplay/src/test/kotlin/net/thunderbird/feature/funding/googleplay/ui/contribution/list/ContributionListKtTest.kt
@@ -1,0 +1,284 @@
+package net.thunderbird.feature.funding.googleplay.ui.contribution.list
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isCloseTo
+import assertk.assertions.isGreaterThanOrEqualTo
+import kotlin.test.Test
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import net.thunderbird.feature.funding.googleplay.domain.entity.AvailableContributions
+import net.thunderbird.feature.funding.googleplay.domain.entity.Contribution
+import net.thunderbird.feature.funding.googleplay.domain.entity.ContributionId
+import net.thunderbird.feature.funding.googleplay.domain.entity.OneTimeContribution
+import net.thunderbird.feature.funding.googleplay.domain.entity.RecurringContribution
+import net.thunderbird.feature.funding.googleplay.ui.contribution.FakeData
+import net.thunderbird.feature.funding.googleplay.ui.contribution.list.ContributionListSliceContract.ContributionType
+import net.thunderbird.feature.funding.googleplay.ui.contribution.list.ContributionListSliceContract.State
+import org.robolectric.annotation.Config
+
+private const val TOLERANCE = 1f
+
+/**
+ * The minimum touch target size recommended by the Material accessibility guidelines.
+ */
+private const val MIN_TOUCH_TARGET_DP = 48f
+
+/**
+ * How many contribution items share a row depends on the available width and on how wide the longest price label is.
+ * The width is therefore set explicitly per test instead of relying on the simulated screen, which is kept large
+ * enough to never constrain the content.
+ */
+@Config(qualifiers = "w1920dp-h1600dp-mdpi")
+internal class ContributionListKtTest : ComposeTest() {
+
+    @Test
+    fun `should keep all items in a single row while they fit`() = runComposeTest {
+        // Arrange
+        val contributions = FakeData.oneTimeContributions
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(width = 420.dp, oneTimeContributions = contributions)
+        }
+
+        // Assert
+        val rows = itemRows(contributions)
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0]).hasSize(contributions.size)
+        assertAllItemsShareTheSameWidth(rows)
+    }
+
+    @Test
+    fun `should not stretch the items of a partially filled last row`() = runComposeTest {
+        // Arrange
+        val contributions = FakeData.oneTimeContributions
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(width = 320.dp, oneTimeContributions = contributions)
+        }
+
+        // Assert
+        val rows = itemRows(contributions)
+        assertThat(rows).hasSize(2)
+        assertThat(rows[1]).hasSize(2)
+        assertAllItemsShareTheSameWidth(rows)
+    }
+
+    @Test
+    fun `should center a partially filled last row below the row above`() = runComposeTest {
+        // Arrange
+        val contributions = FakeData.oneTimeContributions
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(width = 320.dp, oneTimeContributions = contributions)
+        }
+
+        // Assert
+        val rows = itemRows(contributions)
+        assertThat(centerOf(rows[1])).isCloseTo(centerOf(rows[0]), TOLERANCE)
+    }
+
+    @Test
+    fun `should not stretch a single item in the last row`() = runComposeTest {
+        // Arrange
+        val contributions = FakeData.oneTimeContributions
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(width = 360.dp, oneTimeContributions = contributions)
+        }
+
+        // Assert
+        val rows = itemRows(contributions)
+        assertThat(rows).hasSize(2)
+        assertThat(rows[1]).hasSize(1)
+        assertAllItemsShareTheSameWidth(rows)
+    }
+
+    @Test
+    fun `should center a single item in the last row below the row above`() = runComposeTest {
+        // Arrange
+        val contributions = FakeData.oneTimeContributions
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(width = 360.dp, oneTimeContributions = contributions)
+        }
+
+        // Assert
+        val rows = itemRows(contributions)
+        assertThat(centerOf(rows[1])).isCloseTo(centerOf(rows[0]), TOLERANCE)
+    }
+
+    @Test
+    fun `should center the last row when longer price labels reduce the items per row`() = runComposeTest {
+        // Arrange
+        val contributions = longLabelContributions()
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(width = 420.dp, oneTimeContributions = contributions)
+        }
+
+        // Assert
+        val rows = itemRows(contributions)
+        assertThat(rows).hasSize(2)
+        assertThat(rows[1]).hasSize(1)
+        assertAllItemsShareTheSameWidth(rows)
+        assertThat(centerOf(rows[1])).isCloseTo(centerOf(rows[0]), TOLERANCE)
+    }
+
+    @Test
+    fun `should center the last row of the recurring contributions as well`() = runComposeTest {
+        // Arrange
+        val contributions = FakeData.recurringContributions
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(
+                width = 320.dp,
+                oneTimeContributions = FakeData.oneTimeContributions,
+                recurringContributions = contributions,
+                selectedType = ContributionType.Recurring,
+            )
+        }
+
+        // Assert
+        val rows = itemRows(contributions)
+        assertThat(rows).hasSize(2)
+        assertAllItemsShareTheSameWidth(rows)
+        assertThat(centerOf(rows[1])).isCloseTo(centerOf(rows[0]), TOLERANCE)
+    }
+
+    @Test
+    fun `should lay out a single contribution centered in one row`() = runComposeTest {
+        // Arrange
+        val contributions = FakeData.oneTimeContributions.take(1).toImmutableList()
+        val width = 360.dp
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(width = width, oneTimeContributions = contributions)
+        }
+
+        // Assert
+        val rows = itemRows(contributions)
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0]).hasSize(1)
+        assertThat(centerOf(rows[0])).isCloseTo(width.value / 2, TOLERANCE)
+    }
+
+    @Test
+    fun `should give two contributions the same width in one row`() = runComposeTest {
+        // Arrange
+        val contributions = FakeData.oneTimeContributions.take(2).toImmutableList()
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(width = 360.dp, oneTimeContributions = contributions)
+        }
+
+        // Assert
+        val rows = itemRows(contributions)
+        assertThat(rows).hasSize(1)
+        assertAllItemsShareTheSameWidth(rows)
+    }
+
+    @Test
+    fun `should keep every item wide enough to touch on a narrow screen`() = runComposeTest {
+        // Arrange
+        val contributions = FakeData.oneTimeContributions
+
+        // Act
+        setContentWithTheme {
+            ContributionListOfWidth(width = 200.dp, oneTimeContributions = contributions)
+        }
+
+        // Assert
+        itemRows(contributions).flatten().forEach { bounds ->
+            assertThat(bounds.width).isGreaterThanOrEqualTo(MIN_TOUCH_TARGET_DP)
+        }
+    }
+}
+
+@Composable
+private fun ContributionListOfWidth(
+    width: Dp,
+    oneTimeContributions: ImmutableList<OneTimeContribution>,
+    recurringContributions: ImmutableList<RecurringContribution> = FakeData.recurringContributions,
+    selectedType: ContributionType = ContributionType.OneTime,
+) {
+    Box(modifier = Modifier.width(width)) {
+        ContributionList(
+            state = State(
+                contributions = AvailableContributions(
+                    oneTimeContributions = oneTimeContributions,
+                    recurringContributions = recurringContributions,
+                    preselection = FakeData.preselection,
+                ),
+                selectedType = selectedType,
+                isLoading = false,
+            ),
+            onEvent = {},
+        )
+    }
+}
+
+private fun longLabelContributions(): ImmutableList<OneTimeContribution> {
+    val prices = listOf("1.099,00 €", "549,00 €", "329,00 €", "219,00 €", "109,00 €", "65,00 €")
+
+    return prices
+        .mapIndexed { index, price ->
+            OneTimeContribution(
+                id = ContributionId("contribution_long_label_$index"),
+                title = "One time payment: $price",
+                description = "One time payment of $price",
+                price = 1000L * (index + 1),
+                priceFormatted = price,
+            )
+        }
+        .toImmutableList()
+}
+
+private data class ItemBounds(val left: Float, val top: Float, val right: Float) {
+    val width: Float = right - left
+}
+
+/**
+ * The bounds of every contribution item, grouped into the rows they were laid out in.
+ */
+private fun ComposeContentTestRule.itemRows(contributions: List<Contribution>): List<List<ItemBounds>> {
+    return contributions
+        .map { contribution ->
+            onNodeWithText(contribution.priceFormatted).getUnclippedBoundsInRoot().let {
+                ItemBounds(left = it.left.value, top = it.top.value, right = it.right.value)
+            }
+        }
+        .groupBy { it.top }
+        .values
+        .toList()
+}
+
+private fun centerOf(row: List<ItemBounds>): Float = (row.first().left + row.last().right) / 2
+
+private fun assertAllItemsShareTheSameWidth(rows: List<List<ItemBounds>>) {
+    val expectedWidth = rows.first().first().width
+
+    rows.flatten().forEach { bounds ->
+        assertThat(bounds.width).isCloseTo(expectedWidth, TOLERANCE)
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #8355
RFC / Technical Design (if applicable): n/a

#### Description

The contribution items are laid out in a `FlowRow` where each item carries `Modifier.weight(1f)`. Weights are distributed inside a row, so the items shrink to share whatever width the row is given instead of wrapping at their natural size. That produces two visible defects:

- The leftover item of an incomplete last row receives the full remaining width and stretches across the screen. This is what the issue reports.
- Before wrapping happens at all, the items are squeezed below the width their label needs, so a price breaks mid-number and `250 $` renders on two lines. This is not mentioned in the issue but has the same cause.

This replaces the `FlowRow` with a `Layout` that:

- derives one column width from the intrinsic width of the widest item, so items are never squeezed below what their label needs,
- uses that same column width for every row, so an incomplete last row keeps the width of the rows above it,
- centers a row that is not completely filled,
- hands the remainder of the width division to the leftmost columns, so a completely filled row still uses the available width exactly and keeps the pixel layout it had before.

**On the issue title.** The report names a tablet in landscape and the Fold's cover display, but neither the device nor the orientation decides. What decides is the available width relative to the number of items and the length of the price labels. That is why the same layout appears on a phone at certain widths, and why the reporter hit it on a tablet where the shorter sample amounts would not trigger it.

**On the earlier suggestion.** @kewisch proposed capping the items per row in 2024 and was unsure whether that would hold up with different currencies and longer numbers. On its own it does not: with four amounts, a cap of three produces 3 + 1 and the one stretches again. Centering the incomplete row fixes it independently of how many items fit, which is the direction @wmontwe gave when assigning the issue, so no cap is added here. If a cap is wanted for design reasons, that would be a separate change.

**Known limitation.** The screen needs Google Play Billing for real amounts, which requires maintainer level access, so I could not verify it with live data. The layout code does not depend on where the amounts come from, and the preview renders the same production composable with sample data.

#### Screen Shots

Compose preview on a Pixel 10 Pro, widths set with `adb shell wm size`.

| Width | Before | After |
|---|---|---|
| 320 dp | 3 + 3, correct | unchanged |
| 390 dp | 4 + 2, the amounts above break mid-number, the two below are twice as wide | 3 + 3, equal width, no line break |
| 500 dp | all six squeezed into one row, every amount wrapped onto two lines | 5 + 1, the last item at normal width and centered |

##### Width: 320 dp
Before: 
<img width="380" alt="before-320dp"
src="https://github.com/user-attachments/assets/1ede2109-d9ad-460c-8bda-0ea558490d95"
 />
After: 
<img width="380" alt="after-320dp"
src="https://github.com/user-attachments/assets/fbbec6d7-28d2-45c2-85d6-a7aec186ac63"
 />

##### Width: 390 dp
Before: 
<img width="380" alt="before-390dp"
src="https://github.com/user-attachments/assets/e3f654af-d6e8-4c0c-8dd3-2e3f618ffe85"
 />
After: 
<img width="380" alt="after-390dp"
src="https://github.com/user-attachments/assets/d75b814d-0778-4d21-a554-86f9fefa6640"
 />

##### Width: 500 dp
Before: 
<img width="380" alt="before-500dp"
src="https://github.com/user-attachments/assets/61f1c0f3-bd6a-430c-9b5e-bf727164f6a5"
 />
After: 
<img width="380" alt="after-500dp"
src="https://github.com/user-attachments/assets/f706903e-8696-43f0-98fe-25bf2bddb8d3"
 />

#### Testing

To reproduce and verify manually:

1. Run `ContributionListOneTimePreview` from `ContributionListPreview.kt` on a device or emulator via Run Preview
2. Set the width with `adb shell wm size 1500x1100` (500 dp at 3x density)
3. Restart the preview so Compose re-lays out, otherwise a stale layout is shown
4. Before the change: all six amounts sit in one row, each label wrapped onto two lines. After the change: five amounts in the first row, the sixth at the same width and centered below them

`ContributionListKtTest` covers ten cases: the two defect layouts (4 + 2 and 5 + 1) for both equal width and centering, a set of longer price labels that reproduces the reporter's situation, a completely filled row as evidence that the unaffected case does not change, a single amount, two amounts, the recurring amounts on the second tab, and a narrow screen where every item has to stay above the minimum touch target size.

Four of these ten fail on the parent commit and pass with the change:

```
should not stretch the items of a partially filled last row
  expected <140.0f> to be close to <66.0f> with delta of <1.0f>
should not stretch a single item in the last row
  expected <328.0f> to be close to <60.0f> with delta of <1.0f>
should center the last row of the recurring contributions as well
  expected <140.0f> to be close to <66.0f> with delta of <1.0f>
should center the last row when longer price labels reduce the items per row
  expected [size]:<[2]> but was:<[1]>
```

The two pure centering assertions pass on the parent commit as well, which is expected: an item stretched across the full width is trivially centered. They are kept as regression guards.

For side effects I ran a temporary sweep over 204 combinations, 51 widths from 200 dp to 1200 dp against four label lengths from `5 $` to `1.234.567,89 CHF`, asserting per combination that no item is taller than a single line, that all items share one width, that every row is centered in the content area, and that completely filled rows are flush with the edges. The change reports 0 findings, the parent commit reports 25. On a device I checked twelve widths from 280 dp to 952 dp, landscape, and font scale at 200%, all correct. The change can produce one row more than before at some widths, so the screen gets taller; `ContributionContent` already wraps the content in `verticalScroll`, so this is absorbed.

Commands run, all passing:

```
./gradlew :feature:funding:googleplay:testDebugUnitTest --tests "*ContributionListKtTest*"
./gradlew test lint detekt spotlessCheck testsOnCi dependencyGuard :quality:konsist:test
./gradlew check
```

`./gradlew check` was re-run after rebasing onto `upstream/main`. `connectedAndroidTest` was not run because the repository contains no `androidTest` source set, so the task has no tests to execute.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [] This contribution includes changes assisted by AI.
- [x] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla's Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).