### PR TITLE
fix(message-composer): fetch complete message when editing a draft

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1634,7 +1634,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         }
 
         if (!relatedMessageProcessed) {
-            attachmentPresenter.loadAllAvailableAttachments(messageViewInfo);
+            attachmentPresenter.processDraftMessage(messageViewInfo);
         }
 
         // Decode the identity header when loading a draft.
@@ -1947,6 +1947,14 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         @Override
         public void onMessageViewInfoLoadFinished(MessageViewInfo messageViewInfo) {
             internalMessageHandler.sendEmptyMessage(MSG_PROGRESS_OFF);
+
+            // When a draft was incomplete, the attachment presenter asked for the complete message and we end up
+            // here a second time. loadLocalMessageForDisplay() only rebuilds the quoted text in that case, so the
+            // attachments that just arrived have to be picked up explicitly.
+            if (relatedMessageProcessed && action == Action.EDIT_DRAFT) {
+                attachmentPresenter.processDraftMessage(messageViewInfo);
+            }
+
             loadLocalMessageForDisplay(messageViewInfo, action);
 
             if(!recipientPresenter.isToAddressAdded()) {
@@ -2205,6 +2213,16 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         public void showMissingAttachmentsPartialMessageForwardWarning() {
             Toast.makeText(MessageCompose.this,
                     getString(R.string.message_compose_attachments_forward_toast), Toast.LENGTH_LONG).show();
+        }
+
+        @Override
+        public void downloadCompleteMessage() {
+            if (messageLoaderHelper == null) {
+                return;
+            }
+
+            internalMessageHandler.sendEmptyMessage(MSG_PROGRESS_ON);
+            messageLoaderHelper.downloadCompleteMessage();
         }
     };
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -53,6 +53,7 @@ public class AttachmentPresenter {
     private final LinkedHashMap<Uri, InlineAttachment> inlineAttachments;
     private int nextLoaderId = 0;
     private WaitingAction actionToPerformAfterWaiting = WaitingAction.NONE;
+    private boolean completeMessageDownloadRequested = false;
 
 
     public AttachmentPresenter(Context context, AttachmentMvpView attachmentMvpView, LoaderManager loaderManager,
@@ -210,18 +211,50 @@ public class AttachmentPresenter {
         boolean allPartsAvailable = true;
 
         for (AttachmentViewInfo attachmentViewInfo : messageViewInfo.attachments) {
-            if (attachmentViewInfo.isContentAvailable()) {
-                if (attachmentViewInfo.inlineAttachment) {
-                    addInlineAttachment(attachmentViewInfo);
-                } else {
-                    addInternalAttachment(attachmentViewInfo);
-                }
-            } else {
+            if (!attachmentViewInfo.isContentAvailable()) {
                 allPartsAvailable = false;
+                continue;
+            }
+
+            if (isAlreadyAdded(attachmentViewInfo)) {
+                continue;
+            }
+
+            if (attachmentViewInfo.inlineAttachment) {
+                addInlineAttachment(attachmentViewInfo);
+            } else {
+                addInternalAttachment(attachmentViewInfo);
             }
         }
 
         return allPartsAvailable;
+    }
+
+    private boolean isAlreadyAdded(AttachmentViewInfo attachmentViewInfo) {
+        return attachments.containsKey(attachmentViewInfo.internalUri) ||
+                inlineAttachments.containsKey(attachmentViewInfo.internalUri);
+    }
+
+    /**
+     * Loads the attachments of a draft that is being edited.
+     *
+     * <p>Unlike a message that is only displayed, an edited draft is written back to the server. Attachments whose
+     * content was not downloaded are therefore not just missing from the screen, they are lost on the next save. So
+     * the complete message is fetched once, mirroring what the message view offers through its download button.</p>
+     */
+    public void processDraftMessage(MessageViewInfo messageViewInfo) {
+        boolean allPartsAvailable = loadAllAvailableAttachments(messageViewInfo);
+        if (allPartsAvailable) {
+            return;
+        }
+
+        if (completeMessageDownloadRequested) {
+            attachmentMvpView.showMissingAttachmentsPartialMessageWarning();
+            return;
+        }
+
+        completeMessageDownloadRequested = true;
+        attachmentMvpView.downloadCompleteMessage();
     }
 
     public void processMessageToForward(MessageViewInfo messageViewInfo) {
@@ -475,6 +508,7 @@ public class AttachmentPresenter {
 
         void showMissingAttachmentsPartialMessageWarning();
         void showMissingAttachmentsPartialMessageForwardWarning();
+        void downloadCompleteMessage();
     }
 
     public interface AttachmentsChangedListener {

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/compose/AttachmentPresenterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/activity/compose/AttachmentPresenterTest.kt
@@ -44,7 +44,13 @@ private const val ATTACHMENT_NAME = "1x1.png"
 private const val MESSAGE_ID = 1L
 private const val PATH_TO_FILE = "path/to/file.png"
 private const val MIME_TYPE = "image/png"
+private const val SECOND_ATTACHMENT_NAME = "2x2.png"
+private const val THIRD_ATTACHMENT_NAME = "3x3.png"
+private const val CONTENT_ID = "xyz"
+private const val SIZE = 42L
 private val URI = Uri.Builder().scheme("content://").build()
+private val SECOND_URI = Uri.Builder().scheme("content://").appendPath("second").build()
+private val THIRD_URI = Uri.Builder().scheme("content://").appendPath("third").build()
 
 class AttachmentPresenterTest : K9RobolectricTest() {
     lateinit var attachmentPresenter: AttachmentPresenter
@@ -167,11 +173,331 @@ class AttachmentPresenterTest : K9RobolectricTest() {
         assertThat(attachmentPresenter.inlineAttachments).isEmpty()
     }
 
+    @Test
+    fun `processDraftMessage should not request download when all parts are available`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val messageViewInfo = messageViewInfoWith(availableAttachment(ATTACHMENT_NAME))
+        mockLoaderManager({ testSubject.attachments.get(0) as Attachment })
+
+        // Act
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(0)
+        assertThat(fakeView.missingAttachmentsWarningCount).isEqualTo(0)
+        assertThat(testSubject.attachments).hasSize(1)
+    }
+
+    @Test
+    fun `processDraftMessage should request download when a part is missing`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val messageViewInfo = messageViewInfoWith(missingAttachment(ATTACHMENT_NAME))
+
+        // Act
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+        assertThat(fakeView.missingAttachmentsWarningCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `processDraftMessage should request download when only some parts are available`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val messageViewInfo = messageViewInfoWith(
+            availableAttachment(ATTACHMENT_NAME),
+            missingAttachment(SECOND_ATTACHMENT_NAME),
+        )
+        mockLoaderManager({ testSubject.attachments.get(0) as Attachment })
+
+        // Act
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+        assertThat(testSubject.attachments).hasSize(1)
+    }
+
+    @Test
+    fun `processDraftMessage should not add an attachment twice when called again after download`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val firstPass = messageViewInfoWith(
+            availableAttachment(ATTACHMENT_NAME),
+            missingAttachment(SECOND_ATTACHMENT_NAME),
+        )
+        val secondPass = messageViewInfoWith(
+            availableAttachment(ATTACHMENT_NAME),
+            availableAttachment(SECOND_ATTACHMENT_NAME, SECOND_URI),
+        )
+        mockLoaderManager({ firstAttachmentWithMetadata(testSubject) })
+        testSubject.processDraftMessage(firstPass)
+
+        // Act
+        testSubject.processDraftMessage(secondPass)
+
+        // Assert
+        assertThat(testSubject.attachments).hasSize(2)
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `processDraftMessage should do nothing when the draft has no attachments`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val messageViewInfo = messageViewInfoWith()
+
+        // Act
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(0)
+        assertThat(fakeView.missingAttachmentsWarningCount).isEqualTo(0)
+        assertThat(testSubject.attachments).isEmpty()
+    }
+
+    @Test
+    fun `processDraftMessage should request download when an inline part is missing`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val localBodyPart = LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, SIZE)
+        localBodyPart.addHeader(MimeHeader.HEADER_CONTENT_ID, CONTENT_ID)
+        val inlineAttachment =
+            AttachmentViewInfo(MIME_TYPE, ATTACHMENT_NAME, SIZE, URI, true, localBodyPart, false)
+        val messageViewInfo = messageViewInfoWith(inlineAttachment)
+
+        // Act
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `processDraftMessage should warn instead of downloading again when parts are still missing`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val messageViewInfo = messageViewInfoWith(missingAttachment(ATTACHMENT_NAME))
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Act
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+        assertThat(fakeView.missingAttachmentsWarningCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `processMessageToForward should still warn and not request a download`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val messageViewInfo = messageViewInfoWith(missingAttachment(ATTACHMENT_NAME))
+
+        // Act
+        testSubject.processMessageToForward(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.missingAttachmentsWarningCount).isEqualTo(1)
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `processDraftMessage should request download when one of three attachments is missing`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val messageViewInfo = messageViewInfoWith(
+            availableAttachment(ATTACHMENT_NAME),
+            availableAttachment(SECOND_ATTACHMENT_NAME, SECOND_URI),
+            missingAttachment(THIRD_ATTACHMENT_NAME, THIRD_URI),
+        )
+        mockLoaderManager({ firstAttachmentWithMetadata(testSubject) })
+
+        // Act
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+        assertThat(testSubject.attachments).hasSize(2)
+    }
+
+    @Test
+    fun `processDraftMessage should request download when both a normal and an inline part are missing`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val messageViewInfo = messageViewInfoWith(
+            missingAttachment(ATTACHMENT_NAME),
+            missingInlineAttachment(SECOND_ATTACHMENT_NAME, SECOND_URI),
+        )
+
+        // Act
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+        assertThat(testSubject.attachments).isEmpty()
+        assertThat(testSubject.inlineAttachments).isEmpty()
+    }
+
+    @Test
+    fun `processDraftMessage should request download when only the inline part is missing`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val messageViewInfo = messageViewInfoWith(
+            availableAttachment(ATTACHMENT_NAME),
+            missingInlineAttachment(SECOND_ATTACHMENT_NAME, SECOND_URI),
+        )
+        mockLoaderManager({ firstAttachmentWithMetadata(testSubject) })
+
+        // Act
+        testSubject.processDraftMessage(messageViewInfo)
+
+        // Assert
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+        assertThat(testSubject.attachments).hasSize(1)
+        assertThat(testSubject.inlineAttachments).isEmpty()
+    }
+
+    @Test
+    fun `processDraftMessage should stay stable when called a third time`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val incomplete = messageViewInfoWith(
+            availableAttachment(ATTACHMENT_NAME),
+            missingAttachment(SECOND_ATTACHMENT_NAME, SECOND_URI),
+        )
+        val complete = messageViewInfoWith(
+            availableAttachment(ATTACHMENT_NAME),
+            availableAttachment(SECOND_ATTACHMENT_NAME, SECOND_URI),
+        )
+        mockLoaderManager({ firstAttachmentWithMetadata(testSubject) })
+        testSubject.processDraftMessage(incomplete)
+        testSubject.processDraftMessage(complete)
+
+        // Act
+        testSubject.processDraftMessage(complete)
+
+        // Assert
+        assertThat(testSubject.attachments).hasSize(2)
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+        assertThat(fakeView.missingAttachmentsWarningCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `processMessageToForward should be unaffected by a previous draft download request`() {
+        // Arrange
+        val fakeView = FakeAttachmentMvpView()
+        val testSubject = createPresenter(fakeView)
+        val draft = messageViewInfoWith(missingAttachment(ATTACHMENT_NAME))
+        val toForward = messageViewInfoWith(missingAttachment(SECOND_ATTACHMENT_NAME, SECOND_URI))
+        testSubject.processDraftMessage(draft)
+
+        // Act
+        testSubject.processMessageToForward(toForward)
+
+        // Assert
+        assertThat(fakeView.missingAttachmentsWarningCount).isEqualTo(1)
+        assertThat(fakeView.downloadCompleteMessageCount).isEqualTo(1)
+    }
+
+    private fun firstAttachmentWithMetadata(presenter: AttachmentPresenter): Attachment {
+        return presenter.attachments.first {
+            it?.state == com.fsck.k9.message.Attachment.LoadingState.METADATA
+        } as Attachment
+    }
+
+    private fun missingInlineAttachment(name: String, uri: Uri = URI): AttachmentViewInfo {
+        val localBodyPart = LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, SIZE)
+        localBodyPart.addHeader(MimeHeader.HEADER_CONTENT_ID, name)
+        return AttachmentViewInfo(MIME_TYPE, name, SIZE, uri, true, localBodyPart, false)
+    }
+
+    private fun createPresenter(view: AttachmentMvpView): AttachmentPresenter {
+        return AttachmentPresenter(
+            ApplicationProvider.getApplicationContext(),
+            view,
+            loaderManager,
+            listener,
+        )
+    }
+
+    private fun availableAttachment(name: String, uri: Uri = URI): AttachmentViewInfo {
+        return AttachmentViewInfo(
+            MIME_TYPE,
+            name,
+            SIZE,
+            uri,
+            false,
+            LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, SIZE),
+            true,
+        )
+    }
+
+    private fun missingAttachment(name: String, uri: Uri = URI): AttachmentViewInfo {
+        return AttachmentViewInfo(
+            MIME_TYPE,
+            name,
+            SIZE,
+            uri,
+            false,
+            LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, SIZE),
+            false,
+        )
+    }
+
+    private fun messageViewInfoWith(vararg attachments: AttachmentViewInfo): MessageViewInfo {
+        val message = MimeMessage()
+        MimeMessageHelper.setBody(message, TextBody(TEXT))
+        return MessageViewInfo(
+            message, false, message, SUBJECT, false, TEXT, TEXT, attachments.toList(), null, attachmentResolver,
+            EXTRA_TEXT, ArrayList(), null,
+        )
+    }
+
     private fun mockLoaderManager(attachmentSupplier: Supplier<Attachment>) {
         doAnswer {
             val loaderCallbacks = it.getArgument<LoaderCallbacks<Attachment>>(2)
             loaderCallbacks.onLoadFinished(mock(), attachmentSupplier.get().deriveWithLoadComplete(PATH_TO_FILE))
             null
         }.whenever(loaderManager).initLoader(anyInt(), any(), any<LoaderCallbacks<Attachment>>())
+    }
+}
+
+private class FakeAttachmentMvpView : AttachmentMvpView {
+    var downloadCompleteMessageCount = 0
+    var missingAttachmentsWarningCount = 0
+
+    override fun showWaitingForAttachmentDialog(waitingAction: AttachmentPresenter.WaitingAction?) = Unit
+    override fun dismissWaitingForAttachmentDialog() = Unit
+    override fun showPickAttachmentDialog(requestCode: Int) = Unit
+    override fun addAttachmentView(attachment: Attachment?) = Unit
+    override fun removeAttachmentView(attachment: Attachment?) = Unit
+    override fun updateAttachmentView(attachment: Attachment?) = Unit
+    override fun performSendAfterChecks() = Unit
+    override fun performSaveAfterChecks() = Unit
+
+    override fun showMissingAttachmentsPartialMessageWarning() {
+        missingAttachmentsWarningCount++
+    }
+
+    override fun showMissingAttachmentsPartialMessageForwardWarning() = Unit
+
+    override fun downloadCompleteMessage() {
+        downloadCompleteMessageCount++
     }
 }


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #954
RFC / Technical Design (if applicable): not applicable, this is a bug fix within a single issue

