### PR TITLE
feat(settings) default push for inbox

### DIFF
--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
@@ -6,17 +6,21 @@ import app.k9mail.feature.account.common.domain.entity.SpecialFolderOption
 import app.k9mail.feature.account.common.domain.entity.SpecialFolderSettings
 import app.k9mail.feature.account.setup.AccountSetupExternalContract
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
+import app.k9mail.feature.account.setup.domain.usecase.GetSpecialFolderOptions
 import com.fsck.k9.Core
 import com.fsck.k9.Preferences
 import com.fsck.k9.account.DeletePolicyProvider
 import com.fsck.k9.controller.MessagingController
+import com.fsck.k9.mail.FolderType
 import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.mail.folders.FolderFetcher
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.autoDetectNamespace
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.createExtra
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.isSendClientInfo
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.isUseCompression
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.pathPrefix
 import com.fsck.k9.mailstore.SpecialLocalFoldersCreator
+import com.fsck.k9.preferences.FolderSettingsProvider
 import com.fsck.k9.preferences.UnifiedInboxConfigurator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -28,6 +32,7 @@ import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey
 import net.thunderbird.feature.account.avatar.AvatarMonogramCreator
 import net.thunderbird.feature.account.storage.profile.AvatarDto
 import net.thunderbird.feature.account.storage.profile.AvatarTypeDto
+import net.thunderbird.feature.mail.folder.api.FolderDetails
 import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection
 import net.thunderbird.legacy.logging.Log
 
