### PR TITLE
uplift(beta): fix(settings): prevent HTML signature preview reloads on rotation (#11538)

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/setup/signature/SignatureContent.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/setup/signature/SignatureContent.kt
@@ -189,6 +189,10 @@ private fun SignatureHtmlPreview(
     var contentHeight by remember { mutableStateOf(0.dp) }
     val animatedContentHeight by animateDpAsState(contentHeight)
 
+    // AndroidView's update block also runs for unrelated recompositions, e.g. height and window inset changes.
+    // Reloading the document in those cases can produce a new, incorrect content height while rotating the device.
+    val loadState = remember { SignaturePreviewLoadState() }
+
     AndroidView(
         factory = { context ->
             MessageWebView(context).apply {
@@ -196,10 +200,24 @@ private fun SignatureHtmlPreview(
             }
         },
         update = { webView ->
-            webView.displayHtmlContentWithInlineAttachments(debouncedSignature, null) {
-                contentHeight = webView.contentHeight.dp
+            if (loadState.shouldLoad(debouncedSignature)) {
+                contentHeight = 0.dp
+                webView.displayHtmlContentWithInlineAttachments(debouncedSignature, null) {
+                    contentHeight = webView.contentHeight.dp
+                }
             }
         },
         modifier = modifier.height(animatedContentHeight),
     )
+}
+
+internal class SignaturePreviewLoadState {
+    private var loadedSignature: String? = null
+
+    fun shouldLoad(signature: String): Boolean {
+        if (signature == loadedSignature) return false
+
+        loadedSignature = signature
+        return true
+    }
 }

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/setup/signature/SignaturePreviewLoadStateTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/setup/signature/SignaturePreviewLoadStateTest.kt
@@ -1,0 +1,47 @@
+package com.fsck.k9.activity.setup.signature
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+internal class SignaturePreviewLoadStateTest {
+
+    @Test
+    fun `should load first signature`() {
+        // Arrange
+        val testSubject = SignaturePreviewLoadState()
+
+        // Act
+        val shouldLoad = testSubject.shouldLoad("Signature")
+
+        // Assert
+        assertThat(shouldLoad).isTrue()
+    }
+
+    @Test
+    fun `should not reload unchanged signature`() {
+        // Arrange
+        val testSubject = SignaturePreviewLoadState()
+        testSubject.shouldLoad("Signature")
+
+        // Act
+        val shouldLoad = testSubject.shouldLoad("Signature")
+
+        // Assert
+        assertThat(shouldLoad).isFalse()
+    }
+
+    @Test
+    fun `should load changed signature`() {
+        // Arrange
+        val testSubject = SignaturePreviewLoadState()
+        testSubject.shouldLoad("First signature")
+
+        // Act
+        val shouldLoad = testSubject.shouldLoad("Second signature")
+
+        // Assert
+        assertThat(shouldLoad).isTrue()
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: #11528
Original pull request: #11538

#### Description

Uplifts the HTML signature preview rotation fix to `beta`. The preview WebView now reloads only when its HTML content changes, preventing unrelated recompositions during rotation from producing an incorrect preview height.

#### Risk

Low. The change is narrowly scoped to HTML signature preview loading and includes regression tests. No localizable strings or database migrations are changed.

## AI Disclosure

- [ ] This contribution does not include any changes created or assisted by AI.
- [x] This contribution includes changes assisted by AI. (uplift preparation)
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to Mozilla's Community Participation Guidelines
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle
- [x] This contribution does not break existing unit tests
- [x] This contribution includes tests for updated functionality
- [x] This contribution adheres to our Engineering process
- [x] This PR has a descriptive title and body
