### PR TITLE
fix(settings): prevent HTML signature preview reloads on rotation

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/setup/signature/SignatureContent.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/setup/signature/SignatureContent.kt
@@ -189,6 +189,10 @@ private fun SignatureHtmlPreview(
     var contentHeight by remember { mutableStateOf(0.dp) }
     val animatedContentHeight by animateDpAsState(contentHeight)
 
+    // AndroidView's update block also runs for unrelated recompositions, e.g. height and window inset changes.
+    // Reloading the document in those cases can produce a new, incorrect content height while rotating the device.
+    val loadState = remember { SignaturePreviewLoadState() }
+
     AndroidView(
         factory = { context ->
             MessageWebView(context).apply {
@@ -196,10 +200,24 @@ private fun SignatureHtmlPreview(
             }
         },
         update = { webView ->
-            webView.displayHtmlContentWithInlineAttachments(debouncedSignature, null) {
-                contentHeight = webView.contentHeight.dp
+            if (loadState.shouldLoad(debouncedSignature)) {
+                contentHeight = 0.dp
+                webView.displayHtmlContentWithInlineAttachments(debouncedSignature, null) {
+                    contentHeight = webView.contentHeight.dp
+                }
             }
         },
         modifier = modifier.height(animatedContentHeight),
     )
+}
+
+internal class SignaturePreviewLoadState {
+    private var loadedSignature: String? = null
+
+    fun shouldLoad(signature: String): Boolean {
+        if (signature == loadedSignature) return false
+
+        loadedSignature = signature
+        return true
+    }
 }

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/setup/signature/SignaturePreviewLoadStateTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/setup/signature/SignaturePreviewLoadStateTest.kt
@@ -1,0 +1,47 @@
+package com.fsck.k9.activity.setup.signature
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+internal class SignaturePreviewLoadStateTest {
+
+    @Test
+    fun `should load first signature`() {
+        // Arrange
+        val testSubject = SignaturePreviewLoadState()
+
+        // Act
+        val shouldLoad = testSubject.shouldLoad("Signature")
+
+        // Assert
+        assertThat(shouldLoad).isTrue()
+    }
+
+    @Test
+    fun `should not reload unchanged signature`() {
+        // Arrange
+        val testSubject = SignaturePreviewLoadState()
+        testSubject.shouldLoad("Signature")
+
+        // Act
+        val shouldLoad = testSubject.shouldLoad("Signature")
+
+        // Assert
+        assertThat(shouldLoad).isFalse()
+    }
+
+    @Test
+    fun `should load changed signature`() {
+        // Arrange
+        val testSubject = SignaturePreviewLoadState()
+        testSubject.shouldLoad("First signature")
+
+        // Act
+        val shouldLoad = testSubject.shouldLoad("Second signature")
+
+        // Assert
+        assertThat(shouldLoad).isTrue()
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #11528 

#### Description

Prevents the HTML signature preview WebView from reloading during unrelated recompositions, which could produce an incorrect preview height after screen rotation. The preview now reloads only when its HTML content changes. Adds unit tests for the reload behavior.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI. -> researched the cause
- [ ] This contribution includes changes created by AI.
