### PR TITLE
fix: distinguish “from me” and “to me” in message details

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
@@ -22,7 +22,7 @@ internal class RealMessageDetailsParticipantFormatter(
     private val contactNameProvider: ContactNameProvider,
     private val showContactNames: Boolean,
     private val contactNameColor: Int?,
-    private val meText: String,
+    private val toMeText: String,
 ) : MessageDetailsParticipantFormatter {
     override fun getDisplayName(address: Address, account: LegacyAccountDto): CharSequence? {
         val identity = account.findIdentity(address)
@@ -74,6 +74,6 @@ internal fun createMessageDetailsParticipantFormatter(
         } else {
             null
         },
-        meText = resources.getString(R.string.message_view_me_text),
+        toMeText = resources.getString(R.string.message_view_to_me_text),
     )
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
@@ -15,7 +15,7 @@ import net.thunderbird.core.preference.display.visualSettings.message.list.Messa
  * Get the display name for a participant to be shown in the message details screen.
  */
 internal interface MessageDetailsParticipantFormatter {
-    fun getDisplayName(address: Address, account: LegacyAccountDto): CharSequence?
+    fun getDisplayName(address: Address, account: LegacyAccountDto, isSender: Boolean): CharSequence?
 }
 
 internal class RealMessageDetailsParticipantFormatter(
@@ -23,11 +23,12 @@ internal class RealMessageDetailsParticipantFormatter(
     private val showContactNames: Boolean,
     private val contactNameColor: Int?,
     private val toMeText: String,
+    private val fromMeText: String,
 ) : MessageDetailsParticipantFormatter {
-    override fun getDisplayName(address: Address, account: LegacyAccountDto): CharSequence? {
+    override fun getDisplayName(address: Address, account: LegacyAccountDto, isSender: Boolean): CharSequence? {
         val identity = account.findIdentity(address)
         if (identity != null) {
-            return getIdentityName(identity, account)
+            return getIdentityName(identity, account, isSender)
         }
 
         return if (showContactNames) {
@@ -37,7 +38,8 @@ internal class RealMessageDetailsParticipantFormatter(
         }
     }
 
-    private fun getIdentityName(identity: Identity, account: LegacyAccountDto): String {
+    private fun getIdentityName(identity: Identity, account: LegacyAccountDto, isSender: Boolean): String {
+        val meText = if (isSender) fromMeText else toMeText
         return if (account.identities.size == 1) {
             meText
         } else {
@@ -75,5 +77,6 @@ internal fun createMessageDetailsParticipantFormatter(
             null
         },
         toMeText = resources.getString(R.string.message_view_to_me_text),
+        fromMeText = resources.getString(R.string.message_view_from_me_text),
     )
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsViewModel.kt
@@ -83,12 +83,12 @@ internal class MessageDetailsViewModel(
                 val messageDetailsUi = MessageDetailsUi(
                     date = buildDisplayDate(messageDetails.date),
                     cryptoDetails = cryptoResult?.toCryptoDetails(),
-                    from = messageDetails.from.toParticipants(account),
-                    sender = senderList.toParticipants(account),
-                    replyTo = messageDetails.replyTo.toParticipants(account),
-                    to = messageDetails.to.toParticipants(account),
-                    cc = messageDetails.cc.toParticipants(account),
-                    bcc = messageDetails.bcc.toParticipants(account),
+                    from = messageDetails.from.toParticipants(account, isSender = true),
+                    sender = senderList.toParticipants(account, isSender = true),
+                    replyTo = messageDetails.replyTo.toParticipants(account, isSender = true),
+                    to = messageDetails.to.toParticipants(account, isSender = false),
+                    cc = messageDetails.cc.toParticipants(account, isSender = false),
+                    bcc = messageDetails.bcc.toParticipants(account, isSender = false),
                     folder = folder?.toFolderInfo(),
                 )
 
@@ -125,9 +125,9 @@ internal class MessageDetailsViewModel(
         )
     }
 
-    private fun List<Address>.toParticipants(account: LegacyAccountDto): List<Participant> {
+    private fun List<Address>.toParticipants(account: LegacyAccountDto, isSender: Boolean): List<Participant> {
         return this.map { address ->
-            val displayName = participantFormatter.getDisplayName(address, account)
+            val displayName = participantFormatter.getDisplayName(address, account, isSender)
             val emailAddress = address.address
 
             Participant(

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
@@ -91,6 +91,6 @@ internal fun createMessageViewRecipientFormatter(
         } else {
             null
         },
-        meText = resources.getString(R.string.message_view_me_text),
+        meText = resources.getString(R.string.message_view_to_me_text),
     )
 }

--- a/legacy/ui/legacy/src/main/res/values-ar/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ar/strings.xml
@@ -181,7 +181,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">انا</string>
+    <string name="message_view_to_me_text">انا</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">عرض الصور البعيدة</string>
     <string name="message_view_no_viewer">يتعذر إيجاب تطبيق لعرض <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-be/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-be/strings.xml
@@ -177,7 +177,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">я</string>
+    <string name="message_view_to_me_text">я</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Паказваць адлеглыя выявы</string>
     <string name="message_view_no_viewer">Няма праграмы для прагляду <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-bg/strings.xml
@@ -778,7 +778,7 @@
     <string name="general_settings_swipe_action_toggle_read">Отбележи като прочетено/непрочетено</string>
     <string name="action_copy_email_address">Копиране на имейл адрес</string>
     <string name="account_settings_autodownload_message_size_10240">10 МБ</string>
-    <string name="message_view_me_text">мен</string>
+    <string name="message_view_to_me_text">мен</string>
     <string name="account_settings_notification_channels_label">Категории известия</string>
     <string name="action_compose_message_to">Напиши съобщение</string>
     <string name="account_settings_autodownload_message_size_512">512 КБ</string>

--- a/legacy/ui/legacy/src/main/res/values-bn/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-bn/strings.xml
@@ -33,7 +33,7 @@
     <string name="version">সংস্করণ</string>
     <string name="message_compose_subject_hint">বিষয়</string>
     <string name="message_to_label">প্রতি:</string>
-    <string name="message_view_me_text">আমি</string>
+    <string name="message_view_to_me_text">আমি</string>
     <string name="general_settings_swipe_action_archive">সংরক্ষণাগার</string>
     <string name="message_view_cc_label">সিসি:</string>
     <string name="general_settings_swipe_action_delete">অপসারণ</string>

--- a/legacy/ui/legacy/src/main/res/values-br/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-br/strings.xml
@@ -752,7 +752,7 @@
     <string name="new_messages_title">Posteloù nevez</string>
     <string name="debug_export_logs_title">Ezporzhiañ ar c\'herzhlevr</string>
     <string name="debug_export_logs_failure">Faziet war an ezporzhiañ.</string>
-    <string name="message_view_me_text">me</string>
+    <string name="message_view_to_me_text">me</string>
     <string name="general_settings_post_remove_action_return_to_list">Distreiñ da roll ar posteloù</string>
     <string name="general_settings_post_remove_action_title">Goude bezañ dilamet pe dilec\'hiet ur postel</string>
     <string name="account_settings_autodownload_message_size_2048">2 Mie</string>

--- a/legacy/ui/legacy/src/main/res/values-bs/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-bs/strings.xml
@@ -166,7 +166,7 @@
     <string name="message_compose_quote_header_separator">-------- Originalna Poruka --------</string>
     <string name="message_compose_quote_header_send_date">Poslano:</string>
     <string name="message_compose_quote_header_to">Za:</string>
-    <string name="message_view_me_text">mene</string>
+    <string name="message_view_to_me_text">mene</string>
     <string name="message_compose_quote_header_from">Od:</string>
     <string name="message_to_label">Za:</string>
     <string name="message_view_cc_label">Cc:</string>

--- a/legacy/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ca/strings.xml
@@ -175,7 +175,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mi</string>
+    <string name="message_view_to_me_text">mi</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Mostra les imatges remotes</string>
     <string name="message_view_no_viewer">No s\'ha pogut trobar un visualitzador per <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-co/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-co/strings.xml
@@ -139,7 +139,7 @@
     <string name="message_view_cc_label">Cc :</string>
     <string name="message_view_bcc_label">Cci :</string>
     <string name="message_view_status_attachment_not_saved">Impussibule d’arregistrà a pezza ghjunta.</string>
-    <string name="message_view_me_text">eiu</string>
+    <string name="message_view_to_me_text">eiu</string>
     <string name="message_view_no_viewer">Ùn si pò truvà un affissadore per <xliff:g id="mimetype">%s</xliff:g>.</string>
     <string name="message_view_download_remainder">Scaricà u messaghju cumpletu</string>
     <string name="message_view_sender_label">via %1$s</string>

--- a/legacy/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-cs/strings.xml
@@ -177,7 +177,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">Mně</string>
+    <string name="message_view_to_me_text">Mně</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Zobrazit vzdálené obrázky</string>
     <string name="message_view_no_viewer">Nelze nalézt prohlížeč pro <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-cy/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-cy/strings.xml
@@ -863,7 +863,7 @@
     <string name="save_attachment_action">Cadw atodiad</string>
     <string name="message_view_recipients_format">at <xliff:g id="recipients">%s</xliff:g></string>
     <string name="message_view_additional_recipient_prefix">+</string>
-    <string name="message_view_me_text">fi</string>
+    <string name="message_view_to_me_text">fi</string>
     <string name="message_view_show_remote_images_action">Dangos delweddau pell</string>
     <string name="global_settings_messageview_body_content_type_title">Corff Math o Gynnwys</string>
     <string name="global_settings_messageview_body_content_type_text_html">HTML (testun/html)</string>

--- a/legacy/ui/legacy/src/main/res/values-da/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-da/strings.xml
@@ -171,7 +171,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mig</string>
+    <string name="message_view_to_me_text">mig</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Vis eksterne billeder</string>
     <string name="message_view_no_viewer">Kan ikke finde program som kan vise <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-de/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-de/strings.xml
@@ -172,7 +172,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mich</string>
+    <string name="message_view_to_me_text">mich</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Externe Bilder anzeigen</string>
     <string name="message_view_no_viewer">Es wurde kein Anzeigeprogramm für <xliff:g id="mimetype">%s</xliff:g> gefunden.</string>

--- a/legacy/ui/legacy/src/main/res/values-el/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-el/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">εγώ</string>
+    <string name="message_view_to_me_text">εγώ</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Εμφάνιση αποκρυμμένων εικόνων</string>
     <string name="message_view_no_viewer">Δεν υπάρχει πρόγραμμα προβολής για <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-en-rGB/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-en-rGB/strings.xml
@@ -175,7 +175,7 @@
     <string name="font_size_tiniest">Tiniest</string>
     <string name="idle_refresh_period_12min">Every 12 minutes</string>
     <string name="general_no_sender">No sender</string>
-    <string name="message_view_me_text">me</string>
+    <string name="message_view_to_me_text">me</string>
     <string name="notifications_title">Notifications</string>
     <string name="account_settings_notification_channels_label">Notification categories</string>
     <string name="message_compose_quote_header_subject">Subject:</string>

--- a/legacy/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-eo/strings.xml
@@ -793,7 +793,7 @@
     <string name="new_messages_title">Novaj mesaĝoj</string>
     <string name="notification_certificate_error_public">Atestila eraro</string>
     <string name="debug_export_logs_failure">Elportado malsukcesis.</string>
-    <string name="message_view_me_text">mi</string>
+    <string name="message_view_to_me_text">mi</string>
     <string name="unsubscribe_action">Malaboni</string>
     <string name="notification_notify_error_title">Sciiga eraro</string>
     <string name="message_view_show_remote_images_action">Montri forajn bildojn</string>

--- a/legacy/ui/legacy/src/main/res/values-es/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-es/strings.xml
@@ -175,7 +175,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mí</string>
+    <string name="message_view_to_me_text">mí</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Mostrar imágenes remotas</string>
     <string name="message_view_no_viewer">Imposible encontrar visor de <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-et/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-et/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mina</string>
+    <string name="message_view_to_me_text">mina</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Näita kirjavälist sisu</string>
     <string name="message_view_no_viewer">Ei leia <xliff:g id="mimetype">%s</xliff:g> kuvamiseks programmi.</string>

--- a/legacy/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-eu/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">niri</string>
+    <string name="message_view_to_me_text">niri</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Erakutsi urruneko irudiak</string>
     <string name="message_view_no_viewer">Ezin da <xliff:g id="mimetype">%s</xliff:g>-(r)entzako ikustailerik aurkitu.</string>

--- a/legacy/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fa/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">من</string>
+    <string name="message_view_to_me_text">من</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">نمایش تصاویر خارجی</string>
     <string name="message_view_no_viewer">نمایش‌دهنده‌ای برای <xliff:g id="mimetype">%s</xliff:g> پیدا نشد.</string>

--- a/legacy/ui/legacy/src/main/res/values-fi/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fi/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">minä</string>
+    <string name="message_view_to_me_text">minä</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Näytä etäkuvat</string>
     <string name="message_view_no_viewer">Tiedostotyypille <xliff:g id="mimetype">%s</xliff:g> ei löydy katseluohjelmaa.</string>

--- a/legacy/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fr/strings.xml
@@ -175,7 +175,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">moi</string>
+    <string name="message_view_to_me_text">moi</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Afficher les images distantes</string>
     <string name="message_view_no_viewer">Impossible de trouver un visualiseur pour <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-fy/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fy/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">my</string>
+    <string name="message_view_to_me_text">my</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Eksterne ôfbyldingen toane</string>
     <string name="message_view_no_viewer">Gjin viewer te finen foar <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-ga/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ga/strings.xml
@@ -261,7 +261,7 @@
     <string name="message_view_bcc_label">Bcc:</string>
     <string name="message_view_status_attachment_not_saved">Ní féidir iatán a shábháil.</string>
     <string name="message_view_additional_recipient_prefix">+</string>
-    <string name="message_view_me_text">mise</string>
+    <string name="message_view_to_me_text">mise</string>
     <string name="message_view_sender_label">trí %1$s</string>
     <string name="from_same_sender">Tuilleadh ón seoltóir seo</string>
     <string name="message_discarded_toast">Teachtaireacht curtha i leataobh</string>

--- a/legacy/ui/legacy/src/main/res/values-gd/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-gd/strings.xml
@@ -895,5 +895,5 @@
     <string name="debug_enable_sync_debug_logging_title">Cuir an comas logadh dì-bhugachadh an t-sioncronachaidh</string>
     <string name="debug_enable_sync_debug_logging_summary">Dèan loga dhen fhiosrachadh diagnosachd fad 24 uair a thìde</string>
     <string name="debug_sync_export_logs_title">Às-phortaich logaichean an t-sioncronachaidh</string>
-    <string name="message_view_me_text">domh-sa</string>
+    <string name="message_view_to_me_text">domh-sa</string>
 </resources>

--- a/legacy/ui/legacy/src/main/res/values-gl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-gl/strings.xml
@@ -795,7 +795,7 @@
     <!--For unread messages the first line of a message list item is modified by this to improve the experience for people with screen readers.-->
     <string name="new_messages_title">Novas mensaxes</string>
     <string name="unsubscribe_action">Cancelar a subscrición</string>
-    <string name="message_view_me_text">eu</string>
+    <string name="message_view_to_me_text">eu</string>
     <string name="message_view_show_remote_images_action">Mostra imaxes remotas</string>
     <string name="general_settings_contact_name_color_label">Cor do nome do contacto</string>
     <string name="general_settings_post_remove_action_title">Despois de eliminar ou mover unha mensaxe</string>

--- a/legacy/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-hr/strings.xml
@@ -750,7 +750,7 @@
     <string name="notification_notify_error_title">Greška u obavijesti</string>
     <string name="message_view_show_remote_images_action">Prikaži slike s udaljenog poslužitelja</string>
     <string name="message_view_additional_recipient_prefix">+</string>
-    <string name="message_view_me_text">mene</string>
+    <string name="message_view_to_me_text">mene</string>
     <string name="general_settings_post_remove_action_show_previous_message">Prikaži prethodnu poruku</string>
     <string name="general_settings_post_mark_as_unread_action_title">Nakon označavanja poruke kao nepročitane</string>
     <string name="general_settings_swipe_actions_title">Akcije povlačenja</string>

--- a/legacy/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-hu/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">Számomra</string>
+    <string name="message_view_to_me_text">Számomra</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Távoli képek megjelenítése</string>
     <string name="message_view_no_viewer">Nem sikerült megjelenítőt találni ehhez: <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-in/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-in/strings.xml
@@ -779,7 +779,7 @@
     <string name="notification_notify_error_text">Kesalahan telah terjadi saat mencoba untuk membuat notifikasi sistem untuk pesan baru. Kemungkinan besar penyebabnya yaitu hilangnya suara notifikasi. \n \nKetuk untuk membuka pengaturan notifikasi.</string>
     <string name="debug_export_logs_success">Ekspor berhasil. Log mungkin berisi informasi sensitif. Berhati-hatilah kepada siapa Anda mengirimkannya.</string>
     <string name="message_view_additional_recipient_prefix">+</string>
-    <string name="message_view_me_text">saya</string>
+    <string name="message_view_to_me_text">saya</string>
     <string name="message_view_show_remote_images_action">Tampilkan gambar jarak jauh</string>
     <string name="general_settings_right_swipe_title">Geser kanan</string>
     <string name="general_settings_left_swipe_title">Geser kiri</string>

--- a/legacy/ui/legacy/src/main/res/values-is/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-is/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mín</string>
+    <string name="message_view_to_me_text">mín</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Birta fjartengdar myndir</string>
     <string name="message_view_no_viewer">Gat ekki fundið neitt skoðunarforrit fyrir <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-it/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-it/strings.xml
@@ -175,7 +175,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">me</string>
+    <string name="message_view_to_me_text">me</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Mostra immagini remote</string>
     <string name="message_view_no_viewer">Impossibile trovare un visualizzatore per <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-iw/strings.xml
@@ -678,7 +678,7 @@
     <string name="message_view_status_attachment_not_saved">לא ניתן לשמור קבצים מצורפים.</string>
     <string name="message_view_recipients_format">אל <xliff:g id="recipients">%s</xliff:g></string>
     <string name="message_view_additional_recipient_prefix">+</string>
-    <string name="message_view_me_text">אני</string>
+    <string name="message_view_to_me_text">אני</string>
     <string name="font_size_message_compose_input">שדות טקסט</string>
     <string name="dialog_confirm_empty_trash_message">רוצה לרוקן את תיקיית פריטים שנמחקו?</string>
     <plurals name="dialog_confirm_delete_messages">

--- a/legacy/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ja/strings.xml
@@ -171,7 +171,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">自分</string>
+    <string name="message_view_to_me_text">自分</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">リモート画像を表示</string>
     <string name="message_view_no_viewer"><xliff:g id="mimetype">%s</xliff:g> のビューワーが見つかりません。</string>

--- a/legacy/ui/legacy/src/main/res/values-kab/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-kab/strings.xml
@@ -54,7 +54,7 @@
     <string name="message_compose_quote_header_from">Sɣur:</string>
     <string name="message_to_label">I:</string>
     <string name="message_view_bcc_label">Anɣ. Uff. I:</string>
-    <string name="message_view_me_text">nekki</string>
+    <string name="message_view_to_me_text">nekki</string>
     <string name="global_settings_confirm_action_spam">Aspam</string>
     <string name="general_settings_swipe_action_spam">Aspam</string>
     <string name="account_setup_expunge_policy_manual">S ufus</string>

--- a/legacy/ui/legacy/src/main/res/values-ko/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ko/strings.xml
@@ -737,7 +737,7 @@
     <string name="notification_notify_error_title">알림 오류</string>
     <string name="general_settings_post_remove_action_title">메시지를 이동하거나 삭제한 후에</string>
     <string name="message_view_recipients_format"><xliff:g id="recipients">%s</xliff:g>에게</string>
-    <string name="message_view_me_text">나</string>
+    <string name="message_view_to_me_text">나</string>
     <string name="message_view_show_remote_images_action">외부 이미지 표시</string>
     <string name="general_settings_post_remove_action_show_previous_message">이전 메시지 보기</string>
     <string name="general_settings_post_mark_as_unread_action_stay">현재 메시지에 머무르기</string>

--- a/legacy/ui/legacy/src/main/res/values-lt/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-lt/strings.xml
@@ -175,7 +175,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">aš</string>
+    <string name="message_view_to_me_text">aš</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Rodyti nuotolinius paveikslėlius</string>
     <string name="message_view_no_viewer">Nepavyko rasto <xliff:g id="mimetype">%s</xliff:g> peržiūros programos.</string>

--- a/legacy/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-lv/strings.xml
@@ -175,7 +175,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">man</string>
+    <string name="message_view_to_me_text">man</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Rādīt lejupielādējamos attēlus</string>
     <string name="message_view_no_viewer">Nevar atrast programmu, lai atvērtu <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-nb/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-nb/strings.xml
@@ -747,7 +747,7 @@
     <string name="notification_certificate_error_public">Sertifikatsfeil</string>
     <string name="general_settings_swipe_action_toggle_read">Marker som lest/ulest</string>
     <string name="action_copy_email_address">Kopier e-postadresse</string>
-    <string name="message_view_me_text">meg</string>
+    <string name="message_view_to_me_text">meg</string>
     <string name="account_settings_notification_channels_label">Merknadskategorier</string>
     <string name="action_compose_message_to">Skriv melding til</string>
     <string name="copy_subject_to_clipboard">Emnetekst kopiert til utklippstavlen</string>

--- a/legacy/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-nl/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mij</string>
+    <string name="message_view_to_me_text">mij</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Externe afbeeldingen tonen</string>
     <string name="message_view_no_viewer">Niet in staat viewer te vinden voor <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-nn/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-nn/strings.xml
@@ -557,7 +557,7 @@
     <string name="notification_channel_messages_description">Notifikasjonar relatert til meldingar</string>
     <string name="debug_enable_sensitive_logging_summary">Kan vise passord i loggar.</string>
     <string name="global_settings_show_correspondent_names_label">Vis korrespondentnamn</string>
-    <string name="message_view_me_text">meg</string>
+    <string name="message_view_to_me_text">meg</string>
     <string name="global_settings_flag_summary">Stjerner indikerer flagga meldingar</string>
     <string name="global_settings_preview_lines_label">Førehandsvis linjer</string>
     <string name="global_settings_show_correspondent_names_summary">Vis korrespondentnamn i staden for email-adresser</string>

--- a/legacy/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-pl/strings.xml
@@ -178,7 +178,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mnie</string>
+    <string name="message_view_to_me_text">mnie</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Wyświetl zdalne obrazy</string>
     <string name="message_view_no_viewer">Nie moge znaleźć aplikacji do wyświetlenia pliku <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -175,7 +175,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mim</string>
+    <string name="message_view_to_me_text">mim</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Exibir imagens remotas</string>
     <string name="message_view_no_viewer">Não foi possível encontrar um visualizador para <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -175,7 +175,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">eu</string>
+    <string name="message_view_to_me_text">eu</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Mostrar imagens remotas</string>
     <string name="message_view_no_viewer">Incapaz de encontrar visualizador para <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ro/strings.xml
@@ -175,7 +175,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">eu</string>
+    <string name="message_view_to_me_text">eu</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Afișează imagini de la distanță</string>
     <string name="message_view_no_viewer">Nu se poate găsi vizualizator pentru <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ru/strings.xml
@@ -177,7 +177,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">мне</string>
+    <string name="message_view_to_me_text">мне</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Загрузить изображения</string>
     <string name="message_view_no_viewer">Отсутствует просмотрщик <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-sk/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sk/strings.xml
@@ -705,7 +705,7 @@
     <string name="about_app_authors_thunderbird">Tím Thunderbird Mobile</string>
     <string name="notification_notify_error_text">Vyskytla sa chyba počas pokusu o vytvorenie notifikácie pre noú správu. Dôvodom je pravdepodobne nenastavený zvuk notifikácie.\n\nKliknite pre otvorenie nastavení notifikácií.</string>
     <string name="message_view_show_remote_images_action">Zobraziť vzdialené obrázky</string>
-    <string name="message_view_me_text">mne</string>
+    <string name="message_view_to_me_text">mne</string>
     <string name="about_title">O aplikácií <xliff:g id="app_name">%s</xliff:g></string>
     <string name="debug_export_logs_failure">Export zlyhal.</string>
     <string name="general_settings_post_remove_action_title">Po zmazaní alebo presunutí správy</string>

--- a/legacy/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sl/strings.xml
@@ -176,7 +176,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mene</string>
+    <string name="message_view_to_me_text">mene</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Pokaži oddaljene slike</string>
     <string name="message_view_no_viewer">Ni mogoče najti pregledovalnika za vrsto <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sq/strings.xml
@@ -172,7 +172,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mua</string>
+    <string name="message_view_to_me_text">mua</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Shfaq figura të largëta</string>
     <string name="message_view_no_viewer">S’arrihet të gjendet parës për <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sr/strings.xml
@@ -799,7 +799,7 @@
     <string name="debug_export_logs_failure">Извоз није успео.</string>
     <string name="message_view_recipients_format">за <xliff:g id="recipients">%s</xliff:g></string>
     <string name="message_view_additional_recipient_prefix">+</string>
-    <string name="message_view_me_text">мене</string>
+    <string name="message_view_to_me_text">мене</string>
     <string name="general_settings_contact_name_color_label">Боја имена контакта</string>
     <string name="general_settings_post_remove_action_title">Након брисања или премештања поруке</string>
     <string name="general_settings_post_remove_action_return_to_list">Врати се на листу порука</string>

--- a/legacy/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sv/strings.xml
@@ -173,7 +173,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">mig</string>
+    <string name="message_view_to_me_text">mig</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Visa fjärrbilder</string>
     <string name="message_view_no_viewer">Kan inte hitta visare för <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-ta-rIN/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ta-rIN/strings.xml
@@ -239,7 +239,7 @@
     <string name="notification_channel_miscellaneous_description">பிழைகள் போன்ற இதர அறிவிப்புகள்.</string>
     <string name="compose_error_incomplete_recipient">பெறுநரின் புலத்தில் முழுமையற்ற உள்ளீடு உள்ளது!</string>
     <string name="general_settings_right_swipe_title">வலது ச்வைப்</string>
-    <string name="message_view_me_text">நான்</string>
+    <string name="message_view_to_me_text">நான்</string>
     <string name="global_settings_show_correspondent_names_summary">நிருபர் பெயர்களை அவர்களின் மின்னஞ்சல் முகவரிகளைக் காட்டிலும் காண்பி</string>
     <string name="general_settings_message_list_density_title">அடர்த்தி</string>
     <string name="global_settings_privacy_hide_useragent">அஞ்சல் கிளையண்டை மறைக்கவும்</string>

--- a/legacy/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-tr/strings.xml
@@ -817,7 +817,7 @@
     <!--A user visible label for the name and email address copied to the clipboard-->
     <!--Might be displayed in a notification when deleting an account (in the background)-->
     <string name="action_copy_email_address">E-posta adresini kopyala</string>
-    <string name="message_view_me_text">ben</string>
+    <string name="message_view_to_me_text">ben</string>
     <string name="action_compose_message_to">Bu kişiye ileti oluştur</string>
     <string name="account_settings_vibrate_pattern_label">Titreşim şablonu</string>
     <string name="message_list_content_description_unread_prefix">okunmadı, %s</string>

--- a/legacy/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-uk/strings.xml
@@ -177,7 +177,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">мені</string>
+    <string name="message_view_to_me_text">мені</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Показати віддалені зображення</string>
     <string name="message_view_no_viewer">Не знайдено відображувача для <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-vi/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-vi/strings.xml
@@ -169,7 +169,7 @@
     <!--Used to display the recipient list in the message view screen.-->
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">tôi</string>
+    <string name="message_view_to_me_text">tôi</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">Hiển thị hình ảnh từ xa</string>
     <string name="message_view_no_viewer">Không tìm thấy trình hiển thị cho <xliff:g id="mimetype">%s</xliff:g>.</string>

--- a/legacy/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -171,7 +171,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">我</string>
+    <string name="message_view_to_me_text">我</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">显示远程图片</string>
     <string name="message_view_no_viewer">无法找到查看 <xliff:g id="mimetype">%s</xliff:g> 的应用。</string>

--- a/legacy/ui/legacy/src/main/res/values-zh-rTW/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-zh-rTW/strings.xml
@@ -171,7 +171,7 @@
     <!--Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed).-->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!--Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me".-->
-    <string name="message_view_me_text">我</string>
+    <string name="message_view_to_me_text">我</string>
     <!--Text of the button that is displayed below the message header when the message body references one or more remote images-->
     <string name="message_view_show_remote_images_action">顯示遠端圖片</string>
     <string name="message_view_no_viewer">無法開啟<xliff:g id="mimetype">%s</xliff:g>。找不到可以開啟該附件的程式。</string>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -256,6 +256,8 @@
     <string name="message_view_additional_recipient_prefix">+</string>
     <!-- Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me". -->
     <string name="message_view_to_me_text">me</string>
+    <!-- Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me". -->
+    <string name="message_view_from_me_text">me</string>
 
     <!-- Text of the button that is displayed below the message header when the message body references one or more remote images -->
     <string name="message_view_show_remote_images_action">Show remote images</string>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -255,7 +255,7 @@
     <!-- Displayed in the message view screen in front of the number of additional recipients (the ones that are not displayed). -->
     <string name="message_view_additional_recipient_prefix">+</string>
     <!-- Displayed in the message view screen if the message was addressed to the user. Make sure this works with 'message_view_recipient_prefix'. In English it's "to me". -->
-    <string name="message_view_me_text">me</string>
+    <string name="message_view_to_me_text">me</string>
 
     <!-- Text of the button that is displayed below the message header when the message body references one or more remote images -->
     <string name="message_view_show_remote_images_action">Show remote images</string>

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatterTest.kt
@@ -20,7 +20,8 @@ import org.junit.Test
 
 private const val IDENTITY_NAME = "Alice"
 private const val IDENTITY_ADDRESS = "me@domain.example"
-private const val ME_TEXT = "me"
+private const val TO_ME_TEXT = "to me"
+private const val FROM_ME_TEXT = "from me"
 
 class MessageDetailsParticipantFormatterTest : RobolectricTest() {
     private val contactNameProvider = object : ContactNameProvider {
@@ -40,10 +41,25 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
     private val participantFormatter = createParticipantFormatter()
 
     @Test
-    fun `identity address with single identity`() {
-        val displayName = participantFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"), account)
+    fun `identity address with single identity as recipient`() {
+        val displayName = participantFormatter.getDisplayName(
+            address = Address(IDENTITY_ADDRESS, "irrelevant"),
+            account = account,
+            isSender = false,
+        )
 
-        assertThat(displayName).isEqualTo(ME_TEXT)
+        assertThat(displayName).isEqualTo(TO_ME_TEXT)
+    }
+
+    @Test
+    fun `identity address with single identity as sender`() {
+        val displayName = participantFormatter.getDisplayName(
+            address = Address(IDENTITY_ADDRESS, "irrelevant"),
+            account = account,
+            isSender = true,
+        )
+
+        assertThat(displayName).isEqualTo(FROM_ME_TEXT)
     }
 
     @Test
@@ -56,7 +72,11 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
             )
         }
 
-        val displayName = participantFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"), account)
+        val displayName = participantFormatter.getDisplayName(
+            address = Address(IDENTITY_ADDRESS, "irrelevant"),
+            account = account,
+            isSender = false,
+        )
 
         assertThat(displayName).isEqualTo(IDENTITY_NAME)
     }
@@ -67,9 +87,13 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
             identities += Identity(name = null, email = IDENTITY_ADDRESS)
         }
 
-        val displayName = participantFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "Bob"), account)
+        val displayName = participantFormatter.getDisplayName(
+            address = Address(IDENTITY_ADDRESS, "Bob"),
+            account = account,
+            isSender = false,
+        )
 
-        assertThat(displayName).isEqualTo(ME_TEXT)
+        assertThat(displayName).isEqualTo(TO_ME_TEXT)
     }
 
     @Test
@@ -82,21 +106,33 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
             )
         }
 
-        val displayName = participantFormatter.getDisplayName(Address(IDENTITY_ADDRESS), account)
+        val displayName = participantFormatter.getDisplayName(
+            address = Address(IDENTITY_ADDRESS),
+            account = account,
+            isSender = false,
+        )
 
-        assertThat(displayName).isEqualTo(ME_TEXT)
+        assertThat(displayName).isEqualTo(TO_ME_TEXT)
     }
 
     @Test
     fun `email address without display name`() {
-        val displayName = participantFormatter.getDisplayName(Address("alice@domain.example"), account)
+        val displayName = participantFormatter.getDisplayName(
+            address = Address("alice@domain.example"),
+            account = account,
+            isSender = false,
+        )
 
         assertThat(displayName).isNull()
     }
 
     @Test
     fun `email address with display name`() {
-        val displayName = participantFormatter.getDisplayName(Address("alice@domain.example", "Alice"), account)
+        val displayName = participantFormatter.getDisplayName(
+            address = Address("alice@domain.example", "Alice"),
+            account = account,
+            isSender = false,
+        )
 
         assertThat(displayName).isEqualTo("Alice")
     }
@@ -105,21 +141,33 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
     fun `don't look up contact when showContactNames = false`() {
         val participantFormatter = createParticipantFormatter(showContactNames = false)
 
-        val displayName = participantFormatter.getDisplayName(Address("user1@domain.example", "User 1"), account)
+        val displayName = participantFormatter.getDisplayName(
+            address = Address("user1@domain.example", "User 1"),
+            account = account,
+            isSender = false,
+        )
 
         assertThat(displayName).isEqualTo("User 1")
     }
 
     @Test
     fun `contact lookup`() {
-        val displayName = participantFormatter.getDisplayName(Address("user1@domain.example"), account)
+        val displayName = participantFormatter.getDisplayName(
+            address = Address("user1@domain.example"),
+            account = account,
+            isSender = false,
+        )
 
         assertThat(displayName).isEqualTo("Contact One")
     }
 
     @Test
     fun `contact lookup despite display name`() {
-        val displayName = participantFormatter.getDisplayName(Address("user1@domain.example", "User 1"), account)
+        val displayName = participantFormatter.getDisplayName(
+            address = Address("user1@domain.example", "User 1"),
+            account = account,
+            isSender = false,
+        )
 
         assertThat(displayName).isEqualTo("Contact One")
     }
@@ -128,7 +176,11 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
     fun `colored contact name`() {
         val participantFormatter = createParticipantFormatter(contactNameColor = Color.RED)
 
-        val displayName = participantFormatter.getDisplayName(Address("user1@domain.example"), account)
+        val displayName = participantFormatter.getDisplayName(
+            address = Address("user1@domain.example"),
+            account = account,
+            isSender = false,
+        )
 
         assertThat(displayName.toString()).isEqualTo("Contact One")
         assertThat(displayName).isNotNull().isInstanceOf<Spannable>()
@@ -144,7 +196,8 @@ class MessageDetailsParticipantFormatterTest : RobolectricTest() {
             contactNameProvider = contactNameProvider,
             showContactNames = showContactNames,
             contactNameColor = contactNameColor,
-            meText = ME_TEXT,
+            toMeText = TO_ME_TEXT,
+            fromMeText = FROM_ME_TEXT,
         )
     }
 }


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #7917
RFC / Technical Design (if applicable):

#### Description

I introduced a second string message_view_from_me_text to the english strings.xml and renamed the existing message_view_me_text to message_view_to_me_text to avoid confusion. Then I adjusted the existing logic around message_view_me_text to include both strings and display the correct values at their respective positions. For this I also added the boolean isSender. Finally I modified the relevant test to also include both strings.

Important note: This does not fully fix the reported issue. The result of these changes is that the translation for message_view_from_me_text is missing for all other languages and has to be added through Weblate after the merge. This change only introduces the required second variable so the translation can be added as different from message_view_to_me_text in all languages where the two instances of "me" are not translated as the same word.

#### Screen Shots

<img width="473" height="1018" alt="Screenshot_me_text" src="https://github.com/user-attachments/assets/695a0ec3-191d-41ad-aa3e-0163d3367754" />

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
