### PR TITLE
fix(ui): correct keyline alignment in message list and preferences (fixes #8486)

### DIFF
--- a/legacy/ui/base/src/main/res/layout/toolbar.xml
+++ b/legacy/ui/base/src/main/res/layout/toolbar.xml
@@ -2,7 +2,10 @@
 <!-- Don't use a this layout when using a subtitle. See https://issuetracker.google.com/issues/135865267 -->
 <com.google.android.material.appbar.MaterialToolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    app:contentInsetStart="@dimen/materialKeyline"
+    app:contentInsetStartWithNavigation="@dimen/materialKeyline"
     />

--- a/legacy/ui/base/src/main/res/values/dimensions.xml
+++ b/legacy/ui/base/src/main/res/values/dimensions.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="toolbarTitleMarginVertical">8dp</dimen>
+
+    <!-- Keyline -->
+    <dimen name="materialKeyline">72dp</dimen>
 </resources>

--- a/legacy/ui/legacy/src/main/res/layout/activity_account_settings.xml
+++ b/legacy/ui/legacy/src/main/res/layout/activity_account_settings.xml
@@ -24,6 +24,8 @@
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
             tools:navigationIcon="@drawable/ic_arrow_back"
+            app:contentInsetStart="@dimen/materialKeyline"
+            app:contentInsetStartWithNavigation="@dimen/materialKeyline"
             >
 
             <com.fsck.k9.ui.settings.account.AccountSelectionSpinner

--- a/legacy/ui/legacy/src/main/res/layout/message_list_toolbar.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list_toolbar.xml
@@ -2,6 +2,7 @@
 <com.google.android.material.appbar.MaterialToolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
     style="?attr/toolbarStyle"
     android:layout_width="match_parent"
@@ -9,6 +10,8 @@
     android:layout_alignParentTop="true"
     android:minHeight="?attr/actionBarSize"
     tools:navigationIcon="@drawable/ic_arrow_back"
+    app:contentInsetStart="@dimen/messageListStartKeyline"
+    app:contentInsetStartWithNavigation="@dimen/messageListStartKeyline"
     >
 
     <!-- We're not using MaterialToolbar's title/subtitle support because it is broken when using large system

--- a/legacy/ui/legacy/src/main/res/values-sw360dp/values-preference.xml
+++ b/legacy/ui/legacy/src/main/res/values-sw360dp/values-preference.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-Fixes indentation issues in preference screens
-
-Source: https://stackoverflow.com/a/52960668
--->
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <bool name="config_materialPreferenceIconSpaceReserved" tools:ignore="MissingDefaultResource,PrivateResource">false</bool>
-</resources>


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: https://github.com/thunderbird/thunderbird-android/issues/8486

#### Description

Background: Material Design 1 recommended a 72dp keyline for any icons before the start of a line of content.

- Align message list action bar title to keyline. The dimension is already defined as 72dp.
- Align settings action bar title to keyline. New 72dp dimension created in xml.
- Align account settings action bar title to keyline. Same dimension as the above.
- Restore Material Design standard indentation in settings, since the title can now align with its keyline.

#### Screenshots
<table>
<tr><th>After</th><th>Before</th></tr>
<tr><td>
<img src="https://github.com/user-attachments/assets/6f10b48a-32bc-4d07-a3ab-072f286c4c5b"/>
</td>
<td><img src="https://github.com/user-attachments/assets/a451b1d4-09d8-46ec-b941-11f8c4abc10f"/></td>
</tr></table>


---

<table>
<tr><th>After</th><th>Before</th></tr>
<tr><td>
<img src="https://github.com/user-attachments/assets/b8e55090-af57-49fd-bbe8-ab950d3bb885"/>
</td>
<td><img src="https://github.com/user-attachments/assets/08cc2f96-f27d-4c96-82ea-075bdfe79dfc"/></td>
</tr></table>

--


<table>
<tr><th>After</th><th>Before</th></tr>
<tr><td>
<img src="https://github.com/user-attachments/assets/11f25345-fa10-4d64-a36d-cc67944009ca"/>
</td>
<td><img src="https://github.com/user-attachments/assets/2f4a0f13-c1ff-4569-8ef3-b737bb5f317c"/></td>
</tr></table>

---


<table>
<tr><th>After</th><th>Before</th></tr>
<tr><td>
<img src="https://github.com/user-attachments/assets/8c39e12f-5fe2-4b84-8d13-5c88681f02d5"/>
</td>
<td><img src="https://github.com/user-attachments/assets/21d62663-f6f1-4235-9b82-efbde64a7e2e"/></td>
</tr></table>

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