#### Description

Opening a draft that is larger than the account's "Fetch messages up to" limit silently drops its attachments. They are missing in the composer, and once the draft is saved or sent they are gone from the server as well.

**Cause.** The composer only adds attachments whose content is available locally. `AttachmentPresenter.loadAllAvailableAttachments()` skips the ones that were not downloaded and returns `false` when it did. `processMessageToForward()` checks that return value and warns, and the message view offers a "Download complete message" button, but the draft path ignored it entirely.

**Change.** When parts are missing, the composer now asks for the complete message once through the existing `MessageLoaderHelper.downloadCompleteMessage()` and picks up the attachments when they arrive. If parts are still missing after that, the warning that already exists is shown instead of asking again. Attachments that were already added are not added a second time.

This mirrors what the two neighbouring paths already do, so it does not introduce a new concept or a new UI element, and it reuses an existing string.

**Base revision.** Rebased onto `a88ae92739`. The change itself is a single commit.

**Environment used for testing.** Android 16 emulator, `fossDebug` build, real IMAP account at GMX, drafts written into the drafts folder from outside the app via IMAP APPEND, "Fetch messages up to" left at its default of 128 KiB.

**Frequency.** Reproducible every time the whole message exceeds the configured limit, and never below it. Six data points, from a 48 KB attachment up to 1 MB. Because base64 adds about a third, it already breaks at roughly 90 KB of attachment.