@@ -42,8 +47,8 @@ internal class AccountCreator(
     private val deletePolicyProvider: DeletePolicyProvider,
     private val avatarMonogramCreator: AvatarMonogramCreator,
     private val unifiedInboxConfigurator: UnifiedInboxConfigurator,
-    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val featureFlagProvider: FeatureFlagProvider,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AccountSetupExternalContract.AccountCreator {
 
     @Suppress("TooGenericExceptionCaught")
@@ -110,7 +115,19 @@ internal class AccountCreator(
             .onEnabled {
                 // The AccountCreator is only called when not importing settings.
                 // We can update inbox push here by default.
-                // TODO Get inbox and update
+                // TODO Get Inbox folderDetails, then updateFolderSettings
+                // TODO make a use case for getting a folder's settings by type
+                val inboxFolderID: Long? =
+                    messagingController.getMessageStore(newAccount).getFolders(true) { folderDetails ->
+                        if (folderDetails.type == FolderType.INBOX) {
+                            folderDetails.id
+                        } else {
+                            null
+                        }
+                    }.firstOrNull()
+                if (inboxFolderID != null) {
+                    messagingController.getMessageStore(newAccount).setPushEnabled(inboxFolderID, true)
+                }
             }
 
         if (account.options.checkFrequencyInMinutes == -1) {

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.Protocols
+import net.thunderbird.core.featureflag.FeatureFlagProvider
+import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey
 import net.thunderbird.feature.account.avatar.AvatarMonogramCreator
 import net.thunderbird.feature.account.storage.profile.AvatarDto
 import net.thunderbird.feature.account.storage.profile.AvatarTypeDto
@@ -41,6 +43,7 @@ internal class AccountCreator(
     private val avatarMonogramCreator: AvatarMonogramCreator,
     private val unifiedInboxConfigurator: UnifiedInboxConfigurator,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val featureFlagProvider: FeatureFlagProvider,
 ) : AccountSetupExternalContract.AccountCreator {
 
     @Suppress("TooGenericExceptionCaught")
@@ -102,6 +105,13 @@ internal class AccountCreator(
         Core.setServicesEnabled(context)
 
         messagingController.refreshFolderListBlocking(newAccount)
+
+        featureFlagProvider.provide(GeneratedFeatureFlagKey.PUSH_ENABLED_ON_INBOX_BY_DEFAULT)
+            .onEnabled {
+                // The AccountCreator is only called when not importing settings.
+                // We can update inbox push here by default.
+                // TODO Get inbox and update
+            }
 
         if (account.options.checkFrequencyInMinutes == -1) {
             messagingController.checkMail(newAccount, false, true, false, null)

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
@@ -6,21 +6,20 @@ import app.k9mail.feature.account.common.domain.entity.SpecialFolderOption
 import app.k9mail.feature.account.common.domain.entity.SpecialFolderSettings
 import app.k9mail.feature.account.setup.AccountSetupExternalContract
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
-import app.k9mail.feature.account.setup.domain.usecase.GetSpecialFolderOptions
+import app.k9mail.legacy.mailstore.domain.GetFolderIdsForTypeUseCase
+import app.k9mail.legacy.mailstore.domain.SetPushForFolderUseCase
 import com.fsck.k9.Core
 import com.fsck.k9.Preferences
 import com.fsck.k9.account.DeletePolicyProvider
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.mail.FolderType
 import com.fsck.k9.mail.ServerSettings
-import com.fsck.k9.mail.folders.FolderFetcher
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.autoDetectNamespace
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.createExtra
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.isSendClientInfo
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.isUseCompression
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.pathPrefix
 import com.fsck.k9.mailstore.SpecialLocalFoldersCreator
-import com.fsck.k9.preferences.FolderSettingsProvider
 import com.fsck.k9.preferences.UnifiedInboxConfigurator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -32,7 +31,6 @@ import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey
 import net.thunderbird.feature.account.avatar.AvatarMonogramCreator
 import net.thunderbird.feature.account.storage.profile.AvatarDto
 import net.thunderbird.feature.account.storage.profile.AvatarTypeDto
-import net.thunderbird.feature.mail.folder.api.FolderDetails
 import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection
 import net.thunderbird.legacy.logging.Log
 
@@ -48,6 +46,8 @@ internal class AccountCreator(
     private val avatarMonogramCreator: AvatarMonogramCreator,
     private val unifiedInboxConfigurator: UnifiedInboxConfigurator,
     private val featureFlagProvider: FeatureFlagProvider,
+    private val getFolderIdsForTypeUseCase: GetFolderIdsForTypeUseCase,
+    private val setPushForFolderUseCase: SetPushForFolderUseCase,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AccountSetupExternalContract.AccountCreator {
 
@@ -114,19 +114,12 @@ internal class AccountCreator(
         featureFlagProvider.provide(GeneratedFeatureFlagKey.PUSH_ENABLED_ON_INBOX_BY_DEFAULT)
             .onEnabled {
                 // The AccountCreator is only called when not importing settings.
-                // We can update inbox push here by default.
-                // TODO Get Inbox folderDetails, then updateFolderSettings
-                // TODO make a use case for getting a folder's settings by type
-                val inboxFolderID: Long? =
-                    messagingController.getMessageStore(newAccount).getFolders(true) { folderDetails ->
-                        if (folderDetails.type == FolderType.INBOX) {
-                            folderDetails.id
-                        } else {
-                            null
-                        }
-                    }.firstOrNull()
-                if (inboxFolderID != null) {
-                    messagingController.getMessageStore(newAccount).setPushEnabled(inboxFolderID, true)
+                // We can update inbox push here by default, as it's always a new account.
+                getFolderIdsForTypeUseCase(
+                    newAccount.uuid,
+                    FolderType.INBOX,
+                ).firstOrNull()?.let { inboxFolderId ->
+                    setPushForFolderUseCase(accountUuid = newAccount.uuid, folderId = inboxFolderId, enabled = true)
                 }
             }
 

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AppCommonAccountModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AppCommonAccountModule.kt
@@ -92,6 +92,8 @@ internal val appCommonAccountModule = module {
             avatarMonogramCreator = get(),
             unifiedInboxConfigurator = get(),
             featureFlagProvider = get(),
+            getFolderIdsForTypeUseCase = get(),
+            setPushForFolderUseCase = get(),
         )
     }
 }

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AppCommonAccountModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AppCommonAccountModule.kt
@@ -91,6 +91,7 @@ internal val appCommonAccountModule = module {
             messagingController = get(),
             avatarMonogramCreator = get(),
             unifiedInboxConfigurator = get(),
+            featureFlagProvider = get(),
         )
     }
 }

--- a/config/featureflag/thunderbird_mobile_featureflag.catalog.json
+++ b/config/featureflag/thunderbird_mobile_featureflag.catalog.json
@@ -63,6 +63,11 @@
       "default": true,
       "description": "Enables Thundermail onboarding flow.",
       "time_to_promote": "2026-12-31"
+    },
+    {
+      "key": "push_enabled_on_inbox_by_default",
+      "default": false,
+      "description": "Enables push syncing on a new account's inbox when creating the account. Not for imports."
     }
   ],
   "overrides": {
@@ -70,7 +75,8 @@
       "debug": {
         "display_in_app_notifications": true,
         "use_notification_sender_for_system_notifications": true,
-        "message_view_action_export_eml": true
+        "message_view_action_export_eml": true,
+        "push_enabled_on_inbox_by_default": true
       },
       "daily": {
         "display_in_app_notifications": true,
@@ -85,7 +91,8 @@
       "debug": {
         "display_in_app_notifications": true,
         "use_notification_sender_for_system_notifications": true,
-        "message_view_action_export_eml": true
+        "message_view_action_export_eml": true,
+        "push_enabled_on_inbox_by_default": true
       },
       "release": {}
     }

--- a/config/featureflag/thunderbird_mobile_featureflag.catalog.json
+++ b/config/featureflag/thunderbird_mobile_featureflag.catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "thunderbird_mobile_featureflag.schema.json",
-  "version": "2026-07-30.1",
+  "version": "2026-09-10.1",
   "flags": [
     {
       "key": "archive_marks_as_read",

--- a/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/data/BaseLocalFeatureFlagCatalogDataSourceTest.kt
+++ b/core/featureflag/src/commonTest/kotlin/net/thunderbird/core/featureflag/data/BaseLocalFeatureFlagCatalogDataSourceTest.kt
@@ -97,6 +97,7 @@ internal abstract class BaseLocalFeatureFlagCatalogDataSourceTest {
                         "display_in_app_notifications" to true,
                         "use_notification_sender_for_system_notifications" to true,
                         "message_view_action_export_eml" to true,
+                        "push_enabled_on_inbox_by_default" to true,
                     )
                     key("daily").containsOnly(
                         "display_in_app_notifications" to true,
@@ -110,6 +111,7 @@ internal abstract class BaseLocalFeatureFlagCatalogDataSourceTest {
                         "display_in_app_notifications" to true,
                         "use_notification_sender_for_system_notifications" to true,
                         "message_view_action_export_eml" to true,
+                        "push_enabled_on_inbox_by_default" to true,
                     )
                     key("release").isEmpty()
                 }
@@ -165,8 +167,8 @@ internal abstract class BaseLocalFeatureFlagCatalogDataSourceTest {
     )
 
     private companion object {
-        const val CATALOG_VERSION = "2026-07-30.1"
-        const val CATALOG_FLAG_COUNT = 12
+        const val CATALOG_VERSION = "2026-09-10.1"
+        const val CATALOG_FLAG_COUNT = 13
         const val MALFORMED_CATALOG_ERROR_MESSAGE =
             "Unexpected JSON token at offset 42: Expected quotation mark '\"', but had '}' instead"
     }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
@@ -16,6 +16,7 @@ import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSett
 import app.k9mail.feature.account.server.validation.ui.IncomingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.OutgoingServerValidationViewModel
 import app.k9mail.feature.account.server.validation.ui.ServerValidationScreen
+import app.k9mail.feature.account.setup.domain.entity.AccountUuid
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryScreen
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryViewModel
 import app.k9mail.feature.account.setup.ui.createaccount.CreateAccountScreen
@@ -179,7 +180,9 @@ fun AccountSetupNavHost(
 
         composable(route = NESTED_NAVIGATION_CREATE_ACCOUNT) {
             CreateAccountScreen(
-                onNext = { accountUuid -> onFinish(AccountSetupRoute.AccountSetup(accountUuid.value)) },
+                onNext = { accountUuid: AccountUuid ->
+                    onFinish(AccountSetupRoute.AccountSetup(accountUuid.value))
+                },
                 onBack = { navController.popBackStack() },
                 viewModel = koinViewModel<CreateAccountViewModel>(),
                 brandNameProvider = koinInject(),

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupRoute.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupRoute.kt
@@ -6,7 +6,9 @@ import net.thunderbird.core.ui.navigation.Route
 sealed interface AccountSetupRoute : Route {
 
     @Serializable
-    data class AccountSetup(val accountId: String? = null) : AccountSetupRoute {
+    data class AccountSetup(
+        val accountId: String? = null,
+    ) : AccountSetupRoute {
         override val basePath: String = BASE_PATH
 
         override fun route(): String = basePath

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupRoute.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupRoute.kt
@@ -6,9 +6,7 @@ import net.thunderbird.core.ui.navigation.Route
 sealed interface AccountSetupRoute : Route {
 
     @Serializable
-    data class AccountSetup(
-        val accountId: String? = null,
-    ) : AccountSetupRoute {
+    data class AccountSetup(val accountId: String? = null) : AccountSetupRoute {
         override val basePath: String = BASE_PATH
 
         override fun route(): String = basePath

--- a/legacy/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -2,6 +2,8 @@ package com.fsck.k9.controller
 
 import android.content.Context
 import app.k9mail.legacy.mailstore.MessageStoreManager
+import app.k9mail.legacy.mailstore.domain.GetFolderIdsForTypeUseCase
+import app.k9mail.legacy.mailstore.domain.SetPushForFolderUseCase
 import app.k9mail.legacy.message.controller.MessageCountsProvider
 import app.k9mail.legacy.message.controller.MessagingControllerRegistry
 import com.fsck.k9.Preferences
@@ -58,6 +60,18 @@ val controllerModule = module {
             messageStoreManager = get(),
             messagingControllerRegistry = get(),
             outboxFolderManager = get(),
+        )
+    }
+
+    single<GetFolderIdsForTypeUseCase> {
+        GetFolderIdsForTypeUseCase(
+            messageStoreManager = get(),
+        )
+    }
+
+    single<SetPushForFolderUseCase> {
+        SetPushForFolderUseCase(
+            messageStoreManager = get(),
         )
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -88,6 +88,7 @@ import net.thunderbird.core.common.mail.Flag;
 import net.thunderbird.core.featureflag.FeatureFlagProvider;
 import net.thunderbird.core.featureflag.keys.GeneratedFeatureFlagKey;
 import net.thunderbird.core.logging.Logger;
+import net.thunderbird.feature.mail.folder.api.FolderDetails;
 import net.thunderbird.feature.mail.folder.api.OutboxFolderManager;
 import net.thunderbird.feature.mail.folder.api.OutboxFolderManagerKt;
 import net.thunderbird.feature.mail.message.list.LocalDeleteOperationDecider;
@@ -707,6 +708,10 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
     private void updateFolderStatus(LegacyAccountDto account, long folderId, String status) {
         MessageStore messageStore = messageStoreManager.getMessageStore(account);
         messageStore.setStatus(folderId, status);
+    }
+
+    public MessageStore getMessageStore(LegacyAccountDto account) {
+        return messageStoreManager.getMessageStore(account);
     }
 
     public void handleAuthenticationFailure(LegacyAccountDto account, boolean incoming) {

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/domain/GetFolderIdsForTypeUseCase.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/domain/GetFolderIdsForTypeUseCase.kt
@@ -1,0 +1,22 @@
+package app.k9mail.legacy.mailstore.domain
+
+import app.k9mail.legacy.mailstore.MessageStoreManager
+import com.fsck.k9.mail.FolderType
+
+class GetFolderIdsForTypeUseCase(
+    private val messageStoreManager: MessageStoreManager,
+) {
+    operator fun invoke(
+        accountUuid: String,
+        folderType: FolderType,
+    ): List<Long?> {
+        return messageStoreManager.getMessageStore(accountUuid)
+            .getFolders(true) { folderDetails ->
+                if (folderDetails.type == folderType) {
+                    folderDetails.id
+                } else {
+                    null
+                }
+            }
+    }
+}

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/domain/SetPushForFolderUseCase.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/domain/SetPushForFolderUseCase.kt
@@ -1,0 +1,11 @@
+package app.k9mail.legacy.mailstore.domain
+
+import app.k9mail.legacy.mailstore.MessageStoreManager
+
+class SetPushForFolderUseCase(
+    private val messageStoreManager: MessageStoreManager,
+) {
+    operator fun invoke(accountUuid: String, folderId: Long, enabled: Boolean) {
+        messageStoreManager.getMessageStore(accountUuid).setPushEnabled(folderId, enabled)
+    }
+}

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultFolderDetailsRepositoryTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/folder/DefaultFolderDetailsRepositoryTest.kt
@@ -6,6 +6,7 @@ import app.k9mail.legacy.mailstore.ListenableMessageStore
 import app.k9mail.legacy.mailstore.MessageStoreFactory
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.mailstore.MoreMessages
+import app.k9mail.legacy.mailstore.domain.SetPushForFolderUseCase
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
@@ -13,6 +14,8 @@ import assertk.assertions.isNull
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
 import com.fsck.k9.mail.ServerSettings
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
 import kotlin.test.Test
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -281,6 +284,52 @@ class DefaultFolderDetailsRepositoryTest {
             assertThat(result).isInstanceOf(Outcome.Failure::class)
             assertThat((result as Outcome.Failure).error).isInstanceOf(FolderError.FailedPrecondition::class)
         }
+
+    @Test
+    fun `SetPushForFolderUseCase should call setPushEnabled`() = runTest {
+        // Setup fakes
+        var folderAccessor = FakeFolderDetailsAccessor(
+            id = INBOX_FOLDER_ID,
+            isPushEnabled = false,
+        )
+        whenever(messageStore.setPushEnabled(folderId = INBOX_FOLDER_ID, enable = true)).then {
+            folderAccessor = FakeFolderDetailsAccessor(
+                id = INBOX_FOLDER_ID,
+                isPushEnabled = true,
+            )
+        }
+
+        // Get initial values
+        stubGetFolder(INBOX_FOLDER_ID, folderAccessor)
+        var inboxFolderDetails = (testSubject.findById(accountId, INBOX_FOLDER_ID) as Outcome.Success).data
+
+        // Check that push has not been enabled yet
+        assertFalse(
+            "Is push enabled: ${inboxFolderDetails?.isPushEnabled} was supposed to be false " +
+                "before calling SetPushForFolderUseCase.",
+            inboxFolderDetails?.isPushEnabled == true,
+        )
+
+        // Call the same use case used in the account creation function to enable push
+        SetPushForFolderUseCase(
+            messageStoreManager,
+        ).invoke(
+            accountUuid = accountId.value.toString(),
+            folderId = inboxFolderDetails?.folder?.id ?: 0L,
+            enabled = true,
+        )
+
+        // Get updated folder details
+        stubGetFolder(INBOX_FOLDER_ID, folderAccessor)
+        inboxFolderDetails = (testSubject.findById(accountId, INBOX_FOLDER_ID) as Outcome.Success).data
+
+        // Check folder's push settings changed
+        assertTrue(
+            "Is push enabled: ${inboxFolderDetails?.isPushEnabled} was supposed to be true " +
+                "after calling SetPushForFolderUseCase.",
+            inboxFolderDetails?.isPushEnabled == true,
+        )
+    }
 
     private fun stubGetFolder(folderId: Long, accessor: FolderDetailsAccessor) {
         whenever(messageStore.getFolder<FolderDetails?>(eq(folderId), any())).thenAnswer { invocation ->


### PR DESCRIPTION
Closes: #11299 
RFC / Technical Design (if applicable): [RFC 0005](https://github.com/thunderbird/thunderbird-android/blob/main/docs/engineering/rfcs/0005-imap-idle-push-on-new-account-inboxes.md)
feature-flag: `push_enabled_on_inbox_by_default`

#### Description

Enables push on the inbox by default for accounts created through the new account creation process (email and OAuth/password)

## AI Disclosure

Select **one** of the following (mandatory)

- [X] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [X] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [X] This contribution is in Kotlin where possible
- [X] This contribution does not use merge commits
- [X] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [X] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [X] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [X] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