**Factors ruled out.** HTML content is not the cause, plain text drafts behave the same. POP3 is not affected, the limit is only evaluated in `ImapSync`. Drafts created inside the app are fine, but only because the local copy is complete, so the same draft breaks on a second device. Device orientation and restarting the composer make no difference.

**Server state, measured over IMAP independently of the app:**

| action | before the fix | after the fix |
|---|---|---|
| save an edited draft | 168774 B → 1072 B, attachment deleted on the server | 135977 B, attachment still there |
| send a draft | Sent 903 B, recipient 19214 B, no attachment | Sent 718741 B, recipient 737250 B, attachment included |
| discard | unchanged, attachment kept | unchanged, attachment kept |

**Cases from the earlier comments in the issue, all verified on the device:** HTML draft with an attachment (the original 2015 report), inline image referenced by Content-ID, three attachments in one message, just below and just above the limit, a draft over the limit with no attachment at all, a 5 MB attachment, a draft opened twice in a row, discarding after the download, forwarding a partially downloaded message, and drafts that had already been opened before the fix was installed.

**Checks run locally.** `gradlew :legacy:ui:legacy:testDebugUnitTest`, `gradlew spotlessCheck`, `gradlew detekt`, `gradlew lint`. The 17 unit tests in `AttachmentPresenterTest` pass with the fix; with the fix reverted to its previous behaviour, 10 of them fail and no pre-existing test does.

**Not tested.** Encrypted drafts, since they need OpenKeychain and have a failure mode of their own. Only one provider was available to me. There is also a short window while the message is being fetched in which saving is not blocked, because `checkOkForSendingOrDraftSaving()` only looks at attachments that have already been added; I could not trigger it on a device even with a 5 MB attachment, and it is not a regression, since without the fix nothing is fetched at all. I left it alone rather than adding a new guard to legacy code, but I am happy to handle it if you would prefer that.

**One known limitation, not addressed here.** A draft with no attachment but a body larger than the limit is still truncated, and the fetched text is not put back into the input field. That needs a different solution than fetching, since replacing the text could overwrite what the user has typed. I could not find an existing issue for it, #4108 is related but about a notice in the message view. I will file one separately.

**Questions.**

The change is in `MessageCompose` and `AttachmentPresenter`, so legacy code. Is that the right place for this, or would you rather see it elsewhere?

@driehle also mentioned forwarding in his last comment, that the whole message should be fetched there too. I left that out on purpose, because forwarding already warns the user and nothing is lost silently, and because the issue is about drafts. Happy to add it here or open a separate issue, whichever you prefer.

#### Screen Shots

Not applicable, there are no UI changes.

## AI Disclosure

Select **one** of the following (mandatory)

- [ ] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [x] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to Mozilla's Community Participation Guidelines
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle
- [x] This contribution does not break existing unit tests
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This contribution adheres to our Engineering process (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes

Note on the Kotlin box: the new test is Kotlin. The two files changed by the fix are Java, and porting them would be unrelated refactoring inside a bug fix.

